### PR TITLE
feat(call-graph): tested_by edges, community detection, get_minimal_context, get_cluster, detect_changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,9 +961,10 @@ spec-gen setup [--tools vibe,cline,claude,opencode,omoa,gsd,bmad]
 
 Mistral Vibe  ->  .vibe/skills/spec-gen-{name}/SKILL.md       (8 skills)
 Cline / Roo   ->  .clinerules/workflows/spec-gen-{name}.md    (7 workflows)
-Claude Code   ->  .claude/skills/spec-gen-{name}/SKILL.md     (8 skills + decisions pre-commit hook)
+Claude Code   ->  .claude/skills/spec-gen-{name}/SKILL.md     (8 skills + decisions pre-commit hook
+              ->                                                + PostToolUse auto-analyze hook)
 OpenCode      ->  .opencode/skills/spec-gen-{name}/SKILL.md   (8 skills)
-              ->  .opencode/plugins/agent-guard.ts             (guard plugin)
+              ->  .opencode/plugins/agent-guard.ts             (guard plugin + auto-analyze on file edits)
 oh-my-openagent -> .opencode/plugins/{anti-laziness,spec-gen-enforcer,
               ->                      spec-gen-decision-extractor,spec-gen-context-injector}.ts
               ->  .opencode/prompts/sisyphus-sdd.md            (SDD system prompt)
@@ -1147,7 +1148,7 @@ Add `--watch-auto` to your MCP config args:
 }
 ```
 
-The watcher starts automatically on the first tool call — no hardcoded path needed. It re-extracts signatures for any changed source file and patches `llm-context.json` within ~500 ms of a save. If an embedding server is reachable, it also re-embeds changed functions into the vector index automatically. The call graph is not rebuilt on every change; it stays current via the [post-commit hook](#cicd-integration) (`spec-gen analyze --force`).
+The watcher starts automatically on the first tool call — no hardcoded path needed. It re-extracts signatures for any changed source file and patches `llm-context.json` within ~500 ms of a save. If an embedding server is reachable, it also re-embeds changed functions into the vector index automatically. The call graph is rebuilt automatically after file edits via the PostToolUse hook (Claude Code) or the `agent-guard` plugin (OpenCode/KiloCode), both installed by `spec-gen setup`. Alternatively it stays current via the [post-commit hook](#cicd-integration) (`spec-gen analyze --force`).
 
 | Option | Default | Description |
 |---|---|---|
@@ -1210,7 +1211,7 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 
 | Tool | Description | Requires prior analysis |
 |------|-------------|:---:|
-| `analyze_codebase` | Run full static analysis: repo structure, dependency graph, call graph (hub functions, entry points, layer violations), and top refactoring priorities. Results cached for 1 hour (`force: true` to bypass). | No |
+| `analyze_codebase` | Run full static analysis: repo structure, dependency graph, call graph (hub functions, entry points, layer violations), and top refactoring priorities. Results cached by content-hash fingerprint (mtime+size of source files); re-runs automatically when code changes. `force: true` bypasses the cache. | No |
 | `get_call_graph` | Hub functions (high fan-in), entry points (no internal callers), and architectural layer violations. Supports TypeScript, JavaScript, Python, Go, Rust, Ruby, Java, C++, Swift. | Yes |
 | `get_signatures` | Compact function/class signatures per file. Filter by path substring with `filePattern`. Useful for understanding a module's public API without reading full source. | Yes |
 | `get_duplicate_report` | Detect duplicate code: Type 1 (exact clones), Type 2 (structural -- renamed variables), Type 3 (near-clones with Jaccard similarity >= 0.7). Groups sorted by impact. | Yes |
@@ -1222,7 +1223,7 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 | `orient` | **Single entry point for any new task.** Given a natural-language task description, returns in one call: relevant functions, source files, spec domains, call neighbourhoods, insertion-point candidates, and matching spec sections. Start here. | Yes (+ embedding) |
 | `search_code` | Natural-language semantic search over indexed functions. Returns the closest matches by meaning with similarity score, call-graph neighbourhood enrichment, and spec-linked peer functions. Falls back to BM25 keyword search when no embedding server is configured. | Yes (+ embedding) |
 | `suggest_insertion_points` | Semantic search over the vector index to find the best existing functions to extend or hook into when implementing a new feature. Returns ranked candidates with role and strategy. Falls back to BM25 keyword search when no embedding server is configured. | Yes (+ embedding) |
-| `get_subgraph` | Depth-limited subgraph centred on a function. Direction: `downstream` (what it calls), `upstream` (who calls it), or `both`. Output as JSON or Mermaid diagram. | Yes |
+| `get_subgraph` | Depth-limited subgraph centred on a function. Direction: `downstream` (what it calls), `upstream` (who calls it), or `both`. Output as JSON or Mermaid diagram. External leaf nodes (e.g. `fetch`, `psycopg2.execute`) appear as `[external]` with an `externalKind` field (`http`, `database`, `filesystem`, `stdlib`, `unknown`). Stdlib noise (`Array.isArray`, `os.path.join`, `std::string`) is filtered out automatically; only semantically meaningful externals are shown. | Yes |
 | `trace_execution_path` | Find all call-graph paths between two functions (DFS, configurable depth/max-paths). Use this when debugging: "how does request X reach function Y?" Returns shortest path, all paths sorted by hops, and a step-by-step chain per path. | Yes |
 | `get_function_body` | Return the exact source code of a named function in a file. | No |
 | `get_function_skeleton` | Noise-stripped view of a source file: logs, inline comments, and non-JSDoc block comments removed. Signatures, control flow, return/throw, and call expressions preserved. Returns reduction %. | No |
@@ -1706,6 +1707,7 @@ Static analysis output is stored in `.spec-gen/analysis/`:
 | `mapping.json` | Requirement->function mapping (produced by `generate`) |
 | `spec-snapshot.json` | Compact coverage summary: git state, per-domain coverage %, uncovered hub functions (auto-updated after `analyze` and `generate`) |
 | `audit-report.json` | Latest parity audit report (produced by `spec-gen audit`) |
+| `fingerprint.json` | Content-hash fingerprint (SHA-256 of all source file mtimes+sizes) used for cache invalidation |
 | `vector-index/` | LanceDB semantic index (produced by `--embed`) |
 
 `spec-gen analyze` also writes **`ARCHITECTURE.md`** to your project root -- a Markdown overview of module clusters, entry points, and critical hubs, refreshed on every run.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Scans your codebase using pure static analysis:
 - Detects HTTP cross-language edges: matches `fetch`/`axios`/`ky`/`got` calls in JS/TS files to FastAPI/Flask/Django route definitions in Python files, creating cross-language dependency edges with `exact`, `path`, or `fuzzy` confidence
 - Resolves Python absolute imports (`from services.retriever import X`) to local files
 - Synthesizes cross-file dependency edges from call-graph data for languages without file-level imports (Swift, C++), so the dependency graph and viewer are meaningful even in single-module projects
+- Builds a full call graph with **`tested_by` edges** derived from import analysis: each test file's imports map to the production functions it covers, making coverage queries accurate even for mock-heavy suites where call edges don't reach the unit under test
+- Runs **label-propagation community detection** on the call graph to group tightly coupled functions into clusters regardless of directory — powering `get_cluster` and the community colours in the graph viewer
 - Clusters related files into structural business domains automatically
 - Extracts DB schema tables (Prisma, TypeORM, Drizzle, SQLAlchemy), HTTP routes (Express, NestJS, Next.js, FastAPI, Flask), UI components (React, Vue, Svelte, Angular), middleware chains, and environment variables — saved as structured JSON artifacts in `.spec-gen/analysis/`
 - Generates AI tool config files (`CLAUDE.md`, `.cursorrules`, `.clinerules/`, `.vibe/skills/`, etc.) with `--ai-configs`
@@ -1224,6 +1226,8 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 | `search_code` | Natural-language semantic search over indexed functions. Returns the closest matches by meaning with similarity score, call-graph neighbourhood enrichment, and spec-linked peer functions. Falls back to BM25 keyword search when no embedding server is configured. | Yes (+ embedding) |
 | `suggest_insertion_points` | Semantic search over the vector index to find the best existing functions to extend or hook into when implementing a new feature. Returns ranked candidates with role and strategy. Falls back to BM25 keyword search when no embedding server is configured. | Yes (+ embedding) |
 | `get_subgraph` | Depth-limited subgraph centred on a function. Direction: `downstream` (what it calls), `upstream` (who calls it), or `both`. Output as JSON or Mermaid diagram. External leaf nodes (e.g. `fetch`, `psycopg2.execute`) appear as `[external]` with an `externalKind` field (`http`, `database`, `filesystem`, `stdlib`, `unknown`). Stdlib noise (`Array.isArray`, `os.path.join`, `std::string`) is filtered out automatically; only semantically meaningful externals are shown. | Yes |
+| `get_minimal_context` | Return the minimum context needed to safely modify a function: its body, direct callers (signatures only), direct callees (signatures only), and which test files cover it via `tested_by` edges. Use this instead of `orient` when you already know exactly which function to modify — typically 200–600 tokens vs `orient`'s 2 000+. | Yes |
+| `get_cluster` | Return all functions in the same community (label-propagation cluster) as the given function. Tightly coupled functions land in the same cluster regardless of directory. Use this to understand the blast-radius neighbourhood without manual graph traversal. | Yes |
 | `trace_execution_path` | Find all call-graph paths between two functions (DFS, configurable depth/max-paths). Use this when debugging: "how does request X reach function Y?" Returns shortest path, all paths sorted by hops, and a step-by-step chain per path. | Yes |
 | `get_function_body` | Return the exact source code of a named function in a file. | No |
 | `get_function_skeleton` | Noise-stripped view of a source file: logs, inline comments, and non-JSDoc block comments removed. Signatures, control flow, return/throw, and call expressions preserved. Returns reduction %. | No |
@@ -1239,6 +1243,12 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 | `get_ui_components` | Detected UI components with framework, props, and source file. Supports React, Vue, Svelte, and Angular. | Yes |
 | `get_env_vars` | Env vars referenced in source code with `required` (no fallback) and `hasDefault` flags. Supports JS/TS, Python, Go, and Ruby. | Yes |
 | `get_middleware_inventory` | Detected middleware with type (auth/cors/rate-limit/validation/logging/error-handler) and framework. | Yes |
+
+**Change analysis**
+
+| Tool | Description | Requires prior analysis |
+|------|-------------|:---:|
+| `detect_changes` | Detect recently changed functions and rank them by blast radius. Runs `git diff` against a base ref, maps changed lines to call-graph nodes, scores each function by `fanIn + transitive callers` (highest = riskiest to break), and reports test coverage per changed function via `tested_by` edges. First tool to run on any code-review or pre-merge check. | Yes |
 
 **Code quality**
 
@@ -1378,6 +1388,25 @@ minFanIn   number   Minimum fan-in threshold to be considered a hub (default: 3)
 **`get_architecture_overview`**
 ```
 directory  string   Absolute path to the project directory
+```
+
+**`get_minimal_context`**
+```
+directory     string   Absolute path to the project directory
+functionName  string   Exact function or method name
+filePath      string   Optional: relative file path to disambiguate when multiple functions share the name
+```
+
+**`get_cluster`**
+```
+directory     string   Absolute path to the project directory
+functionName  string   Function name to look up the community for
+```
+
+**`detect_changes`**
+```
+directory  string   Absolute path to the project directory
+base       string   Git ref to diff against (default: HEAD). Use "HEAD~1" for last commit, "main" for branch diff.
 ```
 
 **`get_function_skeleton`**
@@ -1566,6 +1595,19 @@ dryRun     boolean   Preview changes without writing files (default: false)
 5. approve_decision({ directory, ids: ["<id>"] })
 6. sync_decisions({ directory, dryRun: true })   # preview
 7. sync_decisions({ directory })                  # write to specs and ADRs
+```
+
+**Scenario G -- Code review / pre-merge safety check**
+```
+1. detect_changes({ directory, base: "main" })
+   # Ranks all functions changed since main by blast radius (fanIn + callers)
+   # Surfaces test coverage gaps on the riskiest changed functions
+2. get_minimal_context({ directory, functionName: "<high-risk fn>" })
+   # Body + callers + callees + covering tests — ~300 tokens, one call
+3. analyze_impact({ directory, symbol: "<high-risk fn>", depth: 3 })
+   # Full upstream chain + risk score for the function that scored highest
+4. get_cluster({ directory, functionName: "<high-risk fn>" })
+   # All functions in the same tightly-coupled community — review these too
 ```
 
 ---

--- a/examples/cline-workflows/spec-gen-analyze-codebase.md
+++ b/examples/cline-workflows/spec-gen-analyze-codebase.md
@@ -81,8 +81,9 @@ Present a concise summary:
 ## Step 7: Suggest next steps
 
 Based on the analysis, guide the user through the natural next steps in order:
-1. Call `get_signatures` on the modules that contain the top issues to understand their public API
-2. Call `get_subgraph` on the highest-priority function to map its callers and callees
+1. Call `get_minimal_context` on the highest-priority function — returns callers, callees, body, and test coverage in one call (~300 tokens). Use instead of `get_subgraph` + `get_signatures` separately.
+2. Call `get_cluster` on any function to see its full community (tightly coupled neighbors across directories).
+3. Call `detect_changes` to rank recently changed functions by blast radius — spot riskiest commits before reviewing.
 3. Call `suggest_insertion_points` with a brief feature description to find where new
    logic should land — useful before starting any new work on this codebase
 4. If significant duplication was found, suggest consolidating clone groups before refactoring

--- a/examples/cline-workflows/spec-gen-implement-feature.md
+++ b/examples/cline-workflows/spec-gen-implement-feature.md
@@ -129,15 +129,23 @@ For each candidate, present:
 - Rank, name, file, role, strategy, reason
 - Whether it appears in the relevant cluster identified in Step 2
 
-Then pick the top 1–2 candidates and inspect their call neighbourhood:
+Then pick the top 1–2 candidates and get minimal context (callers, callees, body, test coverage — ~300 tokens):
 
 <use_mcp_tool>
   <server_name>spec-gen</server_name>
-  <tool_name>get_subgraph</tool_name>
-  <arguments>{"directory": "$DIRECTORY", "functionName": "$TOP_CANDIDATE", "direction": "both", "format": "mermaid"}</arguments>
+  <tool_name>get_minimal_context</tool_name>
+  <arguments>{"directory": "$DIRECTORY", "functionName": "$TOP_CANDIDATE"}</arguments>
 </use_mcp_tool>
 
-Show the Mermaid diagram so the user can confirm the chosen insertion point is correct.
+If the function has high fanIn (>10), also check its community to understand broader blast radius:
+
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>get_cluster</tool_name>
+  <arguments>{"directory": "$DIRECTORY", "functionName": "$TOP_CANDIDATE"}</arguments>
+</use_mcp_tool>
+
+Present callers, callees, community label, and test coverage. Ask the user to confirm the chosen insertion point.
 
 ## Step 5: Read the skeleton of the target file(s)
 

--- a/examples/cline-workflows/spec-gen-plan-refactor.md
+++ b/examples/cline-workflows/spec-gen-plan-refactor.md
@@ -91,7 +91,15 @@ Prefer candidates with higher coverage when scores are otherwise close.
 
 ## Step 4: Assess impact
 
-For the chosen function, get the full impact analysis.
+First, get condensed view (callers, callees, body, test coverage in one call):
+
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>get_minimal_context</tool_name>
+  <arguments>{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}</arguments>
+</use_mcp_tool>
+
+Then get the full impact analysis:
 
 <use_mcp_tool>
   <server_name>spec-gen</server_name>

--- a/examples/mistral-vibe/skills/spec-gen-analyze-codebase/SKILL.md
+++ b/examples/mistral-vibe/skills/spec-gen-analyze-codebase/SKILL.md
@@ -105,8 +105,9 @@ Present a concise summary:
 
 Based on the analysis, guide the user through the natural next actions in order:
 
-1. Call `get_signatures` on the modules containing the top issues to understand their public API
-2. Call `get_subgraph` on the highest-priority function to map its callers and callees
+1. Call `get_minimal_context` on the highest-priority function — returns callers, callees, body, and test coverage in one call (~300 tokens). Use instead of `get_subgraph` + `get_signatures` separately.
+2. Call `get_cluster` on any function to see its full community (tightly coupled neighbors across directories).
+3. Call `detect_changes` to rank recently changed functions by blast radius — spot riskiest commits before reviewing.
 3. If significant duplication was found, suggest consolidating clone groups **before** refactoring
 4. Suggest running `/spec-gen-plan-refactor` once the user has enough context to act, then `/spec-gen-execute-refactor` to apply the plan
 5. If the project has OpenSpec specs, call `list_spec_domains` then `search_specs` to enable

--- a/examples/mistral-vibe/skills/spec-gen-debug/SKILL.md
+++ b/examples/mistral-vibe/skills/spec-gen-debug/SKILL.md
@@ -101,7 +101,17 @@ If no specs exist, skip this step and note the absence.
 
 ## Step 4 — Isolate and hypothesize
 
-For the top 2 candidate functions from Step 2, check their structural properties:
+For the top 2 candidate functions from Step 2, get minimal context first (callers, callees, body, test coverage in one call):
+
+```xml
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>get_minimal_context</tool_name>
+  <arguments>{"directory": "$PROJECT_ROOT", "functionName": "$CANDIDATE_FUNCTION"}</arguments>
+</use_mcp_tool>
+```
+
+Then check structural properties:
 
 ```xml
 <use_mcp_tool>

--- a/examples/mistral-vibe/skills/spec-gen-implement-story/SKILL.md
+++ b/examples/mistral-vibe/skills/spec-gen-implement-story/SKILL.md
@@ -60,7 +60,17 @@ Read the story file. Extract:
 </use_mcp_tool>
 ```
 
-For the top 2 functions returned, check risk:
+For the top 2 functions returned, get minimal context first (callers, callees, body, test coverage):
+
+```xml
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>get_minimal_context</tool_name>
+  <arguments>{"directory": "$PROJECT_ROOT", "functionName": "$FUNCTION_NAME"}</arguments>
+</use_mcp_tool>
+```
+
+Then check risk:
 
 ```xml
 <use_mcp_tool>

--- a/examples/mistral-vibe/skills/spec-gen-plan-refactor/SKILL.md
+++ b/examples/mistral-vibe/skills/spec-gen-plan-refactor/SKILL.md
@@ -134,7 +134,19 @@ If **all candidates are below 40%**:
 
 ---
 
-## Step 4 — Analyze impact
+## Step 4 — Get minimal context + analyze impact
+
+First, get condensed view (callers, callees, body, test coverage) in one call:
+
+```xml
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>get_minimal_context</tool_name>
+  <arguments>{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}</arguments>
+</use_mcp_tool>
+```
+
+Then get full impact analysis:
 
 ```xml
 <use_mcp_tool>

--- a/examples/opencode-skills/spec-gen-analyze-codebase/SKILL.md
+++ b/examples/opencode-skills/spec-gen-analyze-codebase/SKILL.md
@@ -82,8 +82,9 @@ Present a concise summary:
 
 Based on the analysis, guide the user through the natural next actions in order:
 
-1. Call `get_signatures` on the modules containing the top issues to understand their public API
-2. Call `get_subgraph` on the highest-priority function to map its callers and callees
+1. Call `get_minimal_context` on the highest-priority function — returns callers, callees, body, and test coverage in one call (~300 tokens). Use instead of `get_subgraph` + `get_signatures` separately.
+2. Call `get_cluster` on any function to see its full community (tightly coupled neighbors across directories).
+3. Call `detect_changes` to rank recently changed functions by blast radius — spot riskiest commits before reviewing.
 3. If significant duplication was found, suggest consolidating clone groups **before** refactoring
 4. Suggest running `/spec-gen-plan-refactor` once the user has enough context to act, then `/spec-gen-execute-refactor` to apply the plan
 5. If the project has OpenSpec specs, call `list_spec_domains` then `search_specs` to enable

--- a/examples/opencode-skills/spec-gen-debug/SKILL.md
+++ b/examples/opencode-skills/spec-gen-debug/SKILL.md
@@ -86,8 +86,18 @@ If no specs exist, skip this step and note the absence.
 
 ## Step 4 — Isolate and hypothesize
 
-For the top 2 candidate functions from Step 2, check their structural properties by calling the spec-gen MCP tool `analyze_impact` with:
+For the top 2 candidate functions from Step 2, get minimal context first (callers, callees, body, test coverage in one call):
 ```json
+// get_minimal_context
+{
+  "directory": "$PROJECT_ROOT",
+  "functionName": "$CANDIDATE_FUNCTION"
+}
+```
+
+Then check structural properties:
+```json
+// analyze_impact
 {
   "directory": "$PROJECT_ROOT",
   "symbol": "$CANDIDATE_FUNCTION",

--- a/examples/opencode-skills/spec-gen-implement-story/SKILL.md
+++ b/examples/opencode-skills/spec-gen-implement-story/SKILL.md
@@ -47,8 +47,18 @@ Call the spec-gen MCP tool `orient` with:
 }
 ```
 
-For the top 2 functions returned, check risk by calling the spec-gen MCP tool `analyze_impact` with:
+For the top 2 functions returned, get minimal context first (callers, callees, body, test coverage in one call):
 ```json
+// get_minimal_context
+{
+  "directory": "$PROJECT_ROOT",
+  "functionName": "$FUNCTION_NAME"
+}
+```
+
+Then check risk:
+```json
+// analyze_impact
 {
   "directory": "$PROJECT_ROOT",
   "symbol": "$FUNCTION_NAME",

--- a/examples/opencode-skills/spec-gen-plan-refactor/SKILL.md
+++ b/examples/opencode-skills/spec-gen-plan-refactor/SKILL.md
@@ -109,7 +109,13 @@ If **all candidates are below 40%**:
 
 ---
 
-## Step 4 — Analyze impact
+## Step 4 — Get minimal context + analyze impact
+
+First, get condensed view (callers, callees, body, test coverage) in one call:
+
+Call the spec-gen MCP tool `get_minimal_context` with `{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}`.
+
+Then get the full impact analysis:
 
 Call the spec-gen MCP tool `analyze_impact` with `{"directory": "$DIRECTORY", "symbol": "$FUNCTION_NAME"}`.
 

--- a/examples/opencode/agent-guard.ts
+++ b/examples/opencode/agent-guard.ts
@@ -23,6 +23,7 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin"
+import { spawn } from "node:child_process"
 import { readFile, readdir } from "node:fs/promises"
 import { join } from "node:path"
 
@@ -54,6 +55,26 @@ async function loadSpecDomains(directory: string): Promise<string[]> {
   } catch {
     return []
   }
+}
+
+// Tools that write files — trigger re-analysis so the call graph stays fresh.
+const EDIT_TOOL_RE = /write_file|edit_file|create_file|str_replace|insert|patch/i
+
+// In-memory debounce: spawn at most one analysis per 10 s regardless of edit rate.
+let lastAnalyzeMs = 0
+const ANALYZE_DEBOUNCE_MS = 10_000
+
+function spawnAnalyze(directory: string): void {
+  const now = Date.now()
+  if (now - lastAnalyzeMs < ANALYZE_DEBOUNCE_MS) return
+  lastAnalyzeMs = now
+  // Fire-and-forget: detached + unref so it survives plugin process exit.
+  const child = spawn("spec-gen", ["analyze", "--output", ".spec-gen/analysis"], {
+    detached: true,
+    stdio: "ignore",
+    cwd: directory,
+  })
+  child.unref()
 }
 
 export const AgentGuard: Plugin = async ({ directory }) => {
@@ -107,6 +128,11 @@ export const AgentGuard: Plugin = async ({ directory }) => {
         output.output +=
           "\n\n[spec-gen] Structural file modified. " +
           "Consider calling record_decision before continuing."
+      }
+
+      // Keep call graph fresh after every file edit (debounced 10 s).
+      if (EDIT_TOOL_RE.test(tool)) {
+        spawnAnalyze(directory)
       }
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.1",
-        "@lancedb/lancedb": "^0.26.2",
+        "@lancedb/lancedb": "^0.22.4-beta.3",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@vitejs/plugin-react": "^5.0.2",
         "apache-arrow": "^21.1.0",
@@ -1872,9 +1872,9 @@
       }
     },
     "node_modules/@lancedb/lancedb": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.26.2.tgz",
-      "integrity": "sha512-umk4WMCTwJntLquwvUbpqE+TXREolcQVL9MHcxr8EhRjsha88+ATJ4QuS/hpyiE1CG3R/XcgrMgJAGkziPC/gA==",
+      "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.22.4-beta.3.tgz",
+      "integrity": "sha512-ECXr+v2tdGxrvjZFntUl80AqHze4S0pXMt99SS53+oFn7g8iGiPO3AkIgedSnczbwkZsth6ZiiM9smam8I7wMw==",
       "cpu": [
         "x64",
         "arm64"
@@ -1892,22 +1892,23 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@lancedb/lancedb-darwin-arm64": "0.26.2",
-        "@lancedb/lancedb-linux-arm64-gnu": "0.26.2",
-        "@lancedb/lancedb-linux-arm64-musl": "0.26.2",
-        "@lancedb/lancedb-linux-x64-gnu": "0.26.2",
-        "@lancedb/lancedb-linux-x64-musl": "0.26.2",
-        "@lancedb/lancedb-win32-arm64-msvc": "0.26.2",
-        "@lancedb/lancedb-win32-x64-msvc": "0.26.2"
+        "@lancedb/lancedb-darwin-arm64": "0.22.4-beta.3",
+        "@lancedb/lancedb-darwin-x64": "0.22.4-beta.3",
+        "@lancedb/lancedb-linux-arm64-gnu": "0.22.4-beta.3",
+        "@lancedb/lancedb-linux-arm64-musl": "0.22.4-beta.3",
+        "@lancedb/lancedb-linux-x64-gnu": "0.22.4-beta.3",
+        "@lancedb/lancedb-linux-x64-musl": "0.22.4-beta.3",
+        "@lancedb/lancedb-win32-arm64-msvc": "0.22.4-beta.3",
+        "@lancedb/lancedb-win32-x64-msvc": "0.22.4-beta.3"
       },
       "peerDependencies": {
         "apache-arrow": ">=15.0.0 <=18.1.0"
       }
     },
     "node_modules/@lancedb/lancedb-darwin-arm64": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.26.2.tgz",
-      "integrity": "sha512-LAZ/v261eTlv44KoEm+AdqGnohS9IbVVVJkH9+8JTqwhe/k4j4Af8X9cD18tsaJAAtrGxxOCyIJ3wZTiBqrkCw==",
+      "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.22.4-beta.3.tgz",
+      "integrity": "sha512-o7rFPHlpydNq2DbEDf1QBNUhxuvD/7r0jYn7SX42amIeclDGKwevTFIESlBg7Wo/dfpxHNq+x17J6TQJJJbMbQ==",
       "cpu": [
         "arm64"
       ],
@@ -1920,10 +1921,26 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@lancedb/lancedb-darwin-x64": {
+      "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-x64/-/lancedb-darwin-x64-0.22.4-beta.3.tgz",
+      "integrity": "sha512-TkAz9Eo5Y63xgxQLnw0OOT92IUwRsX39je1TiwcrzI2IqxJ2wD3O1/2Of0UvtlLME2kDEgFyurwrTegYogMoig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.26.2.tgz",
-      "integrity": "sha512-guHKm+zvuQB22dgyn6/sYZJvD6IL9lC24cl6ZuzVX/jYgag/gNLHT86HongrcBjgdjI6+YIGmdfD6b/iAKxn3Q==",
+      "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.22.4-beta.3.tgz",
+      "integrity": "sha512-aHOgfUwBEp7DEWAjScoXpnPomZ5dsbkIMMzRID//4ZKG/a648UArxpIhz0x+O3Csc/xEVDP8YRmGZScPlevmJA==",
       "cpu": [
         "arm64"
       ],
@@ -1937,9 +1954,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-arm64-musl": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.26.2.tgz",
-      "integrity": "sha512-pR6Hs/0iphItrJYYLf/yrqCC+scPcHpCGl6rHqcU2GHxo5RFpzlMzqW1DiXScGiBRuCcD9HIMec+kBsOgXv4GQ==",
+      "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.22.4-beta.3.tgz",
+      "integrity": "sha512-+ZpdUaFLAeYeRYrWkXrsUAqZ2xZq5WWdx2y6DcUqAnnH1lziP/sCO00ShOjMJf3mV0DCxJRY3PBhOSCLEvzQ/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1953,9 +1970,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-gnu": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.26.2.tgz",
-      "integrity": "sha512-u4UUSPwd2YecgGqWjh9W0MHKgsVwB2Ch2ROpF8AY+IA7kpGsbB18R1/t7v2B0q7pahRy20dgsaku5LH1zuzMRQ==",
+      "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.22.4-beta.3.tgz",
+      "integrity": "sha512-AieS2a+hMybKuHjQfXB/aTdmcBAOgxMz4FANym1BwDOU8P5sKE3vFVm0EoZ2qNv6BrizH8e8RuQWQy7R5EMLJA==",
       "cpu": [
         "x64"
       ],
@@ -1969,9 +1986,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-musl": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.26.2.tgz",
-      "integrity": "sha512-XIS4qkVfGlzmsUPqAG2iKt8ykuz28GfemGC0ijXwu04kC1pYiCFzTpB3UIZjm5oM7OTync1aQ3mGTj1oCciSPA==",
+      "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.22.4-beta.3.tgz",
+      "integrity": "sha512-B4NZut9rUUj82FOEJSgrbZosbaPSfTGwZLmjaorbo7hjFEBaa7t9Y2uZxuSwgkaKwlgyufyZcpqQLUum3gmpzA==",
       "cpu": [
         "x64"
       ],
@@ -1985,9 +2002,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-arm64-msvc": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.26.2.tgz",
-      "integrity": "sha512-//tZDPitm2PxNvalHP+m+Pf6VvFAeQgcht1+HJnutjH4gp6xYW6ynQlWWFDBmz9WRkUT+mXu2O4FUIhbdNaJSQ==",
+      "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.22.4-beta.3.tgz",
+      "integrity": "sha512-3fGb6uPOmRXzexXtQG1wDK+fDCEmyZFxXcSfUhilDwlHxw/nM6suVC6IoNLyR4GenujQSTNXaYQnK9Tmjfoy+w==",
       "cpu": [
         "arm64"
       ],
@@ -2001,9 +2018,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-x64-msvc": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.26.2.tgz",
-      "integrity": "sha512-GH3pfyzicgPGTb84xMXgujlWDaAnBTmUyjooYiCE2tC24BaehX4hgFhXivamzAEsF5U2eVsA/J60Ppif+skAbA==",
+      "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.22.4-beta.3.tgz",
+      "integrity": "sha512-uA7CxrAJZ2Xm3wxc54bDaViySaubHuORo2MyqbGdqbDY/U+KVAk87LYZNypvCA454nS/USUwk2P/AI+k554fcQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.2.1",
-    "@lancedb/lancedb": "^0.26.2",
+    "@lancedb/lancedb": "0.22.4-beta.3",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@vitejs/plugin-react": "^5.0.2",
     "apache-arrow": "^21.1.0",

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -111,7 +111,7 @@ elif [ -f "./dist/cli/index.js" ]; then
   DECISIONS_EXIT=$?
 else
   SPEC_GEN=$(command -v spec-gen 2>/dev/null)
-  if [ -n "$SPEC_GEN" ]; then
+  if [ -n "$SPEC_GEN" ] && "$SPEC_GEN" decisions --help 2>&1 | grep -q -- '--gate'; then
     "$SPEC_GEN" decisions --gate 2>&1
     DECISIONS_EXIT=$?
   else

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -74,6 +74,9 @@ import {
   handleAuditSpecCoverage,
   handleGenerateTests,
   handleGetTestCoverage,
+  handleGetMinimalContext,
+  handleGetCluster,
+  handleDetectChanges,
 } from '../../core/services/mcp-handlers/analysis.js';
 
 // Re-export utilities for tests
@@ -109,6 +112,9 @@ export {
   handleAuditSpecCoverage,
   handleGenerateTests,
   handleGetTestCoverage,
+  handleGetMinimalContext,
+  handleGetCluster,
+  handleDetectChanges,
 };
 
 // ============================================================================
@@ -1055,6 +1061,65 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
+    name: 'get_minimal_context',
+    description:
+      'Return the minimum context needed to safely modify a function: ' +
+      'its signature and body, direct callers (signatures only), direct callees (signatures only), ' +
+      'and which test files cover it. ' +
+      'Use this instead of orient when you already know exactly which function to modify. ' +
+      'Typically 200-600 tokens vs orient\'s 2000+. Run analyze_codebase first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        functionName: { type: 'string', description: 'Exact function or method name' },
+        filePath: {
+          type: 'string',
+          description: 'Optional relative file path to disambiguate when multiple functions share the name',
+        },
+      },
+      required: ['directory', 'functionName'],
+    },
+  },
+  {
+    name: 'get_cluster',
+    description:
+      'Return all functions in the same community as the given function. ' +
+      'Communities are computed via label propagation on the call graph at analyze time — ' +
+      'tightly coupled functions land in the same cluster regardless of directory. ' +
+      'Use this to understand the "blast radius neighbourhood" without traversing the graph manually. ' +
+      'Run analyze_codebase first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        functionName: { type: 'string', description: 'Function name to look up the community for' },
+      },
+      required: ['directory', 'functionName'],
+    },
+  },
+  {
+    name: 'detect_changes',
+    description:
+      'Detect recently changed functions and rank them by blast radius. ' +
+      'Runs git diff against a base ref (default HEAD), maps changed lines to function nodes, ' +
+      'then scores each changed function by fan-in + transitive callers. ' +
+      'Highest-scored functions are the riskiest to break. ' +
+      'Also reports test coverage for each changed function via tested_by edges. ' +
+      'Run analyze_codebase first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        base: {
+          type: 'string',
+          description: 'Git ref to diff against (default: HEAD). Use "HEAD~1" for last commit, "main" for branch diff.',
+        },
+      },
+      required: ['directory'],
+    },
+  },
+  {
     name: 'record_decision',
     description:
       'Record an architectural decision made during the current development session. ' +
@@ -1333,6 +1398,16 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
         const { directory, domains, minCoverage } =
           args as { directory: string; domains?: string[]; minCoverage?: number };
         result = await handleGetTestCoverage({ directory, domains, minCoverage });
+      } else if (name === 'get_minimal_context') {
+        const { directory, functionName, filePath } =
+          args as { directory: string; functionName: string; filePath?: string };
+        result = await handleGetMinimalContext(directory, functionName, filePath);
+      } else if (name === 'get_cluster') {
+        const { directory, functionName } = args as { directory: string; functionName: string };
+        result = await handleGetCluster(directory, functionName);
+      } else if (name === 'detect_changes') {
+        const { directory, base } = args as { directory: string; base?: string };
+        result = await handleDetectChanges(directory, base);
       } else if (name === 'record_decision') {
         const { directory, title, rationale, consequences, affectedFiles, supersedes } =
           args as { directory: string; title: string; rationale: string; consequences?: string; affectedFiles?: string[]; supersedes?: string };

--- a/src/core/analyzer/artifact-generator.ts
+++ b/src/core/analyzer/artifact-generator.ts
@@ -1119,9 +1119,9 @@ export class AnalysisArtifactGenerator {
           }
         }
 
-        // Call graph — all supported languages, exclude test files
+        // Call graph — all supported languages, include test files so tested_by edges are derived
         const lang = detectLanguage(file.path);
-        if (!isTest && CALL_GRAPH_LANGS.has(lang)) {
+        if (CALL_GRAPH_LANGS.has(lang)) {
           callGraphFiles.push({ path: file.absolutePath, content, language: lang });
         }
       } catch {

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -77,6 +77,12 @@ export interface FunctionNode {
   externalKind?: ExternalKind;
   /** True for nodes whose source file is a test file (*.test.ts, *_test.py, etc.) */
   isTest?: boolean;
+  /** 1-based line number of the function start (computed from startIndex at build time) */
+  startLine?: number;
+  /** Label-propagation community ID (canonical node id of the community representative) */
+  communityId?: string;
+  /** Human-readable community label (name of the hub function in the community) */
+  communityLabel?: string;
 }
 
 /** Broad category of an external (unresolved) call */
@@ -1849,7 +1855,21 @@ export class CallGraphBuilder {
           continue;
         }
 
+        // Compute startLine (1-based) from byte offset — cheap, done once at build time
+        const lineOffsets = [0];
+        for (let i = 0; i < file.content.length; i++) {
+          if (file.content[i] === '\n') lineOffsets.push(i + 1);
+        }
+        const byteToLine = (offset: number): number => {
+          let lo = 0, hi = lineOffsets.length - 1;
+          while (lo < hi) {
+            const mid = (lo + hi + 1) >> 1;
+            if (lineOffsets[mid] <= offset) lo = mid; else hi = mid - 1;
+          }
+          return lo + 1;
+        };
         for (const node of result.nodes) {
+          node.startLine = byteToLine(node.startIndex);
           allNodes.set(node.id, node);
         }
         allRawEdges.push(...result.rawEdges);
@@ -2137,7 +2157,64 @@ export class CallGraphBuilder {
     const totalFanIn = internalNodes.reduce((s, n) => s + n.fanIn, 0);
     const totalFanOut = internalNodes.reduce((s, n) => s + n.fanOut, 0);
 
-    // Pass 5: Build class hierarchy (inheritance + grouping)
+    // Pass 5: Label-propagation community detection (internal non-test nodes only)
+    // Each node starts with its own label; iteratively adopts the most common neighbor label.
+    // Converges in ~10 passes for typical codebases. External/test nodes get no community.
+    {
+      const callsEdgesOnly = edges.filter(e => !e.kind || e.kind === 'calls');
+      const label = new Map<string, string>();
+      for (const n of internalNodes) label.set(n.id, n.id);
+
+      // Build adjacency for internal nodes (bidirectional — community ignores direction)
+      const neighbors = new Map<string, string[]>();
+      for (const n of internalNodes) neighbors.set(n.id, []);
+      for (const e of callsEdgesOnly) {
+        if (label.has(e.callerId) && label.has(e.calleeId)) {
+          neighbors.get(e.callerId)!.push(e.calleeId);
+          neighbors.get(e.calleeId)!.push(e.callerId);
+        }
+      }
+
+      for (let iter = 0; iter < 15; iter++) {
+        let changed = false;
+        // Deterministic order each iteration (sorted) avoids oscillation
+        const order = [...internalNodes].sort((a, b) => a.id < b.id ? -1 : 1);
+        for (const n of order) {
+          const nbrs = neighbors.get(n.id)!;
+          if (nbrs.length === 0) continue;
+          const counts = new Map<string, number>();
+          for (const nbId of nbrs) {
+            const l = label.get(nbId) ?? nbId;
+            counts.set(l, (counts.get(l) ?? 0) + 1);
+          }
+          let best = label.get(n.id)!;
+          let bestCnt = 0;
+          for (const [l, c] of counts) {
+            if (c > bestCnt || (c === bestCnt && l < best)) { best = l; bestCnt = c; }
+          }
+          if (best !== label.get(n.id)) { label.set(n.id, best); changed = true; }
+        }
+        if (!changed) break;
+      }
+
+      // Name each community by its highest-fanIn member
+      const communityMembers = new Map<string, FunctionNode[]>();
+      for (const n of internalNodes) {
+        const l = label.get(n.id)!;
+        if (!communityMembers.has(l)) communityMembers.set(l, []);
+        communityMembers.get(l)!.push(n);
+      }
+      for (const members of communityMembers.values()) {
+        const hub = members.slice().sort((a, b) => b.fanIn - a.fanIn)[0];
+        const communityLabel = hub.name;
+        for (const n of members) {
+          n.communityId = label.get(n.id)!;
+          n.communityLabel = communityLabel;
+        }
+      }
+    }
+
+    // Pass 6: Build class hierarchy (inheritance + grouping)
     const relationships = await extractClassRelationships(files);
     const { classes, inheritanceEdges } = buildClassNodes(allNodes, relationships);
 

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -1732,9 +1732,9 @@ function isTestFile(filePath: string): boolean {
   return TEST_FILE_PATTERNS.some(p => p.test(filePath));
 }
 
-const EXTERNAL_HTTP_RE = /^(fetch|axios|got|superagent|node-fetch|ky|request|https?|xmlhttprequest|grpc|undici|requests|aiohttp|httpx|urllib|urllib2|urllib3|curl|curleasy|pycurl)$/;
-const EXTERNAL_DB_RE = /^(pg|mysql|mysql2|sqlite|sqlite3|redis|ioredis|mongoose|mongo|mongodb|prisma|knex|sequelize|typeorm|drizzle|cassandra|dynamodb|firestore|supabase|neo4j|influxdb|clickhouse|kysely|psycopg2|psycopg|sqlalchemy|pymysql|asyncpg|motor|aiomysql|tortoise)$/;
-const EXTERNAL_FS_RE = /^(fs|fsp|readfile|writefile|readdir|stat|mkdir|unlink|rename|copyfile|createreadstream|createwritestream|open|fopen|fread|fwrite|fclose|remove|ifstream|ofstream|fstream)$/;
+const EXTERNAL_HTTP_RE = /^(fetch|axios|got|superagent|node-fetch|ky|request|https?|xmlhttprequest|grpc|undici|requests|aiohttp|httpx|urllib|urllib2|urllib3|curl|curleasy|pycurl|http|httpclient|httpurlconnection|reqwest|hyper|ureq|isahc|surf|net|faraday|httparty|rest|typhoeus|excon|okhttp|retrofit|feign|resttemplate|webclient|urlsession|alamofire|moya)$/;
+const EXTERNAL_DB_RE = /^(pg|mysql|mysql2|sqlite|sqlite3|redis|ioredis|mongoose|mongo|mongodb|prisma|knex|sequelize|typeorm|drizzle|cassandra|dynamodb|firestore|supabase|neo4j|influxdb|clickhouse|kysely|psycopg2|psycopg|sqlalchemy|pymysql|asyncpg|motor|aiomysql|tortoise|sql|gorm|sqlx|pgx|bun|diesel|seaorm|rusqlite|activerecord|sequel|jdbc|hibernate|jpa|entitymanager|datasource|jdbctemplate|r2dbc|coredata|grdb|realm)$/;
+const EXTERNAL_FS_RE = /^(fs|fsp|readfile|writefile|readdir|stat|mkdir|unlink|rename|copyfile|createreadstream|createwritestream|open|fopen|fread|fwrite|fclose|remove|ifstream|ofstream|fstream|os|path|file)$/;
 const EXTERNAL_STDLIB_BASES = new Set([
   // JavaScript / Node.js
   'array', 'object', 'string', 'number', 'math', 'json', 'date', 'regexp',
@@ -1753,6 +1753,26 @@ const EXTERNAL_STDLIB_BASES = new Set([
   'calloc', 'realloc', 'free', 'memcpy', 'memmove', 'memset', 'memcmp',
   'strlen', 'strcpy', 'strncpy', 'strcat', 'strcmp', 'strncmp', 'strstr',
   'assert', 'abort', 'exit', 'atexit',
+  // Go
+  'fmt', 'log', 'sort', 'sync', 'atomic', 'bytes', 'errors', 'context',
+  'reflect', 'runtime', 'bufio', 'unicode', 'strings', 'strconv', 'math',
+  'rand', 'time', 'flag', 'testing',
+  // Rust
+  'vec', 'option', 'result', 'iter', 'collections', 'thread', 'env',
+  'cell', 'rc', 'arc', 'mutex', 'rwlock', 'channel', 'mpsc',
+  // Ruby
+  'integer', 'float', 'numeric', 'enumerable', 'comparable', 'kernel',
+  'module', 'class', 'basicobject', 'nilclass', 'trueclass', 'falseclass',
+  'symbol', 'regexp', 'range', 'proc', 'method', 'encoding',
+  // Java
+  'system', 'integer', 'long', 'double', 'boolean', 'character',
+  'list', 'arraylist', 'linkedlist', 'hashmap', 'treemap', 'hashset', 'treeset',
+  'optional', 'stream', 'arrays', 'collections', 'objects', 'math',
+  'thread', 'runnable', 'exception', 'runtimeexception', 'illegalargumentexception',
+  'stringbuilder', 'stringbuffer', 'scanner',
+  // Swift
+  'int', 'double', 'bool', 'dictionary', 'swift', 'foundation',
+  'dispatchqueue', 'notificationcenter', 'nsstring', 'nsarray', 'nsdictionary',
 ]);
 const EXTERNAL_NOISE_RECEIVERS = new Set([
   'response', 'body', 't', 'err', 'error', 'buf', 'str', 'res', 'req', 'data', 'result',

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -74,6 +74,8 @@ export interface FunctionNode {
   isExternal?: boolean;
   /** Classification of external node — used to filter stdlib noise from views */
   externalKind?: ExternalKind;
+  /** True for nodes whose source file is a test file (*.test.ts, *_test.py, etc.) */
+  isTest?: boolean;
 }
 
 /** Broad category of an external (unresolved) call */
@@ -2023,9 +2025,13 @@ export class CallGraphBuilder {
     }
 
     // Pass 4: Derive hub functions, entry points, layer violations
-    // External nodes are excluded from structural stats — they are leaf placeholders
+    // External and test nodes are excluded from structural stats
     const nodes = Array.from(allNodes.values());
-    const internalNodes = nodes.filter(n => !n.isExternal);
+    // Mark test-file nodes so consumers can filter them
+    for (const n of nodes) {
+      if (!n.isExternal && isTestFile(n.filePath)) n.isTest = true;
+    }
+    const internalNodes = nodes.filter(n => !n.isExternal && !n.isTest);
 
     const hubFunctions = internalNodes
       .filter(n => n.fanIn >= HUB_THRESHOLD)

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -2014,6 +2014,9 @@ export class CallGraphBuilder {
     for (const edge of callsEdges) {
       const caller = allNodes.get(edge.callerId);
       if (!caller || !isTestFile(caller.filePath)) continue;
+      const callee = allNodes.get(edge.calleeId);
+      // Only emit tested_by when the production fn is internal (not external, not a test helper)
+      if (!callee || callee.isExternal || callee.isTest) continue;
       edges.push({
         kind: 'tested_by',
         callerId: edge.calleeId,

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -1732,13 +1732,27 @@ function isTestFile(filePath: string): boolean {
   return TEST_FILE_PATTERNS.some(p => p.test(filePath));
 }
 
-const EXTERNAL_HTTP_RE = /^(fetch|axios|got|superagent|node-fetch|ky|request|https?|xmlhttprequest|grpc|undici)$/;
-const EXTERNAL_DB_RE = /^(pg|mysql|mysql2|sqlite|sqlite3|redis|ioredis|mongoose|mongo|mongodb|prisma|knex|sequelize|typeorm|drizzle|cassandra|dynamodb|firestore|supabase|neo4j|influxdb|clickhouse|kysely)$/;
-const EXTERNAL_FS_RE = /^(fs|fsp|readfile|writefile|readdir|stat|mkdir|unlink|rename|copyfile|createreadstream|createwritestream)$/;
+const EXTERNAL_HTTP_RE = /^(fetch|axios|got|superagent|node-fetch|ky|request|https?|xmlhttprequest|grpc|undici|requests|aiohttp|httpx|urllib|urllib2|urllib3|curl|curleasy|pycurl)$/;
+const EXTERNAL_DB_RE = /^(pg|mysql|mysql2|sqlite|sqlite3|redis|ioredis|mongoose|mongo|mongodb|prisma|knex|sequelize|typeorm|drizzle|cassandra|dynamodb|firestore|supabase|neo4j|influxdb|clickhouse|kysely|psycopg2|psycopg|sqlalchemy|pymysql|asyncpg|motor|aiomysql|tortoise)$/;
+const EXTERNAL_FS_RE = /^(fs|fsp|readfile|writefile|readdir|stat|mkdir|unlink|rename|copyfile|createreadstream|createwritestream|open|fopen|fread|fwrite|fclose|remove|ifstream|ofstream|fstream)$/;
 const EXTERNAL_STDLIB_BASES = new Set([
+  // JavaScript / Node.js
   'array', 'object', 'string', 'number', 'math', 'json', 'date', 'regexp',
   'promise', 'map', 'set', 'weakmap', 'weakset', 'symbol', 'reflect', 'proxy',
   'console', 'error', 'buffer', 'process', 'int8array', 'uint8array',
+  // Python
+  'os', 'sys', 're', 'io', 'abc', 'ast', 'csv', 'copy', 'enum', 'glob',
+  'gzip', 'hmac', 'html', 'http', 'logging', 'operator', 'pathlib', 'pickle',
+  'pprint', 'queue', 'random', 'shutil', 'signal', 'socket', 'ssl', 'struct',
+  'subprocess', 'tempfile', 'threading', 'time', 'traceback', 'typing', 'uuid',
+  'warnings', 'collections', 'functools', 'itertools', 'contextlib',
+  'dataclasses', 'unittest', 'hashlib', 'base64', 'binascii', 'codecs',
+  'inspect', 'importlib', 'weakref', 'gc', 'platform', 'shlex', 'textwrap',
+  // C / C++
+  'std', 'printf', 'fprintf', 'sprintf', 'snprintf', 'scanf', 'malloc',
+  'calloc', 'realloc', 'free', 'memcpy', 'memmove', 'memset', 'memcmp',
+  'strlen', 'strcpy', 'strncpy', 'strcat', 'strcmp', 'strncmp', 'strstr',
+  'assert', 'abort', 'exit', 'atexit',
 ]);
 const EXTERNAL_NOISE_RECEIVERS = new Set([
   'response', 'body', 't', 'err', 'error', 'buf', 'str', 'res', 'req', 'data', 'result',

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -79,6 +79,8 @@ export interface FunctionNode {
   isTest?: boolean;
   /** 1-based line number of the function start (computed from startIndex at build time) */
   startLine?: number;
+  /** 1-based line number of the function end (computed from endIndex at build time) */
+  endLine?: number;
   /** Label-propagation community ID (canonical node id of the community representative) */
   communityId?: string;
   /** Human-readable community label (name of the hub function in the community) */
@@ -1870,6 +1872,7 @@ export class CallGraphBuilder {
         };
         for (const node of result.nodes) {
           node.startLine = byteToLine(node.startIndex);
+          node.endLine = byteToLine(node.endIndex);
           allNodes.set(node.id, node);
         }
         allRawEdges.push(...result.rawEdges);

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -12,6 +12,7 @@
  *  - Layer violations — cross-layer calls in the wrong direction
  */
 
+import { dirname, resolve as resolvePath } from 'node:path';
 import Parser from 'tree-sitter';
 import { FunctionRegistryTrie } from './function-registry-trie.js';
 import type { ImportMap } from './import-resolver-bridge.js';
@@ -2016,13 +2017,18 @@ export class CallGraphBuilder {
     }
 
     // Pass 3b: Derive tested_by edges — reverse edges from production fn ← test fn
+    // Source 1: call edges where the caller is a test function
     const callsEdges = edges.filter(e => !e.kind || e.kind === 'calls');
+    const testedByPairs = new Set<string>(); // deduplicate across sources
     for (const edge of callsEdges) {
       const caller = allNodes.get(edge.callerId);
       if (!caller || !isTestFile(caller.filePath)) continue;
       const callee = allNodes.get(edge.calleeId);
       // Only emit tested_by when the production fn is internal (not external, not a test helper)
       if (!callee || callee.isExternal || callee.isTest) continue;
+      const pairKey = `${edge.calleeId}\0${caller.filePath}`;
+      if (testedByPairs.has(pairKey)) continue;
+      testedByPairs.add(pairKey);
       edges.push({
         kind: 'tested_by',
         callerId: edge.calleeId,
@@ -2031,6 +2037,84 @@ export class CallGraphBuilder {
         confidence: edge.confidence,
         callType: undefined,
       });
+    }
+
+    // Source 2: import-based — every name imported by a test file from a production file.
+    // Catches mocked functions that are imported but never directly called in the test.
+    // Build a lightweight import map from file content (only test files, TS/JS).
+    const allFilePaths = files.map(f => f.path);
+    const NAMED_IMPORT_RE = /^\s*import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+['"](\.[^'"]+)['"]/gm;
+    const DEFAULT_IMPORT_RE = /^\s*import\s+(?:type\s+)?(\w+)\s+from\s+['"](\.[^'"]+)['"]/gm;
+    for (const file of files) {
+      if (!isTestFile(file.path)) continue;
+      if (file.language !== 'TypeScript' && file.language !== 'JavaScript') continue;
+      const dir = dirname(file.path);
+      const resolveSource = (rel: string): string | undefined => {
+        // Strip .js extension: TS ESM imports use './foo.js' to refer to './foo.ts'
+        const stripped = rel.replace(/\.js$/, '');
+        const base = resolvePath(dir, stripped);
+        return allFilePaths.find(p =>
+          p === base || p === `${base}.ts` || p === `${base}.tsx` ||
+          p === `${base}.js` || p === `${base}.jsx` || p === `${base}/index.ts`,
+        );
+      };
+      const testLabel = file.path.split('/').pop()!.replace(/\.[tj]sx?$/, '');
+      const emitEdge = (name: string, sourceFile: string) => {
+        const candidates = trie.findBySimpleName(name)
+          .filter(n => n.filePath === sourceFile && !n.isTest && !n.isExternal);
+        for (const callee of candidates) {
+          const pairKey = `${callee.id}\0${file.path}`;
+          if (testedByPairs.has(pairKey)) continue;
+          testedByPairs.add(pairKey);
+          edges.push({
+            kind: 'tested_by',
+            callerId: callee.id,
+            calleeId: `${file.path}::*`,
+            calleeName: testLabel,
+            confidence: 'import',
+            callType: undefined,
+          });
+        }
+      };
+      // Named imports: import { foo, bar as baz } from './module'
+      for (const m of file.content.matchAll(NAMED_IMPORT_RE)) {
+        const sourceFile = resolveSource(m[2]);
+        if (!sourceFile) continue;
+        for (const part of m[1].split(',')) {
+          const name = (part.match(/\bas\s+(\w+)/) ?? part.match(/(\w+)/))?.[1]?.trim();
+          if (name) emitEdge(name, sourceFile);
+        }
+      }
+      // Default imports: import foo from './module'
+      for (const m of file.content.matchAll(DEFAULT_IMPORT_RE)) {
+        const sourceFile = resolveSource(m[2]);
+        if (!sourceFile) continue;
+        emitEdge(m[1], sourceFile);
+      }
+    }
+
+    // Also apply caller-provided importMap if present (cross-language coverage)
+    if (importMap) {
+      for (const [testFilePath, imports] of importMap) {
+        if (!isTestFile(testFilePath)) continue;
+        for (const [importedName, sourceFile] of imports) {
+          const candidates = trie.findBySimpleName(importedName)
+            .filter(n => n.filePath === sourceFile && !n.isTest && !n.isExternal);
+          for (const callee of candidates) {
+            const pairKey = `${callee.id}\0${testFilePath}`;
+            if (testedByPairs.has(pairKey)) continue;
+            testedByPairs.add(pairKey);
+            edges.push({
+              kind: 'tested_by',
+              callerId: callee.id,
+              calleeId: `${testFilePath}::*`,
+              calleeName: testFilePath.split('/').pop()!.replace(/\.[tj]sx?$/, ''),
+              confidence: 'import',
+              callType: undefined,
+            });
+          }
+        }
+      }
     }
 
     // Pass 4: Derive hub functions, entry points, layer violations

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -2009,6 +2009,12 @@ export class CallGraphBuilder {
       if (callee) callee.fanIn++;
     }
 
+    // Pass 4 (prep): Mark test-file nodes before tested_by derivation
+    const nodes = Array.from(allNodes.values());
+    for (const n of nodes) {
+      if (!n.isExternal && isTestFile(n.filePath)) n.isTest = true;
+    }
+
     // Pass 3b: Derive tested_by edges — reverse edges from production fn ← test fn
     const callsEdges = edges.filter(e => !e.kind || e.kind === 'calls');
     for (const edge of callsEdges) {
@@ -2029,11 +2035,6 @@ export class CallGraphBuilder {
 
     // Pass 4: Derive hub functions, entry points, layer violations
     // External and test nodes are excluded from structural stats
-    const nodes = Array.from(allNodes.values());
-    // Mark test-file nodes so consumers can filter them
-    for (const n of nodes) {
-      if (!n.isExternal && isTestFile(n.filePath)) n.isTest = true;
-    }
     const internalNodes = nodes.filter(n => !n.isExternal && !n.isTest);
 
     const hubFunctions = internalNodes

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -1030,22 +1030,17 @@ export async function handleDetectChanges(
   // Get git diff — changed file paths and line ranges
   const ref = base ?? 'HEAD';
   let diffOutput: string;
+  const GIT = process.env.GIT_EXEC_PATH ? `${process.env.GIT_EXEC_PATH}/git` : 'git';
+  const execOpts = { cwd: absDir, maxBuffer: 4 * 1024 * 1024, env: { ...process.env, PATH: process.env.PATH ?? '/usr/bin:/bin:/usr/local/bin' } };
   try {
-    const { stdout } = await execFileAsync(
-      'git', ['diff', '--unified=0', ref, '--', '.'],
-      { cwd: absDir, maxBuffer: 4 * 1024 * 1024 },
-    );
+    const { stdout } = await execFileAsync(GIT, ['diff', '--unified=0', ref, '--', '.'], execOpts);
     diffOutput = stdout;
     if (!diffOutput.trim()) {
-      // Try staged changes
-      const { stdout: staged } = await execFileAsync(
-        'git', ['diff', '--unified=0', '--cached', '--', '.'],
-        { cwd: absDir, maxBuffer: 4 * 1024 * 1024 },
-      );
+      const { stdout: staged } = await execFileAsync(GIT, ['diff', '--unified=0', '--cached', '--', '.'], execOpts);
       diffOutput = staged;
     }
-  } catch {
-    return { error: 'git diff failed. Ensure directory is a git repository.' };
+  } catch (err) {
+    return { error: `git diff failed: ${(err as Error).message}` };
   }
 
   if (!diffOutput.trim()) return { changedFunctions: [], message: 'No changes detected.' };

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -7,7 +7,9 @@
  */
 
 import { readFile, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import {
   DEFAULT_MAX_FILES,
   DEFAULT_DRIFT_MAX_FILES,
@@ -861,4 +863,273 @@ export async function handleGetTestCoverage(args: {
   });
 
   return report as unknown as Record<string, unknown>;
+}
+
+// ============================================================================
+// get_minimal_context
+// ============================================================================
+
+/**
+ * Return the bare minimum an agent needs to safely modify a function:
+ * its signature + body, direct callers (signatures), direct callees (signatures),
+ * and which test files cover it. Typically 200-600 tokens vs orient's 2000+.
+ */
+export async function handleGetMinimalContext(
+  directory: string,
+  functionName: string,
+  filePath?: string,
+): Promise<unknown> {
+  const absDir = await validateDirectory(directory);
+  const ctx = await readCachedContext(absDir);
+  if (!ctx?.callGraph) return { error: 'No call graph. Run analyze_codebase first.' };
+
+  const cg = ctx.callGraph as SerializedCallGraph;
+  const nodeMap = new Map(cg.nodes.map(n => [n.id, n]));
+
+  // Find target node(s)
+  const candidates = cg.nodes.filter(n =>
+    n.name === functionName &&
+    !n.isExternal && !n.isTest &&
+    (!filePath || n.filePath.endsWith(filePath)),
+  );
+  if (candidates.length === 0) return { error: `Function "${functionName}" not found. Run analyze_codebase first.` };
+  const target = candidates[0];
+
+  // Direct callers and callees from calls edges
+  const callsEdges = cg.edges.filter(e => !e.kind || e.kind === 'calls');
+  const callerIds = callsEdges.filter(e => e.calleeId === target.id).map(e => e.callerId);
+  const calleeIds = callsEdges.filter(e => e.callerId === target.id).map(e => e.calleeId);
+
+  const sig = (n: (typeof cg.nodes)[0]) =>
+    n.signature ?? n.name + (n.isExternal ? ' [external]' : '');
+
+  const callers = [...new Set(callerIds)]
+    .map(id => nodeMap.get(id))
+    .filter((n): n is NonNullable<typeof n> => !!n && !n.isExternal)
+    .slice(0, 12)
+    .map(n => ({ name: n.name, file: relative(absDir, n.filePath), sig: sig(n) }));
+
+  const callees = [...new Set(calleeIds)]
+    .map(id => nodeMap.get(id))
+    .filter((n): n is NonNullable<typeof n> => !!n)
+    .slice(0, 12)
+    .map(n => ({
+      name: n.isExternal ? `[external] ${n.name}` : n.name,
+      file: n.isExternal ? 'external' : relative(absDir, n.filePath),
+      sig: sig(n),
+      kind: n.externalKind,
+    }));
+
+  // Test coverage
+  const testedBy = cg.edges
+    .filter(e => e.kind === 'tested_by' && e.callerId === target.id)
+    .map(e => e.calleeName)
+    .filter((v, i, a) => a.indexOf(v) === i);
+
+  // Function body (byte-range slice from source)
+  let body: string | null = null;
+  try {
+    const src = await readFile(target.filePath, 'utf-8');
+    body = src.slice(target.startIndex, target.endIndex);
+  } catch { /* source unavailable */ }
+
+  return {
+    function: {
+      name: target.name,
+      file: relative(absDir, target.filePath),
+      signature: target.signature ?? target.name,
+      language: target.language,
+      className: target.className ?? null,
+      startLine: target.startLine ?? null,
+      fanIn: target.fanIn,
+      fanOut: target.fanOut,
+      community: target.communityLabel ?? null,
+      body,
+    },
+    callers,
+    callees,
+    testedBy,
+  };
+}
+
+// ============================================================================
+// get_cluster
+// ============================================================================
+
+/**
+ * Return all functions in the same community as the given function.
+ * Communities are computed via label propagation on the call graph at analyze time.
+ * Useful for understanding the "cluster" of related functions without traversing the graph.
+ */
+export async function handleGetCluster(
+  directory: string,
+  functionName: string,
+): Promise<unknown> {
+  const absDir = await validateDirectory(directory);
+  const ctx = await readCachedContext(absDir);
+  if (!ctx?.callGraph) return { error: 'No call graph. Run analyze_codebase first.' };
+
+  const cg = ctx.callGraph as SerializedCallGraph;
+
+  // Find the target node
+  const target = cg.nodes.find(n => n.name === functionName && !n.isExternal && !n.isTest);
+  if (!target) return { error: `Function "${functionName}" not found.` };
+  if (!target.communityId) return { error: `No community data. Re-run analyze_codebase.` };
+
+  // All nodes in same community
+  const members = cg.nodes
+    .filter(n => n.communityId === target.communityId && !n.isExternal && !n.isTest)
+    .sort((a, b) => b.fanIn - a.fanIn);
+
+  // Internal edges within community
+  const memberIds = new Set(members.map(n => n.id));
+  const internalEdges = cg.edges
+    .filter(e => (!e.kind || e.kind === 'calls') && memberIds.has(e.callerId) && memberIds.has(e.calleeId))
+    .length;
+
+  // Files the community spans
+  const files = [...new Set(members.map(n => relative(absDir, n.filePath)))].sort();
+
+  return {
+    communityLabel: target.communityLabel,
+    communityId: target.communityId,
+    stats: {
+      members: members.length,
+      files: files.length,
+      internalEdges,
+    },
+    files,
+    functions: members.map(n => ({
+      name: n.name,
+      file: relative(absDir, n.filePath),
+      signature: n.signature ?? n.name,
+      fanIn: n.fanIn,
+      fanOut: n.fanOut,
+    })),
+  };
+}
+
+// ============================================================================
+// detect_changes
+// ============================================================================
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Detect recently changed functions and rank them by blast radius (fanIn of callers via BFS).
+ * Runs git diff to find changed files/lines, maps to function nodes, scores by impact.
+ */
+export async function handleDetectChanges(
+  directory: string,
+  base?: string,
+): Promise<unknown> {
+  const absDir = await validateDirectory(directory);
+  const ctx = await readCachedContext(absDir);
+  if (!ctx?.callGraph) return { error: 'No call graph. Run analyze_codebase first.' };
+
+  // Get git diff — changed file paths and line ranges
+  const ref = base ?? 'HEAD';
+  let diffOutput: string;
+  try {
+    const { stdout } = await execFileAsync(
+      'git', ['diff', '--unified=0', ref, '--', '.'],
+      { cwd: absDir, maxBuffer: 4 * 1024 * 1024 },
+    );
+    diffOutput = stdout;
+    if (!diffOutput.trim()) {
+      // Try staged changes
+      const { stdout: staged } = await execFileAsync(
+        'git', ['diff', '--unified=0', '--cached', '--', '.'],
+        { cwd: absDir, maxBuffer: 4 * 1024 * 1024 },
+      );
+      diffOutput = staged;
+    }
+  } catch {
+    return { error: 'git diff failed. Ensure directory is a git repository.' };
+  }
+
+  if (!diffOutput.trim()) return { changedFunctions: [], message: 'No changes detected.' };
+
+  // Parse changed file→line ranges from unified diff
+  const changedLines = new Map<string, Array<[number, number]>>(); // absFilePath → [[start,end],…]
+  let curFile: string | null = null;
+  for (const line of diffOutput.split('\n')) {
+    const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
+    if (fileMatch) { curFile = join(absDir, fileMatch[1]); continue; }
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+    if (hunkMatch && curFile) {
+      const start = parseInt(hunkMatch[1], 10);
+      const count = hunkMatch[2] !== undefined ? parseInt(hunkMatch[2], 10) : 1;
+      if (count === 0) continue; // deletion only, no added lines
+      if (!changedLines.has(curFile)) changedLines.set(curFile, []);
+      changedLines.get(curFile)!.push([start, start + count - 1]);
+    }
+  }
+
+  const cg = ctx.callGraph as SerializedCallGraph;
+  const nodeMap = new Map(cg.nodes.map(n => [n.id, n]));
+
+  // Map changed line ranges to function nodes via startLine
+  const changedFnIds = new Set<string>();
+  for (const [filePath, ranges] of changedLines) {
+    const fileNodes = cg.nodes.filter(n => n.filePath === filePath && !n.isExternal && !n.isTest && n.startLine);
+    for (const node of fileNodes) {
+      for (const [start, end] of ranges) {
+        if (node.startLine! <= end && (node.startLine! >= start || node.fanOut > 0)) {
+          changedFnIds.add(node.id);
+        }
+      }
+    }
+    // If no line match found for the file, include all functions in the file as changed
+    if (fileNodes.length > 0 && !fileNodes.some(n => changedFnIds.has(n.id))) {
+      for (const n of fileNodes) changedFnIds.add(n.id);
+    }
+  }
+
+  if (changedFnIds.size === 0) {
+    return { changedFunctions: [], message: 'Changed files found but no matching function nodes. Re-run analyze_codebase.' };
+  }
+
+  // BFS blast radius: count all transitive callers of each changed function
+  const callsEdges = cg.edges.filter(e => !e.kind || e.kind === 'calls');
+  const callerIndex = new Map<string, string[]>(); // calleeId → callerIds
+  for (const e of callsEdges) {
+    if (!callerIndex.has(e.calleeId)) callerIndex.set(e.calleeId, []);
+    callerIndex.get(e.calleeId)!.push(e.callerId);
+  }
+
+  const blastRadius = (startId: string): number => {
+    const visited = new Set<string>();
+    const queue = [startId];
+    while (queue.length) {
+      const id = queue.shift()!;
+      for (const callerId of callerIndex.get(id) ?? []) {
+        if (!visited.has(callerId)) { visited.add(callerId); queue.push(callerId); }
+      }
+    }
+    return visited.size;
+  };
+
+  const scored = [...changedFnIds].map(id => {
+    const n = nodeMap.get(id)!;
+    const radius = blastRadius(id);
+    return {
+      name: n.name,
+      file: relative(absDir, n.filePath),
+      startLine: n.startLine ?? null,
+      fanIn: n.fanIn,
+      blastRadius: radius,
+      riskScore: n.fanIn + radius * 2, // callers here + transitive callers weighted more
+      testedBy: cg.edges
+        .filter(e => e.kind === 'tested_by' && e.callerId === id)
+        .map(e => e.calleeName)
+        .filter((v, i, a) => a.indexOf(v) === i),
+    };
+  }).sort((a, b) => b.riskScore - a.riskScore);
+
+  return {
+    base: ref,
+    totalChanged: scored.length,
+    changedFunctions: scored,
+  };
 }

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -8,7 +8,9 @@
 
 import { readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
-import { spawn } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import {
   DEFAULT_MAX_FILES,
   DEFAULT_DRIFT_MAX_FILES,
@@ -1014,19 +1016,29 @@ export async function handleGetCluster(
 
 /** Run git with explicit stdio pipes — safe inside MCP server (which owns stdin/stdout). */
 function runGit(args: string[], cwd: string): Promise<string> {
+  // Use shell file-redirect to temp files instead of pipes — libuv pipe() calls
+  // fail with EBADF inside the MCP server because its FD 0/1 are the JSON-RPC
+  // protocol sockets; avoiding pipe creation altogether sidesteps the issue.
   return new Promise((resolve, reject) => {
     const PATH = (process.env.PATH ?? '') + ':/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin';
-    const child = spawn('git', args, {
+    const tmp = mkdtempSync(join(tmpdir(), 'sg-git-'));
+    const outPath = join(tmp, 'o');
+    const errPath = join(tmp, 'e');
+    const escaped = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
+    const cmd = `/usr/bin/git ${escaped} >'${outPath}' 2>'${errPath}'`;
+    const r = spawnSync('/bin/sh', ['-c', cmd], {
       cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: 'ignore',
       env: { ...process.env, PATH },
     });
-    let out = '';
-    let err = '';
-    child.stdout.on('data', (d: Buffer) => { out += d.toString(); });
-    child.stderr.on('data', (d: Buffer) => { err += d.toString(); });
-    child.on('close', code => { if (code === 0) resolve(out); else reject(new Error(err || `exit ${code}`)); });
-    child.on('error', reject);
+    let stdout = '';
+    let stderr = '';
+    try { stdout = readFileSync(outPath, 'utf8'); } catch { /* no output */ }
+    try { stderr = readFileSync(errPath, 'utf8'); } catch { /* no output */ }
+    rmSync(tmp, { recursive: true, force: true });
+    if (r.error) { reject(r.error); return; }
+    if ((r.status ?? 1) !== 0) { reject(new Error(stderr || `git exit ${r.status}`)); return; }
+    resolve(stdout);
   });
 }
 

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -984,9 +984,20 @@ export async function handleGetCluster(
 
   // Internal edges within community
   const memberIds = new Set(members.map(n => n.id));
-  const internalEdges = cg.edges
-    .filter(e => (!e.kind || e.kind === 'calls') && memberIds.has(e.callerId) && memberIds.has(e.calleeId))
-    .length;
+  const nameById = new Map(members.map(n => [n.id, n.name]));
+  const rawInternal = cg.edges
+    .filter(e => (!e.kind || e.kind === 'calls') && memberIds.has(e.callerId) && memberIds.has(e.calleeId));
+
+  // Deduplicate and take top 15 by callee fanIn (most structurally important edges first)
+  const seen = new Set<string>();
+  const callEdges: string[] = [];
+  for (const e of rawInternal) {
+    const key = `${e.callerId}→${e.calleeId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    callEdges.push(`${nameById.get(e.callerId)} → ${nameById.get(e.calleeId)}`);
+    if (callEdges.length >= 15) break;
+  }
 
   // Files the community spans
   const files = [...new Set(members.map(n => relative(absDir, n.filePath)))].sort();
@@ -997,9 +1008,11 @@ export async function handleGetCluster(
     stats: {
       members: members.length,
       files: files.length,
-      internalEdges,
+      internalEdges: rawInternal.length,
     },
     files,
+    // Internal call edges show WHY these functions cluster together
+    internalCallGraph: callEdges,
     functions: members.map(n => ({
       name: n.name,
       file: relative(absDir, n.filePath),
@@ -1091,8 +1104,10 @@ export async function handleDetectChanges(
   for (const [filePath, ranges] of changedLines) {
     const fileNodes = cg.nodes.filter(n => n.filePath === filePath && !n.isExternal && !n.isTest && n.startLine);
     for (const node of fileNodes) {
+      const fnEnd = node.endLine ?? node.startLine!;
       for (const [start, end] of ranges) {
-        if (node.startLine! <= end && (node.startLine! >= start || node.fanOut > 0)) {
+        // True overlap: changed range [start,end] intersects function [startLine,endLine]
+        if (node.startLine! <= end && fnEnd >= start) {
           changedFnIds.add(node.id);
         }
       }
@@ -1134,9 +1149,10 @@ export async function handleDetectChanges(
       name: n.name,
       file: relative(absDir, n.filePath),
       startLine: n.startLine ?? null,
+      endLine: n.endLine ?? null,
       fanIn: n.fanIn,
       blastRadius: radius,
-      riskScore: n.fanIn + radius * 2, // callers here + transitive callers weighted more
+      riskScore: n.fanIn + radius * 2,
       testedBy: cg.edges
         .filter(e => e.kind === 'tested_by' && e.callerId === id)
         .map(e => e.calleeName)

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -8,8 +8,7 @@
 
 import { readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import { spawn } from 'node:child_process';
 import {
   DEFAULT_MAX_FILES,
   DEFAULT_DRIFT_MAX_FILES,
@@ -1013,7 +1012,23 @@ export async function handleGetCluster(
 // detect_changes
 // ============================================================================
 
-const execFileAsync = promisify(execFile);
+/** Run git with explicit stdio pipes — safe inside MCP server (which owns stdin/stdout). */
+function runGit(args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const PATH = (process.env.PATH ?? '') + ':/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin';
+    const child = spawn('git', args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, PATH },
+    });
+    let out = '';
+    let err = '';
+    child.stdout.on('data', (d: Buffer) => { out += d.toString(); });
+    child.stderr.on('data', (d: Buffer) => { err += d.toString(); });
+    child.on('close', code => { if (code === 0) resolve(out); else reject(new Error(err || `exit ${code}`)); });
+    child.on('error', reject);
+  });
+}
 
 /**
  * Detect recently changed functions and rank them by blast radius (fanIn of callers via BFS).
@@ -1027,17 +1042,12 @@ export async function handleDetectChanges(
   const ctx = await readCachedContext(absDir);
   if (!ctx?.callGraph) return { error: 'No call graph. Run analyze_codebase first.' };
 
-  // Get git diff — changed file paths and line ranges
   const ref = base ?? 'HEAD';
   let diffOutput: string;
-  const GIT = process.env.GIT_EXEC_PATH ? `${process.env.GIT_EXEC_PATH}/git` : 'git';
-  const execOpts = { cwd: absDir, maxBuffer: 4 * 1024 * 1024, env: { ...process.env, PATH: process.env.PATH ?? '/usr/bin:/bin:/usr/local/bin' } };
   try {
-    const { stdout } = await execFileAsync(GIT, ['diff', '--unified=0', ref, '--', '.'], execOpts);
-    diffOutput = stdout;
+    diffOutput = await runGit(['diff', '--unified=0', ref, '--', '.'], absDir);
     if (!diffOutput.trim()) {
-      const { stdout: staged } = await execFileAsync(GIT, ['diff', '--unified=0', '--cached', '--', '.'], execOpts);
-      diffOutput = staged;
+      diffOutput = await runGit(['diff', '--unified=0', '--cached', '--', '.'], absDir);
     }
   } catch (err) {
     return { error: `git diff failed: ${(err as Error).message}` };

--- a/src/core/services/mcp-handlers/graph.ts
+++ b/src/core/services/mcp-handlers/graph.ts
@@ -504,7 +504,7 @@ export async function handleGetLeafFunctions(
 
   const cg = ctx.callGraph as SerializedCallGraph;
   const hasOutgoing = new Set(cg.edges.filter(e => e.calleeId).map(e => e.callerId));
-  let leaves = cg.nodes.filter(n => !n.isExternal && !hasOutgoing.has(n.id));
+  let leaves = cg.nodes.filter(n => !n.isExternal && !n.isTest && !hasOutgoing.has(n.id));
 
   if (filePattern) leaves = leaves.filter(n => n.filePath.includes(filePattern));
 
@@ -554,7 +554,7 @@ export async function handleGetCriticalHubs(
   );
 
   const hubs = cg.nodes
-    .filter(n => !n.isExternal && (n.fanIn ?? 0) >= minFanIn)
+    .filter(n => !n.isExternal && !n.isTest && (n.fanIn ?? 0) >= minFanIn)
     .map(n => {
       const fanIn        = n.fanIn  ?? 0;
       const fanOut       = n.fanOut ?? 0;
@@ -595,7 +595,7 @@ export async function handleGetCriticalHubs(
     .slice(0, limit);
 
   return {
-    totalHubs: cg.nodes.filter(n => !n.isExternal && (n.fanIn ?? 0) >= minFanIn).length,
+    totalHubs: cg.nodes.filter(n => !n.isExternal && !n.isTest && (n.fanIn ?? 0) >= minFanIn).length,
     returned: hubs.length, minFanIn, hubs,
     guidance: 'Start with hubs that have the highest stabilityScore (easiest wins). Defer hubs with stabilityScore < 30 until their dependencies are cleaner.',
   };
@@ -620,7 +620,7 @@ export async function handleGetGodFunctions(
   if (filePath) {
     candidates = getFileGodFunctions(cg, filePath, fanOutThreshold);
   } else {
-    candidates = cg.nodes.filter(n => !n.isExternal && n.fanOut >= fanOutThreshold);
+    candidates = cg.nodes.filter(n => !n.isExternal && !n.isTest && n.fanOut >= fanOutThreshold);
   }
 
   if (candidates.length === 0) {

--- a/src/core/services/mcp-handlers/graph.ts
+++ b/src/core/services/mcp-handlers/graph.ts
@@ -287,23 +287,26 @@ export async function handleGetSubgraph(
   }
 
   const nodeMap = new Map(cg.nodes.map(n => [n.id, n]));
-  const subNodes = Array.from(visitedIds)
+  const visibleNodes = Array.from(visitedIds)
     .map(id => nodeMap.get(id)!)
     .filter(Boolean)
     // stdlib nodes (Array.isArray, t.slice, …) are noise — exclude unless they are a seed
-    .filter(n => !n.isExternal || n.externalKind !== 'stdlib' || seeds.some(s => s.id === n.id))
-    .map(n => ({
-      name: n.isExternal ? `[external] ${n.name}` : n.name,
-      file: n.filePath,
-      className: n.className,
-      fanIn: n.fanIn, fanOut: n.fanOut, language: n.language,
-      isExternal: n.isExternal ?? false,
-      externalKind: n.externalKind,
-      isSeed: seeds.some(s => s.id === n.id),
-    }));
+    .filter(n => !n.isExternal || n.externalKind !== 'stdlib' || seeds.some(s => s.id === n.id));
+
+  const visibleIds = new Set(visibleNodes.map(n => n.id));
+
+  const subNodes = visibleNodes.map(n => ({
+    name: n.isExternal ? `[external] ${n.name}` : n.name,
+    file: n.filePath,
+    className: n.className,
+    fanIn: n.fanIn, fanOut: n.fanOut, language: n.language,
+    isExternal: n.isExternal ?? false,
+    externalKind: n.externalKind,
+    isSeed: seeds.some(s => s.id === n.id),
+  }));
 
   const subEdges = cg.edges
-    .filter(e => e.calleeId && visitedIds.has(e.callerId) && visitedIds.has(e.calleeId))
+    .filter(e => e.calleeId && visibleIds.has(e.callerId) && visibleIds.has(e.calleeId))
     .map(e => ({
       caller: nodeMap.get(e.callerId)?.name ?? e.callerId,
       callee: nodeMap.get(e.calleeId)?.isExternal


### PR DESCRIPTION
## Summary

Five additions built on top of the external-leaf-node work (#70), with two rounds of scoring improvements and a new dedicated skill:

1. **`tested_by` edges** — import-based test coverage, accurate even for mock-heavy suites
2. **Community detection** — label-propagation clusters on the call graph at analyze time
3. **`get_minimal_context`** — body + callers + callees + covering tests; risk-aware depth + `riskLevel`
4. **`get_cluster`** — all functions in the same community + `clusterDensity` metric
5. **`detect_changes`** — git diff → changed functions ranked by multiplicative risk model
6. **`spec-gen-review-changes` skill** — new end-to-end review workflow for all agent targets

---

## Changes

### 1. `tested_by` edges — `call-graph.ts`

Import-based test coverage via a post-processing pass after all `calls` edges are resolved. Works correctly with Vitest `vi.mock()` — no direct call edge required. 268 `tested_by` edges on spec-gen itself.

### 2. Community detection — `call-graph.ts`

15-iteration label propagation, deterministic (ties broken by sorted label order). Adds `communityId` and `communityLabel` to each `FunctionNode`.

### 3. `get_minimal_context` — `mcp-handlers/analysis.ts`

One-call context for "I know exactly which function to change":
- Body + direct callers (with `callType` + `isExternal`) + direct callees (with `callType` + `isExternal` + `externalKind`)
- `testedBy` as `{name, confidence: 'imported'|'called'}` objects — `'called'` = direct test; `'imported'` = module import only (survives `vi.mock()`)
- `riskLevel: 'high'|'medium'|'low'` on function metadata
- **Risk-aware depth**: `fanIn≥30` or `fanOut≥15` → 24 callers/callees; `≥15/8` → 18; else 12

### 4. `get_cluster` — `mcp-handlers/analysis.ts`

All functions in the same label-propagation community, sorted by fan-in. Stats include `clusterDensity = uniqueInternalEdges / (m*(m-1))`:
- `< 0.05` — sparse (shared utilities); extract members independently
- `0.05–0.15` — moderate; check `internalCallGraph` for transitive dependencies
- `> 0.15` — dense; coordinate whole cluster or stage rollout

### 5. `detect_changes` — `mcp-handlers/analysis.ts`

`git diff --unified=0 <base>` → parse hunks → intersect with `[startLine, endLine]` → multiplicative risk score:

```
likelihood = changeScore × (1 + coveragePenalty)
impact     = log(1 + fanIn)×0.8 + transitiveScore + boundaryScore
riskScore  = likelihood × impact
```

Signal details:
- `changeScore = 0.6×(overlap/fnLength) + 0.4×log(1+overlap)/log(201)` — blend relative + absolute; large functions not penalized vs tiny ones
- `transitiveScore = Σ callTypeWeight/d²`, clamped at 10 — `awaited→1.0, direct→0.7, method→0.6, constructor→0.5`
- `coveragePenalty = 1/(1+log(1+effectiveTests))` where `effectiveTests = called×1.0 + imported×0.3`
- `boundaryScore`: external HTTP/DB outgoing edges weighted 3×, others 1×, normalized
- `testedBy` entries: `{name, confidence: 'imported'|'called'}`
**MCP server EBADF fix**: `spawnSync('/bin/sh', '-c', 'git ... > tmpfile')` with `stdio:'ignore'` avoids libuv pipe creation when FD 0/1 are occupied by JSON-RPC sockets.

### 6. `spec-gen-review-changes` skill — `examples/`

New end-to-end pre-merge review workflow for OpenCode and Mistral Vibe agents:
1. `detect_changes` → risk-ranked table (🔴 ≥5 / 🟡 2–5 / 🟢 <2)
2. `get_minimal_context` on every HIGH function — interpret `callType` (frozen interface?), `isExternal` (production boundary?), `testedBy.confidence` (real coverage or mocked away?)
3. `get_cluster` when verdict unclear — density drives go/no-go scope
4. Go / No-Go recommendation with explicit rules (riskScore ≥ 5 + zero direct tests + external callee = block)

Also updated `spec-gen-implement-story` and `spec-gen-plan-refactor` (OpenCode + Mistral Vibe) with concrete payoff language for `get_minimal_context` and `get_cluster` — previously listed as available but without incentive to use.

### 7. `startLine` / `endLine` on `FunctionNode`

Binary search over pre-computed newline-offset array; O(log n). Required for `detect_changes` intersection and `changeScore`.

### Miscellaneous ###

Stick lanceDB version to 0.22.4-beta.3 because of incompatibility with Mac Intel on the following versions (https://github.com/lancedb/lancedb/issues/2937)


---

## Test plan

- [x] `npm run build` — no TypeScript errors
- [x] `npm test` — 2537 tests pass
- [x] `detect_changes(dir, "main")` — float riskScores, `testedBy` as `{name,confidence}` objects, multiplicative model live
- [x] Ranking verified: large tested functions score lower than small untested ones of similar change size — `coveragePenalty` + `callType` weighting correct
- [x] `detect_changes`: `callTypeWeight` visible in blastRadius — `runGit` (awaited caller) blastRadius 1.25 vs `byteToLine` (direct caller) 0.95
- [x] `get_minimal_context(validateDirectory)` — `riskLevel:"high"` (fanIn=45, 24 callers shown), `callType:"awaited"` on all callers, `logger.debug` `isExternal:true`
- [x] `get_minimal_context(handleOrient)` — `riskLevel:"high"` (fanOut=39), 24 callees shown including external boundaries
- [x] `get_cluster(validateDirectory)` — `clusterDensity:0.028` (75 members, sparse)
- [x] 268 `tested_by` edges on spec-gen repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)