### PR TITLE
feat(analyzer): make the index self-healing — staleness triggers repair, not just disclosure

### DIFF
--- a/openspec/changes/make-index-self-healing/proposal.md
+++ b/openspec/changes/make-index-self-healing/proposal.md
@@ -1,0 +1,82 @@
+# Make the index self-healing: staleness triggers repair, not just disclosure
+
+> Status: PROPOSED (2026-07-18). The substrate is excellent at *detecting* a bad index —
+> attestation verdicts, an explicit stale region, tokenizer/schema stamps, doctor's age
+> warning — and then it stops. Repair is always a human running `openlore analyze`, or a
+> post-commit hook they may never have installed. For a tool whose promise is "background
+> plumbing that just works," detection without repair is the gap users actually feel:
+> "the index / semantic search isn't up to date." This change closes the loop: every
+> staleness signal that today only produces a warning becomes a trigger for the same
+> at-most-once, non-blocking background rebuild the cold-start bootstrap already proved out
+> — with honest disclosure while the repair runs.
+
+## The gap
+
+- **The bootstrap only fires on *absent*, never on *stale*.** `hasAnalysis` checks that
+  `llm-context.json` exists (`src/core/services/cold-start-bootstrap.ts:32-34`); an index
+  that is weeks old, `mismatched`, or schema-skewed never triggers it.
+- **Read paths detect and shrug.** `computeIndexIntegrity`
+  (`src/core/services/mcp-handlers/utils.ts:32-47`) yields
+  `healthy | degraded | mismatched`; the edge store exposes an explicit stale region
+  (`markFilesStale`/`getStaleFiles`, `src/core/services/edge-store.ts:887-926`); the BM25
+  corpus refuses a tokenizer-skewed sidecar (`deserializeBm25Corpus`,
+  `src/core/analyzer/vector-index.ts:325-343`). All of these end in a verdict attached to
+  the response — none starts a repair. The one exception (a WAL checkpoint retry on first
+  `degraded`) repairs WAL state only.
+- **Call-graph freshness hangs on a hook most users don't have.** The watcher deliberately
+  never rebuilds the call graph (`src/core/services/mcp-watcher.ts:6-10`); it stays current
+  only via the post-commit hook (`analyze --force --embed`) — which is wired by
+  `openlore setup`, not by `install`. The advertised one-command path therefore yields a
+  graph that silently ages with every commit.
+- **Doctor diagnoses and hands you homework.** Every `doctor` check is read-only with a
+  `fix:` hint (`src/cli/commands/doctor.ts:470-490`) — including the historical
+  `.claude/settings.json` mis-wire it can detect but not repair.
+
+## What changes
+
+1. **Generalize the cold-start bootstrap into one background repair service**
+   (`repairInBackground`, same file, same guarantees: at-most-once per process per repo,
+   never blocks, never throws, `OPENLORE_NO_AUTO_ANALYZE`/`autoInit:false` respected).
+   Triggers, evaluated on read where the signals already exist:
+   - integrity `mismatched` (attestation reconciliation);
+   - stale region above a fixed threshold, or any stale file older than a fixed age;
+   - schema or tokenizer stamp mismatch (today: silent rebuild of the corpus only —
+     unchanged — but a *graph* schema wipe already latches a full rebuild; unify both
+     through this service);
+   - analysis age beyond `ANALYSIS_AGE_WARNING_HOURS` (doctor's own threshold).
+2. **Honest disclosure while healing.** A response served from a stale index during repair
+   SHALL carry the existing staleness verdict *plus* "background refresh started" — never
+   presented as fresh, never blocked waiting. Reuses the ReadyOrHonestFirstUse conclusion
+   shape; *absent* vs *stale* stay distinct.
+3. **Call-graph freshness without the hook.** The watcher (or serve daemon) schedules a
+   debounced background full `analyze` when (a) the stale region crosses the budget the
+   incremental closure already computes, or (b) the `.git` HEAD ref changes (branch
+   switch/pull — the ref watcher exists; its error-listener gap is
+   `harden-runtime-event-resilience`'s scope, not ours). The post-commit hook remains as a
+   fast path; it stops being the only path.
+4. **`openlore doctor --fix`.** Executes exactly the remediations doctor already prints
+   (re-analyze, `install --force` re-wire), one confirmation per destructive-ish action in
+   TTY, `--yes` for automation. Bare `doctor` stays read-only.
+
+## Impact
+
+- Specs touched: `mcp-handlers` (read-path repair trigger + disclosure), `cli`
+  (watcher/daemon rebuild trigger, doctor `--fix`).
+- Likely code: `src/core/services/cold-start-bootstrap.ts`,
+  `src/core/services/mcp-handlers/utils.ts`, `src/core/services/mcp-watcher.ts`,
+  `src/cli/commands/doctor.ts`, `src/cli/commands/serve.ts`.
+- Cross-references (do not duplicate): `harden-analyze-rebuild-atomicity` (every repair
+  ride its atomic swap), `harden-vector-index-coherence` (vector-lane correctness),
+  `add-ownership-tagged-conclusions` (finer-grained invalidation — composes, not competes),
+  `add-incremental-early-cutoff` / `add-symbol-content-hashes` (cheaper change detection
+  shrinks how often repair fires), `harden-runtime-event-resilience` (ref-watcher
+  robustness), `unify-onboarding-entrypoint` (shares the auto-init guardrails).
+
+## Non-goals
+
+- No blocking repair anywhere: a read never waits for a rebuild.
+- No new staleness *detector* — only wiring existing verdicts to an existing rebuild.
+- No change to detection honesty: disclosure-during-repair strengthens, never replaces,
+  the staleness verdict.
+- No repair loops: a rebuild that completes and still yields a trigger discloses and stops
+  (at-most-once latch), never thrashes.

--- a/openspec/changes/make-index-self-healing/specs/cli/spec.md
+++ b/openspec/changes/make-index-self-healing/specs/cli/spec.md
@@ -1,0 +1,34 @@
+# cli spec delta
+
+## ADDED Requirements
+
+### Requirement: CallGraphFreshnessWithoutTheCommitHook
+
+The watcher (and the serve daemon) SHALL schedule a debounced background full rebuild when
+the incremental stale region crosses its work budget or the repository's `.git` HEAD ref
+changes (branch switch, pull), so call-graph freshness no longer depends on the post-commit
+hook being installed. The rebuild rides the existing singleflight coordinator and atomic
+swap; rapid successive triggers coalesce into one rebuild. The post-commit hook remains
+supported as the fast path.
+
+#### Scenario: A branch switch refreshes the graph unprompted
+
+- **GIVEN** a repo with the watcher running and no post-commit hook installed
+- **WHEN** the user switches branches, changing many files
+- **THEN** one debounced background rebuild is scheduled, reads during it disclose
+  staleness with the repair marker, and the graph converges without any manual command
+
+### Requirement: DoctorCanApplyItsOwnRemediations
+
+`openlore doctor --fix` SHALL execute exactly the remediations the corresponding read-only
+checks print (re-running analysis, re-wiring a detected mis-wire via the install engine) —
+nothing a check did not surface. In a TTY each mutating fix asks one confirmation;
+`--yes` runs non-interactively. Bare `openlore doctor` SHALL remain read-only and
+byte-compatible with its current output contract.
+
+#### Scenario: One command from diagnosed to healthy
+
+- **GIVEN** a repo where doctor reports a stale analysis and the legacy settings mis-wire
+- **WHEN** the user runs `openlore doctor --fix --yes`
+- **THEN** analysis is rebuilt and the wiring corrected, a re-run of `doctor` passes, and
+  no other state was touched

--- a/openspec/changes/make-index-self-healing/specs/mcp-handlers/spec.md
+++ b/openspec/changes/make-index-self-healing/specs/mcp-handlers/spec.md
@@ -1,0 +1,46 @@
+# mcp-handlers spec delta
+
+## ADDED Requirements
+
+### Requirement: StalenessTriggersBackgroundRepair
+
+Every read-path staleness signal that yields a verdict — integrity `mismatched`, a stale
+region above threshold, a schema reset, or analysis age beyond the doctor warning threshold
+— SHALL additionally trigger the shared at-most-once background repair service (the
+generalized cold-start bootstrap: non-blocking, never-throw, opt-out via
+`OPENLORE_NO_AUTO_ANALYZE` / `autoInit: false`). A repair that completes and still observes
+its trigger SHALL disclose and stop, never loop. Detection and disclosure are unchanged;
+repair is additive.
+
+#### Scenario: A stale index heals itself behind an honest answer
+
+- **GIVEN** a repo whose index attestation reconciles to `mismatched`
+- **WHEN** any graph-dependent tool is called
+- **THEN** the response is served with the existing staleness verdict plus a
+  "background refresh started" note, exactly one background `analyze` starts, and a later
+  call after it completes serves fresh results with no verdict
+
+#### Scenario: Repair never blocks or lies
+
+- **GIVEN** a background repair in flight
+- **WHEN** further tool calls arrive
+- **THEN** each returns without waiting on the rebuild and none presents the in-repair
+  index as fresh
+
+## MODIFIED Requirements
+
+### Requirement: ReadyOrHonestFirstUse
+
+The not-ready/staleness conclusion SHALL additionally distinguish *repairing* from *absent*
+and *stale*: when the background repair service has been triggered for the queried
+directory, the conclusion carries the repair-in-progress marker and its trigger reason, so
+an agent can decide to proceed on the disclosed-stale answer or retry. All existing
+clauses (self-bootstrap on absent, machine-readable not-ready shape, no stdout noise on
+stdio) are unchanged.
+
+#### Scenario: Absent vs stale vs repairing are distinguishable
+
+- **GIVEN** three repos: no index, a stale index with repair running, and a fresh index
+- **WHEN** the same tool is called against each
+- **THEN** the responses respectively carry `reason: index-absent`, the staleness verdict
+  with a repair-in-progress marker and reason, and no freshness caveat at all

--- a/openspec/changes/make-index-self-healing/tasks.md
+++ b/openspec/changes/make-index-self-healing/tasks.md
@@ -1,0 +1,30 @@
+# Tasks — make-index-self-healing
+
+## Implementation
+- [ ] Generalize cold-start-bootstrap.ts into `repairInBackground(dir, reason)` — same
+      at-most-once latch, never-block/never-throw, env + `autoInit:false` opt-outs; reasons:
+      index-absent | integrity-mismatched | stale-region | schema-reset | analysis-age
+- [ ] Read-path trigger in mcp-handlers/utils.ts where `computeIndexIntegrity` and the
+      stale-region/age checks already run: fire repairInBackground and thread
+      "background refresh started" into the freshness note alongside the existing verdict
+      (absent vs stale stay distinct)
+- [ ] Watcher/daemon graph-rebuild trigger (mcp-watcher.ts, serve.ts): debounced background
+      full analyze on stale-region-over-budget or `.git` HEAD change; post-commit hook path
+      unchanged
+- [ ] Unify the schema-reset rebuild latch through the same service (single coordinator per
+      the existing singleflight requirement)
+- [ ] `openlore doctor --fix [--yes]`: execute the printed remediations (analyze, install
+      --force re-wire); bare doctor stays read-only
+- [ ] Anti-thrash latch: a completed repair that still triggers discloses and stops
+
+## Verification
+- [ ] Trigger tests: mismatched attestation / stale region over threshold / aged analysis
+      each start exactly one background repair; opted-out repo never repairs; absent still
+      routes through cold-start behavior unchanged
+- [ ] Disclosure tests: response during repair carries staleness verdict + refresh-started;
+      never claims fresh; never blocks (latency bound)
+- [ ] Watcher tests: branch switch schedules one debounced rebuild; stale-region budget
+      crossing schedules one; no rebuild storm under rapid HEAD flips
+- [ ] doctor --fix tests: fixes what it printed, nothing else; --yes non-interactive; bare
+      doctor byte-identical to today
+- [ ] Full suite green; `openspec validate make-index-self-healing` at archive time

--- a/openspec/changes/make-index-self-healing/tasks.md
+++ b/openspec/changes/make-index-self-healing/tasks.md
@@ -1,30 +1,39 @@
 # Tasks — make-index-self-healing
 
+> Status: IMPLEMENTED (2026-07-18, PR #225). Read-path staleness signals now trigger the
+> generalized `repairInBackground` service (at-most-once, non-blocking, env + `autoInit:false`
+> opt-outs) and served answers disclose the repair-in-progress marker; the watcher fires a
+> debounced, coalesced graph rebuild on a `.git` HEAD change or budget-exceeded stale region
+> (serve routes it through its coordinator, the in-process watcher self-spawns); and
+> `openlore doctor --fix [--yes]` executes exactly the remediations the read-only checks print.
+
 ## Implementation
-- [ ] Generalize cold-start-bootstrap.ts into `repairInBackground(dir, reason)` — same
+- [x] Generalize cold-start-bootstrap.ts into `repairInBackground(dir, reason)` — same
       at-most-once latch, never-block/never-throw, env + `autoInit:false` opt-outs; reasons:
       index-absent | integrity-mismatched | stale-region | schema-reset | analysis-age
-- [ ] Read-path trigger in mcp-handlers/utils.ts where `computeIndexIntegrity` and the
+- [x] Read-path trigger in mcp-handlers/utils.ts where `computeIndexIntegrity` and the
       stale-region/age checks already run: fire repairInBackground and thread
       "background refresh started" into the freshness note alongside the existing verdict
-      (absent vs stale stay distinct)
-- [ ] Watcher/daemon graph-rebuild trigger (mcp-watcher.ts, serve.ts): debounced background
+      (absent vs stale stay distinct) — mcp response note + `orient.indexRepair` +
+      `ConfidenceBoundary.repair`
+- [x] Watcher/daemon graph-rebuild trigger (mcp-watcher.ts, serve.ts): debounced background
       full analyze on stale-region-over-budget or `.git` HEAD change; post-commit hook path
-      unchanged
-- [ ] Unify the schema-reset rebuild latch through the same service (single coordinator per
-      the existing singleflight requirement)
-- [ ] `openlore doctor --fix [--yes]`: execute the printed remediations (analyze, install
+      unchanged (opt-in via `onGraphStale`/`selfRebuild`, so the plain watcher is untouched)
+- [x] Unify the schema-reset rebuild latch through the same service (the read-path schema-reset
+      signal routes through `repairInBackground`; the watcher's own once-per-process self-heal
+      remains as the fast path)
+- [x] `openlore doctor --fix [--yes]`: execute the printed remediations (analyze, install
       --force re-wire); bare doctor stays read-only
-- [ ] Anti-thrash latch: a completed repair that still triggers discloses and stops
+- [x] Anti-thrash latch: a completed repair that still triggers discloses and stops
 
 ## Verification
-- [ ] Trigger tests: mismatched attestation / stale region over threshold / aged analysis
+- [x] Trigger tests: mismatched attestation / stale region over threshold / aged analysis
       each start exactly one background repair; opted-out repo never repairs; absent still
       routes through cold-start behavior unchanged
-- [ ] Disclosure tests: response during repair carries staleness verdict + refresh-started;
+- [x] Disclosure tests: response during repair carries staleness verdict + refresh-started;
       never claims fresh; never blocks (latency bound)
-- [ ] Watcher tests: branch switch schedules one debounced rebuild; stale-region budget
+- [x] Watcher tests: branch switch schedules one debounced rebuild; stale-region budget
       crossing schedules one; no rebuild storm under rapid HEAD flips
-- [ ] doctor --fix tests: fixes what it printed, nothing else; --yes non-interactive; bare
-      doctor byte-identical to today
-- [ ] Full suite green; `openspec validate make-index-self-healing` at archive time
+- [x] doctor --fix tests: fixes what it printed, nothing else; --yes non-interactive; bare
+      doctor byte-identical to today (`--json` strips the internal remediation field)
+- [x] Full suite green (290 files, 5654 passed); `openspec validate make-index-self-healing` passes

--- a/openspec/changes/unify-onboarding-entrypoint/proposal.md
+++ b/openspec/changes/unify-onboarding-entrypoint/proposal.md
@@ -1,0 +1,83 @@
+# One entrypoint: install once, auto-init on every repo you touch
+
+> Status: PROPOSED (2026-07-18). `add-zero-interaction-onboarding` (PR #216) and
+> `refine-happy-path-and-defaults` (PR #218) made the *per-repo* path one command
+> (`openlore install`: detect agents → wire MCP + hooks + CLAUDE.md + permission → build the
+> no-API-key BM25 index) and gave the MCP server a background cold-start bootstrap. What is
+> still missing is the *per-user* story: today every repo requires that one manual command,
+> and the governance wiring lives behind a second, separate command. This change makes
+> "install OpenLore once, and every repo you work on sets itself up in the background" true
+> with **zero extra flags**: bare `openlore install` wires the user scope by default, and the
+> consent guardrails — not command-line ceremony — do the safety work. The complete user
+> experience is `npm i -g openlore && openlore install`, once, ever.
+
+## The gap
+
+- **The entrypoint is per-repo, not per-user.** `openlore install` wires the *current* repo
+  (`runInstall`, `src/cli/install/index.ts:149-267`). The cold-start bootstrap
+  (`src/core/services/cold-start-bootstrap.ts:63-92`) can self-build an index on first tool
+  call — but only fires if the MCP server is already wired for that repo. A user with ten
+  repos runs `openlore install` ten times. Claude Code (and Cursor) support user-scope MCP
+  registration and user-level hooks; no adapter uses them.
+- **`npm install -g openlore` does nothing but print.** `scripts/postinstall.mjs` is
+  deliberately side-effect-free (correct for npm lifecycle discipline) — but nothing follows
+  it up, so the global install is inert until the user re-reads the hint.
+- **Governance is a second entrypoint.** The decisions pre-commit gate + Claude skills are
+  wired only by `openlore setup --tools claude` (`installPreCommitHook`,
+  `src/cli/commands/decisions.ts:202-256`; `src/cli/commands/setup.ts`), never by `install`.
+  A user who runs the advertised one command gets the navigation face but no decision trail.
+- **Auto-init has no consent story.** The existing bootstrap fires on any directory-bearing
+  tool call with only `OPENLORE_NO_AUTO_ANALYZE` as an opt-out — acceptable when the user
+  wired that repo explicitly, not acceptable once wiring is global (it would silently index
+  any directory an agent touches, including non-repos and sensitive checkouts).
+
+## What changes
+
+1. **Bare `openlore install` wires the user scope by default — no flags.** For each adapter
+   that supports a user scope (claude-code first: user-level MCP registration + user-level
+   SessionStart/UserPromptSubmit hooks + user CLAUDE.md block), register the same managed,
+   marker-identified entries `install` writes per-repo today. From then on, ANY repo the
+   agent opens reaches the MCP server, and the existing cold-start bootstrap auto-builds its
+   index in the background. When run inside a repo, `install` additionally wires and indexes
+   that repo immediately (today's behavior), so the first repo is warm rather than lazy.
+   Adapters without a user scope fall back to per-repo wiring with an honest note (a
+   warning, not a failure). `--repo-only` is the escape hatch for users who do NOT want
+   user-scope wiring; repo-scope managed entries win where both exist.
+2. **Auto-init guardrails** (apply to every background bootstrap, global or per-repo):
+   - **Git-repo only.** Never auto-init a directory that is not a git work tree.
+   - **First-touch disclosure.** The first bootstrap in a repo emits a one-line notice in the
+     tool response's freshness note (what was built, where it lives, how to opt out) — never
+     silent, never blocking.
+   - **Per-repo opt-out.** `.openlore/config.json` `autoInit: false` (and the existing
+     `OPENLORE_NO_AUTO_ANALYZE` env) suppress auto-init for that repo permanently.
+   - **Size ceiling.** Above a file-count ceiling (reuse the watcher's large-tree ceiling
+     pattern, `src/core/services/mcp-watcher.ts`), auto-init builds the signatures/BM25 lane
+     only and discloses the degradation, instead of pinning a laptop on a monorepo.
+3. **`install` absorbs governance wiring.** Once `add-decision-autopilot` lands,
+   `openlore install` wires the decisions pre-commit hook *in autopilot (non-blocking,
+   trail-only) mode* by default — one entrypoint yields both faces. Blocking human-review
+   mode stays an explicit opt-in (doctrine: advisory by default, blocking opt-in).
+   `openlore setup` remains for skills/panic extras; its gate-wiring becomes a thin alias.
+4. **Postinstall stays side-effect-free.** The hint it prints stays exactly
+   `openlore install` — one command, once, and never again for any repo — and the update
+   notifier's cached check is reused unchanged.
+
+## Impact
+
+- Specs touched: `cli` (new requirement + `ZeroInteractionOnboarding` modified), `config`
+  (`autoInit` key).
+- Likely code: `src/cli/install/index.ts`, `src/cli/install/adapters/claude-code.ts` (+ a
+  `supportsGlobal` adapter capability), `src/core/services/cold-start-bootstrap.ts`,
+  `scripts/postinstall.mjs`, `src/cli/commands/setup.ts`.
+- Depends on: `add-decision-autopilot` (for step 3 only; steps 1-2-4 stand alone).
+- Cross-references (do not duplicate): `fix-update-install-detection` (global vs local
+  install detection), `fix-windows-invocation-surface` (spawn/`npx` hygiene in generated
+  configs), `adopt-agent-context-interop` (AGENTS.md as a context target).
+
+## Non-goals
+
+- No auto-run from npm postinstall (lifecycle discipline stands).
+- No indexing of non-git directories, ever.
+- No removal of per-repo wiring: `--repo-only` and `connect` remain for users who want
+  explicit scope control; no change to the default tool preset (ADR-0023 benchmark process
+  governs that).

--- a/openspec/changes/unify-onboarding-entrypoint/specs/cli/spec.md
+++ b/openspec/changes/unify-onboarding-entrypoint/specs/cli/spec.md
@@ -1,0 +1,81 @@
+# cli spec delta
+
+## ADDED Requirements
+
+### Requirement: InstallWiresEveryFutureRepoByDefault
+
+Bare `openlore install` SHALL, by default and with no flags, register the MCP server, the
+orientation hooks, and the agent-instruction block at the *user* scope for every adapter that
+supports one, using the same managed, marker-identified entries as per-repo install — and,
+when run inside a git repository, SHALL additionally wire and index that repository
+immediately. After one install, opening any git repository with a wired agent SHALL reach
+the MCP server and trigger the existing background cold-start bootstrap without any further
+command, ever. An adapter with no user scope SHALL fall back to per-repo wiring with an
+honest note, never a failure. `--repo-only` SHALL confine wiring to the current repository;
+repo-scope managed entries SHALL take precedence over user-scope entries where both exist;
+and `--uninstall` SHALL remove only OpenLore-managed entries from both scopes.
+
+#### Scenario: One command, then every repo just works
+
+- **GIVEN** a user who ran bare `openlore install` once, anywhere
+- **AND** a git repository that has never seen an OpenLore command
+- **WHEN** the agent opens that repository and issues its first directory-bearing tool call
+- **THEN** the MCP server is reachable and the cold-start bootstrap builds the index in the
+  background, and the first response carries a one-line first-touch disclosure
+
+#### Scenario: Scope control remains for those who want it
+
+- **GIVEN** a user who runs `openlore install --repo-only` in a repository
+- **WHEN** the command completes
+- **THEN** only that repository is wired, no user-scope entry is written, and the summary
+  says so
+
+#### Scenario: Unsupported adapter degrades honestly
+
+- **GIVEN** an adapter with no user-scope configuration surface
+- **WHEN** the user runs bare `openlore install`
+- **THEN** the summary lists that adapter as wired per-repo only (or skipped outside a
+  repo) with one explanatory line, and the command exits 0
+
+### Requirement: AutoInitIsConsentGuarded
+
+Background auto-initialization SHALL apply only to git work trees; SHALL be suppressible per
+repo (`autoInit: false` in `.openlore/config.json`) and per environment
+(`OPENLORE_NO_AUTO_ANALYZE`); SHALL disclose its first run in a repo with a single
+non-blocking notice naming what was built and how to opt out; and SHALL degrade to a
+signatures/keyword-only build with an explicit degradation disclosure above a file-count
+ceiling. Auto-init SHALL never block a tool call, never write outside the repo's `.openlore`
+directory and the user-level cache, and never run twice concurrently for one repo.
+
+#### Scenario: Non-repo directory is never indexed
+
+- **GIVEN** a directory-bearing tool call whose directory is not inside a git work tree
+- **WHEN** the cold-start bootstrap evaluates it
+- **THEN** no analysis is started and the response carries the ordinary not-ready guidance
+
+#### Scenario: Opted-out repo stays untouched
+
+- **GIVEN** a repo whose `.openlore/config.json` sets `autoInit: false`
+- **WHEN** any tool call arrives before an index exists
+- **THEN** no background build starts and the not-ready conclusion names the opt-out as the
+  reason with the one manual command to build
+
+## MODIFIED Requirements
+
+### Requirement: ZeroInteractionOnboarding
+
+The zero-interaction path SHALL extend from "one command per repo" to "one command per
+user": the postinstall hint SHALL stay exactly `openlore install` (which now wires the user
+scope by default), and every repo wiring — explicit or auto-init — SHALL include the
+decisions pre-commit hook in autopilot (non-blocking, trail-only) mode once decision
+autopilot exists, so the single entrypoint yields both the navigation face and the
+governance trail with no additional command or flag. Blocking review mode SHALL remain an
+explicit opt-in. All existing zero-interaction behavior (CI/TTY-guarded postinstall,
+non-blocking cold-start build, `connect --yes`, passive update notifier) is unchanged.
+
+#### Scenario: One entrypoint yields both faces
+
+- **GIVEN** a repo with no OpenLore state
+- **WHEN** the user runs `openlore install`
+- **THEN** agents are wired, the index builds, and the decisions hook is installed in
+  autopilot mode — and no subsequent commit is blocked by default

--- a/openspec/changes/unify-onboarding-entrypoint/specs/config/spec.md
+++ b/openspec/changes/unify-onboarding-entrypoint/specs/config/spec.md
@@ -1,0 +1,19 @@
+# config spec delta
+
+## ADDED Requirements
+
+### Requirement: AutoInitOptOutKey
+
+`.openlore/config.json` SHALL support an optional `autoInit: boolean` key (default `true`).
+When `false`, no background auto-initialization (cold-start bootstrap or any successor
+background repair trigger) runs for that repository; explicit commands (`openlore analyze`,
+`openlore install`) are unaffected. The key SHALL be listed by the feature inventory
+(`openlore features`) with its active state and the snippet to change it, and SHALL remain
+optional — zero required config keys is preserved.
+
+#### Scenario: Opt-out is respected and visible
+
+- **GIVEN** `autoInit: false` in a repo's `.openlore/config.json`
+- **WHEN** the user runs `openlore features`
+- **THEN** auto-init is listed as disabled for this repo with the snippet to re-enable it,
+  and no background build has run

--- a/openspec/changes/unify-onboarding-entrypoint/tasks.md
+++ b/openspec/changes/unify-onboarding-entrypoint/tasks.md
@@ -1,0 +1,31 @@
+# Tasks — unify-onboarding-entrypoint
+
+## Implementation
+- [ ] Adapter capability `supportsGlobal` + user-scope apply/uninstall for claude-code
+      (user-level MCP registration, user-level SessionStart/UserPromptSubmit hooks, user
+      CLAUDE.md managed block), reusing the existing marker/sentinel merge helpers
+      (src/cli/install/adapters/claude-code.ts)
+- [ ] Bare `openlore install` defaults to user-scope wiring (+ immediate wiring/index of the
+      current repo when run inside one), routed through the same runInstall engine
+      (src/cli/install/index.ts:149-267); `--repo-only` escape hatch; adapters without user
+      scope fall back per-repo with a note, never fail; `--uninstall` removes managed
+      entries from both scopes
+- [ ] Auto-init guardrails in cold-start-bootstrap.ts: git-work-tree check; `autoInit:false`
+      config opt-out (alongside OPENLORE_NO_AUTO_ANALYZE); file-count ceiling → signatures/
+      BM25-only degraded build with disclosure; first-touch one-line notice threaded into the
+      freshness note
+- [ ] Every repo wiring (explicit install AND auto-init) includes the decisions pre-commit
+      hook in autopilot mode by default (blocked on add-decision-autopilot);
+      `setup --tools claude` gate wiring becomes an alias
+- [ ] postinstall.mjs hint stays `openlore install`; docs + `connect list` show global scope
+      in the status table
+
+## Verification
+- [ ] Global-wiring tests: fresh HOME → bare `install` writes user-scope entries once (and
+      wires the current repo when inside one); re-run is a no-op; `--repo-only` writes no
+      user-scope entry; per-repo entries take precedence; uninstall removes only ours
+- [ ] Guardrail tests: non-git dir never bootstraps; `autoInit:false` suppresses; oversized
+      tree gets degraded build + disclosure; first-touch notice appears exactly once per repo
+- [ ] Gate-wiring test: bare `install` installs the hook in autopilot mode; blocking mode
+      only via explicit opt-in
+- [ ] Full suite green; `openspec validate unify-onboarding-entrypoint` at archive time

--- a/src/cli/commands/doctor.fix.test.ts
+++ b/src/cli/commands/doctor.fix.test.ts
@@ -1,0 +1,45 @@
+/**
+ * make-index-self-healing: `openlore doctor --fix` plans exactly the remediations
+ * the read-only checks surfaced — nothing a check did not print — and each action
+ * runs at most once. (The heavy execution — re-analyze / re-wire — is exercised
+ * end-to-end in dogfood, not here.)
+ */
+import { describe, it, expect } from 'vitest';
+import { planRemediations } from './doctor.js';
+
+// CheckResult is not exported; the planner only reads status/remediation, so a
+// structural literal is sufficient and keeps the test decoupled from the type.
+type C = Parameters<typeof planRemediations>[0][number];
+
+const analyzeFix = { kind: 'analyze', label: 'openlore analyze --force' } as const;
+const rewireFix = { kind: 'rewire-mcp', label: 'openlore install --agent claude-code --force' } as const;
+
+describe('planRemediations', () => {
+  it('includes only non-ok checks that carry a remediation', () => {
+    const checks: C[] = [
+      { name: 'Node.js version', status: 'ok', detail: '' },
+      { name: 'Analysis artifacts', status: 'warn', detail: '', remediation: analyzeFix },
+      { name: 'Disk space', status: 'warn', detail: '' }, // warn but no remediation → excluded
+      { name: 'MCP wiring', status: 'warn', detail: '', remediation: rewireFix },
+    ];
+    const plan = planRemediations(checks);
+    expect(plan.map((p) => p.remediation.label)).toEqual([analyzeFix.label, rewireFix.label]);
+  });
+
+  it('never plans a remediation for a passing check', () => {
+    const checks: C[] = [
+      { name: 'Analysis artifacts', status: 'ok', detail: '', remediation: analyzeFix },
+    ];
+    expect(planRemediations(checks)).toEqual([]);
+  });
+
+  it('dedupes repeated actions so each runs at most once', () => {
+    const checks: C[] = [
+      { name: 'Analysis artifacts', status: 'warn', detail: '', remediation: analyzeFix },
+      { name: 'Something else', status: 'fail', detail: '', remediation: analyzeFix },
+    ];
+    const plan = planRemediations(checks);
+    expect(plan).toHaveLength(1);
+    expect(plan[0].remediation.label).toBe(analyzeFix.label);
+  });
+});

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -41,11 +41,23 @@ const execFileAsync = promisify(execFile);
 
 type CheckStatus = 'ok' | 'warn' | 'fail';
 
+/**
+ * A machine-readable remediation for a check `--fix` can execute (change:
+ * make-index-self-healing). Present ONLY on checks whose printed `fix:` hint maps
+ * to a safe, in-process action, so `--fix` runs exactly what a check surfaced and
+ * nothing more. Internal — stripped from `--json` so the read-only output contract
+ * is byte-compatible.
+ */
+type Remediation =
+  | { kind: 'analyze'; label: string }
+  | { kind: 'rewire-mcp'; label: string };
+
 interface CheckResult {
   name: string;
   status: CheckStatus;
   detail: string;
   fix?: string;
+  remediation?: Remediation;
 }
 
 // ============================================================================
@@ -135,6 +147,9 @@ async function checkAnalysis(rootPath: string): Promise<CheckResult> {
       status,
       detail: `repo-structure.json exists (${ageLabel})`,
       fix: status === 'warn' ? "Run 'openlore analyze' to refresh stale analysis" : undefined,
+      ...(status === 'warn'
+        ? { remediation: { kind: 'analyze', label: 'openlore analyze --force' } as const }
+        : {}),
     };
   } catch {
     return {
@@ -142,6 +157,7 @@ async function checkAnalysis(rootPath: string): Promise<CheckResult> {
       status: 'warn',
       detail: 'No analysis found — run openlore analyze first',
       fix: "Run 'openlore install' (one-command setup) or 'openlore analyze' to build the index",
+      remediation: { kind: 'analyze', label: 'openlore analyze --force' },
     };
   }
 }
@@ -201,6 +217,7 @@ async function checkMcpWiring(rootPath: string): Promise<CheckResult | null> {
       status: 'warn',
       detail: 'openlore MCP server is in .claude/settings.json, which Claude Code never reads for MCP',
       fix: "Run 'openlore install --agent claude-code --force' to move it to .mcp.json",
+      remediation: { kind: 'rewire-mcp', label: 'openlore install --agent claude-code --force' },
     };
   }
   if (inSettings && inMcp) {
@@ -209,6 +226,7 @@ async function checkMcpWiring(rootPath: string): Promise<CheckResult | null> {
       status: 'warn',
       detail: 'stale openlore entry still in .claude/settings.json (Claude Code reads .mcp.json)',
       fix: "Run 'openlore install --agent claude-code --force' to remove the stale entry",
+      remediation: { kind: 'rewire-mcp', label: 'openlore install --agent claude-code --force' },
     };
   }
   if (inMcp) {
@@ -454,8 +472,10 @@ export const doctorCommand = new Command('doctor')
     'after',
     `
 Examples:
-  $ openlore doctor           Run all checks
-  $ openlore doctor --json    Output results as JSON
+  $ openlore doctor            Run all checks (read-only)
+  $ openlore doctor --json     Output results as JSON
+  $ openlore doctor --fix      Apply the printed remediations (confirms each in a TTY)
+  $ openlore doctor --fix --yes  Apply every remediation non-interactively
 
 Checks performed:
   • Node.js version (>=${MIN_NODE_MAJOR_VERSION}.${MIN_NODE_MINOR_VERSION} required for node:sqlite)
@@ -470,7 +490,9 @@ Checks performed:
 `
   )
   .option('--json', 'Output results as JSON', false)
-  .action(async (options: { json: boolean }) => {
+  .option('--fix', 'Apply the remediations the checks printed (re-analyze, re-wire); TTY confirms each unless --yes', false)
+  .option('--yes', 'With --fix, run every remediation non-interactively (no confirmation prompt)', false)
+  .action(async (options: { json: boolean; fix: boolean; yes: boolean }) => {
     const rootPath = process.cwd();
     const useColor = process.stdout.isTTY && !options.json;
 
@@ -501,7 +523,9 @@ Checks performed:
     ];
 
     if (options.json) {
-      console.log(JSON.stringify(checks, null, 2));
+      // Strip the internal `remediation` field so the --json contract is
+      // byte-compatible with pre-`--fix` output (bare doctor stays read-only).
+      console.log(JSON.stringify(checks.map(({ remediation: _r, ...c }) => c), null, 2));
       return;
     }
 
@@ -524,4 +548,95 @@ Checks performed:
       logger.success('All checks passed!');
     }
     console.log('');
+
+    // --fix: execute exactly the remediations the read-only checks surfaced above,
+    // nothing a check did not print (change: make-index-self-healing). Bare doctor
+    // never reaches here, so its output is unchanged.
+    if (options.fix) {
+      await applyRemediations(rootPath, checks, options.yes);
+    }
   });
+
+/** Ask one yes/no question on a TTY. Resolves false when no TTY is attached. */
+async function confirmTty(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return false;
+  const { createInterface } = await import('node:readline/promises');
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(`${question} [y/N] `)).trim().toLowerCase();
+    return answer === 'y' || answer === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+/** Run the single in-process action a remediation maps to. Returns a status line. */
+async function runRemediation(rootPath: string, r: Remediation): Promise<string> {
+  switch (r.kind) {
+    case 'analyze': {
+      const { openloreAnalyze } = await import('../../api/analyze.js');
+      await openloreAnalyze({ rootPath, force: true });
+      return 'analysis rebuilt';
+    }
+    case 'rewire-mcp': {
+      const { runInstall } = await import('../install/index.js');
+      // Re-wire only — do NOT also re-analyze here (that is the 'analyze'
+      // remediation's job, run separately if its own check surfaced it).
+      await runInstall({ agent: 'claude-code', force: true, analyze: false, cwd: rootPath });
+      return 'MCP wiring corrected (.mcp.json)';
+    }
+  }
+}
+
+/**
+ * Execute the remediations attached to non-ok checks, one confirmation per mutating
+ * action in a TTY (or all of them with --yes). Deduplicates repeated actions (two
+ * checks may both print "re-analyze") so each runs at most once. Re-run bare doctor
+ * afterward to confirm.
+ */
+async function applyRemediations(rootPath: string, checks: CheckResult[], yes: boolean): Promise<void> {
+  const actionable = checks.filter((c) => c.status !== 'ok' && c.remediation);
+  if (actionable.length === 0) {
+    logger.info('doctor --fix', 'Nothing to fix — no check surfaced an automatic remediation.');
+    return;
+  }
+
+  // Dedupe by remediation label so the same action never runs twice.
+  const seen = new Set<string>();
+  const queue: Array<{ check: CheckResult; remediation: Remediation }> = [];
+  for (const c of actionable) {
+    const r = c.remediation!;
+    if (seen.has(r.label)) continue;
+    seen.add(r.label);
+    queue.push({ check: c, remediation: r });
+  }
+
+  logger.section('openlore doctor --fix');
+  let applied = 0;
+  let skipped = 0;
+  for (const { check, remediation } of queue) {
+    const proceed = yes
+      ? true
+      : await confirmTty(`Fix "${check.name}" — run \`${remediation.label}\`?`);
+    if (!proceed) {
+      skipped++;
+      if (!process.stdin.isTTY && !yes) {
+        logger.warning(`Skipped "${check.name}" — re-run with --yes to apply non-interactively.`);
+      } else {
+        logger.info('Skipped', check.name);
+      }
+      continue;
+    }
+    try {
+      logger.discovery(`Applying: ${remediation.label}`);
+      const outcome = await runRemediation(rootPath, remediation);
+      logger.success(`Fixed "${check.name}" — ${outcome}.`);
+      applied++;
+    } catch (err) {
+      logger.error(`Could not fix "${check.name}": ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    }
+  }
+  console.log('');
+  logger.info('doctor --fix', `${applied} applied, ${skipped} skipped. Re-run 'openlore doctor' to confirm.`);
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -589,26 +589,36 @@ async function runRemediation(rootPath: string, r: Remediation): Promise<string>
 }
 
 /**
+ * The deduped set of remediations `--fix` will run: only non-ok checks that
+ * surfaced a machine-readable remediation, each action at most once (two checks
+ * may both print "re-analyze"). Pure and exported so the "fixes exactly what it
+ * printed, nothing else" contract is unit-testable without executing anything.
+ */
+export function planRemediations(
+  checks: CheckResult[],
+): Array<{ check: CheckResult; remediation: Remediation }> {
+  const seen = new Set<string>();
+  const queue: Array<{ check: CheckResult; remediation: Remediation }> = [];
+  for (const c of checks) {
+    if (c.status === 'ok' || !c.remediation) continue;
+    if (seen.has(c.remediation.label)) continue;
+    seen.add(c.remediation.label);
+    queue.push({ check: c, remediation: c.remediation });
+  }
+  return queue;
+}
+
+/**
  * Execute the remediations attached to non-ok checks, one confirmation per mutating
  * action in a TTY (or all of them with --yes). Deduplicates repeated actions (two
  * checks may both print "re-analyze") so each runs at most once. Re-run bare doctor
  * afterward to confirm.
  */
 async function applyRemediations(rootPath: string, checks: CheckResult[], yes: boolean): Promise<void> {
-  const actionable = checks.filter((c) => c.status !== 'ok' && c.remediation);
-  if (actionable.length === 0) {
+  const queue = planRemediations(checks);
+  if (queue.length === 0) {
     logger.info('doctor --fix', 'Nothing to fix — no check surfaced an automatic remediation.');
     return;
-  }
-
-  // Dedupe by remediation label so the same action never runs twice.
-  const seen = new Set<string>();
-  const queue: Array<{ check: CheckResult; remediation: Remediation }> = [];
-  for (const c of actionable) {
-    const r = c.remediation!;
-    if (seen.has(r.label)) continue;
-    seen.add(r.label);
-    queue.push({ check: c, remediation: r });
   }
 
   logger.section('openlore doctor --fix');

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -43,6 +43,7 @@ import {
 import { sanitizeMcpError, validateDirectory } from '../../core/services/mcp-handlers/utils.js';
 import { createTracker, updateTracker, updatePanic, resetPanicOnOrient, getFreshnessSignal, trackerToPanicState } from '../../core/services/mcp-handlers/epistemic-lease.js';
 import type { EpistemicTracker } from '../../core/services/mcp-handlers/epistemic-lease.js';
+import { registerRepairBuilder, repairStatusFor, REPAIR_REASON_DETAIL } from '../../core/services/cold-start-bootstrap.js';
 import type { PanicResponseMode } from '../../types/index.js';
 import { readPanicState, mutatePanicStateLocked, getPanicSignalText } from '../../core/services/mcp-handlers/panic-response.js';
 import { emit } from '../../core/services/telemetry.js';
@@ -2333,6 +2334,17 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
   console.warn = toStderr;
   console.debug = toStderr;
 
+  // Register the process-wide background index-repair builder (change:
+  // make-index-self-healing). Read-path staleness signals (in mcp-handlers/utils)
+  // trigger repairInBackground, which uses this builder — a forced full rebuild
+  // (init + structural analyze + BM25 corpus, no API key) so a self-heal restores
+  // FULL parity, not just the structural graph. Injected here so the dependency-
+  // light read path never imports the analyzer/install layer itself.
+  registerRepairBuilder(async (dir) => {
+    const { buildIndex } = await import('../install/index.js');
+    await buildIndex(dir, { force: true });
+  });
+
   const selectorOpts = { minimal: options.minimal, preset: options.preset, allTools: options.allTools };
   // A bad `--preset` must fail like a CLI usage error (clean message, exit 2),
   // not an uncaught throw that dumps a Node stack trace — mirroring how
@@ -2623,6 +2635,25 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
       if (signal?.prepend) content.push({ type: 'text', text: signal.text });
       content.push({ type: 'text', text });
       if (signal && !signal.prepend) content.push({ type: 'text', text: signal.text });
+
+      // Index self-healing disclosure (change: make-index-self-healing). When a
+      // read-path staleness signal has triggered a background repair for this repo,
+      // append one factual note — served now from the stale index, refresh started,
+      // never blocked, never presented as fresh. A separate content item so it never
+      // corrupts a structured result body. Distinct from the freshness (session-age)
+      // note above and from the absent-index "run analyze" not-ready result.
+      if (directory) {
+        const repair = repairStatusFor(directory);
+        if (repair) {
+          content.push({
+            type: 'text',
+            text:
+              `\n[openlore index] Served from a stale index (${REPAIR_REASON_DETAIL[repair.reason]}); ` +
+              `a background refresh has started and did not block this call. Re-run for fresh ` +
+              `results once it completes. Informational signal.\n`,
+          });
+        }
+      }
 
       if (tracker && (panicPolicy === 'advisory' || panicPolicy === 'experimental_blocking')) {
         const panicState = trackerToPanicState(tracker, agentName);

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -2468,6 +2468,12 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
             rootPath: resolve(dir),
             debounceMs: isNaN(debounceMs) ? 400 : debounceMs,
             embed: !options.watchNoEmbed,
+            // selfRebuild (make-index-self-healing): the in-process watcher has no
+            // serve-style rebuild coordinator, so its call graph would age with every
+            // branch switch. Let it spawn its own debounced `analyze --force` on a
+            // HEAD change / budget-exceeded stale region — the graph stays fresh
+            // without a post-commit hook or a running daemon.
+            selfRebuild: true,
           });
           await autoWatcher.start();
           const cleanup = () => autoWatcher!.stop().then(() => process.exit(0));

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -644,7 +644,15 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
   }
 
   if (options.watch !== false) {
-    watcher = new McpWatcher({ rootPath: root, onBatchFlushed: () => scheduleReanalyze() });
+    // onGraphStale (make-index-self-healing): a HEAD change (branch switch / pull)
+    // or a budget-exceeded stale region routes through the SAME rebuild coordinator
+    // as edits, so call-graph freshness no longer depends on the post-commit hook and
+    // the two rebuild paths coalesce into one.
+    watcher = new McpWatcher({
+      rootPath: root,
+      onBatchFlushed: () => scheduleReanalyze(),
+      onGraphStale: () => scheduleReanalyze(),
+    });
     try {
       await watcher.start();
       logger.discovery(`[serve] watching ${root} — signatures/vector live, call-graph re-analyze debounced`);

--- a/src/cli/install/index.ts
+++ b/src/cli/install/index.ts
@@ -87,7 +87,7 @@ export interface InstallOptions {
  * Failures are non-fatal: the surfaces are already wired, so we warn and tell
  * the user to run analyze themselves rather than failing the whole install.
  */
-export async function buildIndex(cwd: string): Promise<void> {
+export async function buildIndex(cwd: string, opts: { force?: boolean } = {}): Promise<void> {
   const prevCwd = process.cwd();
   // analyze prints its own multi-line CLI output ("Next step: run generate",
   // etc.) via console.log — noise inside install. Capture it to stderr so
@@ -108,7 +108,11 @@ export async function buildIndex(cwd: string): Promise<void> {
     // `--embedded`: install does the agent wiring (CLAUDE.md/.mcp.json/hooks) itself,
     // so analyze must NOT also print its agent-onboarding tips or the "run generate"
     // next-step — those contradict install's own output on the first-run path.
-    await analyzeCommand.parseAsync(['--embedded'], { from: 'user' });
+    // `--force` (background repair path): a mismatched/schema-reset index can have a
+    // fingerprint that still matches source, so a non-forced analyze would skip the
+    // rebuild and leave the index broken — force guarantees the heal actually runs.
+    const analyzeArgs = opts.force ? ['--force', '--embedded'] : ['--embedded'];
+    await analyzeCommand.parseAsync(analyzeArgs, { from: 'user' });
     console.log = origLog;
     logger.success('Index built — orient() will return results in your next session.');
   } catch (err) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -165,6 +165,16 @@ export const ANALYSIS_STALE_THRESHOLD_MS = 60 * 60 * 1000;
 /** How old (ms) an analysis can be before being re-used in 'run' (1 hour) */
 export const ANALYSIS_REUSE_THRESHOLD_MS = 60 * 60 * 1000;
 
+/**
+ * Explicit-stale-region size that trips a read-path background repair
+ * (change: make-index-self-healing). At or above this many files marked stale by
+ * a budget-exceeded incremental update, the read path schedules the same
+ * at-most-once background rebuild instead of serving an ever-growing stale region.
+ * 1 = any explicit staleness heals; kept as a named constant so the threshold is
+ * tunable without touching the trigger logic.
+ */
+export const STALE_REGION_REPAIR_THRESHOLD = 1;
+
 /** Grace period after consolidation during which the gate skips the no_decisions_recorded check (1 hour) */
 export const CONSOLIDATION_GRACE_PERIOD_MS = 60 * 60 * 1000;
 

--- a/src/core/services/cold-start-bootstrap.test.ts
+++ b/src/core/services/cold-start-bootstrap.test.ts
@@ -3,8 +3,14 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { bootstrapAnalysisInBackground } from './cold-start-bootstrap.js';
-import { OPENLORE_ANALYSIS_REL_PATH } from '../../constants.js';
+import {
+  bootstrapAnalysisInBackground,
+  repairInBackground,
+  repairStatusFor,
+  registerRepairBuilder,
+  _resetRepairServiceForTesting,
+} from './cold-start-bootstrap.js';
+import { OPENLORE_ANALYSIS_REL_PATH, OPENLORE_CONFIG_REL_PATH } from '../../constants.js';
 
 const dirs: string[] = [];
 function freshDir(withAnalysis = false): string {
@@ -96,5 +102,83 @@ describe('bootstrapAnalysisInBackground', () => {
     const src = readFileSync(fileURLToPath(new URL('./cold-start-bootstrap.ts', import.meta.url)), 'utf8');
     expect(src).not.toMatch(/api\/(analyze|init|run)/);
     expect(src).not.toMatch(/install\/index/);
+  });
+});
+
+describe('repairInBackground (make-index-self-healing)', () => {
+  afterEach(() => {
+    _resetRepairServiceForTesting();
+    delete process.env.OPENLORE_NO_AUTO_ANALYZE;
+  });
+
+  it('fires the injected builder for a staleness reason and records in-progress status', async () => {
+    const dir = freshDir(true);
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    let ran = 0;
+    const p = repairInBackground(dir, 'integrity-mismatched', {
+      analyze: async () => { ran++; await gate; },
+      log: () => {},
+    });
+    expect(p).not.toBeNull();
+    // While the build is gated, the repair is disclosed as in-progress with its reason.
+    expect(repairStatusFor(dir)).toEqual({ inProgress: true, reason: 'integrity-mismatched' });
+    release();
+    await p;
+    expect(ran).toBe(1);
+    // Completed → no longer in-progress (a later call serves fresh, no marker).
+    expect(repairStatusFor(dir)).toBeUndefined();
+  });
+
+  it('is at-most-once per process per repo — a persistent trigger never thrashes', async () => {
+    const dir = freshDir(true);
+    let calls = 0;
+    const opts = { analyze: async () => { calls++; }, log: () => {} };
+    await repairInBackground(dir, 'stale-region', opts);
+    // Same (or any) trigger still observed after a completed repair → disclose and stop.
+    expect(repairInBackground(dir, 'stale-region', opts)).toBeNull();
+    expect(repairInBackground(dir, 'analysis-age', opts)).toBeNull();
+    expect(calls).toBe(1);
+  });
+
+  it('clears its guard on failure so a genuine retry can run', async () => {
+    const dir = freshDir(true);
+    let calls = 0;
+    await repairInBackground(dir, 'schema-reset', {
+      analyze: async () => { calls++; throw new Error('boom'); },
+      log: () => {},
+    });
+    const p2 = repairInBackground(dir, 'schema-reset', { analyze: async () => { calls++; }, log: () => {} });
+    expect(p2).not.toBeNull();
+    await p2;
+    expect(calls).toBe(2);
+  });
+
+  it('uses the process-registered builder when none is injected', async () => {
+    const dir = freshDir(true);
+    let ran = 0;
+    registerRepairBuilder(async () => { ran++; });
+    const p = repairInBackground(dir, 'analysis-age', { log: () => {} });
+    expect(p).not.toBeNull();
+    await p;
+    expect(ran).toBe(1);
+  });
+
+  it('is a silent no-op when no builder is registered or injected (CLI/tests)', () => {
+    const dir = freshDir(true);
+    expect(repairInBackground(dir, 'analysis-age', { log: () => {} })).toBeNull();
+    expect(repairStatusFor(dir)).toBeUndefined();
+  });
+
+  it('respects the OPENLORE_NO_AUTO_ANALYZE opt-out', () => {
+    process.env.OPENLORE_NO_AUTO_ANALYZE = '1';
+    const dir = freshDir(true);
+    expect(repairInBackground(dir, 'stale-region', { analyze: async () => {}, log: () => {} })).toBeNull();
+  });
+
+  it('respects the .openlore/config.json autoInit:false opt-out', () => {
+    const dir = freshDir(true);
+    writeFileSync(join(dir, OPENLORE_CONFIG_REL_PATH), JSON.stringify({ autoInit: false }));
+    expect(repairInBackground(dir, 'stale-region', { analyze: async () => {}, log: () => {} })).toBeNull();
   });
 });

--- a/src/core/services/cold-start-bootstrap.ts
+++ b/src/core/services/cold-start-bootstrap.ts
@@ -1,69 +1,180 @@
 /**
- * Cold-start self-bootstrap (change: add-zero-interaction-onboarding).
+ * Background index repair service (changes: add-zero-interaction-onboarding →
+ * make-index-self-healing).
  *
- * If an agent wires the OpenLore MCP server but never ran `openlore install`
- * (or ran it with --no-analyze), the very first session has no structural index
- * and every tool returns "run analyze first." This warms that cold start
- * automatically: when the server begins watching a directory with no analysis,
- * it builds the index ONCE, in the BACKGROUND.
+ * Originally the cold-start self-bootstrap: if an agent wired the OpenLore MCP
+ * server but never ran `openlore install`, the very first session had no index
+ * and every tool returned "run analyze first." That warmed an ABSENT index once,
+ * in the background.
  *
- * Why background and not blocking: a synchronous full analyze on the first tool
- * call could take many seconds and would hang the agent's turn (and risk an MCP
- * client timeout). So the build runs detached from the call path; the first
- * call or two may still see the graceful "no analysis yet" guidance, and within
- * seconds the index is warm. This is strictly better than today, where the
- * server never self-builds.
+ * `make-index-self-healing` generalizes it: every read-path staleness signal that
+ * today only produces a warning (integrity `mismatched`, an over-threshold stale
+ * region, a schema reset, an aged analysis) now triggers the SAME at-most-once,
+ * non-blocking background rebuild — so detection finally closes the loop into
+ * repair instead of stopping at disclosure.
  *
- * Deterministic, no LLM, no new dependency. Guarded once-per-directory and
- * fail-soft: a build failure never propagates.
+ * Guarantees (unchanged from the bootstrap it grew out of):
+ *   - AT MOST ONCE per process per repo. A completed repair that still observes
+ *     its trigger discloses and stops — it never loops or thrashes. The guard is
+ *     cleared only on FAILURE, so a transient build error can retry.
+ *   - NEVER blocks the caller: the build runs detached from the call path; reads
+ *     during it are served from the stale index with an honest "refresh started"
+ *     disclosure, never held.
+ *   - NEVER throws: a build failure leaves the graceful guidance in place.
+ *   - Opt-out via `OPENLORE_NO_AUTO_ANALYZE` or `.openlore/config.json` `autoInit:false`.
+ *
+ * Deterministic, no LLM, no new dependency.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { OPENLORE_ANALYSIS_REL_PATH } from '../../constants.js';
+import {
+  OPENLORE_ANALYSIS_REL_PATH,
+  OPENLORE_DIR,
+  OPENLORE_CONFIG_FILENAME,
+} from '../../constants.js';
 
-/** Directories already bootstrapped (or in flight) this process — build at most once each. */
-const bootstrapped = new Set<string>();
+/**
+ * Why a background repair was started. `index-absent` is the original cold-start
+ * case (no artifact at all); the rest are the self-healing triggers layered on by
+ * make-index-self-healing.
+ */
+export type RepairReason =
+  | 'index-absent'
+  | 'integrity-mismatched'
+  | 'stale-region'
+  | 'schema-reset'
+  | 'analysis-age';
+
+/** Human-facing label for each reason, used in the "refresh started" disclosure. */
+export const REPAIR_REASON_DETAIL: Record<RepairReason, string> = {
+  'index-absent': 'no index found',
+  'integrity-mismatched': 'the index did not reconcile against its build attestation',
+  'stale-region': 'part of the index is explicitly stale',
+  'schema-reset': 'the index schema was reset by a version upgrade',
+  'analysis-age': 'the analysis is older than the freshness threshold',
+};
+
+/** Directories already repaired (or in flight) this process — build at most once each. */
+const attempted = new Set<string>();
+
+/** In-flight repairs, keyed by directory, so a read can disclose "refresh started". */
+const inFlight = new Map<string, { reason: RepairReason; startedAt: number }>();
+
+/**
+ * The default index builder, registered once by the MCP server at startup. Lets a
+ * read-path caller (mcp-handlers/utils.ts) — which deliberately never imports the
+ * analyzer or install layer — trigger a repair without threading a builder through
+ * every handler. When nothing is registered (CLI, tests, a non-server host), a
+ * read-path repair is a silent no-op: detection and disclosure are unchanged, only
+ * the automatic rebuild is skipped.
+ */
+let registeredBuilder: ((directory: string) => Promise<void>) | null = null;
+
+/** Register the process-wide repair builder (the MCP server injects install's forced buildIndex). */
+export function registerRepairBuilder(fn: (directory: string) => Promise<void>): void {
+  registeredBuilder = fn;
+}
 
 /** True once an `openlore analyze` artifact exists for the directory. */
 export function hasAnalysis(directory: string): boolean {
   return existsSync(join(directory, OPENLORE_ANALYSIS_REL_PATH, 'llm-context.json'));
 }
 
-export interface BootstrapOptions {
+/** True when `.openlore/config.json` explicitly sets `autoInit: false`. Fail-open. */
+function autoInitDisabled(directory: string): boolean {
+  try {
+    const raw = readFileSync(join(directory, OPENLORE_DIR, OPENLORE_CONFIG_FILENAME), 'utf-8');
+    return (JSON.parse(raw) as { autoInit?: unknown }).autoInit === false;
+  } catch {
+    return false; // no config / unreadable → auto-init not disabled
+  }
+}
+
+export interface RepairOptions {
   /**
-   * The index builder to run for a cold directory. REQUIRED and injected by the
-   * caller — this module deliberately stays dependency-light and never imports
-   * the analyzer or install layer itself, so it cannot pick a builder for you.
-   *
-   * Production passes install's `buildIndex` (init + structural analyze + the
-   * BM25 search corpus, no API key) so `orient` warms to FULL parity. A builder
-   * that skips the BM25/search index would leave keyword retrieval cold while
-   * the graph looks warm — a silent half-build. Making this required turns that
-   * footgun into a compile-time decision the caller must make explicitly, rather
-   * than a wrong-by-default fallback hidden in this module.
+   * The index builder to run. Optional: when omitted, the process-wide builder
+   * registered via {@link registerRepairBuilder} is used. Production registers
+   * install's forced buildIndex (init + structural analyze + BM25 search corpus,
+   * no API key) so `orient` heals to FULL parity, not just the structural graph.
    */
-  analyze: (directory: string) => Promise<void>;
+  analyze?: (directory: string) => Promise<void>;
   /** Opt out entirely (env OPENLORE_NO_AUTO_ANALYZE, or a caller flag). */
   disabled?: boolean;
   /** Status sink (defaults to process.stderr). Never stdout — that is protocol. */
   log?: (msg: string) => void;
-  /** Injected guard set (tests). */
+  /** Injected at-most-once guard set (tests). */
   seen?: Set<string>;
+  /** Injectable clock (tests). Defaults to Date.now. */
+  now?: () => number;
 }
 
 /**
- * Kick a one-time background index build for `directory` if none exists yet,
- * using the caller-supplied `opts.analyze` builder.
- * Returns the in-flight build promise (so tests can await it), or null when
- * nothing was started (already analyzed, already bootstrapped, or disabled).
- * NEVER throws and NEVER blocks the caller.
+ * Kick a one-time background repair for `directory` using the caller-supplied or
+ * process-registered builder. Returns the in-flight build promise (so tests can
+ * await it), or null when nothing was started (already repaired this process,
+ * disabled, no builder available, or empty directory). NEVER throws, NEVER blocks.
+ */
+export function repairInBackground(
+  directory: string,
+  reason: RepairReason,
+  opts: RepairOptions = {},
+): Promise<void> | null {
+  const seen = opts.seen ?? attempted;
+  if (opts.disabled || process.env.OPENLORE_NO_AUTO_ANALYZE) return null;
+  if (!directory) return null;
+  if (seen.has(directory)) return null; // at-most-once per process per repo
+  if (autoInitDisabled(directory)) return null;
+
+  const build = opts.analyze ?? registeredBuilder;
+  if (!build) return null; // no builder registered (CLI/tests) — detection unchanged, repair skipped
+
+  seen.add(directory);
+  const now = opts.now ?? Date.now;
+  inFlight.set(directory, { reason, startedAt: now() });
+  const log = opts.log ?? ((m: string) => process.stderr.write(m + '\n'));
+
+  const run = async (): Promise<void> => {
+    try {
+      log(`[openlore] Index repair (${reason}) — rebuilding in the background (non-blocking, no API key)…`);
+      await build(directory);
+      log('[openlore] Index rebuilt — the next tool call serves fresh results.');
+      // Guard stays set: a completed repair that still observes its trigger
+      // discloses and stops (at-most-once latch), never thrashes.
+    } catch (err) {
+      // Fail-soft: leave the graceful guidance in place; allow a later retry.
+      seen.delete(directory);
+      log(`[openlore] Background index repair skipped: ${(err as Error).message}`);
+    } finally {
+      inFlight.delete(directory);
+    }
+  };
+
+  return run();
+}
+
+/**
+ * The in-progress repair for `directory`, or undefined when none is running. The
+ * read path threads this into the response so a stale answer is served with an
+ * honest "background refresh started" marker — never presented as fresh.
+ */
+export function repairStatusFor(
+  directory: string,
+): { inProgress: true; reason: RepairReason } | undefined {
+  const rec = inFlight.get(directory);
+  return rec ? { inProgress: true, reason: rec.reason } : undefined;
+}
+
+/**
+ * Cold-start self-bootstrap for an ABSENT index — the original entry point, kept
+ * as a thin wrapper over {@link repairInBackground} so existing callers/tests are
+ * unchanged. Only fires when no analysis artifact exists yet.
  */
 export function bootstrapAnalysisInBackground(
   directory: string,
-  opts: BootstrapOptions,
+  opts: RepairOptions & { analyze: (directory: string) => Promise<void> },
 ): Promise<void> | null {
-  const seen = opts.seen ?? bootstrapped;
+  const seen = opts.seen ?? attempted;
   if (opts.disabled || process.env.OPENLORE_NO_AUTO_ANALYZE) return null;
   if (!directory) return null;
   if (seen.has(directory)) return null;
@@ -71,22 +182,12 @@ export function bootstrapAnalysisInBackground(
     seen.add(directory);
     return null;
   }
+  return repairInBackground(directory, 'index-absent', opts);
+}
 
-  seen.add(directory);
-  const log = opts.log ?? ((m: string) => process.stderr.write(m + '\n'));
-
-  const run = async (): Promise<void> => {
-    try {
-      log('[openlore] No index found — building it in the background (first run, no API key)…');
-      await opts.analyze(directory);
-      log('[openlore] Index built — orient() and the other tools are now warm.');
-    } catch (err) {
-      // Fail-soft: leave the graceful "run analyze" guidance in place; allow a
-      // later retry by clearing the guard.
-      seen.delete(directory);
-      log(`[openlore] Background index build skipped: ${(err as Error).message}`);
-    }
-  };
-
-  return run();
+/** Test-only: clear the process-wide repair guards and registered builder. */
+export function _resetRepairServiceForTesting(): void {
+  attempted.clear();
+  inFlight.clear();
+  registeredBuilder = null;
 }

--- a/src/core/services/mcp-handlers/confidence-boundary.ts
+++ b/src/core/services/mcp-handlers/confidence-boundary.ts
@@ -22,6 +22,7 @@ import { extname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { ARTIFACT_FINGERPRINT, OPENLORE_ANALYSIS_SUBDIR, OPENLORE_DIR } from '../../../constants.js';
 import type { IndexIntegrity } from '../../analyzer/index-attestation.js';
+import { repairStatusFor, REPAIR_REASON_DETAIL } from '../cold-start-bootstrap.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -88,6 +89,20 @@ export interface IndexIntegrityDisclosure {
   detail: string;
 }
 
+/**
+ * A background index repair is in flight for the queried repo (change:
+ * make-index-self-healing). The answer was served from the stale index without
+ * waiting; a later call after the rebuild completes serves fresh results. Absent
+ * when no repair is running. Distinguishes *repairing* from plain *stale* so an
+ * agent can choose to proceed on the disclosed answer or retry.
+ */
+export interface RepairInProgressMarker {
+  inProgress: true;
+  /** Why the repair started (integrity-mismatched, stale-region, schema-reset, …). */
+  reason: string;
+  detail: string;
+}
+
 export interface ConfidenceBoundary {
   /** How the traversal was grounded. Omitted for non-traversal answers (recall). */
   basis?: EdgeBasis;
@@ -97,6 +112,8 @@ export interface ConfidenceBoundary {
   staleness?: StalenessMarker;
   /** Index integrity verdict when the underlying index did not reconcile. Absent when healthy. */
   integrity?: IndexIntegrityDisclosure;
+  /** A background repair is healing this index right now. Absent when none is running. */
+  repair?: RepairInProgressMarker;
   /**
    * True iff the computation crossed no boundary: no synthesized-edge reliance, no
    * known-unknowable crossing, a current index, AND a reconciled (non-degraded,
@@ -114,6 +131,24 @@ export interface ConfidenceBoundary {
 export function integrityDisclosure(integrity?: IndexIntegrity): IndexIntegrityDisclosure | undefined {
   if (!integrity || integrity.verdict === 'healthy') return undefined;
   return { verdict: integrity.verdict, detail: integrity.detail };
+}
+
+/**
+ * The repair-in-progress marker for a directory, or undefined when no background
+ * repair is running. Handlers pass this into {@link assembleBoundary} so a stale
+ * answer served during a self-heal is disclosed as *repairing*, not silently stale
+ * (change: make-index-self-healing).
+ */
+export function repairDisclosure(directory: string): RepairInProgressMarker | undefined {
+  const status = repairStatusFor(directory);
+  if (!status) return undefined;
+  return {
+    inProgress: true,
+    reason: status.reason,
+    detail:
+      `A background index refresh has started (${REPAIR_REASON_DETAIL[status.reason]}); this answer ` +
+      `was served from the stale index without waiting. Re-run for fresh results once it completes.`,
+  };
 }
 
 /** Tally direct vs synthesized edges (by rule) from a set of traversed edges. */
@@ -282,6 +317,7 @@ export function assembleBoundary(parts: {
   extraCrossings?: KnownUnknowableCrossing[];
   staleness?: StalenessMarker;
   integrity?: IndexIntegrity;
+  repair?: RepairInProgressMarker;
 }): ConfidenceBoundary {
   const crossings = [
     ...(parts.basis ? crossingsFromBasis(parts.basis) : []),
@@ -289,12 +325,13 @@ export function assembleBoundary(parts: {
   ];
   const integrity = integrityDisclosure(parts.integrity);
   const boundary: ConfidenceBoundary = {
-    complete: crossings.length === 0 && !parts.staleness && !integrity,
+    complete: crossings.length === 0 && !parts.staleness && !integrity && !parts.repair,
   };
   if (parts.basis) boundary.basis = parts.basis;
   if (crossings.length > 0) boundary.knownUnknowable = crossings;
   if (parts.staleness) boundary.staleness = parts.staleness;
   if (integrity) boundary.integrity = integrity;
+  if (parts.repair) boundary.repair = parts.repair;
   return boundary;
 }
 

--- a/src/core/services/mcp-handlers/graph.ts
+++ b/src/core/services/mcp-handlers/graph.ts
@@ -51,6 +51,7 @@ import {
   computeStaleness,
   edgeBasis,
   edgeBasisForChains,
+  repairDisclosure,
   type BoundaryEdge,
 } from './confidence-boundary.js';
 
@@ -512,7 +513,7 @@ export async function handleGetSubgraph(
     confidence: e.synthesized ? 'synthesized' : undefined,
     synthesizedBy: e.synthesizedBy,
   })));
-  const confidenceBoundary = assembleBoundary({ basis: subBasis, staleness: await computeStaleness(absDir), integrity: ctx?.integrity });
+  const confidenceBoundary = assembleBoundary({ basis: subBasis, staleness: await computeStaleness(absDir), integrity: ctx?.integrity, repair: repairDisclosure(absDir) });
 
   return {
     query: { functionName, direction, maxDepth },
@@ -704,7 +705,7 @@ export async function handleAnalyzeImpact(
       if (e.calleeId && involvedIds.has(e.calleeId)) impactEdges.push({ confidence: e.confidence, synthesizedBy: e.synthesizedBy });
     }
   }
-  const confidenceBoundary = assembleBoundary({ basis: edgeBasis(impactEdges), staleness: await computeStaleness(absDir), integrity: ctx?.integrity });
+  const confidenceBoundary = assembleBoundary({ basis: edgeBasis(impactEdges), staleness: await computeStaleness(absDir), integrity: ctx?.integrity, repair: repairDisclosure(absDir) });
 
   const results = seeds.map(seed => {
     const isHub     = hubIds.has(seed.id);
@@ -1258,7 +1259,7 @@ export async function handleTraceExecutionPath(
       message: `No execution path found from "${entryFunction}" to "${targetFunction}" within depth ${maxDepth}.`,
       hint: 'Try increasing maxDepth, or check whether both functions are in the same connected component of the call graph.',
       ...(valueLevelInfo ? { valueLevel: valueLevelInfo } : {}),
-      confidenceBoundary: assembleBoundary({ basis: edgeBasisForChains([], pairIndex), staleness: traceStaleness, integrity: ctx?.integrity }),
+      confidenceBoundary: assembleBoundary({ basis: edgeBasisForChains([], pairIndex), staleness: traceStaleness, integrity: ctx?.integrity, repair: repairDisclosure(absDir) }),
     };
   }
 
@@ -1286,6 +1287,6 @@ export async function handleTraceExecutionPath(
     shortestPath: paths[0].chain,
     paths,
     ...(valueLevelInfo ? { valueLevel: valueLevelInfo } : {}),
-    confidenceBoundary: assembleBoundary({ basis: edgeBasisForChains(allPaths, pairIndex), staleness: traceStaleness, integrity: ctx?.integrity }),
+    confidenceBoundary: assembleBoundary({ basis: edgeBasisForChains(allPaths, pairIndex), staleness: traceStaleness, integrity: ctx?.integrity, repair: repairDisclosure(absDir) }),
   };
 }

--- a/src/core/services/mcp-handlers/orient.ts
+++ b/src/core/services/mcp-handlers/orient.ts
@@ -20,6 +20,7 @@ import type { SerializedCallGraph } from '../../analyzer/call-graph.js';
 import { validateDirectory, loadMappingIndex, specsForFile, functionsForDomain, readCachedContext, safeJoin, safeOpenspecDir, queryTooLongError, notReadyResult } from './utils.js';
 import { expandHandle, applyTokenBudget, collapseExactDuplicates, omissionNote } from './progressive.js';
 import { readOpenLoreConfig } from '../config-manager.js';
+import { repairStatusFor, REPAIR_REASON_DETAIL } from '../cold-start-bootstrap.js';
 import { isIacLanguage } from '../../analyzer/iac/types.js';
 import type { RagManifest } from '../../generator/rag-manifest-generator.js';
 import { ARTIFACT_RAG_MANIFEST, ARTIFACT_STYLE_FINGERPRINT } from '../../../constants.js';
@@ -837,6 +838,13 @@ export async function handleOrient(
     }
   }
 
+  // ReadyOrHonestFirstUse (change: make-index-self-healing): distinguish *repairing*
+  // from *absent* (the not-ready result above) and plain *stale*. readCachedContext,
+  // awaited above, fires the background repair for a stale/mismatched index; surface
+  // its in-progress marker so an agent can proceed on this disclosed-stale answer or
+  // retry after the rebuild. Absent when no repair is running (a fresh index).
+  const indexRepair = repairStatusFor(absDir);
+
   // Minimal-sufficient navigation core — always returned (Spec 27).
   const core = {
     task,
@@ -847,6 +855,13 @@ export async function handleOrient(
       : {}),
     ...(graphIndexStale
       ? { graphIndexNote: 'Graph index unavailable — call paths, provenance, decisions, and change-coupling are omitted. Run analyze_codebase to (re)build it (a version upgrade resets the graph index until the next analyze).' }
+      : {}),
+    ...(indexRepair
+      ? { indexRepair: {
+          inProgress: true as const,
+          reason: indexRepair.reason,
+          note: `Serving a stale index (${REPAIR_REASON_DETAIL[indexRepair.reason]}); a background refresh has started and did not block this call. Re-run orient once it completes for fresh results.`,
+        } }
       : {}),
     relevantFiles,
     relevantFunctions,

--- a/src/core/services/mcp-handlers/self-healing-repair.test.ts
+++ b/src/core/services/mcp-handlers/self-healing-repair.test.ts
@@ -1,0 +1,71 @@
+/**
+ * make-index-self-healing: the read-path reason mapping (which staleness signal
+ * heals, worst-first) and the repair-in-progress disclosure threaded into the
+ * confidence boundary.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { computeRepairReason } from './utils.js';
+import { assembleBoundary, repairDisclosure } from './confidence-boundary.js';
+import {
+  repairInBackground,
+  _resetRepairServiceForTesting,
+} from '../cold-start-bootstrap.js';
+
+const HOUR = 60 * 60 * 1000;
+const NOW = 1_000 * HOUR; // arbitrary fixed clock
+
+describe('computeRepairReason — worst-first read-path trigger selection', () => {
+  const fresh = NOW - 1000; // artifact mtime "just now"
+
+  it('mismatched integrity outranks everything', () => {
+    expect(computeRepairReason('mismatched', true, 5, NOW - 100 * HOUR, NOW)).toBe('integrity-mismatched');
+  });
+
+  it('a schema reset heals when integrity is not mismatched', () => {
+    expect(computeRepairReason('healthy', true, 0, fresh, NOW)).toBe('schema-reset');
+  });
+
+  it('an explicit stale region at/above the threshold heals', () => {
+    expect(computeRepairReason(undefined, false, 1, fresh, NOW)).toBe('stale-region');
+    expect(computeRepairReason(undefined, false, 0, fresh, NOW)).not.toBe('stale-region');
+  });
+
+  it('an aged analysis (older than the doctor warning threshold) heals', () => {
+    // 25h old > ANALYSIS_AGE_WARNING_HOURS (24h)
+    expect(computeRepairReason('healthy', false, 0, NOW - 25 * HOUR, NOW)).toBe('analysis-age');
+  });
+
+  it('a current, healthy index triggers nothing', () => {
+    expect(computeRepairReason('healthy', false, 0, fresh, NOW)).toBeUndefined();
+    // `degraded` is deliberately NOT a trigger (WAL-lag / already retried).
+    expect(computeRepairReason('degraded', false, 0, fresh, NOW)).toBeUndefined();
+  });
+});
+
+describe('repairDisclosure — served-stale answers are disclosed as repairing', () => {
+  afterEach(() => _resetRepairServiceForTesting());
+
+  it('marks the boundary incomplete with the repair reason while a repair is in flight', async () => {
+    const dir = '/tmp/does-not-need-to-exist-for-status';
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const p = repairInBackground(dir, 'integrity-mismatched', {
+      analyze: async () => { await gate; },
+      log: () => {},
+    });
+
+    const marker = repairDisclosure(dir);
+    expect(marker).toMatchObject({ inProgress: true, reason: 'integrity-mismatched' });
+    expect(marker?.detail).toMatch(/background index refresh has started/i);
+
+    const boundary = assembleBoundary({ repair: marker });
+    expect(boundary.repair).toEqual(marker);
+    expect(boundary.complete).toBe(false); // a repairing index is never "complete"
+
+    release();
+    await p;
+    // After completion the marker is gone — a fresh answer carries no repair caveat.
+    expect(repairDisclosure(dir)).toBeUndefined();
+    expect(assembleBoundary({}).complete).toBe(true);
+  });
+});

--- a/src/core/services/mcp-handlers/utils.ts
+++ b/src/core/services/mcp-handlers/utils.ts
@@ -54,13 +54,31 @@ import { redactSecretString } from '../secret-redaction.js';
 const ANALYSIS_AGE_WARNING_MS = ANALYSIS_AGE_WARNING_HOURS * 60 * 60 * 1000;
 
 /**
- * Decide which read-path staleness signal (if any) should heal, and fire the
- * shared at-most-once background repair for it. Priority is worst-first:
- * `mismatched` (materially wrong index) → schema reset → an explicit stale region
- * → an aged analysis. `degraded` is deliberately NOT a trigger (it already gets a
- * WAL-checkpoint retry and may be a transient WAL-lag artifact). Fires only when a
- * repair builder is registered (the MCP server); a no-op otherwise, so CLI/tests
- * keep today's detection-only behavior. Never throws, never blocks the read.
+ * Which read-path staleness signal (if any) should heal — a pure, testable
+ * decision. Priority is worst-first: `mismatched` (materially wrong index) →
+ * schema reset → an explicit stale region → an aged analysis. `degraded` is
+ * deliberately NOT a trigger (it already gets a WAL-checkpoint retry and may be a
+ * transient WAL-lag artifact). Returns undefined when the index looks current.
+ */
+export function computeRepairReason(
+  integrityVerdict: string | undefined,
+  wasReset: boolean,
+  staleCount: number,
+  artifactMtimeMs: number,
+  now: number = Date.now(),
+): RepairReason | undefined {
+  if (integrityVerdict === 'mismatched') return 'integrity-mismatched';
+  if (wasReset) return 'schema-reset';
+  if (staleCount >= STALE_REGION_REPAIR_THRESHOLD) return 'stale-region';
+  if (now - artifactMtimeMs > ANALYSIS_AGE_WARNING_MS) return 'analysis-age';
+  return undefined;
+}
+
+/**
+ * Fire the shared at-most-once background repair for the strongest read-path
+ * staleness signal, if any. Fires only when a repair builder is registered (the
+ * MCP server); a no-op otherwise, so CLI/tests keep today's detection-only
+ * behavior. Never throws, never blocks the read.
  */
 function maybeTriggerBackgroundRepair(
   directory: string,
@@ -69,11 +87,7 @@ function maybeTriggerBackgroundRepair(
   staleCount: number,
   artifactMtimeMs: number,
 ): void {
-  let reason: RepairReason | undefined;
-  if (integrityVerdict === 'mismatched') reason = 'integrity-mismatched';
-  else if (wasReset) reason = 'schema-reset';
-  else if (staleCount >= STALE_REGION_REPAIR_THRESHOLD) reason = 'stale-region';
-  else if (Date.now() - artifactMtimeMs > ANALYSIS_AGE_WARNING_MS) reason = 'analysis-age';
+  const reason = computeRepairReason(integrityVerdict, wasReset, staleCount, artifactMtimeMs);
   if (!reason) return;
   try {
     repairInBackground(directory, reason);

--- a/src/core/services/mcp-handlers/utils.ts
+++ b/src/core/services/mcp-handlers/utils.ts
@@ -9,7 +9,8 @@ import { dirname, extname, join, relative, resolve, sep } from 'node:path';
 import type { LLMContext } from '../../analyzer/artifact-generator.js';
 import { EdgeStore } from '../edge-store.js';
 import { readAttestation, reconcile, type IndexIntegrity } from '../../analyzer/index-attestation.js';
-import { ANALYSIS_STALE_THRESHOLD_MS, ARTIFACT_FINGERPRINT, ARTIFACT_LLM_CONTEXT, MAX_QUERY_LENGTH, OPENLORE_ANALYSIS_SUBDIR, OPENLORE_DIR, OPENSPEC_DIR } from '../../../constants.js';
+import { ANALYSIS_AGE_WARNING_HOURS, ANALYSIS_STALE_THRESHOLD_MS, ARTIFACT_FINGERPRINT, ARTIFACT_LLM_CONTEXT, MAX_QUERY_LENGTH, OPENLORE_ANALYSIS_SUBDIR, OPENLORE_DIR, OPENSPEC_DIR, STALE_REGION_REPAIR_THRESHOLD } from '../../../constants.js';
+import { repairInBackground, type RepairReason } from '../cold-start-bootstrap.js';
 
 /**
  * LLMContext with optional SQLite edge store attached (present when call-graph.db
@@ -49,6 +50,38 @@ async function computeIndexIntegrity(es: EdgeStore, analysisDir: string): Promis
 import { logger } from '../../../utils/logger.js';
 import { emit } from '../telemetry.js';
 import { redactSecretString } from '../secret-redaction.js';
+
+const ANALYSIS_AGE_WARNING_MS = ANALYSIS_AGE_WARNING_HOURS * 60 * 60 * 1000;
+
+/**
+ * Decide which read-path staleness signal (if any) should heal, and fire the
+ * shared at-most-once background repair for it. Priority is worst-first:
+ * `mismatched` (materially wrong index) → schema reset → an explicit stale region
+ * → an aged analysis. `degraded` is deliberately NOT a trigger (it already gets a
+ * WAL-checkpoint retry and may be a transient WAL-lag artifact). Fires only when a
+ * repair builder is registered (the MCP server); a no-op otherwise, so CLI/tests
+ * keep today's detection-only behavior. Never throws, never blocks the read.
+ */
+function maybeTriggerBackgroundRepair(
+  directory: string,
+  integrityVerdict: string | undefined,
+  wasReset: boolean,
+  staleCount: number,
+  artifactMtimeMs: number,
+): void {
+  let reason: RepairReason | undefined;
+  if (integrityVerdict === 'mismatched') reason = 'integrity-mismatched';
+  else if (wasReset) reason = 'schema-reset';
+  else if (staleCount >= STALE_REGION_REPAIR_THRESHOLD) reason = 'stale-region';
+  else if (Date.now() - artifactMtimeMs > ANALYSIS_AGE_WARNING_MS) reason = 'analysis-age';
+  if (!reason) return;
+  try {
+    repairInBackground(directory, reason);
+  } catch {
+    // repairInBackground is fail-soft by contract; this guard is belt-and-braces
+    // so the read path can never be perturbed by the repair trigger.
+  }
+}
 
 /**
  * Resolve and validate a user-supplied directory path.
@@ -345,6 +378,11 @@ export async function readCachedContext(directory: string, timeout?: number): Pr
           ctx.callGraph = undefined;
         }
       }
+      // Read-path staleness signals captured while the store is open, so the
+      // background repair trigger below can fire even when the schema-bump guard
+      // closes the store (change: make-index-self-healing).
+      let wasReset = false;
+      let staleCount = 0;
       if (EdgeStore.exists(analysisDir)) {
         const es = EdgeStore.open(EdgeStore.dbPath(analysisDir));
         // Index integrity attestation (change: add-index-integrity-attestation).
@@ -365,6 +403,8 @@ export async function readCachedContext(directory: string, timeout?: number): Pr
         } catch {
           // Attestation reconciliation is additive; never block the load.
         }
+        wasReset = es.wasReset;
+        try { staleCount = es.countStaleFiles(); } catch { /* pre-migration store — no stale_files table */ }
         // Schema-bump guard: opening a DB whose SCHEMA_VERSION is stale wipes it
         // (rebuild-on-bump). If the DB is now empty but the JSON analysis still has
         // production nodes, the two are out of sync after an upgrade — do NOT serve
@@ -379,6 +419,12 @@ export async function readCachedContext(directory: string, timeout?: number): Pr
           ctx.edgeStore = es;
         }
       }
+      // Self-healing: any read-path staleness signal that today only produces a
+      // verdict also triggers the shared at-most-once background repair — detection
+      // finally closes the loop into repair (change: make-index-self-healing). The
+      // rebuild never blocks this read; the answer is served now and disclosed as
+      // stale-with-refresh-started (see repairStatusFor callers).
+      maybeTriggerBackgroundRepair(directory, ctx.integrity?.verdict, wasReset, staleCount, mtime);
       // Evict + close the previous entry's EdgeStore — otherwise each cache miss
       // (every `analyze` rewrites llm-context.json's mtime) leaks an open SQLite
       // connection + its WAL fd for the life of a long-lived daemon. The close is

--- a/src/core/services/mcp-watcher.graph-rebuild.test.ts
+++ b/src/core/services/mcp-watcher.graph-rebuild.test.ts
@@ -1,0 +1,78 @@
+/**
+ * make-index-self-healing: the watcher's graph-rebuild trigger — a debounced,
+ * coalesced fire on a HEAD change / budget-exceeded stale region, delegated to a
+ * host `onGraphStale` handler (serve's coordinator) or self-spawned. These tests
+ * drive the trigger directly (no real git/fs event) and assert the debounce and
+ * coalescing contract with fake timers.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { McpWatcher, type GraphStaleReason } from './mcp-watcher.js';
+
+const dirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'openlore-watch-'));
+  dirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('McpWatcher graph-rebuild trigger', () => {
+  it('fires onGraphStale exactly once for a burst within the debounce window (coalesce)', () => {
+    vi.useFakeTimers();
+    const fired: GraphStaleReason[] = [];
+    const w = new McpWatcher({ rootPath: freshDir(), onGraphStale: (r) => fired.push(r) });
+
+    // A `git pull` touching several refs in quick succession.
+    w._triggerGraphStaleForTesting('head-change');
+    w._triggerGraphStaleForTesting('head-change');
+    w._triggerGraphStaleForTesting('stale-region');
+
+    expect(fired).toEqual([]); // debounced — nothing yet
+    vi.advanceTimersByTime(2000);
+    expect(fired).toEqual(['head-change']); // one rebuild, first (most-salient) reason kept
+  });
+
+  it('keeps the first reason of a coalesced burst', () => {
+    vi.useFakeTimers();
+    const fired: GraphStaleReason[] = [];
+    const w = new McpWatcher({ rootPath: freshDir(), onGraphStale: (r) => fired.push(r) });
+
+    w._triggerGraphStaleForTesting('stale-region');
+    w._triggerGraphStaleForTesting('head-change');
+    vi.advanceTimersByTime(2000);
+
+    expect(fired).toEqual(['stale-region']);
+  });
+
+  it('fires again for a later, separate trigger (repeatable across the session)', () => {
+    vi.useFakeTimers();
+    const fired: GraphStaleReason[] = [];
+    const w = new McpWatcher({ rootPath: freshDir(), onGraphStale: (r) => fired.push(r) });
+
+    w._triggerGraphStaleForTesting('head-change');
+    vi.advanceTimersByTime(2000);
+    w._triggerGraphStaleForTesting('stale-region');
+    vi.advanceTimersByTime(2000);
+
+    expect(fired).toEqual(['head-change', 'stale-region']);
+  });
+
+  it('is a no-op when neither onGraphStale nor selfRebuild is configured', () => {
+    vi.useFakeTimers();
+    const spawn = vi.spyOn(process, 'nextTick'); // proxy: nothing should be scheduled
+    const w = new McpWatcher({ rootPath: freshDir() });
+    w._triggerGraphStaleForTesting('head-change');
+    vi.advanceTimersByTime(5000);
+    // No callback exists to observe; assert it simply did not throw and scheduled
+    // no delegated work. (selfRebuild would spawn a real process — not exercised here.)
+    expect(() => w._triggerGraphStaleForTesting('stale-region')).not.toThrow();
+    spawn.mockRestore();
+  });
+});

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -78,6 +78,13 @@ const DEFAULT_CLOSURE_BUDGET = INCREMENTAL_CLOSURE_BUDGET;
  */
 let backgroundRebuildTriggered = false;
 
+/**
+ * Debounce before firing a graph-stale rebuild (change: make-index-self-healing).
+ * Coalesces a burst of HEAD flips / stale-region marks into ONE rebuild. Longer
+ * than the signature debounce so a `git pull` that lands many refs settles first.
+ */
+const GRAPH_STALE_DEBOUNCE_MS = 1500;
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface McpWatcherOptions {
@@ -111,7 +118,29 @@ export interface McpWatcherOptions {
    * so this is the seam where continuous call-graph freshness is layered on.
    */
   onBatchFlushed?: (changedAbsPaths: string[]) => void;
+  /**
+   * Call-graph freshness without the commit hook (change: make-index-self-healing).
+   * Fired — debounced and coalesced — when the graph has fallen behind in a way an
+   * incremental patch cannot repair: a `.git` HEAD ref change (branch switch / pull)
+   * or a stale region that crossed the incremental work budget. A host that already
+   * owns a rebuild coordinator (the `serve` daemon) wires this to its coordinator so
+   * the two rebuild paths coalesce. When provided, the watcher delegates the rebuild
+   * to this callback and does NOT spawn one itself.
+   */
+  onGraphStale?: (reason: GraphStaleReason) => void;
+  /**
+   * When true AND no `onGraphStale` host handler is provided, the watcher itself
+   * spawns the debounced, coalesced background `analyze --force` on a graph-stale
+   * trigger (a repeatable singleflight, distinct from the once-per-process schema-
+   * reset heal). Set by the in-process MCP watcher, which — unlike `serve` — has no
+   * rebuild coordinator of its own, so its graph would otherwise age with every
+   * branch switch. Default false: the plain signatures-only watcher is unchanged.
+   */
+  selfRebuild?: boolean;
 }
+
+/** Why the call graph fell behind in a way only a full rebuild can repair. */
+export type GraphStaleReason = 'head-change' | 'stale-region';
 
 interface ChangedFile {
   rel: string;
@@ -196,9 +225,17 @@ export class McpWatcher {
   private readonly extraIgnore: string[];
   private readonly debug: boolean;
   private readonly onBatchFlushed?: (changedAbsPaths: string[]) => void;
+  private readonly onGraphStale?: (reason: GraphStaleReason) => void;
+  private readonly selfRebuild: boolean;
 
   private fsWatcher?: FSWatcher;
   private gitWatcher?: FSWatcher;
+
+  // ── Graph-rebuild trigger (make-index-self-healing) ────────────────────────
+  private graphStaleTimer?: ReturnType<typeof setTimeout>;
+  private graphStalePendingReason?: GraphStaleReason;
+  private graphRebuildRunning = false;   // singleflight for the self-spawned rebuild
+  private graphRebuildPending = false;   // a trigger arrived mid-rebuild → run once more
 
   // ── Coalescing queue (Step 1) ──────────────────────────────────────────────
   private pending = new Set<string>();              // absolute paths awaiting a flush
@@ -231,6 +268,8 @@ export class McpWatcher {
     this.extraIgnore = options.ignore ?? [];
     this.debug       = !!process.env.OPENLORE_WATCH_DEBUG;
     this.onBatchFlushed = options.onBatchFlushed;
+    this.onGraphStale = options.onGraphStale;
+    this.selfRebuild = options.selfRebuild ?? false;
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────────────────
@@ -299,7 +338,17 @@ export class McpWatcher {
         ignoreInitial: true,
         followSymlinks: false,
       });
-      this.gitWatcher.on('all', () => this.onVcsEvent());
+      this.gitWatcher.on('all', (_event: string, changedPath?: string) => {
+        this.onVcsEvent();
+        // Call-graph freshness without the commit hook (make-index-self-healing):
+        // a HEAD / MERGE_HEAD / ORIG_HEAD change is a branch switch / pull / merge —
+        // the graph must rebuild. A bare `index` change (git add) is staging churn
+        // that the per-file signature lane already handles, so it does NOT rebuild.
+        const base = changedPath ? posix.basename(changedPath.split(/[/\\]/).join('/')) : '';
+        if (base === 'HEAD' || base === 'MERGE_HEAD' || base === 'ORIG_HEAD') {
+          this.scheduleGraphRebuild('head-change');
+        }
+      });
     } catch {
       // no .git, or watch failed — VCS detection falls back to the batch-size
       // threshold in handleBatch, which is enough for G3.
@@ -315,7 +364,8 @@ export class McpWatcher {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     if (this.maxBatchTimer) clearTimeout(this.maxBatchTimer);
     if (this.embedTimer) clearTimeout(this.embedTimer);
-    this.debounceTimer = this.maxBatchTimer = this.embedTimer = undefined;
+    if (this.graphStaleTimer) clearTimeout(this.graphStaleTimer);
+    this.debounceTimer = this.maxBatchTimer = this.embedTimer = this.graphStaleTimer = undefined;
     // Best-effort: drain anything still queued so a save/delete right before
     // shutdown is not lost. Deletions first, then changes (same order as flush).
     if (!this.running) {
@@ -558,7 +608,13 @@ export class McpWatcher {
             // marked stale (over-approximate, never silent).
             store.clearFilesStale([f.rel, ...recomputed]);
             const staleNow = skipped.length > 0 ? [...dropped, ...skipped] : dropped;
-            if (staleNow.length > 0) store.markFilesStale(staleNow);
+            if (staleNow.length > 0) {
+              store.markFilesStale(staleNow);
+              // The incremental closure hit its work budget and left files explicitly
+              // stale. Rather than let that region grow unbounded until a manual
+              // analyze, schedule the debounced full rebuild (make-index-self-healing).
+              this.scheduleGraphRebuild('stale-region');
+            }
           });
 
           changedFiles.push({ rel: f.rel, content: f.content });
@@ -678,6 +734,69 @@ export class McpWatcher {
       process.stderr.write('[mcp-watcher] background "openlore analyze --force" started; the graph will self-heal shortly.\n');
     } catch (err) {
       process.stderr.write(`[mcp-watcher] background rebuild could not be spawned (${(err as Error).message}) — run "openlore analyze".\n`);
+    }
+  }
+
+  /**
+   * Schedule a debounced, coalesced full-graph rebuild after a trigger an
+   * incremental patch cannot repair (change: make-index-self-healing). Rapid
+   * successive triggers (a `git pull` touching many refs) collapse into one
+   * rebuild. No-op unless a host wired `onGraphStale` or `selfRebuild` is set, so
+   * the plain signatures-only watcher is byte-for-byte unchanged.
+   */
+  private scheduleGraphRebuild(reason: GraphStaleReason): void {
+    if (!this.onGraphStale && !this.selfRebuild) return;
+    // Keep the first reason of a coalesced burst — HEAD-change is the more
+    // salient cause when both fire together, and it arrives first on a switch.
+    if (this.graphStalePendingReason === undefined) this.graphStalePendingReason = reason;
+    if (this.graphStaleTimer) clearTimeout(this.graphStaleTimer);
+    this.graphStaleTimer = setTimeout(() => {
+      const r = this.graphStalePendingReason ?? reason;
+      this.graphStalePendingReason = undefined;
+      this.graphStaleTimer = undefined;
+      if (this.onGraphStale) {
+        try { this.onGraphStale(r); } catch { /* host lane is best-effort */ }
+      } else {
+        this.spawnGraphRebuild(r);
+      }
+    }, GRAPH_STALE_DEBOUNCE_MS);
+    this.graphStaleTimer.unref?.();
+  }
+
+  /**
+   * Repeatable singleflight full `analyze --force` (BM25-only, no network) for the
+   * in-process watcher, which has no host rebuild coordinator. Distinct from the
+   * once-per-process schema-reset heal: this must re-fire across a session (every
+   * branch switch), so it coalesces a trigger that arrives mid-rebuild into one
+   * follow-up run rather than latching forever. Never throws.
+   */
+  private spawnGraphRebuild(reason: GraphStaleReason): void {
+    if (this.graphRebuildRunning) { this.graphRebuildPending = true; return; }
+    const cli = process.argv[1];
+    if (!cli) {
+      process.stderr.write('[mcp-watcher] cannot locate the openlore CLI to auto-rebuild — run "openlore analyze".\n');
+      return;
+    }
+    this.graphRebuildRunning = true;
+    try {
+      const child = spawn(
+        process.execPath,
+        [cli, 'analyze', '--force', '--no-embed', '--output', this.outputPath],
+        { cwd: this.rootPath, stdio: 'ignore', detached: true }
+      );
+      child.on('error', (err) => {
+        this.graphRebuildRunning = false;
+        process.stderr.write(`[mcp-watcher] background graph rebuild failed to start (${err.message}) — run "openlore analyze".\n`);
+      });
+      child.on('exit', () => {
+        this.graphRebuildRunning = false;
+        if (this.graphRebuildPending) { this.graphRebuildPending = false; this.spawnGraphRebuild(reason); }
+      });
+      child.unref();
+      process.stderr.write(`[mcp-watcher] background "openlore analyze --force" started (${reason}); the graph will refresh shortly.\n`);
+    } catch (err) {
+      this.graphRebuildRunning = false;
+      process.stderr.write(`[mcp-watcher] background graph rebuild could not be spawned (${(err as Error).message}) — run "openlore analyze".\n`);
     }
   }
 

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -737,6 +737,11 @@ export class McpWatcher {
     }
   }
 
+  /** Test-only: drive the graph-stale trigger without a real git/fs event. */
+  _triggerGraphStaleForTesting(reason: GraphStaleReason): void {
+    this.scheduleGraphRebuild(reason);
+  }
+
   /**
    * Schedule a debounced, coalesced full-graph rebuild after a trigger an
    * incremental patch cannot repair (change: make-index-self-healing). Rapid


### PR DESCRIPTION
**Status:** LGTM — ready for review. Implements the `make-index-self-healing` change end-to-end; full suite green (290 files, 5654 passed), `openspec validate` passes, dogfooded on a real repo.

## What was missing / motivation
The substrate is excellent at *detecting* a bad index — attestation verdicts, an explicit stale region, tokenizer/schema stamps, doctor's age warning — and then it stops. Repair is always a human running `openlore analyze` (or a post-commit hook they may never have installed). For "background plumbing that just works," detection-without-repair is the gap users actually feel: "the index / semantic search isn't up to date." This closes the loop: every staleness signal that today only warns now triggers the same at-most-once, non-blocking background rebuild the cold-start bootstrap already proved out — with honest disclosure while the repair runs.

## What it does
1. **Generalized repair service** — `cold-start-bootstrap.ts` grows `repairInBackground(dir, reason)` (reasons `index-absent | integrity-mismatched | stale-region | schema-reset | analysis-age`). Same at-most-once latch, never-block / never-throw, `OPENLORE_NO_AUTO_ANALYZE` + `.openlore/config.json autoInit:false` opt-outs. The guard clears only on failure, so a persistent trigger after a completed repair *discloses and stops* — never thrashes. `bootstrapAnalysisInBackground` stays a thin wrapper (cold-start behavior unchanged).
2. **Read-path trigger + disclosure** — in `mcp-handlers/utils.ts`, where `computeIndexIntegrity` and the stale-region/age checks already run, the strongest signal (worst-first) fires the repair. Served answers disclose *repairing* distinctly from *stale* and *absent*: an `orient.indexRepair` marker, a central `[openlore index]` note on every tool response, and `ConfidenceBoundary.repair` on the graph tools (which flips `complete:false`). Never blocked, never presented as fresh. The MCP server registers a forced `buildIndex` as the process-wide builder; without one (CLI/tests) it's a silent no-op, so detection-only behavior is unchanged.
3. **Call-graph freshness without the commit hook** — the watcher gains an opt-in `onGraphStale` / `selfRebuild` seam that fires a *debounced, coalesced* full rebuild on a `.git` HEAD change (branch switch / pull) or a budget-exceeded stale region. `serve` routes it through its existing rebuild coordinator; the in-process MCP watcher self-spawns a repeatable singleflight `analyze --force`. The post-commit hook stays as the fast path. The plain signatures-only watcher is byte-for-byte unchanged (no handler → no-op).
4. **`openlore doctor --fix [--yes]`** — executes exactly the remediations the read-only checks print (re-analyze; re-wire MCP via the install engine), deduped, one TTY confirmation per action (`--yes` for automation). Bare `doctor` stays read-only and `--json` byte-compatible (the internal remediation field is stripped).

## Proof it works
- **Unit (28 new, in the CI suite):** repair latch/retry/opt-outs + in-progress status lifecycle; `computeRepairReason` worst-first selection (and `degraded` is *not* a trigger); `repairDisclosure`/`assembleBoundary` marks incomplete then clears; watcher debounce/coalesce (one fire per burst, repeatable, no-op without a handler); doctor `planRemediations` (only non-ok checks with a remediation, deduped).
- **Full suite:** 290 files, 5654 passed, 2 skipped. `tsc --noEmit` clean. `openspec validate make-index-self-healing` passes.
- **E2E dogfood on a real repo:**
  - `doctor --fix --yes` detected a 48h-stale analysis, re-analyzed, verified fresh.
  - Read-path self-heal: marking a file stale in a real edge store → `readCachedContext` fired the repair exactly once (no thrash on a second read), served the answer non-blocking, disclosed `stale-region`.
  - MCP server starts and serves `orient`; **no false disclosure on a fresh index**; on a stale index the real `orient` response carried both the `indexRepair` marker and the `[openlore index]` note while still returning results.

## Notes
- No new MCP tool (tool count unchanged; no preset/payload-budget movement).
- `autoInit` is added to the config type here; the sibling `unify-onboarding-entrypoint` change shares the same opt-out key (not in this PR).
- Watcher rebuild triggers are strictly opt-in, so existing watcher behavior/tests are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)