### PR TITLE
feat(decisions): decision autopilot — auto-accept governance with an append-only audit trail

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -308,6 +308,16 @@ openlore decisions [options]
   --consolidate          # Manually trigger LLM consolidation + diff verification of drafts
   --json                 # Machine-readable output
   --uninstall-hook       # Remove decisions pre-commit hook (install via: openlore setup --tools claude)
+
+# Decision autopilot (opt-in: { "governance": { "autopilot": true } } in .openlore/config.json):
+# the gate auto-accepts verified decisions (distinct `auto-approved` status), syncs them to
+# specs with an "Auto-accepted (unreviewed)" marker, and never blocks a commit. Every status
+# transition — in every mode — lands on an append-only ledger.
+openlore decisions log [--json] [--since <ref|ISO date>]
+                         # Show the transition ledger, newest first
+openlore decisions review [--promote <ids|all>] [--reject <ids|all>] [--note <text>] [--json]
+                         # List auto-accepted decisions awaiting review; promote (drops the
+                         # unreviewed marker) or reject (retires from specs, kept in history)
 ```
 
 ### Verify Options

--- a/openspec/changes/add-decision-autopilot/proposal.md
+++ b/openspec/changes/add-decision-autopilot/proposal.md
@@ -1,0 +1,77 @@
+# Decision autopilot: auto-accept governance with a first-class audit trail
+
+> Status: PROPOSED (2026-07-18). The decisions gate is the substrate's governance heartbeat,
+> but its only mode is *blocking human review*: every commit with staged source either stops
+> for interactive approval or is bypassed with `--no-verify`. That friction is exactly why
+> the gate ships behind a separate opt-in command and why real users end up rubber-stamping.
+> This change adds an **autopilot** mode: decisions are recorded, consolidated, auto-accepted,
+> and synced entirely in the background — commits never block — while every acceptance lands
+> on an append-only, human-readable trail that can be reviewed, promoted, or reverted at any
+> time. Governance gets out of the way without disappearing.
+
+## The gap
+
+- **No auto-accept exists.** Approval is human-only (`--approve <id>`,
+  `src/cli/commands/decisions.ts:418-429`); the gate state machine
+  (`classifyGateState`, `src/core/decisions/gate-state.ts:55-70`) has no non-blocking
+  resolution for `verified` decisions — they wait for a human or a `--no-verify` bypass.
+- **The bypass is the de-facto autopilot, minus the trail.** The post-commit detector
+  (`decisions.ts:164-179`) already shows users route around the gate; when they do, nothing
+  is approved, nothing syncs to specs, and the decision record silently rots. The observed
+  field behavior (standing "approve without prompting" authorizations) is autopilot demand
+  being served manually.
+- **Provenance would be lost if we faked it.** Auto-accepting by writing status `approved`
+  would be indistinguishable from human review — the exact conflation
+  `fix-decision-status-transitions` exists to prevent. Autopilot needs its own status and
+  its own legal transitions in that state machine, not a side door.
+- **There is no trail to inspect.** `pending.json` (`src/core/decisions/store.ts:18-22`)
+  holds current status only; transitions overwrite. Nobody can answer "what did OpenLore
+  accept on my behalf last week, and who said so?"
+
+## What changes
+
+1. **A `governance.autopilot` mode** (config: `governance: { autopilot: true }`). When on:
+   - decisions reaching `verified` are transitioned to a NEW status **`auto-approved`**
+     (actor `autopilot`, timestamp, triggering commit) and synced to specs in the background;
+   - the pre-commit gate never blocks — it emits one advisory line
+     ("2 decisions auto-accepted · `openlore decisions log`") and exits 0;
+   - infrastructure failure (consolidation/sync error) degrades to a caveat and exits 0,
+     reusing the impact-certificate advisory-safety discipline.
+   When off, behavior is exactly today's blocking review flow.
+2. **An append-only ledger.** Every status transition (record, consolidate, verify,
+   auto-approve, human approve/reject, sync, supersede) appends
+   `{ id, title, from, to, actor: human|autopilot|agent|sync, at, commit }` to
+   `.openlore/decisions/ledger.jsonl`. `openlore decisions log [--json] [--since <ref>]`
+   renders it newest-first. The ledger is written by the same code path for every mode —
+   human review gets the trail too.
+3. **Review and revert, any time.** `openlore decisions review` lists auto-approved-and-
+   never-human-reviewed decisions for bulk disposition: promote (→ human `approved`) or
+   reject. Rejecting an auto-approved decision retires it from specs through the existing
+   supersession machinery (kept queryable via `asOf`) — reversible, not destructive.
+4. **Honest provenance everywhere.** Specs render auto-approved decisions with an explicit
+   "auto-accepted (unreviewed)" marker; `recall` and `verify_claim`'s `decision-current`
+   treat `auto-approved` as authoritative but carry the provenance so an agent citing the
+   decision can say so. Status-transition legality extends `fix-decision-status-transitions`:
+   `verified → auto-approved` is legal only for actor `autopilot` with the mode on;
+   `rejected → *` remains human-only — autopilot can never resurrect a human rejection.
+
+## Impact
+
+- Specs touched: `cli` (gate + ledger + review requirements), `mcp-handlers`
+  (recall/verify provenance).
+- Likely code: `src/core/decisions/gate-state.ts`, `src/core/decisions/store.ts` (+ ledger
+  writer), `src/cli/commands/decisions.ts`, `src/core/decisions/syncer.ts`,
+  `src/core/services/mcp-handlers/memory.ts` / `verify.ts` (provenance surfacing).
+- Enables: `unify-onboarding-entrypoint` step 3 (install wires the hook in autopilot mode
+  by default).
+- Cross-references (do not duplicate): `fix-decision-status-transitions` and
+  `harden-decision-consolidation` fix the *existing* transition/CAS/spawn defects — this
+  change layers a new legal transition on top of their state machine, and depends on their
+  CAS discipline for ledger+status writes.
+
+## Non-goals
+
+- No LLM in any new path (consolidation already owns that; unchanged).
+- No change to `approve_decision` requiring human authorization — autopilot is a *mode the
+  human turned on*, recorded as such; the MCP tool still never self-approves.
+- No deletion: rejection of an auto-approved decision supersedes, never erases.

--- a/openspec/changes/add-decision-autopilot/proposal.md
+++ b/openspec/changes/add-decision-autopilot/proposal.md
@@ -1,6 +1,6 @@
 # Decision autopilot: auto-accept governance with a first-class audit trail
 
-> Status: PROPOSED (2026-07-18). The decisions gate is the substrate's governance heartbeat,
+> Status: IMPLEMENTED (2026-07-18, PR #223). The decisions gate is the substrate's governance heartbeat,
 > but its only mode is *blocking human review*: every commit with staged source either stops
 > for interactive approval or is bypassed with `--no-verify`. That friction is exactly why
 > the gate ships behind a separate opt-in command and why real users end up rubber-stamping.

--- a/openspec/changes/add-decision-autopilot/specs/cli/spec.md
+++ b/openspec/changes/add-decision-autopilot/specs/cli/spec.md
@@ -1,0 +1,58 @@
+# cli spec delta
+
+## ADDED Requirements
+
+### Requirement: DecisionAutopilotMode
+
+When `governance.autopilot` is enabled, the decisions gate SHALL auto-accept: decisions
+reaching `verified` transition to a distinct `auto-approved` status (actor `autopilot`, with
+timestamp and triggering commit) and are synced to specs in the background; the pre-commit
+gate SHALL never block a commit — it emits a single advisory line naming the count of
+auto-accepted decisions and the trail command, and exits 0. Infrastructure failure in
+consolidation or sync SHALL degrade to a caveat and exit 0, never a block. With autopilot
+disabled, gate behavior SHALL be unchanged from the blocking human-review flow.
+`auto-approved` SHALL be a distinct status, never conflated with human `approved`, and
+autopilot SHALL never transition a human-`rejected` decision.
+
+#### Scenario: A commit sails through with a trail
+
+- **GIVEN** `governance.autopilot: true` and two verified decisions pending
+- **WHEN** the user runs `git commit`
+- **THEN** the commit succeeds, both decisions become `auto-approved` and sync in the
+  background, and stderr carries one advisory line pointing at `openlore decisions log`
+
+#### Scenario: Autopilot cannot resurrect a rejection
+
+- **GIVEN** a decision a human explicitly rejected
+- **WHEN** any number of autopilot gate runs occur
+- **THEN** the decision remains `rejected` and never re-enters specs
+
+### Requirement: DecisionLedgerIsAppendOnly
+
+Every decision status transition — in every mode — SHALL append one entry
+`{ id, title, from, to, actor: human|autopilot|agent|sync, at, commit }` to an append-only ledger
+(`.openlore/decisions/ledger.jsonl`). `openlore decisions log` SHALL render the ledger
+newest-first with `--json` and `--since <ref>` filters. Ledger writes SHALL use the same
+cross-process serialization as the decision store, and existing entries SHALL never be
+rewritten or deleted.
+
+#### Scenario: The trail answers "what did you accept for me?"
+
+- **GIVEN** a week of autopilot commits
+- **WHEN** the user runs `openlore decisions log --since main@{1.week.ago}`
+- **THEN** every auto-accepted decision appears with actor `autopilot`, its commit, and its
+  timestamp
+
+### Requirement: AutoApprovedDecisionsAreReviewableAndReversible
+
+`openlore decisions review` SHALL list every `auto-approved` decision not yet human-reviewed
+and support bulk disposition: promote (transition to human `approved`) or reject. Rejecting
+an auto-approved decision SHALL retire it from specs through the existing supersession
+machinery — remaining queryable via `asOf` — never by deletion.
+
+#### Scenario: Reverting a bad auto-acceptance
+
+- **GIVEN** an auto-approved decision the user disagrees with
+- **WHEN** they reject it in `openlore decisions review`
+- **THEN** it leaves the authoritative spec surface, `recall`/`verify_claim` stop serving it
+  as current, and `asOf` queries before the rejection still return it

--- a/openspec/changes/add-decision-autopilot/specs/mcp-handlers/spec.md
+++ b/openspec/changes/add-decision-autopilot/specs/mcp-handlers/spec.md
@@ -1,0 +1,19 @@
+# mcp-handlers spec delta
+
+## ADDED Requirements
+
+### Requirement: AutoApprovedProvenanceIsAlwaysDisclosed
+
+`recall` and `verify_claim` (`decision-current`) SHALL treat `auto-approved` decisions as
+authoritative but SHALL carry their provenance (`approvedBy: autopilot`, acceptance
+timestamp) in the response, so an agent citing the decision can disclose that it was
+machine-accepted and unreviewed. Spec rendering of an auto-approved decision SHALL carry an
+explicit "auto-accepted (unreviewed)" marker. A decision promoted by a human loses the
+marker; provenance SHALL never be silently upgraded.
+
+#### Scenario: Citing an auto-accepted decision honestly
+
+- **GIVEN** an `auto-approved` decision governing a file the agent is changing
+- **WHEN** the agent calls `verify_claim` with kind `decision-current` for it
+- **THEN** the verdict is `verified` (it is the live authority) and the receipt includes
+  `approvedBy: autopilot`, enabling the agent to disclose the provenance to the human

--- a/openspec/changes/add-decision-autopilot/tasks.md
+++ b/openspec/changes/add-decision-autopilot/tasks.md
@@ -1,0 +1,31 @@
+# Tasks — add-decision-autopilot
+
+## Implementation
+- [x] `auto-approved` status + legality rules layered on the transition state machine
+      (gate-state.ts, store.ts): `verified → auto-approved` only for actor `autopilot` with
+      `governance.autopilot: true`; `rejected → *` stays human-only; all writes ride the CAS
+      discipline from harden-decision-consolidation
+- [x] Append-only ledger writer in store.ts: every transition appends
+      `{id, title, from, to, actor: human|autopilot|agent|sync, at, commit}` to `.openlore/decisions/ledger.jsonl`
+      (all modes, not just autopilot); ensure `.openlore/decisions` gitignore coverage holds
+- [x] Gate autopilot path (decisions.ts --gate): verified decisions auto-approve + background
+      sync; one advisory stderr line; exit 0 always in autopilot; infra failure → caveat +
+      exit 0 (impact-certificate discipline)
+- [x] `openlore decisions log [--json] [--since <ref>]` (ledger render, newest-first) and
+      `openlore decisions review` (bulk promote/reject of auto-approved-unreviewed; reject
+      retires from specs via existing supersession, queryable via asOf)
+- [x] Provenance surfacing: spec renderer marks auto-approved as "auto-accepted (unreviewed)";
+      recall + verify_claim decision-current carry `approvedBy: autopilot` provenance
+- [x] `governance.autopilot` config key + `openlore features` listing
+
+## Verification
+- [x] Transition tests: autopilot never touches human-rejected decisions; mode off →
+      byte-identical behavior to today; sync can still not promote (fix-decision-status-
+      transitions composition)
+- [x] Ledger tests: every transition appends exactly once; log/--since render; ledger
+      survives concurrent gate + MCP writes (file lock)
+- [x] Gate tests: autopilot commit never blocks; advisory line lists count; infra failure
+      exits 0 with caveat
+- [x] Review/revert round-trip: auto-approve → reject retires from specs, asOf still serves
+      history; promote upgrades to human `approved`
+- [ ] Full suite green; `openspec validate add-decision-autopilot` at archive time

--- a/src/cli/commands/decisions-autopilot.test.ts
+++ b/src/cli/commands/decisions-autopilot.test.ts
@@ -1,0 +1,275 @@
+/**
+ * CLI-level tests for decision autopilot (change: add-decision-autopilot):
+ * the gate auto-accepts + syncs + never blocks; provenance markers land in
+ * specs; `decisions review` promotes/rejects; `decisions log` renders the
+ * ledger; autopilot never touches a human-rejected decision; with autopilot
+ * off the blocking gate behaves exactly as before.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { decisionsCommand } from './decisions.js';
+import { loadDecisionStore, saveDecisionStore } from '../../core/decisions/store.js';
+import { readLedger } from '../../core/decisions/ledger.js';
+import type { Command, Option } from 'commander';
+import type { PendingDecision, DecisionStore } from '../../types/index.js';
+
+/**
+ * Commander keeps option values between parseAsync() calls on the same command
+ * instance (same quirk analyze-no-embed.test.ts works around) — a stale parent
+ * `--reject` from one test would hijack the next test's `--gate` parse. Reset
+ * every option on the command tree to its declared default between tests.
+ */
+function resetCommanderState(root: Command): void {
+  const cmds: Command[] = [root, ...root.commands];
+  for (const c of cmds) {
+    for (const o of (c as unknown as { options: Option[] }).options) {
+      c.setOptionValue(o.attributeName(), o.defaultValue);
+    }
+  }
+}
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { warning: vi.fn(), info: vi.fn(), error: vi.fn(), success: vi.fn(), section: vi.fn(), discovery: vi.fn(), analysis: vi.fn(), blank: vi.fn() },
+}));
+
+const BASE_CONFIG = {
+  version: '1.0.0',
+  projectType: 'nodejs',
+  openspecPath: 'openspec',
+  analysis: { maxFiles: 1000, includePatterns: [], excludePatterns: [] },
+  generation: { model: 'claude-sonnet-4-6', domains: 'auto' },
+  createdAt: '2026-07-18T00:00:00Z',
+  lastRun: null,
+};
+
+const CACHE_SPEC = `# Cache Spec
+
+> Source files: src/cache.ts
+
+## Requirements
+
+### Requirement: Caching
+
+The system SHALL cache.
+`;
+
+function makeDecision(overrides: Partial<PendingDecision> = {}): PendingDecision {
+  return {
+    id: 'aaaabbbb',
+    status: 'verified',
+    title: 'Use Redis for caching',
+    rationale: 'Reduces DB load',
+    consequences: 'Cache invalidation to manage',
+    proposedRequirement: null,
+    affectedDomains: ['cache'],
+    affectedFiles: ['src/cache.ts'],
+    sessionId: 'session123',
+    recordedAt: '2026-07-18T00:00:00.000Z',
+    confidence: 'high',
+    syncedToSpecs: [],
+    ...overrides,
+  };
+}
+
+function makeStore(decisions: PendingDecision[]): DecisionStore {
+  return {
+    version: '1',
+    sessionId: 'session123',
+    updatedAt: '2026-07-18T00:00:00.000Z',
+    sequence: 0,
+    decisions,
+  };
+}
+
+describe('decision autopilot', () => {
+  let dir: string;
+  let prevCwd: string;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrChunks: string[];
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `decisions-autopilot-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(join(dir, '.openlore'), { recursive: true });
+    await mkdir(join(dir, 'openspec', 'specs', 'cache'), { recursive: true });
+    await writeFile(join(dir, 'openspec', 'specs', 'cache', 'spec.md'), CACHE_SPEC, 'utf-8');
+    prevCwd = process.cwd();
+    process.chdir(dir);
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrChunks = [];
+    errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      stderrChunks.push(args.map(String).join(' '));
+    });
+    process.exitCode = undefined;
+    resetCommanderState(decisionsCommand);
+  });
+
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    stdoutSpy.mockRestore();
+    errorSpy.mockRestore();
+    process.exitCode = undefined;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function writeConfig(governance?: { autopilot?: boolean }): Promise<void> {
+    await writeFile(
+      join(dir, '.openlore', 'config.json'),
+      JSON.stringify({ ...BASE_CONFIG, ...(governance ? { governance } : {}) }, null, 2),
+      'utf-8',
+    );
+  }
+
+  function stdoutText(): string {
+    return stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+  }
+
+  async function runGate(): Promise<void> {
+    await decisionsCommand.parseAsync(['--gate'], { from: 'user' });
+  }
+
+  it('auto-accepts a verified decision, syncs it with the unreviewed marker, and never blocks', async () => {
+    await writeConfig({ autopilot: true });
+    await saveDecisionStore(dir, makeStore([makeDecision()]));
+
+    await runGate();
+
+    expect(process.exitCode ?? 0).toBe(0);
+
+    const store = await loadDecisionStore(dir);
+    const d = store.decisions.find((x) => x.id === 'aaaabbbb')!;
+    expect(d.status).toBe('auto-approved');
+    expect(d.approvedBy).toBe('autopilot');
+    expect(d.syncedToSpecs.length).toBeGreaterThan(0);
+
+    const spec = await readFile(join(dir, 'openspec', 'specs', 'cache', 'spec.md'), 'utf-8');
+    expect(spec).toContain('**ID:** aaaabbbb');
+    expect(spec).toContain('**Status:** Auto-accepted (unreviewed)');
+
+    const ledger = await readLedger(dir);
+    expect(ledger.some((e) => e.from === 'verified' && e.to === 'auto-approved' && e.actor === 'autopilot')).toBe(true);
+
+    // One advisory line, pointing at the trail.
+    expect(stderrChunks.join('\n')).toContain('auto-accepted');
+    expect(stderrChunks.join('\n')).toContain('openlore decisions log');
+  });
+
+  it('never resurrects a human-rejected decision', async () => {
+    await writeConfig({ autopilot: true });
+    await saveDecisionStore(dir, makeStore([makeDecision({ status: 'rejected', reviewNote: 'no' })]));
+
+    await runGate();
+
+    expect(process.exitCode ?? 0).toBe(0);
+    const store = await loadDecisionStore(dir);
+    expect(store.decisions.find((x) => x.id === 'aaaabbbb')!.status).toBe('rejected');
+    const spec = await readFile(join(dir, 'openspec', 'specs', 'cache', 'spec.md'), 'utf-8');
+    expect(spec).not.toContain('aaaabbbb');
+  });
+
+  it('exits 0 even when sync infrastructure is missing (fail-soft)', async () => {
+    await writeConfig({ autopilot: true });
+    await rm(join(dir, 'openspec'), { recursive: true, force: true });
+    await saveDecisionStore(dir, makeStore([makeDecision()]));
+
+    await runGate();
+
+    expect(process.exitCode ?? 0).toBe(0);
+    const store = await loadDecisionStore(dir);
+    // Accepted (trail intact) even though the spec write had nowhere to go.
+    expect(store.decisions[0].status).toBe('auto-approved');
+    expect(store.decisions[0].syncedToSpecs).toHaveLength(0);
+  });
+
+  it('with autopilot off, the blocking gate is unchanged', async () => {
+    await writeConfig();
+    await saveDecisionStore(dir, makeStore([makeDecision()]));
+
+    await runGate();
+
+    expect(process.exitCode).toBe(1);
+    const store = await loadDecisionStore(dir);
+    expect(store.decisions[0].status).toBe('verified');
+    const payload = JSON.parse(stdoutText());
+    expect(payload.gated).toBe(true);
+    expect(payload.reason).toBe('verified');
+  });
+
+  it('review --reject retires the decision from specs (annotated, not deleted) and trails actor human', async () => {
+    await writeConfig({ autopilot: true });
+    await saveDecisionStore(dir, makeStore([makeDecision({ proposedRequirement: 'cache reads through Redis' })]));
+    await runGate();
+
+    await decisionsCommand.parseAsync(['review', '--reject', 'aaaabbbb', '--note', 'wrong call'], { from: 'user' });
+
+    expect(process.exitCode ?? 0).toBe(0);
+    const store = await loadDecisionStore(dir);
+    const d = store.decisions.find((x) => x.id === 'aaaabbbb')!;
+    expect(d.status).toBe('rejected');
+    expect(d.humanReviewedAt).toBeTruthy();
+
+    const spec = await readFile(join(dir, 'openspec', 'specs', 'cache', 'spec.md'), 'utf-8');
+    // Entry stays (history preserved) but its authority label is rewritten…
+    expect(spec).toContain('**ID:** aaaabbbb');
+    expect(spec).toMatch(/\*\*Status:\*\* Rejected \(auto-acceptance reverted \d{4}-\d{2}-\d{2}\)/);
+    expect(spec).not.toContain('**Status:** Auto-accepted (unreviewed)');
+    // …and the synced requirement block is annotated as rejected.
+    expect(spec).toMatch(/> Decision recorded: aaaabbbb\n> Rejected: \d{4}-\d{2}-\d{2}/);
+
+    const ledger = await readLedger(dir);
+    expect(ledger.some((e) => e.from === 'auto-approved' && e.to === 'rejected' && e.actor === 'human')).toBe(true);
+  });
+
+  it('review --promote drops the unreviewed marker and settles the decision as synced', async () => {
+    await writeConfig({ autopilot: true });
+    await saveDecisionStore(dir, makeStore([makeDecision()]));
+    await runGate();
+
+    await decisionsCommand.parseAsync(['review', '--promote', 'all'], { from: 'user' });
+
+    expect(process.exitCode ?? 0).toBe(0);
+    const store = await loadDecisionStore(dir);
+    const d = store.decisions.find((x) => x.id === 'aaaabbbb');
+    // Promoted decisions settle to synced; a later purge may drop them from the
+    // store, but never silently: if present, provenance must be intact.
+    if (d) {
+      expect(d.status).toBe('synced');
+      expect(d.approvedBy).toBe('autopilot');
+      expect(d.humanReviewedAt).toBeTruthy();
+    }
+    const spec = await readFile(join(dir, 'openspec', 'specs', 'cache', 'spec.md'), 'utf-8');
+    expect(spec).toContain('**Status:** Approved');
+    expect(spec).not.toContain('**Status:** Auto-accepted (unreviewed)');
+  });
+
+  it('repeated gates are idempotent: no duplicate spec entries, no duplicate transitions', async () => {
+    await writeConfig({ autopilot: true });
+    await saveDecisionStore(dir, makeStore([makeDecision()]));
+
+    await runGate();
+    await runGate();
+
+    const spec = await readFile(join(dir, 'openspec', 'specs', 'cache', 'spec.md'), 'utf-8');
+    expect(spec.match(/\*\*ID:\*\* aaaabbbb/g)).toHaveLength(1);
+    const ledger = await readLedger(dir);
+    expect(ledger.filter((e) => e.to === 'auto-approved')).toHaveLength(1);
+  });
+
+  it('decisions log renders the ledger newest-first as JSON', async () => {
+    await writeConfig({ autopilot: true });
+    await saveDecisionStore(dir, makeStore([makeDecision()]));
+    await runGate();
+    stdoutSpy.mockClear();
+
+    await decisionsCommand.parseAsync(['log', '--json'], { from: 'user' });
+
+    const entries = JSON.parse(stdoutText());
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries[0]).toHaveProperty('actor');
+    expect(entries[0]).toHaveProperty('to');
+  });
+});

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -29,6 +29,8 @@ import {
   getDecisionsByStatus,
   INACTIVE_STATUSES,
 } from '../../core/decisions/store.js';
+import { readLedger } from '../../core/decisions/ledger.js';
+import { rewriteSyncedDecisionStatus } from '../../core/decisions/syncer.js';
 import { consolidateDrafts } from '../../core/decisions/consolidator.js';
 import { classifyGateState } from '../../core/decisions/gate-state.js';
 import { acquireDecisionsLock } from '../../core/decisions/lock.js';
@@ -368,16 +370,116 @@ export async function uninstallClaudeHook(rootPath: string): Promise<void> {
 }
 
 // ============================================================================
+// DECISION AUTOPILOT (change: add-decision-autopilot)
+// ============================================================================
+
+/**
+ * Autopilot gate resolution: auto-accept verified decisions (distinct
+ * `auto-approved` status, actor `autopilot` on the ledger), sync them (plus any
+ * human-approved ones) to specs, and NEVER block the commit — one advisory
+ * stderr line, exit 0. Infrastructure failure degrades to a caveat and exit 0
+ * (the impact-certificate advisory-safety discipline): a broken trail write or
+ * sync must never stop a commit the human is making.
+ *
+ * Legality: only decisions still in `verified` transition — a human-`rejected`
+ * decision is never resurrected by autopilot, and concurrent status changes
+ * win (the CAS mutate re-checks status on the freshest store).
+ */
+async function runAutopilotGate(
+  rootPath: string,
+  config: NonNullable<Awaited<ReturnType<typeof readOpenLoreConfig>>>,
+  jsonMode: boolean,
+): Promise<void> {
+  try {
+    let store = await loadDecisionStore(rootPath);
+    const verifiedIds = getDecisionsByStatus(store, 'verified').map((d) => d.id);
+
+    if (verifiedIds.length > 0) {
+      const now = new Date().toISOString();
+      store = await updateDecisionStore(rootPath, (s) =>
+        verifiedIds.reduce((acc, id) => {
+          const cur = acc.decisions.find((d) => d.id === id);
+          if (!cur || cur.status !== 'verified') return acc; // legality: verified-only
+          return patchDecision(acc, id, {
+            status: 'auto-approved',
+            approvedBy: 'autopilot',
+            reviewedAt: now,
+          });
+        }, s), 'autopilot');
+      for (const id of verifiedIds) {
+        const d = store.decisions.find((x) => x.id === id);
+        if (d?.status === 'auto-approved') {
+          emit(rootPath, 'decisions', { event: 'decision_auto_approved', id, title: d.title, transport: 'cli-gate' });
+        }
+      }
+    }
+
+    // Background-style sync in the same pass (deterministic, no LLM): approved
+    // (human) decisions sync as today; auto-approved sync with the unreviewed
+    // marker and stay in the store as the review queue.
+    const accepted = store.decisions.filter((d) => d.status === 'auto-approved' && d.syncedToSpecs.length === 0);
+    const approved = getDecisionsByStatus(store, 'approved');
+    let syncedCount = 0;
+    let syncErrors: Array<{ id: string; error: string }> = [];
+    if (accepted.length > 0 || approved.length > 0) {
+      const openspecPath = join(rootPath, config.openspecPath ?? OPENSPEC_DIR);
+      if (await fileExists(join(openspecPath, OPENSPEC_SPECS_SUBDIR))) {
+        const specMap = await buildSpecMap({ rootPath, openspecPath });
+        const { result } = await syncApprovedDecisions(store, {
+          rootPath, openspecPath, specMap, includeAutoApproved: true,
+        });
+        syncedCount = result.synced.length;
+        syncErrors = result.errors;
+      }
+    }
+
+    const fresh = await loadDecisionStore(rootPath);
+    const draftCount = getDecisionsByStatus(fresh, 'draft').length;
+    const unreviewedCount = fresh.decisions.filter((d) => d.status === 'auto-approved' && !d.humanReviewedAt).length;
+
+    const parts: string[] = [];
+    if (verifiedIds.length > 0) parts.push(`${verifiedIds.length} decision(s) auto-accepted`);
+    if (syncedCount > 0) parts.push(`${syncedCount} synced to specs`);
+    if (draftCount > 0) parts.push(`${draftCount} draft(s) pending background consolidation`);
+    if (syncErrors.length > 0) parts.push(`${syncErrors.length} sync error(s) — will retry next gate`);
+    if (parts.length > 0 || unreviewedCount > 0) {
+      console.error(
+        `openlore autopilot: ${parts.length ? parts.join(' · ') : 'nothing new'}`
+        + `${unreviewedCount > 0 ? ` · ${unreviewedCount} awaiting review (openlore decisions review)` : ''}`
+        + ` · trail: openlore decisions log`,
+      );
+    }
+    if (jsonMode) {
+      process.stdout.write(JSON.stringify({
+        gated: false,
+        autopilot: true,
+        autoAccepted: verifiedIds.length,
+        synced: syncedCount,
+        draftsPending: draftCount,
+        awaitingReview: unreviewedCount,
+        syncErrors,
+      }, null, 2) + '\n');
+    }
+    process.exitCode = 0;
+  } catch (err) {
+    // Advisory-safety: an autopilot fault never blocks the commit.
+    console.error(`openlore autopilot: skipped (${(err as Error).message}) — commit not blocked`);
+    process.exitCode = 0;
+  }
+}
+
+// ============================================================================
 // DISPLAY HELPERS
 // ============================================================================
 
 function displayDecision(d: PendingDecision, verbose = false): void {
   const icon =
-    d.status === 'verified' ? '✓' :
-    d.status === 'phantom'  ? '↗' :
-    d.status === 'approved' ? '●' :
-    d.status === 'synced'   ? '✔' :
-    d.status === 'rejected' ? '✗' : '○';
+    d.status === 'verified'      ? '✓' :
+    d.status === 'phantom'       ? '↗' :
+    d.status === 'approved'      ? '●' :
+    d.status === 'auto-approved' ? '◉' :
+    d.status === 'synced'        ? '✔' :
+    d.status === 'rejected'      ? '✗' : '○';
 
   const confidence =
     d.confidence === 'high'   ? '\x1b[32mhigh\x1b[0m' :
@@ -425,7 +527,7 @@ export const decisionsCommand = new Command('decisions')
   .option('--sync', 'Sync all approved decisions to spec.md files', false)
   .option('--dry-run', 'Preview sync without writing', false)
   .option('--list', 'List decisions (default action when no other flag given)', false)
-  .option('--status <status>', 'Filter list by status (draft|consolidated|verified|approved|rejected|synced)')
+  .option('--status <status>', 'Filter list by status (draft|consolidated|verified|approved|auto-approved|rejected|synced)')
   .option('--uninstall-hook', 'Remove pre-commit hook', false)
   .option('--verbose', 'Show detailed decision info', false)
   .option('--json', 'Output as JSON', false)
@@ -445,6 +547,12 @@ Examples:
   $ openlore decisions --approve a1b2c3d4          Approve decision a1b2c3d4
   $ openlore decisions --sync                      Sync approved decisions
   $ openlore decisions --status verified --json    Machine-readable output
+  $ openlore decisions log                         Transition ledger (audit trail)
+  $ openlore decisions review                      Auto-accepted decisions awaiting review
+
+Decision autopilot (opt-in: { "governance": { "autopilot": true } } in .openlore/config.json):
+the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accepted
+(unreviewed)", and never blocks a commit. Every transition lands on the ledger.
 `
   )
   .action(async function (this: Command, options: {
@@ -498,11 +606,12 @@ Examples:
       }
       const approvePatch = {
         status: 'approved' as const,
+        approvedBy: 'human' as const,
         reviewedAt: new Date().toISOString(),
         reviewNote: options.note ?? options.reason,
       };
       // CAS so the write can't clobber a concurrent record/consolidate write.
-      const updated = await updateDecisionStore(rootPath, (s) => patchDecision(s, id, approvePatch));
+      const updated = await updateDecisionStore(rootPath, (s) => patchDecision(s, id, approvePatch), 'human');
       emit(rootPath, 'decisions', { event: 'decision_approved', id, title: decision.title, transport: 'cli' });
       logger.success(`Decision ${id} approved.`);
       if (!options.json) displayDecision({ ...decision, status: 'approved' }, true);
@@ -543,7 +652,7 @@ Examples:
         status: 'rejected',
         reviewedAt: new Date().toISOString(),
         reviewNote: options.note ?? options.reason,
-      }));
+      }), 'human');
       emit(rootPath, 'decisions', { event: 'decision_rejected', id, title: decision.title, transport: 'cli' });
       logger.success(`Decision ${id} rejected.`);
 
@@ -675,6 +784,13 @@ Examples:
         return { ...next, lastConsolidatedAt: new Date().toISOString() };
       });
 
+      // Decision autopilot: resolve the freshly-verified decisions without
+      // blocking — auto-accept, sync, advisory line, exit 0. (add-decision-autopilot)
+      if (options.gate && openloreConfig.governance?.autopilot === true) {
+        await runAutopilotGate(rootPath, openloreConfig, options.json);
+        return;
+      }
+
       if (options.json) {
         process.stdout.write(JSON.stringify({ verified, phantom, missing }, null, 2) + '\n');
         if (options.gate && missing.length > 0) process.exitCode = 1;
@@ -695,7 +811,11 @@ Examples:
           }
         }
         await updateDecisionStore(rootPath, (s) =>
-          tuiPatches.reduce((acc, p) => patchDecision(acc, p.id, { status: p.status, reviewedAt }), s));
+          tuiPatches.reduce((acc, p) => patchDecision(acc, p.id, {
+            status: p.status,
+            reviewedAt,
+            ...(p.status === 'approved' ? { approvedBy: 'human' as const } : {}),
+          }), s), 'human');
 
         const stillPending = verified.filter(
           (d) => !results.has(d.id) || results.get(d.id) === 'skipped',
@@ -780,6 +900,12 @@ Examples:
 
     // ── Gate only (no consolidation — consolidation happens on record_decision) ──
     if (options.gate && !options.consolidate) {
+      // Decision autopilot: accept + sync + trail, never block. (add-decision-autopilot)
+      const gateConfig = await readOpenLoreConfig(rootPath);
+      if (gateConfig?.governance?.autopilot === true) {
+        await runAutopilotGate(rootPath, gateConfig, options.json);
+        return;
+      }
       const approved = getDecisionsByStatus(store, 'approved');
       const verified = getDecisionsByStatus(store, 'verified');
       const drafts = getDecisionsByStatus(store, 'draft');
@@ -888,7 +1014,11 @@ Examples:
           }
         }
         await updateDecisionStore(rootPath, (s) =>
-          tuiPatches.reduce((acc, p) => patchDecision(acc, p.id, { status: p.status, reviewedAt }), s));
+          tuiPatches.reduce((acc, p) => patchDecision(acc, p.id, {
+            status: p.status,
+            reviewedAt,
+            ...(p.status === 'approved' ? { approvedBy: 'human' as const } : {}),
+          }), s), 'human');
         const stillPending = verified.filter(
           (d) => !results.has(d.id) || results.get(d.id) === 'skipped',
         );
@@ -983,7 +1113,7 @@ Examples:
     }
 
     // ── Default: list ────────────────────────────────────────────────────────
-    const VALID_STATUSES = new Set(['draft', 'consolidated', 'verified', 'phantom', 'approved', 'rejected', 'synced']);
+    const VALID_STATUSES = new Set(['draft', 'consolidated', 'verified', 'phantom', 'approved', 'auto-approved', 'rejected', 'synced']);
     if (options.status && !VALID_STATUSES.has(options.status)) {
       logger.error(`Invalid status "${options.status}". Valid values: ${[...VALID_STATUSES].join('|')}`);
       process.exitCode = 1;
@@ -1009,6 +1139,173 @@ Examples:
     } catch (err) {
       logger.error(`decisions command failed: ${(err as Error).message}`);
       if (process.env.DEBUG) console.error(err);
+      process.exitCode = 1;
+    } finally {
+      restoreStdout?.();
+    }
+  });
+
+// ============================================================================
+// SUBCOMMANDS: log · review (change: add-decision-autopilot)
+// ============================================================================
+
+/** Resolve a `--since` value to an epoch ms cutoff: ISO date, or a git ref's commit time. */
+async function resolveSinceCutoff(rootPath: string, since: string): Promise<number> {
+  const asDate = Date.parse(since);
+  if (!Number.isNaN(asDate)) return asDate;
+  const { stdout } = await execFileAsync('git', ['show', '-s', '--format=%cI', since], { cwd: rootPath });
+  const t = Date.parse(stdout.trim().split('\n').pop() ?? '');
+  if (Number.isNaN(t)) throw new Error(`--since "${since}" is neither an ISO date nor a resolvable git ref`);
+  return t;
+}
+
+decisionsCommand
+  .command('log')
+  .description('Show the append-only decision transition ledger (newest first)')
+  .option('--json', 'Output as JSON', false)
+  .option('--since <ref>', 'Only entries after this ISO date or git ref (commit time)')
+  .action(async (opts: { json: boolean; since?: string }, cmd: Command) => {
+    // The parent `decisions` command declares same-named options (--json) and,
+    // without positional-option mode, commander parses them greedily out of the
+    // subcommand argv — merge them back so `decisions log --json` works.
+    const parentOpts = (cmd.parent?.opts() ?? {}) as { json?: boolean };
+    const json = Boolean(opts.json || parentOpts.json);
+    const restoreStdout = json ? redirectConsoleToStderr() : null;
+    try {
+      const rootPath = process.cwd();
+      let entries = await readLedger(rootPath);
+      if (opts.since) {
+        const cutoff = await resolveSinceCutoff(rootPath, opts.since);
+        entries = entries.filter((e) => Date.parse(e.at) >= cutoff);
+      }
+      entries.reverse(); // newest first
+
+      if (json) {
+        process.stdout.write(JSON.stringify(entries, null, 2) + '\n');
+        return;
+      }
+      if (entries.length === 0) {
+        console.log('Decision ledger is empty — no transitions recorded yet.');
+        return;
+      }
+      logger.section('Decision Ledger (newest first)');
+      for (const e of entries) {
+        const when = e.at.replace('T', ' ').slice(0, 19);
+        const commit = e.commit ? ` @${e.commit}` : '';
+        console.log(`${when}  [${e.id}] ${e.from ?? '∅'} → ${e.to}  by ${e.actor}${commit}  ${e.title}`);
+      }
+      console.log(`\nTotal: ${entries.length} transition(s)`);
+    } catch (err) {
+      logger.error(`decisions log failed: ${(err as Error).message}`);
+      process.exitCode = 1;
+    } finally {
+      restoreStdout?.();
+    }
+  });
+
+/** Parse a `--promote/--reject` id list ("all" or comma-separated 8-char ids) against the queue. */
+function resolveReviewIds(raw: string, queue: PendingDecision[]): string[] {
+  if (raw.trim().toLowerCase() === 'all') return queue.map((d) => d.id);
+  const ids = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  const queueIds = new Set(queue.map((d) => d.id));
+  const unknown = ids.filter((id) => !queueIds.has(id));
+  if (unknown.length > 0) {
+    throw new Error(`not in the auto-accepted review queue: ${unknown.join(', ')} (see: openlore decisions review)`);
+  }
+  return ids;
+}
+
+decisionsCommand
+  .command('review')
+  .description('List auto-accepted (unreviewed) decisions; --promote or --reject them')
+  .option('--promote <ids>', 'Comma-separated ids, or "all": confirm as human-approved (drops the unreviewed marker)')
+  .option('--reject <ids>', 'Comma-separated ids, or "all": reject and retire from specs (kept queryable in history)')
+  .option('--note <text>', 'Review note to attach')
+  .option('--json', 'Output as JSON', false)
+  .action(async (opts: { promote?: string; reject?: string; note?: string; json: boolean }, cmd: Command) => {
+    // The parent `decisions` command declares same-named options (--reject,
+    // --note, --json) and, without positional-option mode, commander parses
+    // them greedily out of the subcommand argv — merge them back so
+    // `decisions review --reject <ids>` reaches this action.
+    const parentOpts = (cmd.parent?.opts() ?? {}) as { reject?: string; note?: string; json?: boolean };
+    const promoteRaw = opts.promote;
+    const rejectRaw = opts.reject ?? parentOpts.reject;
+    const note = opts.note ?? parentOpts.note;
+    const json = Boolean(opts.json || parentOpts.json);
+    const restoreStdout = json ? redirectConsoleToStderr() : null;
+    try {
+      const rootPath = process.cwd();
+      const store = await loadDecisionStore(rootPath);
+      const queue = store.decisions.filter((d) => d.status === 'auto-approved' && !d.humanReviewedAt);
+
+      if (promoteRaw && rejectRaw) {
+        // Same id in both would be ambiguous; require distinct sets.
+        const overlap = resolveReviewIds(promoteRaw, queue).filter((id) =>
+          resolveReviewIds(rejectRaw, queue).includes(id));
+        if (overlap.length > 0) {
+          logger.error(`ids in both --promote and --reject: ${overlap.join(', ')}`);
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      const now = new Date().toISOString();
+      const results: Array<{ id: string; title: string; disposition: 'promoted' | 'rejected'; specsUpdated: string[] }> = [];
+
+      for (const [raw, disposition] of [[promoteRaw, 'promoted'], [rejectRaw, 'rejected']] as const) {
+        if (!raw) continue;
+        const ids = resolveReviewIds(raw, queue);
+        for (const id of ids) {
+          const decision = queue.find((d) => d.id === id)!;
+          await updateDecisionStore(rootPath, (s) => {
+            const cur = s.decisions.find((d) => d.id === id);
+            // Legality: only a still-unreviewed auto-approved decision transitions.
+            if (!cur || cur.status !== 'auto-approved' || cur.humanReviewedAt) return s;
+            return patchDecision(s, id, {
+              status: disposition === 'promoted' ? 'synced' : 'rejected',
+              humanReviewedAt: now,
+              reviewedAt: now,
+              ...(note ? { reviewNote: note } : {}),
+            });
+          }, 'human');
+          const specsUpdated = await rewriteSyncedDecisionStatus(rootPath, decision, disposition);
+          emit(rootPath, 'decisions', {
+            event: disposition === 'promoted' ? 'decision_review_promoted' : 'decision_review_rejected',
+            id, title: decision.title, transport: 'cli-review',
+          });
+          results.push({ id, title: decision.title, disposition, specsUpdated });
+        }
+      }
+
+      const fresh = await loadDecisionStore(rootPath);
+      const remaining = fresh.decisions.filter((d) => d.status === 'auto-approved' && !d.humanReviewedAt);
+
+      if (json) {
+        process.stdout.write(JSON.stringify({
+          reviewed: results,
+          awaitingReview: remaining.map((d) => ({
+            id: d.id, title: d.title, rationale: d.rationale,
+            reviewedAt: d.reviewedAt, syncedToSpecs: d.syncedToSpecs,
+          })),
+        }, null, 2) + '\n');
+        return;
+      }
+
+      for (const r of results) {
+        const verb = r.disposition === 'promoted' ? 'promoted to Approved' : 'rejected (retired from specs)';
+        logger.success(`[${r.id}] ${verb} — ${r.title}`);
+        for (const p of r.specsUpdated) console.log(`   → ${p}`);
+      }
+      if (remaining.length === 0) {
+        console.log(results.length > 0 ? '\nReview queue is empty.' : 'No auto-accepted decisions await review.');
+        return;
+      }
+      logger.section('Auto-accepted decisions awaiting review');
+      for (const d of remaining) displayDecision(d, true);
+      console.log(`\nPromote: openlore decisions review --promote <id,id|all>`);
+      console.log(`Reject:  openlore decisions review --reject <id,id|all>`);
+    } catch (err) {
+      logger.error(`decisions review failed: ${(err as Error).message}`);
       process.exitCode = 1;
     } finally {
       restoreStdout?.();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -601,6 +601,9 @@ export const OPENLORE_DECISIONS_SUBDIR = 'decisions';
 /** Filename for the pending decisions store */
 export const DECISIONS_PENDING_FILE = 'pending.json';
 
+/** Filename for the append-only decision transition ledger (JSONL, one entry per status transition) */
+export const DECISIONS_LEDGER_FILE = 'ledger.jsonl';
+
 /** Sub-directory inside OPENLORE_DIR where code-anchored agent memory (notes) is stored */
 export const OPENLORE_MEMORY_SUBDIR = 'memory';
 

--- a/src/core/decisions/ledger.test.ts
+++ b/src/core/decisions/ledger.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the decision transition ledger (change: add-decision-autopilot):
+ * pure diffing, append/read round-trip, malformed-line tolerance, and the
+ * automatic trail written by updateDecisionStore.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdir, rm, readFile, appendFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { diffStoreTransitions, appendLedgerEntries, readLedger, ledgerPath } from './ledger.js';
+import { loadDecisionStore, saveDecisionStore, updateDecisionStore, patchDecision } from './store.js';
+import type { PendingDecision, DecisionStore } from '../../types/index.js';
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { warning: vi.fn(), info: vi.fn(), error: vi.fn(), success: vi.fn(), section: vi.fn(), discovery: vi.fn(), analysis: vi.fn(), blank: vi.fn() },
+}));
+
+async function createTempDir(): Promise<string> {
+  const dir = join(tmpdir(), `decisions-ledger-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function makeDecision(overrides: Partial<PendingDecision> = {}): PendingDecision {
+  return {
+    id: 'aaaabbbb',
+    status: 'draft',
+    title: 'Use Redis for caching',
+    rationale: 'Reduces DB load',
+    consequences: 'Cache invalidation to manage',
+    proposedRequirement: null,
+    affectedDomains: ['cache'],
+    affectedFiles: ['src/cache.ts'],
+    sessionId: 'session123',
+    recordedAt: '2026-01-01T00:00:00.000Z',
+    confidence: 'medium',
+    syncedToSpecs: [],
+    ...overrides,
+  };
+}
+
+function makeStore(decisions: PendingDecision[]): DecisionStore {
+  return {
+    version: '1',
+    sessionId: 'session123',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    sequence: 0,
+    decisions,
+  };
+}
+
+describe('diffStoreTransitions', () => {
+  it('emits a creation entry (from: null) for a new decision', () => {
+    const before = makeStore([]);
+    const after = makeStore([makeDecision()]);
+    const entries = diffStoreTransitions(before, after, 'agent', '2026-07-18T00:00:00.000Z', 'abc1234');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ id: 'aaaabbbb', from: null, to: 'draft', actor: 'agent', commit: 'abc1234' });
+  });
+
+  it('emits one entry per status change and none for unchanged decisions', () => {
+    const before = makeStore([
+      makeDecision({ id: 'aaaabbbb', status: 'verified' }),
+      makeDecision({ id: 'ccccdddd', status: 'draft', title: 'Other' }),
+    ]);
+    const after = makeStore([
+      makeDecision({ id: 'aaaabbbb', status: 'auto-approved' }),
+      makeDecision({ id: 'ccccdddd', status: 'draft', title: 'Other' }),
+    ]);
+    const entries = diffStoreTransitions(before, after, 'autopilot', '2026-07-18T00:00:00.000Z');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ id: 'aaaabbbb', from: 'verified', to: 'auto-approved', actor: 'autopilot' });
+    expect(entries[0].commit).toBeUndefined();
+  });
+});
+
+describe('ledger append/read', () => {
+  it('round-trips entries and preserves earlier entries on later appends', async () => {
+    const dir = await createTempDir();
+    try {
+      await appendLedgerEntries(dir, [
+        { id: 'aaaabbbb', title: 'First', from: null, to: 'draft', actor: 'agent', at: '2026-07-18T00:00:00.000Z' },
+      ]);
+      await appendLedgerEntries(dir, [
+        { id: 'aaaabbbb', title: 'First', from: 'draft', to: 'verified', actor: 'sync', at: '2026-07-18T00:01:00.000Z' },
+      ]);
+      const entries = await readLedger(dir);
+      expect(entries).toHaveLength(2);
+      expect(entries[0].to).toBe('draft');
+      expect(entries[1].to).toBe('verified');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips malformed lines without losing valid ones', async () => {
+    const dir = await createTempDir();
+    try {
+      await appendLedgerEntries(dir, [
+        { id: 'aaaabbbb', title: 'First', from: null, to: 'draft', actor: 'agent', at: '2026-07-18T00:00:00.000Z' },
+      ]);
+      await appendFile(ledgerPath(dir), '{"torn": tru\n', 'utf-8');
+      await appendLedgerEntries(dir, [
+        { id: 'aaaabbbb', title: 'First', from: 'draft', to: 'verified', actor: 'sync', at: '2026-07-18T00:01:00.000Z' },
+      ]);
+      const entries = await readLedger(dir);
+      expect(entries).toHaveLength(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('append failure is fail-soft (never throws)', async () => {
+    const dir = await createTempDir();
+    try {
+      // Make the ledger path unwritable by placing a directory where the file goes.
+      await mkdir(ledgerPath(dir), { recursive: true });
+      await expect(appendLedgerEntries(dir, [
+        { id: 'aaaabbbb', title: 'X', from: null, to: 'draft', actor: 'agent', at: '2026-07-18T00:00:00.000Z' },
+      ])).resolves.toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('updateDecisionStore ledger trail', () => {
+  it('trails every committed status transition with the given actor', async () => {
+    const dir = await createTempDir();
+    try {
+      await saveDecisionStore(dir, makeStore([makeDecision({ status: 'verified' })]));
+      await updateDecisionStore(dir, (s) => patchDecision(s, 'aaaabbbb', {
+        status: 'auto-approved', approvedBy: 'autopilot',
+      }), 'autopilot');
+
+      const entries = await readLedger(dir);
+      const transition = entries.find((e) => e.to === 'auto-approved');
+      expect(transition).toBeDefined();
+      expect(transition).toMatchObject({ id: 'aaaabbbb', from: 'verified', actor: 'autopilot' });
+
+      const store = await loadDecisionStore(dir);
+      expect(store.decisions[0].status).toBe('auto-approved');
+      expect(store.decisions[0].approvedBy).toBe('autopilot');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a no-op mutate appends nothing', async () => {
+    const dir = await createTempDir();
+    try {
+      await saveDecisionStore(dir, makeStore([makeDecision()]));
+      await updateDecisionStore(dir, (s) => s, 'human');
+      const entries = await readLedger(dir);
+      expect(entries).toHaveLength(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ledger lines are valid JSONL a human can audit', async () => {
+    const dir = await createTempDir();
+    try {
+      await saveDecisionStore(dir, makeStore([]));
+      await updateDecisionStore(dir, (s) => ({
+        ...s, decisions: [makeDecision()],
+      }), 'agent');
+      const raw = await readFile(ledgerPath(dir), 'utf-8');
+      const lines = raw.trim().split('\n');
+      expect(lines).toHaveLength(1);
+      const parsed = JSON.parse(lines[0]);
+      expect(parsed).toMatchObject({ id: 'aaaabbbb', from: null, to: 'draft', actor: 'agent' });
+      expect(typeof parsed.at).toBe('string');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/decisions/ledger.ts
+++ b/src/core/decisions/ledger.ts
@@ -1,0 +1,136 @@
+/**
+ * Decision transition ledger — append-only audit trail for every decision
+ * status transition, in every mode. (change: add-decision-autopilot)
+ *
+ * One JSONL line per transition in `.openlore/decisions/ledger.jsonl`:
+ *   { id, title, from, to, actor, at, commit? }
+ *
+ * `from: null` marks creation (a new decision entering the store). Actors:
+ *   - 'human'     — explicit approve / reject / review (CLI, TUI, MCP on behalf of a human)
+ *   - 'autopilot' — the decision autopilot auto-accepting a verified decision
+ *   - 'agent'     — an agent recording a draft (record_decision)
+ *   - 'sync'      — system transitions (consolidation, verification, spec sync)
+ *
+ * Writes are a single O_APPEND `appendFile` call per batch — atomic for the
+ * small line sizes involved — and are deliberately fail-soft: a ledger write
+ * failure warns on stderr and never fails the underlying store transition
+ * (losing a trail line is bad; losing the decision write is worse). Existing
+ * entries are never rewritten or deleted.
+ */
+
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+import { DECISIONS_LEDGER_FILE, OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR } from '../../constants.js';
+import { fileExists } from '../../utils/command-helpers.js';
+import type { DecisionStatus, DecisionStore } from '../../types/index.js';
+
+// Path is built locally (not via store.ts) to keep this module dependency-free
+// of the store, which imports the ledger — no import cycle.
+function ledgerDir(rootPath: string): string {
+  return join(rootPath, OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR);
+}
+
+export type LedgerActor = 'human' | 'autopilot' | 'agent' | 'sync';
+
+export interface LedgerEntry {
+  /** 8-char decision id. */
+  id: string;
+  title: string;
+  /** Prior status; null when the decision first entered the store. */
+  from: DecisionStatus | null;
+  to: DecisionStatus;
+  actor: LedgerActor;
+  /** ISO timestamp of the transition. */
+  at: string;
+  /** HEAD commit at transition time (best-effort; absent outside a git repo). */
+  commit?: string;
+}
+
+export function ledgerPath(rootPath: string): string {
+  return join(ledgerDir(rootPath), DECISIONS_LEDGER_FILE);
+}
+
+/**
+ * HEAD commit (short) at transition time, best-effort. During a pre-commit hook
+ * this is the parent of the commit being created — the closest honest anchor
+ * available before the new commit exists. Undefined outside a git repo.
+ */
+export async function currentHeadCommit(rootPath: string): Promise<string | undefined> {
+  try {
+    // Imported lazily so this module stays loadable under tests that partially
+    // mock node:child_process (several decision suites mock only `spawn`).
+    const { execFile } = await import('node:child_process');
+    const { stdout } = await promisify(execFile)('git', ['rev-parse', '--short', 'HEAD'], { cwd: rootPath });
+    const sha = String(stdout).trim();
+    return sha || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Diff two store snapshots into ledger entries: one per status change, plus a
+ * creation entry (from: null) per decision present after but not before. Pure.
+ */
+export function diffStoreTransitions(
+  before: DecisionStore,
+  after: DecisionStore,
+  actor: LedgerActor,
+  at: string,
+  commit?: string,
+): LedgerEntry[] {
+  const prior = new Map(before.decisions.map((d) => [d.id, d]));
+  const entries: LedgerEntry[] = [];
+  for (const d of after.decisions) {
+    const was = prior.get(d.id);
+    if (!was) {
+      entries.push({ id: d.id, title: d.title, from: null, to: d.status, actor, at, ...(commit ? { commit } : {}) });
+    } else if (was.status !== d.status) {
+      entries.push({ id: d.id, title: d.title, from: was.status, to: d.status, actor, at, ...(commit ? { commit } : {}) });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Append entries to the ledger. Fail-soft: warns on stderr, never throws —
+ * the store transition this trails must not be broken by a trail write fault.
+ */
+export async function appendLedgerEntries(rootPath: string, entries: LedgerEntry[]): Promise<void> {
+  if (entries.length === 0) return;
+  try {
+    const path = ledgerPath(rootPath);
+    await mkdir(ledgerDir(rootPath), { recursive: true });
+    const lines = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+    await appendFile(path, lines, 'utf-8');
+  } catch (err) {
+    console.error(`openlore: decision ledger append failed (trail line lost): ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Read the full ledger, oldest-first. Malformed lines are skipped (a torn tail
+ * line from a crashed writer must not poison the readable history).
+ */
+export async function readLedger(rootPath: string): Promise<LedgerEntry[]> {
+  const path = ledgerPath(rootPath);
+  if (!(await fileExists(path))) return [];
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf-8');
+  } catch {
+    return [];
+  }
+  const entries: LedgerEntry[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as LedgerEntry;
+      if (parsed && typeof parsed.id === 'string' && typeof parsed.to === 'string') entries.push(parsed);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return entries;
+}

--- a/src/core/decisions/store.ts
+++ b/src/core/decisions/store.ts
@@ -12,6 +12,7 @@ import {
 } from '../../constants.js';
 import { fileExists } from '../../utils/command-helpers.js';
 import { atomicWriteFile, casUpdate, quarantineCorrupt } from './atomic-store.js';
+import { appendLedgerEntries, currentHeadCommit, diffStoreTransitions, type LedgerActor } from './ledger.js';
 import type { PendingDecision, DecisionStore, DecisionStatus } from '../../types/index.js';
 
 export function decisionsDir(rootPath: string): string {
@@ -73,17 +74,38 @@ export async function saveDecisionStore(rootPath: string, store: DecisionStore):
  * {@link patchDecision}), and commits under compare-and-swap so two concurrent
  * writers never lose a decision — on a conflict the mutate is re-applied to the
  * newer store. (harden-memory-integrity-invariant)
+ *
+ * Every committed status transition (and creation) is trailed on the append-only
+ * decision ledger, attributed to `actor` (change: add-decision-autopilot). The
+ * diff is taken against the exact snapshot the winning mutate ran on, so a CAS
+ * retry never double-logs. Default actor 'sync' marks a system write; callers
+ * acting for a human, an agent, or the autopilot pass that explicitly.
  */
 export async function updateDecisionStore(
   rootPath: string,
   mutate: (store: DecisionStore) => DecisionStore,
+  actor: LedgerActor = 'sync',
 ): Promise<DecisionStore> {
-  return casUpdate<DecisionStore>({
+  // casUpdate re-invokes mutate on a conflict; the last invocation's input is
+  // the snapshot the committed result was derived from.
+  let winningBefore: DecisionStore | undefined;
+  const committed = await casUpdate<DecisionStore>({
     storePath: decisionsPath(rootPath),
     load: () => loadDecisionStore(rootPath),
-    mutate: (current) => ({ ...mutate(current), updatedAt: new Date().toISOString() }),
+    mutate: (current) => {
+      winningBefore = current;
+      return { ...mutate(current), updatedAt: new Date().toISOString() };
+    },
     serialize: (next) => JSON.stringify(next, null, 2) + '\n',
   });
+  if (winningBefore) {
+    const entries = diffStoreTransitions(
+      winningBefore, committed, actor, new Date().toISOString(),
+      await currentHeadCommit(rootPath),
+    );
+    await appendLedgerEntries(rootPath, entries);
+  }
+  return committed;
 }
 
 /**

--- a/src/core/decisions/syncer.ts
+++ b/src/core/decisions/syncer.ts
@@ -30,6 +30,14 @@ export interface SyncOptions {
   openspecPath: string;
   specMap: SpecMap;
   dryRun?: boolean;
+  /**
+   * Also sync `auto-approved` decisions (decision autopilot). Unlike `approved`
+   * decisions — which transition to `synced` and purge — an auto-approved
+   * decision keeps its status after the spec write (it stays in the store as the
+   * human review queue) and its spec entry carries the
+   * "Auto-accepted (unreviewed)" marker. (change: add-decision-autopilot)
+   */
+  includeAutoApproved?: boolean;
 }
 
 export interface SyncResult {
@@ -43,6 +51,11 @@ export async function syncApprovedDecisions(
   options: SyncOptions,
 ): Promise<{ store: DecisionStore; result: SyncResult }> {
   const approved = store.decisions.filter((d) => d.status === 'approved');
+  // Auto-approved decisions re-sync idempotently (spec writes dedupe by id), so
+  // ones already written are skipped by their recorded syncedToSpecs.
+  const autoApproved = options.includeAutoApproved
+    ? store.decisions.filter((d) => d.status === 'auto-approved' && d.syncedToSpecs.length === 0)
+    : [];
   const synced: PendingDecision[] = [];
   const errors: Array<{ id: string; error: string }> = [];
   const modifiedSpecs = new Set<string>();
@@ -60,6 +73,23 @@ export async function syncApprovedDecisions(
         syncedToSpecs: modified,
       });
       synced.push({ ...decision, status: 'synced', syncedAt: now, syncedToSpecs: modified });
+    } catch (err) {
+      errors.push({ id: decision.id, error: String(err) });
+    }
+  }
+
+  for (const decision of autoApproved) {
+    try {
+      const modified = await syncDecision(decision, options);
+      for (const p of modified) modifiedSpecs.add(p);
+      const now = new Date().toISOString();
+      // Status stays 'auto-approved': the decision remains in the store as the
+      // human review queue until promoted or rejected.
+      updatedStore = patchDecision(updatedStore, decision.id, {
+        syncedAt: now,
+        syncedToSpecs: modified,
+      });
+      synced.push({ ...decision, syncedAt: now, syncedToSpecs: modified });
     } catch (err) {
       errors.push({ id: decision.id, error: String(err) });
     }
@@ -207,10 +237,21 @@ function appendDecisionSection(content: string, decision: PendingDecision): stri
   return content.trimEnd() + '\n\n## Decisions\n\n' + entry.trimStart();
 }
 
+/** Human-visible status label for a spec Decisions entry. Auto-accepted
+ * decisions are always marked unreviewed until a human promotes them —
+ * provenance is disclosed, never silently upgraded. (add-decision-autopilot) */
+export const AUTO_ACCEPTED_STATUS_LABEL = 'Auto-accepted (unreviewed)';
+
+function specStatusLabel(decision: PendingDecision): string {
+  return decision.approvedBy === 'autopilot' && !decision.humanReviewedAt
+    ? AUTO_ACCEPTED_STATUS_LABEL
+    : 'Approved';
+}
+
 function buildDecisionEntry(decision: PendingDecision): string {
   return `### ${decision.title}
 
-**Status:** Approved
+**Status:** ${specStatusLabel(decision)}
 **Date:** ${(decision.syncedAt ?? new Date().toISOString()).slice(0, 10)}
 **ID:** ${decision.id}
 
@@ -244,11 +285,14 @@ async function createADR(
   const adrPath = join(decisionsDir, filename);
 
   const domains = decision.affectedDomains.join(', ');
+  const adrStatus = decision.approvedBy === 'autopilot' && !decision.humanReviewedAt
+    ? 'accepted (auto-accepted, unreviewed)'
+    : 'accepted';
   const content = `# ADR-${num}: ${decision.title}
 
 ## Status
 
-accepted
+${adrStatus}
 
 **Domains**: ${domains}
 
@@ -270,6 +314,71 @@ ${decision.consequences}
 
   await writeFile(adrPath, content, 'utf-8');
   return `openspec/decisions/${filename}`;
+}
+
+// ============================================================================
+// Human review of auto-accepted decisions (change: add-decision-autopilot)
+// ============================================================================
+
+/**
+ * Rewrite the status marker of an already-synced decision across the spec/ADR
+ * files it landed in. Used when a human reviews an auto-accepted decision:
+ *   - promote → "Approved" (the unreviewed marker is dropped)
+ *   - reject  → "Rejected (auto-acceptance reverted <date>)" — a supersession-
+ *     style annotation, never a deletion: the entry (and its git history, for
+ *     asOf queries) stays in place, only its authority label changes. A synced
+ *     requirement block is annotated with a rejection line for the same reason.
+ *
+ * Returns the repo-relative paths actually modified. Missing files or absent
+ * markers are skipped silently — the ledger, not the spec text, is the
+ * authoritative trail; this is presentation-layer honesty.
+ */
+export async function rewriteSyncedDecisionStatus(
+  rootPath: string,
+  decision: PendingDecision,
+  disposition: 'promoted' | 'rejected',
+): Promise<string[]> {
+  const date = new Date().toISOString().slice(0, 10);
+  const newLabel = disposition === 'promoted'
+    ? 'Approved'
+    : `Rejected (auto-acceptance reverted ${date})`;
+  const modified: string[] = [];
+
+  for (const relPath of decision.syncedToSpecs) {
+    const absPath = join(rootPath, relPath);
+    if (!(await fileExists(absPath))) continue;
+    let content = await readFile(absPath, 'utf-8');
+    const before = content;
+
+    // Decisions-section entry: the Status line two lines above this id's marker.
+    const entryRe = new RegExp(
+      `(\\*\\*Status:\\*\\* )[^\\n]*(\\n\\*\\*Date:\\*\\* [^\\n]*\\n\\*\\*ID:\\*\\* ${decision.id}\\b)`,
+    );
+    content = content.replace(entryRe, `$1${newLabel}$2`);
+
+    // ADR file: rewrite the Status section when this file carries the decision id.
+    if (content.includes(`> Decision ID: ${decision.id}`)) {
+      content = content.replace(
+        /(## Status\n\n)[^\n]*/,
+        `$1${disposition === 'promoted' ? 'accepted' : `rejected (auto-acceptance reverted ${date})`}`,
+      );
+    }
+
+    // Synced requirement block: annotate on rejection so the requirement is not
+    // read as authoritative; leave untouched on promotion (it already reads clean).
+    if (disposition === 'rejected') {
+      const reqMarker = `> Decision recorded: ${decision.id}`;
+      if (content.includes(reqMarker) && !content.includes(`${reqMarker}\n> Rejected:`)) {
+        content = content.replace(reqMarker, `${reqMarker}\n> Rejected: ${date} (auto-acceptance reverted by human review)`);
+      }
+    }
+
+    if (content !== before) {
+      await writeFile(absPath, content, 'utf-8');
+      modified.push(relPath);
+    }
+  }
+  return modified;
 }
 
 function toPascalCase(str: string): string {

--- a/src/core/services/feature-inventory.test.ts
+++ b/src/core/services/feature-inventory.test.ts
@@ -214,6 +214,7 @@ describe('feature-inventory', () => {
       enforcement: { policy: { x: 'blocking' } },
       panicResponse: { mode: 'advisory' },
       specStore: { name: 's', path: '~/s', targets: [] },
+      governance: { autopilot: true },
     });
     await writeFile(join(dir, '.openlore', 'architecture.json'), '{}');
     await mkdir(join(dir, '.git', 'hooks'), { recursive: true });
@@ -223,8 +224,8 @@ describe('feature-inventory', () => {
       JSON.stringify({ repos: [{ name: 'a' }] })
     );
     const inv = await collectFeatureInventory(dir);
-    // 9 opt-in features, all active.
-    expect(inv.activeCount).toBe(9);
-    expect(inv.optInCount).toBe(9);
+    // 10 opt-in features, all active (decision autopilot added the 10th).
+    expect(inv.activeCount).toBe(10);
+    expect(inv.optInCount).toBe(10);
   });
 });

--- a/src/core/services/feature-inventory.ts
+++ b/src/core/services/feature-inventory.ts
@@ -261,6 +261,21 @@ export async function collectFeatureInventory(rootPath: string): Promise<Feature
     docs: 'docs/ci-cd.md',
   });
 
+  // Decision autopilot (change: add-decision-autopilot).
+  const autopilotOn = config?.governance?.autopilot === true;
+  features.push({
+    id: 'decision-autopilot',
+    title: 'Decision autopilot (auto-accept + audit trail)',
+    group: 'Governance & guardrails',
+    state: autopilotOn ? 'active' : 'inactive',
+    optIn: true,
+    detail: autopilotOn
+      ? 'verified decisions auto-accept and sync; commits never block; trail via `openlore decisions log`'
+      : 'off — the commit gate blocks for human review of verified decisions',
+    activate: autopilotOn ? '' : 'set { "governance": { "autopilot": true } } in .openlore/config.json',
+    docs: 'docs/cli-reference.md',
+  });
+
   // Panic / agent behavioral governance.
   const panicMode = config?.panicResponse?.mode;
   const panicActive = Boolean(panicMode) && panicMode !== 'off';

--- a/src/core/services/mcp-handlers/claim-verification.ts
+++ b/src/core/services/mcp-handlers/claim-verification.ts
@@ -361,6 +361,12 @@ interface DecisionReceipt {
     recordedAt?: string;
     /** The live decision that retired this one, when superseded. */
     supersededBy?: string;
+    /**
+     * Acceptance provenance: 'autopilot' marks an auto-accepted, not-yet-human-
+     * reviewed decision — authoritative, but the agent citing it should disclose
+     * the provenance. (change: add-decision-autopilot)
+     */
+    approvedBy?: 'human' | 'autopilot';
   };
   evidence: string;
 }
@@ -419,7 +425,7 @@ async function verifyDecisionCurrent(absDir: string, subject: string): Promise<u
     const evidence = `decision ${id} ("${shortTitle(target.title)}") was superseded by ${supersededBy}${superseder ? ` ("${shortTitle(superseder.title)}")` : ''}`;
     const receipt: DecisionReceipt = {
       indexCommit,
-      decision: { id, title: target.title, status: target.status, ...(target.recordedAt ? { recordedAt: target.recordedAt } : {}), supersededBy },
+      decision: { id, title: target.title, status: target.status, ...(target.recordedAt ? { recordedAt: target.recordedAt } : {}), ...(target.approvedBy ? { approvedBy: target.approvedBy } : {}), supersededBy },
       evidence,
     };
     return {
@@ -437,17 +443,20 @@ async function verifyDecisionCurrent(absDir: string, subject: string): Promise<u
       claim,
       verdict: 'refuted' as Verdict,
       reason: `${evidence}. Do not cite it as governing code.`,
-      receipt: { indexCommit, decision: { id, title: target.title, status: target.status, ...(target.recordedAt ? { recordedAt: target.recordedAt } : {}) }, evidence } satisfies DecisionReceipt,
+      receipt: { indexCommit, decision: { id, title: target.title, status: target.status, ...(target.recordedAt ? { recordedAt: target.recordedAt } : {}), ...(target.approvedBy ? { approvedBy: target.approvedBy } : {}) }, evidence } satisfies DecisionReceipt,
       confidenceBoundary: cleanBoundary,
     };
   }
 
-  const evidence = `decision ${id} ("${shortTitle(target.title)}") is recorded with status "${target.status}" and is not superseded by any recorded decision`;
+  const provenance = target.approvedBy === 'autopilot' && !target.humanReviewedAt
+    ? ' (auto-accepted by decision autopilot, not yet human-reviewed — disclose this provenance when citing it)'
+    : '';
+  const evidence = `decision ${id} ("${shortTitle(target.title)}") is recorded with status "${target.status}"${provenance} and is not superseded by any recorded decision`;
   return {
     claim,
     verdict: 'confirmed' as Verdict,
     reason: `${evidence}; citing it as current is sound.`,
-    receipt: { indexCommit, decision: { id, title: target.title, status: target.status, ...(target.recordedAt ? { recordedAt: target.recordedAt } : {}) }, evidence } satisfies DecisionReceipt,
+    receipt: { indexCommit, decision: { id, title: target.title, status: target.status, ...(target.recordedAt ? { recordedAt: target.recordedAt } : {}), ...(target.approvedBy ? { approvedBy: target.approvedBy } : {}) }, evidence } satisfies DecisionReceipt,
     confidenceBoundary: cleanBoundary,
   };
 }

--- a/src/core/services/mcp-handlers/decisions.ts
+++ b/src/core/services/mcp-handlers/decisions.ts
@@ -163,7 +163,7 @@ export async function handleRecordDecision(
     await updateDecisionStore(rootPath, (s) => {
       recordedId = makeDecisionId(s.sessionId, primaryDomain, title.trim());
       return upsertDecisions(s, [{ ...decision, id: recordedId, sessionId: s.sessionId }]);
-    });
+    }, 'agent');
 
     // Consolidate in background so commit-time gate is instant
     spawnConsolidateBackground(rootPath);
@@ -208,6 +208,10 @@ export async function handleListDecisions(
         proposedRequirement: d.proposedRequirement,
         recordedAt: d.recordedAt,
         syncedToSpecs: d.syncedToSpecs,
+        // Provenance is always disclosed: an autopilot-accepted decision is
+        // authoritative but never presented as human-reviewed. (add-decision-autopilot)
+        ...(d.approvedBy ? { approvedBy: d.approvedBy } : {}),
+        ...(d.humanReviewedAt ? { humanReviewedAt: d.humanReviewedAt } : {}),
       })),
     };
   } catch (err) {
@@ -234,9 +238,10 @@ export async function handleApproveDecision(
 
     const committed = await updateDecisionStore(rootPath, (s) => patchDecision(s, id, {
       status: 'approved',
+      approvedBy: 'human',
       reviewedAt: new Date().toISOString(),
       reviewNote: note,
-    }));
+    }), 'human');
     // The patch no-ops if the decision was concurrently removed/synced — report
     // honestly rather than a false success.
     const after = committed.decisions.find((d) => d.id === id);
@@ -271,7 +276,7 @@ export async function handleRejectDecision(
       status: 'rejected',
       reviewedAt: new Date().toISOString(),
       reviewNote: note,
-    }));
+    }), 'human');
     const after = committed.decisions.find((d) => d.id === id);
     if (!after || after.status !== 'rejected') {
       return { error: `Decision ${id} could not be rejected — it was concurrently removed or changed.` };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,16 @@ export interface OpenLoreConfig {
    */
   specStore?: SpecStoreConfig;
   /**
+   * Optional governance behavior (change: add-decision-autopilot). With
+   * `autopilot: true`, the decisions commit gate auto-accepts verified decisions
+   * (distinct `auto-approved` status, actor recorded on an append-only ledger),
+   * syncs them to specs, and never blocks a commit; blocking human review is the
+   * behavior when absent/false. Autopilot never touches a human-rejected decision.
+   */
+  governance?: {
+    autopilot?: boolean;
+  };
+  /**
    * Optional declared covering surfaces + advisory posture for the change-impact
    * certificate (change: add-change-impact-certificate). A covering surface is a
    * declared semantic/governance boundary (a set of symbols or files), not a
@@ -588,6 +598,7 @@ export type DecisionStatus =
   | 'verified'      // cross-checked against diff — has code evidence
   | 'phantom'       // recorded but no matching code change found
   | 'approved'      // human/agent approved for sync
+  | 'auto-approved' // accepted by decision autopilot: synced to specs, awaiting optional human review
   | 'rejected'      // human/agent rejected
   | 'synced';       // written to spec files
 
@@ -634,6 +645,16 @@ export interface PendingDecision {
   // Review
   reviewedAt?: string;
   reviewNote?: string;
+  /**
+   * Who accepted this decision: 'human' (explicit approve) or 'autopilot'
+   * (decision autopilot auto-accepted it). Absent on decisions accepted before
+   * this field existed — treated as 'human'. Provenance is never silently
+   * upgraded: a later human review sets humanReviewedAt, it does not rewrite
+   * approvedBy. (change: add-decision-autopilot)
+   */
+  approvedBy?: 'human' | 'autopilot';
+  /** Set when a human reviewed (promoted or rejected) an auto-accepted decision. */
+  humanReviewedAt?: string;
 
   // Sync tracking
   syncedAt?: string;


### PR DESCRIPTION
**Status:** LGTM — built, tested (16 new tests + full suite), and e2e-smoked on the packaged CLI.

**What was missing / the motivation:** The decisions gate had exactly one mode: blocking human review. Every commit with verified decisions stopped for interactive approval or got bypassed with `--no-verify` — which approves nothing, syncs nothing, and leaves no trace. There was no auto-accept mode anywhere, and no transition history: nobody could answer "what did OpenLore accept on my behalf last week?" This is the first build from the onboarding/autopilot spec arc (openspec change `add-decision-autopilot`, included in this PR) and the prerequisite for wiring governance into `openlore install` by default.

**What it does:**
- **`governance.autopilot` config mode** — the gate transitions `verified` decisions to a new, distinct `auto-approved` status (never conflated with human `approved`), syncs them to specs marked **"Auto-accepted (unreviewed)"**, prints one advisory stderr line, and exits 0. Any infrastructure failure degrades to a caveat and still exits 0 (the impact-certificate advisory-safety discipline). Autopilot only ever touches `verified` decisions — a human-rejected decision can never be resurrected.
- **Append-only ledger** — every status transition, in every mode, is diffed inside the CAS store update (`updateDecisionStore`) and appended to `.openlore/decisions/ledger.jsonl` as `{id, title, from, to, actor: human|autopilot|agent|sync, at, commit}` — so no transition can be missed at any call site. Fail-soft: a trail-write fault never breaks the store write.
- **`openlore decisions log [--json] [--since <ref|date>]`** — the trail, newest-first.
- **`openlore decisions review [--promote|--reject <ids|all>]`** — the human back-pressure: promote drops the unreviewed marker in the synced specs; reject retires the entry via a supersession-style annotation (`Rejected (auto-acceptance reverted …)` + a rejection line on the synced requirement) — never deletion, history stays queryable.
- **Provenance disclosed everywhere** — `approvedBy` flows through `list_decisions` and `verify_claim` `decision-current` receipts (an auto-accepted decision verifies as current but the receipt says autopilot accepted it, unreviewed); explicit human approvals now stamp `approvedBy: human`.
- Off by default: with no config key, gate behavior is byte-for-byte today's blocking flow.

**Proof it works:**
- 16 new tests (`ledger.test.ts`, `decisions-autopilot.test.ts`): auto-accept + marker sync + never-blocks, rejected-decision immunity, sync-infra-missing fail-soft, unchanged blocking gate with autopilot off, review promote/reject round-trips with spec rewrites and `asOf`-friendly annotations, gate idempotency (no duplicate spec entries or ledger lines), log rendering, ledger append-only/malformed-line tolerance/fail-soft.
- Full suite: 5,632 passed. The only failures across runs were `mcp-watcher-parity` and `memory-invariant` — the documented flaky-under-full-suite-load pair, unrelated to decisions; both pass in isolation on this branch.
- E2E on the built CLI in a scratch git repo: `decisions --gate` → advisory line + exit 0 + `auto-approved`/`approvedBy: autopilot` + spec marker + ledger entry with commit sha; `review --reject` → spec retirement annotations + `human` ledger entry; second gate idempotent.

**Notes / nits:**
- Commander parses parent-declared option names (`--reject`, `--note`, `--json`) greedily out of subcommand argv; the `log`/`review` actions merge those parent-consumed values back (commented in code) rather than enabling positional-option mode program-wide.
- The ledger's `commit` field is HEAD at transition time (the parent commit during a pre-commit hook) — the closest honest anchor before the new commit exists.
- Follow-ups (out of scope, per the spec arc): `openlore install` wiring autopilot by default (`unify-onboarding-entrypoint`), and the pre-existing `sync_decisions` id-promotion defect tracked by `fix-decision-status-transitions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)