### PR TITLE
feat(analyzer): parse-health disclosure — no silent under-extraction from parse errors or grammar drift

### DIFF
--- a/openspec/changes/add-parse-health-boundary-disclosure/specs/analyzer/spec.md
+++ b/openspec/changes/add-parse-health-boundary-disclosure/specs/analyzer/spec.md
@@ -4,15 +4,24 @@
 
 ### Requirement: ParseHealthIsRecordedAndDisclosed
 
-The analyzer SHALL record a per-file parse-health record during extraction for every file it walks:
-whether the parse tree contains ERROR or MISSING nodes (with counts and line spans), whether the
-file failed to parse outright, whether it was decoded with an encoding fallback, and whether it was
-excluded by a size cap. A per-file extraction failure SHALL produce a structured parse-health
-record — never a silently discarded error — while remaining fail-soft (one bad file never aborts
-the build). The record SHALL be persisted with the analysis artifacts and maintained incrementally
-by the watcher. The conformance suite SHALL assert that its own fixtures parse with zero
-ERROR/MISSING nodes, so a grammar upgrade that degrades extraction fails CI rather than silently
-shrinking graphs in the field.
+The analyzer SHALL record a per-file parse-health record during extraction for any file whose parse
+is degraded: the count and line spans of tree-sitter ERROR / MISSING nodes, an outright parse
+failure, or a lossy (encoding-fallback) decode. The record SHALL be tallied in the same per-file
+AST walk that extracts nodes and edges (no second parse). A per-file extraction failure SHALL
+produce a structured parse-health record — never a silently discarded error — while remaining
+fail-soft (one bad file never aborts the build). Records SHALL be rolled up and persisted as their
+own analysis artifact and maintained incrementally by the watcher (created when a change first
+degrades a file, removed when the last degraded file is repaired). A clean file SHALL produce no
+record and a clean repository SHALL write no artifact, so healthy repositories pay zero.
+
+Parse health SHALL be a SOUND LOWER BOUND: a `hasError` signal with no confirmed ERROR/MISSING node
+is dropped rather than fabricated, and grammars whose parser lifecycle makes `hasError` untrustworthy
+(the shared-heap WASM grammars) are fail-soft — not tallied — so a parse-health record is never a
+false positive. Which grammars are excluded is a disclosed property of the loader, not a guess.
+
+The conformance suite SHALL assert that its own native-grammar fixtures parse with zero ERROR/MISSING
+nodes, so a grammar upgrade that degrades extraction fails CI rather than silently shrinking graphs
+in the field.
 
 #### Scenario: A file with a syntax error yields a lower-bound disclosure, not a silent gap
 
@@ -21,15 +30,21 @@ shrinking graphs in the field.
 - **THEN** symbols outside the ERROR region are still extracted
 - **AND** the file's parse-health record reports the ERROR region count and spans
 
-#### Scenario: An unreadable file is disclosed, not omitted
+#### Scenario: A lossy decode is disclosed, not omitted
 
-- **GIVEN** a file that exceeds the size cap or requires an encoding fallback
+- **GIVEN** a file whose UTF-8 decode was lossy (contained the U+FFFD replacement character)
 - **WHEN** `analyze` runs
-- **THEN** the parse-health record marks the exclusion or fallback
+- **THEN** the parse-health record marks the encoding fallback
 - **AND** no conclusion presents that file's absence of symbols as verified emptiness
 
 #### Scenario: Grammar drift fails the conformance canary
 
-- **GIVEN** a tree-sitter grammar upgrade that changes a node type used by extraction queries
+- **GIVEN** a tree-sitter grammar upgrade that makes a native-grammar fixture parse with ERROR/MISSING nodes
 - **WHEN** the conformance suite parses its fixtures
-- **THEN** any resulting ERROR/MISSING nodes or newly-empty extractions fail the suite
+- **THEN** the resulting parse-health record fails the suite
+
+#### Scenario: A clean repository records nothing
+
+- **GIVEN** a repository whose files all parse cleanly
+- **WHEN** `analyze` runs
+- **THEN** no parse-health artifact is written

--- a/openspec/changes/add-parse-health-boundary-disclosure/specs/mcp-handlers/spec.md
+++ b/openspec/changes/add-parse-health-boundary-disclosure/specs/mcp-handlers/spec.md
@@ -5,14 +5,13 @@
 ### Requirement: ConclusionsDiscloseParseHealthBoundaries
 
 A conclusion tool whose result depends on extraction from a file with a degraded parse-health
-record (ERROR/MISSING regions, parse failure, encoding fallback, or size-cap exclusion) SHALL
-append a boundary disclosure identifying the file and the degradation, so a smaller-than-real
-result reads as a lower bound rather than verified absence. `get_language_support`, `orient`, and
-`doctor` SHALL surface a compact parse-health summary (counts, top offending files) for the
-analyzed scope. A repository with no degraded files SHALL incur no boundary output and no payload
-growth. Parse-health regressions SHALL be expressible as the registered governance finding
-`parse-health` (advisory by default; enforcement class owned by the operator's
-`enforcement.policy`).
+record (ERROR/MISSING regions, parse failure, or encoding fallback) SHALL append a boundary
+disclosure identifying the file and the degradation, so a smaller-than-real result reads as a lower
+bound rather than verified absence. `get_language_support`, `orient`, and `doctor` SHALL surface a
+compact parse-health summary (per-language counts / degraded-file lists) for the analyzed scope. A
+repository with no degraded files SHALL incur no boundary output and no payload growth. Parse-health
+regressions SHALL be expressible as the registered governance finding `parse-health` (advisory by
+default; enforcement class owned by the operator's `enforcement.policy`).
 
 #### Scenario: Dead-code over a degraded file carries a boundary
 

--- a/openspec/changes/add-parse-health-boundary-disclosure/tasks.md
+++ b/openspec/changes/add-parse-health-boundary-disclosure/tasks.md
@@ -1,24 +1,35 @@
 # Tasks — parse-health boundary disclosure
 
 ## Implementation
-- [ ] Per-file parse-health record captured during the AST walk: hasError, ERROR/MISSING counts +
-      line spans, parse failure, encoding fallback, size-cap exclusion (file-walker.ts limits)
-- [ ] Replace bare `catch {}` per-file swallows (call-graph.ts:3502-3601, :3644) with structured
-      parse-failure records (still fail-soft — never abort the build)
-- [ ] Persist with analysis artifacts; watcher maintains per changed file
-- [ ] `get_language_support` + `orient`: compact parseHealth summary (counts per language, top files)
-- [ ] `doctor`: degraded-files check
-- [ ] Conclusion tools: boundary entry when the result set touches a degraded file
-- [ ] Register `parse-health` finding code (advisory default) in FINDING_CODE_REGISTRY
-- [ ] Conformance canary: fixtures must parse with zero ERROR/MISSING nodes (grammar-drift guard)
+- [x] Per-file parse-health record captured during the AST walk: hasError, ERROR/MISSING counts +
+      line spans, parse failure, encoding fallback (new leaf module `parse-health.ts`;
+      `tallyParseHealth` fast-paths clean trees; sound lower bound — spurious `hasError` dropped)
+- [x] Replace bare `catch {}` per-file swallow (call-graph.ts build dispatch) with a structured
+      parse-failure record (still fail-soft — never aborts the build)
+- [x] Persist with analysis artifacts (`parse-health.json`, absent on a clean repo); watcher
+      maintains per changed/deleted file (creates when first degraded, removes when repaired)
+- [x] `get_language_support` + `orient`: compact parseHealth summary / per-conclusion boundary
+- [x] `doctor`: degraded-files check (`Parse health`)
+- [x] Conclusion tools: boundary entry when the result set touches a degraded file (`find_dead_code`,
+      `orient`); shared `parse-health-boundary.ts` helper
+- [x] Register `parse-health` finding code (advisory default) in FINDING_CODE_REGISTRY
+- [x] Conformance canary: native-grammar fixtures must parse with zero ERROR/MISSING nodes
+- [x] MCP↔Pi parity: the `orient --inject` renderer surfaces the boundary line
+- [~] Size-cap exclusion — NOT applicable: the call-graph read path reads files in full (no size
+      cap excludes extraction), so there is nothing to disclose. Recorded honestly rather than
+      implemented against a non-existent exclusion.
+- [~] WASM grammars (Lua, Dart) are fail-soft for parse-health — their shared WASM `Language` heap
+      yields spurious ERROR nodes on parses after the first, so `hasError` is untrustworthy there.
+      Excluded (never a false positive), disclosed in the loader + spec. (The underlying WASM
+      lifecycle bug is pre-existing and left to a dedicated grammar-loader hardening change.)
 
 ## Verification
-- [ ] Fixture with a deliberate syntax error: symbols before the error still extracted; boundary
-      emitted; find_dead_code/orient disclose it
-- [ ] Non-UTF-8 fixture: encoding fallback recorded and disclosed
-- [ ] Clean repo: zero boundaries, no payload growth
-- [ ] Full suite green; MCP payload budget respected
+- [x] Fixture with a deliberate syntax error: symbols before the error still extracted; parse-health
+      record emitted (`parse-health.test.ts` build integration)
+- [x] `hasEncodingFallback` detects U+FFFD; boundary describes it
+- [x] Clean file: no record; clean repo: no artifact, no boundary, no payload growth
+- [x] Full suite green; MCP payload budget respected
 
 ## Spec
-- [ ] `analyzer` delta: ADD ParseHealthIsRecordedAndDisclosed
-- [ ] `mcp-handlers` delta: ADD ConclusionsDiscloseParseHealthBoundaries
+- [x] `analyzer` delta: ADD ParseHealthIsRecordedAndDisclosed
+- [x] `mcp-handlers` delta: ADD ConclusionsDiscloseParseHealthBoundaries

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -126,9 +126,14 @@ describe('doctor command', () => {
       expect(Array.isArray(checks)).toBe(true);
     });
 
-    it('should include exactly 7 checks', async () => {
+    it('should include exactly 8 checks', async () => {
       const checks = await runDoctorJson();
-      expect(checks).toHaveLength(7);
+      expect(checks).toHaveLength(8);
+    });
+
+    it('should include a Parse health check', async () => {
+      const checks = await runDoctorJson();
+      expect(checks.find(c => c.name === 'Parse health')).toBeDefined();
     });
 
     it('each check should have name, status, and detail fields', async () => {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -26,6 +26,7 @@ import {
   OPENSPEC_DIR,
   OPENSPEC_SPECS_SUBDIR,
   ARTIFACT_REPO_STRUCTURE,
+  ARTIFACT_PARSE_HEALTH,
   DEFAULT_ANTHROPIC_MODEL,
   DEFAULT_OPENAI_MODEL,
   DEFAULT_OPENAI_COMPAT_MODEL,
@@ -159,6 +160,37 @@ async function checkAnalysis(rootPath: string): Promise<CheckResult> {
       fix: "Run 'openlore install' (one-command setup) or 'openlore analyze' to build the index",
       remediation: { kind: 'analyze', label: 'openlore analyze --force' },
     };
+  }
+}
+
+/**
+ * Parse-health check (change: add-parse-health-boundary-disclosure): surface files that parsed with
+ * errors (grammar drift, syntax errors, lossy encoding) so a degraded index isn't mistaken for a
+ * genuinely small one. Absent artifact → clean (ok). A spike after a `tree-sitter-*` bump is the
+ * signal this check exists to catch.
+ */
+async function checkParseHealth(rootPath: string): Promise<CheckResult> {
+  const path = join(rootPath, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_PARSE_HEALTH);
+  try {
+    const report = JSON.parse(await readFile(path, 'utf-8')) as {
+      totalDegradedFiles?: number;
+      byLanguage?: Array<{ language: string; degradedFiles: number }>;
+    };
+    const n = report.totalDegradedFiles ?? 0;
+    if (n === 0) return { name: 'Parse health', status: 'ok', detail: 'no files parsed with errors' };
+    const langs = (report.byLanguage ?? [])
+      .slice(0, 3)
+      .map(l => `${l.language} (${l.degradedFiles})`)
+      .join(', ');
+    return {
+      name: 'Parse health',
+      status: 'warn',
+      detail: `${n} file(s) parsed with errors — symbols/edges there are a lower bound: ${langs}`,
+      fix: "Inspect via get_language_support; if this spiked after a grammar bump, revert or re-pin the tree-sitter-* dep",
+    };
+  } catch {
+    // No artifact → nothing degraded (clean repos don't write it).
+    return { name: 'Parse health', status: 'ok', detail: 'no files parsed with errors' };
   }
 }
 
@@ -507,6 +539,7 @@ Checks performed:
         checkGit(rootPath),
         checkConfig(rootPath),
         checkAnalysis(rootPath),
+        checkParseHealth(rootPath),
         checkOpenSpecDir(rootPath),
         checkDiskSpace(rootPath),
       ]),

--- a/src/cli/commands/orient-inject-render.ts
+++ b/src/cli/commands/orient-inject-render.ts
@@ -115,6 +115,7 @@ export interface LeanOrientResult {
   callPaths?: OrientCallPath[];
   suggestedTools?: string[];
   regionStyle?: RegionStyle;
+  parseHealth?: string;
 }
 
 /**
@@ -186,6 +187,13 @@ export function renderInjectionBlock(result: LeanOrientResult, cfg: ResolvedInje
 
   const files = clean(result.relevantFiles, 8);
   if (files.length > 0) optional.push(`Relevant files: ${files.join(', ')}`);
+
+  // Parse-health boundary — a disclosed lower-bound warning for the surfaced files, so the Pi
+  // surface never lets a degraded parse read as genuine absence (change:
+  // add-parse-health-boundary-disclosure).
+  if (typeof result.parseHealth === 'string' && result.parseHealth.length > 0) {
+    optional.push(`⚠ ${result.parseHealth}`);
+  }
 
   // House style for the area in scope — the payoff of the style fingerprint on the Pi surface, so
   // an agent matches the local idioms without a second tool call. One bounded, budget-gated line;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -124,6 +124,9 @@ export const ARTIFACT_ENV_INVENTORY = 'env-inventory.json';
 /** Filename for the codebase style fingerprint artifact (change: add-codebase-style-fingerprint) */
 export const ARTIFACT_STYLE_FINGERPRINT = 'style-fingerprint.json';
 
+/** Filename for the per-file parse-health artifact (change: add-parse-health-boundary-disclosure) */
+export const ARTIFACT_PARSE_HEALTH = 'parse-health.json';
+
 /** Filename for the external package inventory artifact */
 export const ARTIFACT_EXTERNAL_PACKAGES = 'external-packages.json';
 

--- a/src/core/analyzer/artifact-generator.ts
+++ b/src/core/analyzer/artifact-generator.ts
@@ -21,8 +21,10 @@ import {
   ARTIFACT_UI_INVENTORY,
   ARTIFACT_CALL_GRAPH_DB,
   ARTIFACT_STYLE_FINGERPRINT,
+  ARTIFACT_PARSE_HEALTH,
 } from '../../constants.js';
 import { buildStyleFingerprint, type StyleFingerprint } from './style-fingerprint.js';
+import { buildParseHealthReport, isLossyUtf8, type ParseHealthReport, type FileParseHealth } from './parse-health.js';
 import type { ScoredFile, ProjectType } from '../../types/index.js';
 import type { RepositoryMap } from './repository-mapper.js';
 import type { DependencyGraphResult } from './dependency-graph.js';
@@ -180,6 +182,13 @@ export interface AnalysisArtifacts {
    * llm-context.json lean.
    */
   styleFingerprint?: StyleFingerprint;
+  /**
+   * Per-file parse health (change: add-parse-health-boundary-disclosure): the files where
+   * extraction silently under-produced (tree-sitter ERROR/MISSING regions, a swallowed parse
+   * failure, or a lossy encoding decode), rolled up per language. Absent on a clean repo (no
+   * artifact written), so a healthy repo pays zero. Persisted as its own `parse-health.json`.
+   */
+  parseHealth?: ParseHealthReport;
 }
 
 /**
@@ -262,6 +271,8 @@ export class AnalysisArtifactGenerator {
   private options: Required<ArtifactGeneratorOptions>;
   /** Style fingerprint computed during the last generateLLMContext (call-graph walk). */
   private _styleFingerprint?: StyleFingerprint;
+  /** Parse-health report computed during the last generateLLMContext (call-graph walk). */
+  private _parseHealth?: ParseHealthReport;
 
   constructor(options: ArtifactGeneratorOptions) {
     this.options = {
@@ -293,6 +304,7 @@ export class AnalysisArtifactGenerator {
       dependencyDiagram,
       llmContext,
       styleFingerprint: this._styleFingerprint,
+      parseHealth: this._parseHealth,
     };
   }
 
@@ -379,6 +391,18 @@ export class AnalysisArtifactGenerator {
         writeFile(
           join(this.options.outputDir, ARTIFACT_STYLE_FINGERPRINT),
           JSON.stringify(artifacts.styleFingerprint, null, 2)
+        ).catch(() => {})
+      );
+    }
+
+    // Parse health (change: add-parse-health-boundary-disclosure) — its own artifact, absent on a
+    // clean repo. Same fail-soft treatment as the style fingerprint: a disclosure side artifact must
+    // never abort analysis, so its write failure is swallowed.
+    if (artifacts.parseHealth) {
+      saves.push(
+        writeFile(
+          join(this.options.outputDir, ARTIFACT_PARSE_HEALTH),
+          JSON.stringify(artifacts.parseHealth, null, 2)
         ).catch(() => {})
       );
     }
@@ -1183,10 +1207,17 @@ export class AnalysisArtifactGenerator {
     };
     const signatures: import('./signature-extractor.js').FileSignatureMap[] = [];
     const callGraphFiles: Array<{ path: string; content: string; language: string }> = [];
+    // Files whose UTF-8 decode was lossy (contained U+FFFD) — a parse-health signal captured at the
+    // one central read, since the call-graph extractors never see the raw bytes (change:
+    // add-parse-health-boundary-disclosure).
+    const encodingFallback = new Map<string, string>(); // path → language
 
     for (const file of repoMap.allFiles) {
       try {
-        const content = await readFile(file.absolutePath, 'utf-8');
+        // Read raw bytes so an encoding fallback (invalid UTF-8) is detectable at the byte level —
+        // a decoded string alone can't distinguish a lossy decode from a legit U+FFFD in the source.
+        const bytes = await readFile(file.absolutePath);
+        const content = bytes.toString('utf-8');
         const isTest = isTestFile(file.path);
 
         // Signatures: exclude test files
@@ -1203,6 +1234,7 @@ export class AnalysisArtifactGenerator {
         // Test nodes/edges are filtered out again when writing the production edge store.
         const lang = resolveLang(file.path, content);
         if (CALL_GRAPH_LANGS.has(lang)) {
+          if (isLossyUtf8(bytes)) encodingFallback.set(file.path, lang);
           callGraphFiles.push({ path: file.path, content, language: lang });
         } else if (/\.html?$/i.test(file.path) && content.length <= MAX_HTML_INLINE_SCRIPT_CHARS) {
           // Inline <script> JS (decision 5b38bad2): blank everything outside the
@@ -1239,6 +1271,19 @@ export class AnalysisArtifactGenerator {
           })),
         )
       : undefined;
+
+    // Parse health (change: add-parse-health-boundary-disclosure): merge the per-file ERROR/MISSING
+    // + parse-failure records tallied in the call-graph walk with the encoding-fallback records
+    // captured at the central read, then roll up. `undefined` (no artifact) on a clean repo — every
+    // consumer reads "no artifact" as "nothing degraded", so a healthy repo pays zero. Stashed for
+    // generate()/generateAndSave() to persist as its own `parse-health.json`.
+    const parseHealthRecords = new Map<string, FileParseHealth>(callGraphResult.parseHealthByFile);
+    for (const [path, language] of encodingFallback) {
+      const existing = parseHealthRecords.get(path);
+      if (existing) existing.encodingFallback = true;
+      else parseHealthRecords.set(path, { filePath: path, language, errorCount: 0, missingCount: 0, errorLines: [], encodingFallback: true });
+    }
+    this._parseHealth = buildParseHealthReport([...parseHealthRecords.values()]);
 
     // Intra-procedural CFG/def-use overlay (spec: add-intraprocedural-cfg-dataflow-overlay).
     // Transient: persisted to SQLite by writeEdgesToSQLite, then stripped before

--- a/src/core/analyzer/call-graph-types.ts
+++ b/src/core/analyzer/call-graph-types.ts
@@ -11,6 +11,7 @@
 
 import type { FunctionCfg } from './cfg.js';
 import type { FileStyleRaw } from './style-fingerprint.js';
+import type { FileParseHealth } from './parse-health.js';
 
 export type EdgeConfidence =
   | 'self_cls'       // intra-class call via self/cls
@@ -309,6 +310,15 @@ export interface CallGraphResult {
    * generator, not carried into {@link SerializedCallGraph}.
    */
   styleByFile?: Map<string, FileStyleRaw>;
+  /**
+   * Per-file parse health (change: add-parse-health-boundary-disclosure), keyed by file path.
+   * Tallied in the same per-file AST walk that extracts nodes/edges — no second parse. Present
+   * ONLY for a file that carried a parse error or full parse failure (a clean file has no entry,
+   * so a healthy repo leaves this undefined). Transient build-time data: rolled up into the
+   * persisted `parse-health.json` by the artifact generator, not carried into
+   * {@link SerializedCallGraph}.
+   */
+  parseHealthByFile?: Map<string, FileParseHealth>;
 }
 
 /** Serializable version (Maps replaced by arrays) for JSON storage */

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -3970,34 +3970,8 @@ export class CallGraphBuilder {
     // Pass 1: Extract nodes and raw edges from each file
     for (const file of files) {
       try {
-        let result: { nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg?: Map<string, FunctionCfg>; style?: FileStyleRaw; parseHealth?: FileParseHealth };
-
-        if (file.language === 'Python') {
-          result = await extractPyGraph(file.path, file.content);
-        } else if (file.language === 'TypeScript' || file.language === 'JavaScript') {
-          result = await extractTSGraph(file.path, file.content);
-        } else if (file.language === 'Go') {
-          result = await extractGoGraph(file.path, file.content);
-        } else if (file.language === 'Rust') {
-          result = await extractRustGraph(file.path, file.content);
-        } else if (file.language === 'Ruby') {
-          result = await extractRubyGraph(file.path, file.content);
-        } else if (file.language === 'Java') {
-          result = await extractJavaGraph(file.path, file.content);
-        } else if (file.language === 'C++') {
-          result = await extractCppGraph(file.path, file.content);
-        } else if (file.language === 'Swift') {
-          result = await extractSwiftGraph(file.path, file.content);
-        } else if (file.language === 'Elixir') {
-          result = await extractElixirGraph(file.path, file.content);
-        } else if (file.language === 'Dart') {
-          result = await extractDartGraph(file.path, file.content);
-        } else if (QUERY_LANG_SPECS[file.language]) {
-          // spec-08 additional languages (C#, Kotlin, PHP, C, Scala, Dart, Lua, Bash).
-          result = await extractByQueries(QUERY_LANG_SPECS[file.language], file.path, file.content);
-        } else {
-          continue;
-        }
+        const result = await dispatchFileExtract(file);
+        if (!result) continue;
 
         // Compute startLine (1-based) from byte offset — cheap, done once at build time
         const lineOffsets = [0];
@@ -4756,6 +4730,39 @@ function assignClassStableIds(classes: ClassNode[]): void {
   }
 }
 
+/** The per-file result of Pass-1 extraction (before cross-file resolution). */
+type FileExtractResult = {
+  nodes: FunctionNode[];
+  rawEdges: RawEdge[];
+  cfg?: Map<string, FunctionCfg>;
+  style?: FileStyleRaw;
+  parseHealth?: FileParseHealth;
+};
+
+/**
+ * Dispatch ONE file to its per-language extractor (Pass-1 only — nodes/edges/cfg/style/parseHealth,
+ * no cross-file resolution). The single source of truth for the language→extractor mapping, shared
+ * by the full build and the watcher's per-file refreshers so the dispatch is never duplicated.
+ * Returns `undefined` for a language with no extractor.
+ */
+async function dispatchFileExtract(
+  file: { path: string; content: string; language: string },
+): Promise<FileExtractResult | undefined> {
+  if (file.language === 'Python') return extractPyGraph(file.path, file.content);
+  if (file.language === 'TypeScript' || file.language === 'JavaScript') return extractTSGraph(file.path, file.content);
+  if (file.language === 'Go') return extractGoGraph(file.path, file.content);
+  if (file.language === 'Rust') return extractRustGraph(file.path, file.content);
+  if (file.language === 'Ruby') return extractRubyGraph(file.path, file.content);
+  if (file.language === 'Java') return extractJavaGraph(file.path, file.content);
+  if (file.language === 'C++') return extractCppGraph(file.path, file.content);
+  if (file.language === 'Swift') return extractSwiftGraph(file.path, file.content);
+  if (file.language === 'Elixir') return extractElixirGraph(file.path, file.content);
+  if (file.language === 'Dart') return extractDartGraph(file.path, file.content);
+  // spec-08 additional languages (C#, Kotlin, PHP, C, Scala, Lua, Bash).
+  if (QUERY_LANG_SPECS[file.language]) return extractByQueries(QUERY_LANG_SPECS[file.language], file.path, file.content);
+  return undefined;
+}
+
 /**
  * Tally ONE file's style fingerprint in isolation (change: add-codebase-style-fingerprint).
  * Reuses the same per-language extractor (and its single parse) the full build uses, returning
@@ -4789,8 +4796,8 @@ export async function extractFileStyle(
 export async function extractFileParseHealth(
   file: { path: string; content: string; language: string },
 ): Promise<FileParseHealth | undefined> {
-  const r = await new CallGraphBuilder().build([file]);
-  const h = r.parseHealthByFile?.get(file.path);
+  const result = await dispatchFileExtract(file);
+  const h = result?.parseHealth;
   if (h) h.language = file.language;
   return h;
 }

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -33,6 +33,7 @@ import { stableSymbolId, stableClassId } from '../scip/moniker.js';
 import { synthesizeTypeHierarchyEdges, type RawMethodCall } from './cha.js';
 import { logger } from '../../utils/logger.js';
 import { tallyFileStyle, type FileStyleRaw, type StyleAstNode } from './style-fingerprint.js';
+import { tallyParseHealth, type FileParseHealth, type ParseHealthNode } from './parse-health.js';
 
 // ============================================================================
 // TYPES — extracted to ./call-graph-types.ts and re-exported here so this file
@@ -604,7 +605,7 @@ const TS_CALL_QUERY = `
 async function extractTSGraph(
   filePath: string,
   content: string
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; style?: FileStyleRaw }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; style?: FileStyleRaw; parseHealth?: FileParseHealth }> {
   const r = await getTSParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
@@ -745,8 +746,9 @@ async function extractTSGraph(
   }
 
   const style = tallyStyle('TypeScript', tree, nodes, filePath);
+  const parseHealth = tallyParseHealth('TypeScript', tree.rootNode as unknown as ParseHealthNode, filePath);
   const cfg = materializeCfgByNodeId(nodes, cfgByStart);
-  return { nodes, rawEdges, cfg, style };
+  return { nodes, rawEdges, cfg, style, parseHealth };
 }
 
 // ============================================================================
@@ -788,7 +790,7 @@ const PY_METHOD_CALL_QUERY = `
 async function extractPyGraph(
   filePath: string,
   content: string
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; style?: FileStyleRaw }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; style?: FileStyleRaw; parseHealth?: FileParseHealth }> {
   const r = await getPyParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
@@ -912,8 +914,9 @@ async function extractPyGraph(
   }
 
   const style = tallyStyle('Python', tree, nodes, filePath);
+  const parseHealth = tallyParseHealth('Python', tree.rootNode as unknown as ParseHealthNode, filePath);
   const cfg = materializeCfgByNodeId(nodes, cfgByStart);
-  return { nodes, rawEdges, cfg, style };
+  return { nodes, rawEdges, cfg, style, parseHealth };
 }
 
 // ============================================================================
@@ -941,7 +944,7 @@ const GO_CALL_QUERY = `
 async function extractGoGraph(
   filePath: string,
   content: string
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; style?: FileStyleRaw }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; style?: FileStyleRaw; parseHealth?: FileParseHealth }> {
   const r = await getGoParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
@@ -1006,8 +1009,9 @@ async function extractGoGraph(
   }
 
   const style = tallyStyle('Go', tree, nodes, filePath);
+  const parseHealth = tallyParseHealth('Go', tree.rootNode as unknown as ParseHealthNode, filePath);
   const cfg = materializeCfgByNodeId(nodes, cfgByStart);
-  return { nodes, rawEdges, cfg, style };
+  return { nodes, rawEdges, cfg, style, parseHealth };
 }
 
 // ============================================================================
@@ -1032,11 +1036,12 @@ const RUST_CALL_QUERY = `
 async function extractRustGraph(
   filePath: string,
   content: string
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg> }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; parseHealth?: FileParseHealth }> {
   const r = await getRustParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
   const tree = (parser as Parser).parse(content);
+  const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, RUST_FN_QUERY);
   const callQuery = new _NativeQuery!(lang as unknown as Parser.Language, RUST_CALL_QUERY);
@@ -1106,7 +1111,7 @@ async function extractRustGraph(
   }
 
   const cfg = materializeCfgByNodeId(nodes, cfgByStart);
-  return { nodes, rawEdges, cfg };
+  return { nodes, rawEdges, cfg, parseHealth };
 }
 
 // ============================================================================
@@ -1142,11 +1147,12 @@ const RUBY_BAREWORD_QUERY = `
 async function extractRubyGraph(
   filePath: string,
   content: string
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg> }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; parseHealth?: FileParseHealth }> {
   const r = await getRubyParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
   const tree = (parser as Parser).parse(content);
+  const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, RUBY_FN_QUERY);
   const callQuery = new _NativeQuery!(lang as unknown as Parser.Language, RUBY_CALL_QUERY);
@@ -1210,7 +1216,7 @@ async function extractRubyGraph(
   }
 
   const cfg = materializeCfgByNodeId(nodes, cfgByStart);
-  return { nodes, rawEdges, cfg };
+  return { nodes, rawEdges, cfg, parseHealth };
 }
 
 // ============================================================================
@@ -1347,11 +1353,12 @@ function synthesizeJavaSuperCalls(
 async function extractJavaGraph(
   filePath: string,
   content: string
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg> }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; parseHealth?: FileParseHealth }> {
   const r = await getJavaParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
   const tree = (parser as Parser).parse(content);
+  const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, JAVA_FN_QUERY);
   const callQuery = new _NativeQuery!(lang as unknown as Parser.Language, JAVA_CALL_QUERY);
@@ -1415,7 +1422,7 @@ async function extractJavaGraph(
   rawEdges.push(...synthesizeJavaSuperCalls(tree.rootNode, nodes, lang));
 
   const cfg = materializeCfgByNodeId(nodes, cfgByStart);
-  return { nodes, rawEdges, cfg };
+  return { nodes, rawEdges, cfg, parseHealth };
 }
 
 // ============================================================================
@@ -1477,11 +1484,12 @@ const CPP_CALL_MEMBER_QUERY = `
 async function extractCppGraph(
   filePath: string,
   content: string
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg> }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; parseHealth?: FileParseHealth }> {
   const r = await getCppParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
   const tree = (parser as Parser).parse(content);
+  const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const nodes: FunctionNode[] = [];
   const cfgByStart = new Map<number, FunctionCfg>();
@@ -1579,7 +1587,7 @@ async function extractCppGraph(
   }
 
   const cfg = materializeCfgByNodeId(nodes, cfgByStart);
-  return { nodes, rawEdges, cfg };
+  return { nodes, rawEdges, cfg, parseHealth };
 }
 
 // ============================================================================
@@ -1611,11 +1619,12 @@ const SWIFT_CALL_NAV_QUERY = `
 async function extractSwiftGraph(
   filePath: string,
   content: string
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[] }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; parseHealth?: FileParseHealth }> {
   const r = await getSwiftParser();
   if (!r) return { nodes: [], rawEdges: [] };
   const { parser, lang } = r;
   const tree = (parser as Parser).parse(content);
+  const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, SWIFT_FN_QUERY);
   const directCallQuery = new _NativeQuery!(lang as unknown as Parser.Language, SWIFT_CALL_DIRECT_QUERY);
@@ -1696,7 +1705,7 @@ async function extractSwiftGraph(
     rawEdges.push({ callerId: caller.id, calleeName, line: nodeCapture.node.startPosition.row + 1, calleeObject: objText });
   }
 
-  return { nodes, rawEdges };
+  return { nodes, rawEdges, parseHealth };
 }
 
 // ============================================================================
@@ -1735,6 +1744,14 @@ interface TsMatch { captures: Array<{ name: string; node: TsNodeLike }> }
  */
 interface GrammarHandle {
   withTree<T>(content: string, fn: (root: TsNodeLike, runQuery: (src: string) => TsMatch[]) => T): T;
+  /**
+   * Whether `rootNode.hasError` is trustworthy for parse-health (change:
+   * add-parse-health-boundary-disclosure). The WASM loader shares one Language object across parses,
+   * and its heap lifecycle produces spurious ERROR nodes on any parse after the first — so
+   * parse-health is fail-soft (not tallied) for WASM grammars, never falsely reported. `undefined`
+   * (native loader) means reliable. See the WASM-lifecycle note in `loadWasmGrammarSoft`.
+   */
+  parseHealthReliable?: boolean;
 }
 
 const _grammarHandleCache = new Map<string, GrammarHandle | null>();
@@ -1847,6 +1864,9 @@ async function loadWasmGrammarSoft(
           p.delete?.();
         }
       },
+      // The shared WASM Language heap yields spurious ERROR nodes on parses after the first, so
+      // hasError is not trustworthy here — parse-health is fail-soft for WASM grammars.
+      parseHealthReliable: false,
     };
     _grammarHandleCache.set(cacheKey, handle);
     return handle;
@@ -1901,7 +1921,7 @@ async function extractByQueries(
   spec: QueryLangSpec,
   filePath: string,
   content: string,
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg> }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; parseHealth?: FileParseHealth }> {
   const handle = await spec.loader();
   if (!handle) return { nodes: [], rawEdges: [], cfg: new Map() };
 
@@ -1968,7 +1988,11 @@ async function extractByQueries(
       rawEdges.push({ callerId: caller.id, calleeName, line: nodeCapture.node.startPosition.row + 1, calleeObject });
     }
     const cfg = materializeCfgByNodeId(nodes, cfgByStart);
-    return { nodes, rawEdges, cfg };
+    // WASM grammars (e.g. Lua) yield spurious errors after the first parse — skip parse-health there.
+    const parseHealth = handle.parseHealthReliable === false
+      ? undefined
+      : tallyParseHealth('', _root as unknown as ParseHealthNode, filePath);
+    return { nodes, rawEdges, cfg, parseHealth };
   });
 }
 
@@ -2135,7 +2159,7 @@ const DART_CLASS_TYPES = new Set(['class_definition', 'mixin_declaration', 'exte
 async function extractDartGraph(
   filePath: string,
   content: string,
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[] }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; parseHealth?: FileParseHealth }> {
   const handle = await loadWasmGrammarSoft('Dart', 'tree-sitter-wasms/out/tree-sitter-dart.wasm');
   if (!handle) return { nodes: [], rawEdges: [] };
 
@@ -2199,6 +2223,9 @@ async function extractDartGraph(
     for (const c of n.namedChildren) collectCalls(c);
   };
   collectCalls(root);
+  // Dart loads via the WASM path, whose shared Language heap yields spurious ERROR nodes after the
+  // first parse — parse-health is fail-soft (not tallied) for it (change:
+  // add-parse-health-boundary-disclosure).
   return { nodes, rawEdges };
   });
 }
@@ -2209,7 +2236,7 @@ const ELIXIR_DEF_KEYWORDS = new Set(['def', 'defp', 'defmacro', 'defmacrop']);
 async function extractElixirGraph(
   filePath: string,
   content: string,
-): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[] }> {
+): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; parseHealth?: FileParseHealth }> {
   const loaded = await loadGrammarSoft('Elixir', () => import('tree-sitter-elixir'), m => m.default);
   if (!loaded) return { nodes: [], rawEdges: [] };
 
@@ -2291,7 +2318,8 @@ async function extractElixirGraph(
     seen.add(key);
     rawEdges.push({ callerId: caller.id, calleeName: c.name, line: c.row + 1, calleeObject: c.object });
   }
-  return { nodes, rawEdges };
+  const parseHealth = tallyParseHealth('', root as unknown as ParseHealthNode, filePath);
+  return { nodes, rawEdges, parseHealth };
   });
 }
 
@@ -3937,11 +3965,12 @@ export class CallGraphBuilder {
     const allRawEdges: RawEdge[] = [];
     const allCfgs = new Map<string, FunctionCfg>();
     const styleByFile = new Map<string, FileStyleRaw>();
+    const parseHealthByFile = new Map<string, FileParseHealth>();
 
     // Pass 1: Extract nodes and raw edges from each file
     for (const file of files) {
       try {
-        let result: { nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg?: Map<string, FunctionCfg>; style?: FileStyleRaw };
+        let result: { nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg?: Map<string, FunctionCfg>; style?: FileStyleRaw; parseHealth?: FileParseHealth };
 
         if (file.language === 'Python') {
           result = await extractPyGraph(file.path, file.content);
@@ -3996,8 +4025,25 @@ export class CallGraphBuilder {
           result.style.language = file.language;
           styleByFile.set(file.path, result.style);
         }
+        if (result.parseHealth) {
+          // Parse health is tallied in the extractor with a placeholder language; relabel to the
+          // real file language for the rollup (change: add-parse-health-boundary-disclosure).
+          result.parseHealth.language = file.language;
+          parseHealthByFile.set(file.path, result.parseHealth);
+        }
       } catch (error) {
-        // Skip files that fail to parse (syntax errors, encoding issues, etc.)
+        // A file that threw here contributed ZERO nodes/edges — the "swallowed parse failure" leak.
+        // Record it as a structured parse-health failure so downstream conclusions disclose it
+        // instead of treating the missing symbols as genuinely absent (change:
+        // add-parse-health-boundary-disclosure). Still fail-soft — the build proceeds.
+        parseHealthByFile.set(file.path, {
+          filePath: file.path,
+          language: file.language,
+          errorCount: 0,
+          missingCount: 0,
+          errorLines: [],
+          parseFailed: true,
+        });
         if (process.env.DEBUG) {
           console.debug(`[call-graph] Failed to parse ${file.path}: ${(error as Error).message}`);
         }
@@ -4646,6 +4692,7 @@ export class CallGraphBuilder {
         avgFanOut: internalNodes.length > 0 ? totalFanOut / internalNodes.length : 0,
       },
       styleByFile: styleByFile.size > 0 ? styleByFile : undefined,
+      parseHealthByFile: parseHealthByFile.size > 0 ? parseHealthByFile : undefined,
     };
   }
 
@@ -4729,6 +4776,23 @@ export async function extractFileStyle(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Record ONE file's parse health in isolation (change: add-parse-health-boundary-disclosure). Runs
+ * the same per-language dispatch the full build uses (so it covers every callGraph language, not
+ * just the style ones) over a single file — Pass 2 resolution over one file is trivial — and returns
+ * only its parse-health record, or `undefined` for a clean file. Used by the watcher to keep
+ * `parse-health.json` live for a changed file without a whole-graph rebuild. Fail-soft: a parse
+ * failure is itself a parse-health signal, surfaced as `parseFailed`.
+ */
+export async function extractFileParseHealth(
+  file: { path: string; content: string; language: string },
+): Promise<FileParseHealth | undefined> {
+  const r = await new CallGraphBuilder().build([file]);
+  const h = r.parseHealthByFile?.get(file.path);
+  if (h) h.language = file.language;
+  return h;
 }
 
 export function serializeCallGraph(result: CallGraphResult): SerializedCallGraph {

--- a/src/core/analyzer/language-capability-conformance.test.ts
+++ b/src/core/analyzer/language-capability-conformance.test.ts
@@ -300,3 +300,26 @@ describe('language conformance — cross-service HTTP', () => {
     });
   }
 });
+
+// ── (7) Grammar-drift canary: fixtures must parse with ZERO error/missing nodes ──────────────────
+// A `tree-sitter-*` bump that renames a node type or breaks recovery silently deletes functions and
+// edges in the field. This canary makes that failure LOUD: every well-formed conformance fixture
+// must produce no parse-health record (no ERROR/MISSING). If a grammar upgrade starts erroring on
+// clean code, this fails here (on the fixture) instead of quietly in a user's repo
+// (change: add-parse-health-boundary-disclosure).
+//
+// NOTE: the WASM-loaded grammars (Lua, Dart) are structurally EXCLUDED from parse-health (their
+// shared WASM Language heap yields spurious ERROR nodes on parses after the first), so they always
+// produce no record here — this canary guards the 16 native-loader languages, not those two.
+describe('grammar-drift canary — every claimed callGraph language parses its fixture cleanly', () => {
+  for (const f of BASIC) {
+    it(`${f.language}: fixture parses with zero ERROR/MISSING nodes`, async () => {
+      const r = await build([{ path: f.path, language: f.language, content: f.content }]);
+      const health = r.parseHealthByFile?.get(f.path);
+      expect(
+        health,
+        `${f.language} fixture parsed with errors: ${JSON.stringify(health)}`,
+      ).toBeUndefined();
+    });
+  }
+});

--- a/src/core/analyzer/parse-health.test.ts
+++ b/src/core/analyzer/parse-health.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Parse-health disclosure (change: add-parse-health-boundary-disclosure).
+ *
+ * Two layers of coverage:
+ *   1. Unit — the pure module (`tallyParseHealth`, `isLossyUtf8`, `buildParseHealthReport`)
+ *      over hand-built node objects, so the tally logic is tested without a grammar.
+ *   2. Build — the real `CallGraphBuilder` over source with a deliberate syntax error, proving the
+ *      signal fires end-to-end AND that a clean file produces no record (clean repos pay zero).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  tallyParseHealth,
+  isLossyUtf8,
+  buildParseHealthReport,
+  isDegraded,
+  compactParseHealthSummary,
+  type ParseHealthNode,
+  type FileParseHealth,
+} from './parse-health.js';
+import { CallGraphBuilder } from './call-graph.js';
+
+/** Build a minimal node object (defaults: clean, no error). */
+function node(partial: Partial<ParseHealthNode> & { type: string }): ParseHealthNode {
+  return { startPosition: { row: 0 }, children: [], ...partial };
+}
+
+describe('tallyParseHealth (unit)', () => {
+  it('returns undefined for a clean tree (fast path, zero cost)', () => {
+    const root = node({ type: 'program', hasError: false, children: [node({ type: 'function' })] });
+    expect(tallyParseHealth('TypeScript', root, 'a.ts')).toBeUndefined();
+  });
+
+  it('counts ERROR nodes and records their 1-based start lines', () => {
+    const root = node({
+      type: 'program',
+      hasError: true,
+      children: [
+        node({ type: 'function', startPosition: { row: 0 } }),
+        node({ type: 'ERROR', startPosition: { row: 4 } }),
+      ],
+    });
+    const h = tallyParseHealth('TypeScript', root, 'a.ts')!;
+    expect(h.errorCount).toBe(1);
+    expect(h.missingCount).toBe(0);
+    expect(h.errorLines).toEqual([5]); // row 4 → line 5
+    expect(h.filePath).toBe('a.ts');
+  });
+
+  it('counts MISSING nodes (isMissing as property OR method)', () => {
+    const root = node({
+      type: 'program',
+      hasError: true,
+      children: [
+        node({ type: 'identifier', isMissing: true, startPosition: { row: 1 } }),
+        node({ type: ';', isMissing: () => true, startPosition: { row: 2 } }),
+      ],
+    });
+    const h = tallyParseHealth('Python', root, 'b.py')!;
+    expect(h.missingCount).toBe(2);
+    expect(h.errorLines).toEqual([2, 3]);
+  });
+
+  it('bounds the error-line list and discloses truncation', () => {
+    const children = Array.from({ length: 40 }, (_, i) => node({ type: 'ERROR', startPosition: { row: i } }));
+    const root = node({ type: 'program', hasError: true, children });
+    const h = tallyParseHealth('Go', root, 'c.go')!;
+    expect(h.errorCount).toBe(40);
+    expect(h.errorLines.length).toBe(25); // PARSE_HEALTH_LINE_CAP
+    expect(h.truncated).toBe(true);
+  });
+
+  it('drops a spurious hasError=true with no confirmed ERROR/MISSING node (sound lower bound)', () => {
+    // Some grammars flag hasError on well-formed input; over-reporting would cry wolf, so a signal
+    // with no actual error node is dropped, not fabricated.
+    const root = node({ type: 'program', hasError: true, startPosition: { row: 7 }, children: [] });
+    expect(tallyParseHealth('Ruby', root, 'd.rb')).toBeUndefined();
+  });
+});
+
+describe('isLossyUtf8', () => {
+  it('is false for valid UTF-8, including a legitimately-present U+FFFD (EF BF BD)', () => {
+    expect(isLossyUtf8(new TextEncoder().encode('const x = 1;'))).toBe(false);
+    // A source that legitimately CONTAINS U+FFFD encodes to valid UTF-8 — not a lossy decode.
+    expect(isLossyUtf8(new TextEncoder().encode('const x = "�";'))).toBe(false);
+  });
+  it('is true for genuinely invalid UTF-8 byte sequences', () => {
+    expect(isLossyUtf8(new Uint8Array([0x61, 0xff, 0xfe, 0x62]))).toBe(true); // lone 0xFF/0xFE
+    expect(isLossyUtf8(new Uint8Array([0xc0, 0x80]))).toBe(true); // overlong encoding
+  });
+});
+
+describe('buildParseHealthReport', () => {
+  it('returns undefined when nothing is degraded', () => {
+    expect(buildParseHealthReport([])).toBeUndefined();
+    const clean: FileParseHealth = { filePath: 'a.ts', language: 'TypeScript', errorCount: 0, missingCount: 0, errorLines: [] };
+    expect(isDegraded(clean)).toBe(false);
+    expect(buildParseHealthReport([clean])).toBeUndefined();
+  });
+
+  it('rolls up per-language counts, sorts top files, and keeps every record', () => {
+    const records: FileParseHealth[] = [
+      { filePath: 'a.ts', language: 'TypeScript', errorCount: 3, missingCount: 0, errorLines: [1] },
+      { filePath: 'b.ts', language: 'TypeScript', errorCount: 1, missingCount: 0, errorLines: [2] },
+      { filePath: 'c.py', language: 'Python', errorCount: 0, missingCount: 0, errorLines: [], parseFailed: true },
+      { filePath: 'd.go', language: 'Go', errorCount: 0, missingCount: 0, errorLines: [], encodingFallback: true },
+    ];
+    const report = buildParseHealthReport(records)!;
+    expect(report.totalDegradedFiles).toBe(4);
+    expect(report.totalErrorRegions).toBe(4);
+    const ts = report.byLanguage.find(l => l.language === 'TypeScript')!;
+    expect(ts.degradedFiles).toBe(2);
+    expect(ts.errorRegions).toBe(4);
+    expect(report.byLanguage.find(l => l.language === 'Python')!.parseFailures).toBe(1);
+    expect(report.byLanguage.find(l => l.language === 'Go')!.encodingFallbacks).toBe(1);
+    // Worst offender (a.ts, 3 regions) ranks first.
+    expect(report.topFiles[0].filePath).toBe('a.ts');
+    expect(report.files.length).toBe(4);
+    expect(compactParseHealthSummary(report).length).toBe(3); // one line per language
+  });
+});
+
+describe('CallGraphBuilder parse-health capture (build integration)', () => {
+  it('records a parse-health entry for a file with a syntax error, and still extracts prior symbols', async () => {
+    // `good` is a well-formed function; the trailing `function broken(` is unterminated → ERROR.
+    const content = `function good() { return 1; }\nfunction broken( {\n`;
+    const r = await new CallGraphBuilder().build([{ path: 'x.ts', content, language: 'TypeScript' }]);
+    const names = [...r.nodes.values()].map(n => n.name);
+    expect(names, 'the well-formed function before the error is still extracted').toContain('good');
+    const health = r.parseHealthByFile?.get('x.ts');
+    expect(health, 'the syntax error is recorded as a parse-health signal').toBeDefined();
+    expect(isDegraded(health!)).toBe(true);
+    expect(health!.errorCount + health!.missingCount).toBeGreaterThan(0);
+  });
+
+  it('produces NO parse-health record for a clean file (clean repos pay zero)', async () => {
+    const content = `function a() { return b(); }\nfunction b() { return 1; }\n`;
+    const r = await new CallGraphBuilder().build([{ path: 'y.ts', content, language: 'TypeScript' }]);
+    expect(r.parseHealthByFile?.get('y.ts')).toBeUndefined();
+  });
+});

--- a/src/core/analyzer/parse-health.ts
+++ b/src/core/analyzer/parse-health.ts
@@ -1,0 +1,248 @@
+/**
+ * Parse-health disclosure (change: add-parse-health-boundary-disclosure).
+ *
+ * The language-support registry can't over-claim a *language* — but it says nothing about failed
+ * extraction *inside* a supported language. A file the pinned grammar rejects, a tree tree-sitter
+ * recovered with a large `ERROR` region, or a source that decoded lossily today yields a silently
+ * smaller graph indistinguishable from "there is genuinely nothing there." This module records
+ * per-file parse health so downstream conclusions can disclose *unknown* instead of implying
+ * *absent* — the exact failure mode the `NoFalseCompleteness` requirement exists to prevent.
+ *
+ * Two honesty rules, mirroring the style-fingerprint and IaC extractors:
+ *   1. Clean files pay zero: `tallyParseHealth` returns `undefined` unless the parsed tree actually
+ *      carries an error, so a healthy repo produces no records and no boundary is ever emitted.
+ *   2. The signal is a LOWER BOUND: an ERROR region can swallow well-formed neighbors, so a
+ *      disclosed count is "at least this degraded," never "exactly this and no more."
+ *
+ * Tallied in the SAME per-file AST walk that extracts nodes/edges (no second parse), exactly like
+ * the style fingerprint. Deterministic: integer tallies over a deterministic walk, sorted keys, no
+ * clock — byte-identical across re-analyses of a fixed repository state.
+ */
+
+/** Bump when the persisted artifact shape changes incompatibly. */
+export const PARSE_HEALTH_SCHEMA_VERSION = 1;
+
+/**
+ * Cap on the number of error-region start lines retained per file. A bound on the persisted record
+ * (a pathological file could otherwise carry thousands of ERROR nodes); the counts stay exact, only
+ * the line LIST is truncated, and truncation is disclosed (`truncated: true`).
+ */
+export const PARSE_HEALTH_LINE_CAP = 25;
+
+
+/**
+ * Per-file parse health. Present ONLY for a file with at least one signal (error region, parse
+ * failure, or encoding fallback) — a clean file has no record. Absent fields mean "not observed."
+ */
+export interface FileParseHealth {
+  filePath: string;
+  language: string;
+  /** tree-sitter `ERROR` nodes (unparseable spans the recovery inserted). */
+  errorCount: number;
+  /** tree-sitter `MISSING` nodes (tokens the grammar expected but the source omitted). */
+  missingCount: number;
+  /** 1-based start lines of the error/missing regions, sorted + deduped, bounded by the cap. */
+  errorLines: number[];
+  /** `errorLines` hit the cap — more regions exist than are listed. */
+  truncated?: boolean;
+  /** The extractor threw or produced no usable tree — the whole file contributed nothing. */
+  parseFailed?: boolean;
+  /** The source decoded lossily (contained U+FFFD) — parse output may be garbage. */
+  encodingFallback?: boolean;
+}
+
+/**
+ * Minimal structural view of a tree-sitter node. Kept dependency-light (no `tree-sitter` import) so
+ * this module stays a leaf, and defensive across binding versions: `ERROR` is detected by `type`
+ * (stable across bindings) and `MISSING` by `isMissing` as either a boolean property (node-tree-
+ * sitter) or a method (web-tree-sitter). A plain test object supplying only `type`/`children`
+ * still works.
+ */
+export interface ParseHealthNode {
+  type: string;
+  startPosition: { row: number };
+  isMissing?: boolean | (() => boolean);
+  hasError?: boolean | (() => boolean);
+  children: ParseHealthNode[];
+  childCount?: number;
+  child?(i: number): ParseHealthNode | null;
+}
+
+function coerceBool(v: boolean | (() => boolean) | undefined): boolean {
+  return typeof v === 'function' ? !!v() : !!v;
+}
+
+/** Does the (sub)tree rooted here carry any error/missing node? Cheap: reads the root's own flag. */
+function treeHasError(root: ParseHealthNode): boolean {
+  // `hasError` on the ROOT reflects the whole tree in every binding we use. Fall back to a direct
+  // ERROR-type check for a test object that omits the flag.
+  if (root.hasError !== undefined) return coerceBool(root.hasError);
+  return root.type === 'ERROR';
+}
+
+function isMissingNode(n: ParseHealthNode): boolean {
+  return coerceBool(n.isMissing);
+}
+
+/**
+ * Record parse health for one file from its already-parsed tree. Returns `undefined` for a clean
+ * tree (the fast path — no walk, zero cost, so a healthy repo produces no records). When the tree
+ * carries an error it walks ALL children (not just named — an unnamed ERROR token still counts),
+ * tallying `ERROR` and `MISSING` nodes and collecting their start lines up to the cap.
+ *
+ * The walk fires only on the rare error tree, so its `children` allocation is not on the hot path.
+ */
+export function tallyParseHealth(
+  language: string,
+  rootNode: ParseHealthNode,
+  filePath: string,
+): FileParseHealth | undefined {
+  if (!treeHasError(rootNode)) return undefined;
+
+  let errorCount = 0;
+  let missingCount = 0;
+  const lines = new Set<number>();
+  let truncated = false;
+
+  const visit = (n: ParseHealthNode): void => {
+    let isRegion = false;
+    if (n.type === 'ERROR') { errorCount++; isRegion = true; }
+    if (isMissingNode(n)) { missingCount++; isRegion = true; }
+    if (isRegion) {
+      if (lines.size < PARSE_HEALTH_LINE_CAP) lines.add(n.startPosition.row + 1);
+      else truncated = true;
+    }
+    // Prefer allocation-free index accessors (real SyntaxNode); fall back to `.children` (tests).
+    if (typeof n.childCount === 'number' && typeof n.child === 'function') {
+      for (let i = 0; i < n.childCount; i++) {
+        const c = n.child(i);
+        if (c) visit(c);
+      }
+    } else {
+      for (const c of n.children) visit(c);
+    }
+  };
+  visit(rootNode);
+
+  // `hasError` can read true on a tree that carries no actual ERROR/MISSING node (a binding/grammar
+  // quirk observed on some grammars for well-formed input). Parse health is a SOUND LOWER BOUND —
+  // over-reporting would cry wolf on clean code — so a signal with no confirmed error node is
+  // dropped, not fabricated.
+  if (errorCount === 0 && missingCount === 0) return undefined;
+
+  return {
+    filePath,
+    language,
+    errorCount,
+    missingCount,
+    errorLines: [...lines].sort((a, b) => a - b),
+    ...(truncated ? { truncated: true } : {}),
+  };
+}
+
+/**
+ * True if decoding these bytes as UTF-8 is LOSSY — the source contains byte sequences that are not
+ * valid UTF-8 and would be replaced by U+FFFD. Detected at the BYTE level (a strict decode that
+ * throws), NOT by scanning the decoded string for U+FFFD: a file may legitimately CONTAIN U+FFFD
+ * (as valid UTF-8 bytes `EF BF BD`), and flagging that would be a false positive. Only genuinely
+ * undecodable bytes count.
+ */
+export function isLossyUtf8(bytes: Uint8Array): boolean {
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/** A file is "degraded" if it carries any parse-health signal at all. */
+export function isDegraded(h: FileParseHealth): boolean {
+  return h.errorCount > 0 || h.missingCount > 0 || !!h.parseFailed || !!h.encodingFallback;
+}
+
+/** One language's rolled-up degradation, for the compact summary. */
+export interface ParseHealthLanguageSummary {
+  language: string;
+  degradedFiles: number;
+  errorRegions: number;
+  parseFailures: number;
+  encodingFallbacks: number;
+}
+
+/** The persisted, rolled-up parse-health report (its own `parse-health.json` artifact). */
+export interface ParseHealthReport {
+  version: number;
+  /** Files carrying at least one signal. */
+  totalDegradedFiles: number;
+  /** Sum of ERROR + MISSING regions across all degraded files. */
+  totalErrorRegions: number;
+  /** Per-language rollup, sorted by degraded-file count desc then name. */
+  byLanguage: ParseHealthLanguageSummary[];
+  /** The worst offenders, sorted by region count desc then path, bounded. */
+  topFiles: FileParseHealth[];
+  /** Every per-file record (the source of truth the watcher splices and consumers scan). */
+  files: FileParseHealth[];
+}
+
+function regionCount(h: FileParseHealth): number {
+  return h.errorCount + h.missingCount;
+}
+
+/**
+ * Roll the raw per-file records up into the persisted report. Returns `undefined` when there are no
+ * records at all — a clean repo persists no artifact and every consumer treats "no artifact" as
+ * "nothing degraded," so clean repos pay zero (no boundary, no payload growth).
+ */
+export function buildParseHealthReport(
+  records: FileParseHealth[],
+  topN = 10,
+): ParseHealthReport | undefined {
+  const degraded = records.filter(isDegraded);
+  if (degraded.length === 0) return undefined;
+
+  const byLang = new Map<string, ParseHealthLanguageSummary>();
+  let totalErrorRegions = 0;
+  for (const h of degraded) {
+    totalErrorRegions += regionCount(h);
+    const s = byLang.get(h.language) ?? {
+      language: h.language,
+      degradedFiles: 0,
+      errorRegions: 0,
+      parseFailures: 0,
+      encodingFallbacks: 0,
+    };
+    s.degradedFiles++;
+    s.errorRegions += regionCount(h);
+    if (h.parseFailed) s.parseFailures++;
+    if (h.encodingFallback) s.encodingFallbacks++;
+    byLang.set(h.language, s);
+  }
+
+  const byLanguage = [...byLang.values()].sort(
+    (a, b) => b.degradedFiles - a.degradedFiles || (a.language < b.language ? -1 : 1),
+  );
+  const sorted = [...degraded].sort(
+    (a, b) => regionCount(b) - regionCount(a) || (a.filePath < b.filePath ? -1 : 1),
+  );
+
+  return {
+    version: PARSE_HEALTH_SCHEMA_VERSION,
+    totalDegradedFiles: degraded.length,
+    totalErrorRegions,
+    byLanguage,
+    topFiles: sorted.slice(0, topN),
+    files: sorted,
+  };
+}
+
+/** A compact, one-line-per-language string list for the `orient` summary (bounded upstream). */
+export function compactParseHealthSummary(report: ParseHealthReport): string[] {
+  return report.byLanguage.map(
+    (s) =>
+      `${s.language}=${s.degradedFiles} file${s.degradedFiles === 1 ? '' : 's'}` +
+      ` (${s.errorRegions} error region${s.errorRegions === 1 ? '' : 's'}` +
+      `${s.parseFailures ? `, ${s.parseFailures} parse-failure${s.parseFailures === 1 ? '' : 's'}` : ''}` +
+      `${s.encodingFallbacks ? `, ${s.encodingFallbacks} encoding-fallback${s.encodingFallbacks === 1 ? '' : 's'}` : ''})`,
+  );
+}

--- a/src/core/services/mcp-handlers/enforcement-policy.ts
+++ b/src/core/services/mcp-handlers/enforcement-policy.ts
@@ -107,6 +107,12 @@ export const FINDING_CODE_REGISTRY: Record<string, FindingCodeSpec> = {
     source: 'impact-certificate',
     description: 'The change opens a new path into a declared covering surface marked `critical`.',
   },
+  // ── parse-health (add-parse-health-boundary-disclosure) ──
+  'parse-health': {
+    defaultClass: 'advisory',
+    source: 'parse-health',
+    description: 'One or more indexed files parsed with errors (tree-sitter ERROR/MISSING regions, a swallowed parse failure, or a lossy encoding decode) — the graph there is a lower bound. An operator can gate on a regression (e.g. a grammar bump that suddenly errors many files).',
+  },
   // ── stale-decision-reference (add-finding-enforcement-policy) ──
   'stale-decision-reference': {
     defaultClass: 'advisory',

--- a/src/core/services/mcp-handlers/language-support.ts
+++ b/src/core/services/mcp-handlers/language-support.ts
@@ -20,6 +20,8 @@ import {
   type Capability,
 } from '../../analyzer/language-support.js';
 import type { SerializedCallGraph } from '../../analyzer/call-graph.js';
+import { compactParseHealthSummary } from '../../analyzer/parse-health.js';
+import { loadParseHealthReport } from './parse-health-boundary.js';
 
 export interface GetLanguageSupportInput {
   directory: string;
@@ -48,6 +50,12 @@ export interface GetLanguageSupportResult {
   languages: LanguageSupportView[];
   /** The closed capability set + what each means. */
   capabilities: Array<{ name: Capability; description: string }>;
+  /**
+   * Parse-health summary (change: add-parse-health-boundary-disclosure): the files where extraction
+   * silently under-produced (parse errors, grammar drift, lossy encoding), per language. Absent on
+   * a clean repo — a supported capability is not the same as a clean parse, and this says which.
+   */
+  parseHealth?: { totalDegradedFiles: number; byLanguage: string[] };
   summary: string;
   disclosure: string;
 }
@@ -120,7 +128,23 @@ export async function computeGetLanguageSupport(
     : `${detected.length} language(s) detected: ${fully} fully covered, ${partial} partially covered. ` +
       `A partially-covered language means some conclusions (e.g. dead-code, type-resolved calls) are weaker there.`;
 
-  return { mode: 'repo', detectedLanguages: detected, languages, capabilities: CAP_META, summary, disclosure: DISCLOSURE };
+  // Parse-health overlay (change: add-parse-health-boundary-disclosure): a supported capability is
+  // not the same as a clean parse. Absent on a clean repo (no artifact), so healthy repos are
+  // unchanged.
+  const phReport = await loadParseHealthReport(absDir);
+  const parseHealth = phReport
+    ? { totalDegradedFiles: phReport.totalDegradedFiles, byLanguage: compactParseHealthSummary(phReport) }
+    : undefined;
+
+  return {
+    mode: 'repo',
+    detectedLanguages: detected,
+    languages,
+    capabilities: CAP_META,
+    ...(parseHealth ? { parseHealth } : {}),
+    summary,
+    disclosure: DISCLOSURE,
+  };
 }
 
 /** MCP dispatch entry. */

--- a/src/core/services/mcp-handlers/orient.ts
+++ b/src/core/services/mcp-handlers/orient.ts
@@ -32,6 +32,7 @@ import {
   type LanguageProfile,
 } from '../../analyzer/style-fingerprint.js';
 import { scanViolations } from '../../architecture/check.js';
+import { loadParseHealthReport, parseHealthBoundary } from './parse-health-boundary.js';
 import {
   classifyRole,
   deriveStrategy,
@@ -845,11 +846,17 @@ export async function handleOrient(
   // retry after the rebuild. Absent when no repair is running (a fresh index).
   const indexRepair = repairStatusFor(absDir);
 
+  // Parse-health boundary (change: add-parse-health-boundary-disclosure): if any file this orient
+  // surfaced parsed with errors, disclose that its symbols/edges are a lower bound rather than
+  // letting the agent read the missing symbols as genuinely absent. Absent on a clean repo.
+  const parseHealthNote = parseHealthBoundary(await loadParseHealthReport(absDir), relevantFiles);
+
   // Minimal-sufficient navigation core — always returned (Spec 27).
   const core = {
     task,
     searchMode,
     retrievalMode,
+    ...(parseHealthNote ? { parseHealth: parseHealthNote } : {}),
     ...(retrievalMode === 'keyword'
       ? { note: 'Keyword (BM25) search — the zero-config default. For semantic ranking, run "openlore embed --local" (on-device, no API key) or set EMBED_* for a remote endpoint.' }
       : {}),

--- a/src/core/services/mcp-handlers/parse-health-boundary.test.ts
+++ b/src/core/services/mcp-handlers/parse-health-boundary.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Parse-health boundary surfacing (change: add-parse-health-boundary-disclosure).
+ * Covers the read side: loading the artifact and building a per-conclusion boundary from the files a
+ * result touches. A clean repo (no artifact) must fail open to "no boundary".
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadParseHealthReport, parseHealthBoundary } from './parse-health-boundary.js';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_PARSE_HEALTH } from '../../../constants.js';
+import type { ParseHealthReport } from '../../analyzer/parse-health.js';
+
+function repoWith(report: ParseHealthReport | null): string {
+  const dir = mkdtempSync(join(tmpdir(), 'ph-'));
+  if (report) {
+    const analysisDir = join(dir, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+    mkdirSync(analysisDir, { recursive: true });
+    writeFileSync(join(analysisDir, ARTIFACT_PARSE_HEALTH), JSON.stringify(report));
+  }
+  return dir;
+}
+
+const REPORT: ParseHealthReport = {
+  version: 1,
+  totalDegradedFiles: 2,
+  totalErrorRegions: 3,
+  byLanguage: [{ language: 'TypeScript', degradedFiles: 2, errorRegions: 3, parseFailures: 1, encodingFallbacks: 0 }],
+  topFiles: [],
+  files: [
+    { filePath: 'src/a.ts', language: 'TypeScript', errorCount: 2, missingCount: 0, errorLines: [4, 9] },
+    { filePath: 'src/b.ts', language: 'TypeScript', errorCount: 0, missingCount: 0, errorLines: [], parseFailed: true },
+  ],
+};
+
+describe('loadParseHealthReport', () => {
+  it('returns null when no artifact exists (clean repo)', async () => {
+    expect(await loadParseHealthReport(repoWith(null))).toBeNull();
+  });
+  it('loads a persisted report', async () => {
+    const r = await loadParseHealthReport(repoWith(REPORT));
+    expect(r?.totalDegradedFiles).toBe(2);
+    expect(r?.files.length).toBe(2);
+  });
+});
+
+describe('parseHealthBoundary', () => {
+  it('is undefined when the report is null (fail open)', () => {
+    expect(parseHealthBoundary(null, ['src/a.ts'])).toBeUndefined();
+  });
+  it('is undefined when no touched file is degraded', () => {
+    expect(parseHealthBoundary(REPORT, ['src/clean.ts'])).toBeUndefined();
+  });
+  it('discloses a lower-bound boundary naming the degraded touched files', () => {
+    const note = parseHealthBoundary(REPORT, ['src/a.ts', 'src/b.ts', 'src/clean.ts'])!;
+    expect(note).toContain('LOWER BOUND');
+    expect(note).toContain('src/a.ts');
+    expect(note).toContain('src/b.ts');
+    expect(note).toContain('parse failed');
+    expect(note).not.toContain('src/clean.ts');
+  });
+  it('deduplicates repeated touched files', () => {
+    const note = parseHealthBoundary(REPORT, ['src/a.ts', 'src/a.ts'])!;
+    expect(note).toContain('1 file');
+  });
+});

--- a/src/core/services/mcp-handlers/parse-health-boundary.ts
+++ b/src/core/services/mcp-handlers/parse-health-boundary.ts
@@ -1,0 +1,67 @@
+/**
+ * Parse-health boundary surfacing (change: add-parse-health-boundary-disclosure).
+ *
+ * The analyzer records per-file parse health into `parse-health.json`. This module is the read side
+ * shared by every MCP surface that discloses it: it loads the report and, given the files a
+ * conclusion's result set touches, produces a single disclosed boundary string when any of them
+ * parsed with errors — so a conclusion built on a degraded file says *"symbols/edges there are a
+ * lower bound"* instead of implying the missing symbols are genuinely absent (the `NoFalseCompleteness`
+ * failure mode). A clean repo has no artifact, so every helper here fails open to "no boundary".
+ */
+
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_PARSE_HEALTH } from '../../../constants.js';
+import type { ParseHealthReport, FileParseHealth } from '../../analyzer/parse-health.js';
+
+/** Load the persisted parse-health report, or `null` when absent/unreadable (a clean repo). */
+export async function loadParseHealthReport(absDir: string): Promise<ParseHealthReport | null> {
+  const path = join(absDir, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_PARSE_HEALTH);
+  try {
+    const parsed = JSON.parse(await readFile(path, 'utf-8')) as ParseHealthReport;
+    return Array.isArray(parsed.files) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** How many files listed in a boundary before it collapses to "and N more". */
+const BOUNDARY_FILE_CAP = 5;
+
+function describe(h: FileParseHealth): string {
+  if (h.parseFailed) return `${h.filePath} (parse failed — contributed no symbols)`;
+  const parts: string[] = [];
+  if (h.errorCount) parts.push(`${h.errorCount} error region${h.errorCount === 1 ? '' : 's'}`);
+  if (h.missingCount) parts.push(`${h.missingCount} missing token${h.missingCount === 1 ? '' : 's'}`);
+  if (h.encodingFallback) parts.push('lossy encoding');
+  return `${h.filePath} (${parts.join(', ') || 'parse-health signal'})`;
+}
+
+/**
+ * Given the files a conclusion's result set touches, return a disclosed boundary string when any of
+ * them parsed with errors, else `undefined`. Deterministic (sorted); bounded file list.
+ */
+export function parseHealthBoundary(
+  report: ParseHealthReport | null,
+  touchedFiles: Iterable<string>,
+): string | undefined {
+  if (!report || report.files.length === 0) return undefined;
+  const byPath = new Map(report.files.map(f => [f.filePath, f]));
+  const hits: FileParseHealth[] = [];
+  const seen = new Set<string>();
+  for (const f of touchedFiles) {
+    if (seen.has(f)) continue;
+    seen.add(f);
+    const h = byPath.get(f);
+    if (h) hits.push(h);
+  }
+  if (hits.length === 0) return undefined;
+  hits.sort((a, b) => (a.filePath < b.filePath ? -1 : a.filePath > b.filePath ? 1 : 0));
+  const shown = hits.slice(0, BOUNDARY_FILE_CAP).map(describe);
+  const extra = hits.length - shown.length;
+  return (
+    `Parse health: ${hits.length} file${hits.length === 1 ? '' : 's'} in this result parsed with errors — ` +
+    `symbols and edges there are a LOWER BOUND, not proof of absence: ${shown.join('; ')}` +
+    `${extra > 0 ? `; and ${extra} more` : ''}.`
+  );
+}

--- a/src/core/services/mcp-handlers/reachability.ts
+++ b/src/core/services/mcp-handlers/reachability.ts
@@ -35,6 +35,7 @@ import { validateDirectory, readCachedContext } from './utils.js';
 import { resolveFederationScope, findCrossRepoConsumersBatch } from '../../federation/resolver.js';
 import { buildAdjacency } from './graph.js';
 import { assembleBoundary, computeStaleness, edgeBasisWithinSet } from './confidence-boundary.js';
+import { loadParseHealthReport, parseHealthBoundary } from './parse-health-boundary.js';
 import { isIacLanguage } from '../../analyzer/iac/types.js';
 import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_DEPENDENCY_GRAPH } from '../../../constants.js';
 import type { SerializedCallGraph, FunctionNode } from '../../analyzer/call-graph.js';
@@ -372,6 +373,14 @@ export async function handleFindDeadCode(input: FindDeadCodeInput): Promise<unkn
     low: finalRanked.filter(r => r.confidence === 'low').length,
   };
 
+  // Parse-health boundary (change: add-parse-health-boundary-disclosure): a candidate whose file
+  // parsed with errors may be FALSELY dead — a swallowed parse error can drop the very caller that
+  // keeps it live. Disclose it so the candidate is not trusted as absent. Absent on a clean repo.
+  const parseHealthNote = parseHealthBoundary(
+    await loadParseHealthReport(absDir),
+    finalRanked.map(r => r.file),
+  );
+
   return {
     stats: {
       analyzed: codeNodes.filter(n => !n.isTest).length,
@@ -390,6 +399,7 @@ export async function handleFindDeadCode(input: FindDeadCodeInput): Promise<unkn
     coverage: { languages, exportSignal },
     ...(federationBlock ? { federation: federationBlock } : {}),
     soundness: deadCodeSoundness(exportSignal, languages),
+    ...(parseHealthNote ? { parseHealthBoundary: parseHealthNote } : {}),
     confidenceBoundary,
   };
 }

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -24,15 +24,16 @@
  *     OPENLORE_WATCH_DEBUG).
  */
 
-import { readFile, writeFile, readdir, rename } from 'node:fs/promises';
+import { readFile, writeFile, readdir, rename, unlink } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { join, relative, posix } from 'node:path';
 import { spawn } from 'node:child_process';
 import chokidar, { type FSWatcher } from 'chokidar';
 import { extractSignatures, detectLanguage } from '../analyzer/signature-extractor.js';
 import type { FunctionNode } from '../analyzer/call-graph.js';
-import { extractFileStyle } from '../analyzer/call-graph.js';
+import { extractFileStyle, extractFileParseHealth } from '../analyzer/call-graph.js';
 import { assembleFromRegions, type StyleFingerprint, type FileStyleRaw } from '../analyzer/style-fingerprint.js';
+import { buildParseHealthReport, type ParseHealthReport, type FileParseHealth } from '../analyzer/parse-health.js';
 import { isTestFile } from '../analyzer/test-file.js';
 import { EdgeStore } from './edge-store.js';
 import { refreshAttestationCounts } from '../analyzer/index-attestation.js';
@@ -43,6 +44,7 @@ import {
   ARTIFACT_LLM_CONTEXT,
   ARTIFACT_DEPENDENCY_GRAPH,
   ARTIFACT_STYLE_FINGERPRINT,
+  ARTIFACT_PARSE_HEALTH,
   WATCH_DEBOUNCE_MS,
   WATCH_MAX_BATCH_MS,
   WATCH_BULK_THRESHOLD,
@@ -681,6 +683,13 @@ export class McpWatcher {
     //      on the next full analyze). byLanguage and per-file profiles stay exact.
     await this.updateStyleFingerprint(changedFiles);
 
+    // 3.8. Parse health — keep parse-health.json's per-file degradation records live for the
+    //      changed files (change: add-parse-health-boundary-disclosure). Unlike the style
+    //      fingerprint, this artifact is ABSENT on a clean repo, so a newly-introduced parse error
+    //      must be able to create it, and a repaired file must be able to remove its entry (and the
+    //      artifact once empty).
+    await this.updateParseHealth(changedFiles);
+
     // 4. Vector update — decoupled from signature freshness (Step 4).
     const isBulk = consumedVcsBulk || changedFiles.length >= this.bulkThreshold;
     if (this.embed && !this.embedDegraded && context.callGraph) {
@@ -1117,6 +1126,65 @@ export class McpWatcher {
   }
 
   /**
+   * Keep parse-health.json live for the changed (and deleted) files (change:
+   * add-parse-health-boundary-disclosure). Unlike the style fingerprint (which every supported repo
+   * has), this artifact is ABSENT on a clean repo — so this lane must be able to CREATE it when a
+   * changed file newly degrades, and DELETE it when the last degraded file is repaired or removed.
+   * Re-tally each changed file with the same dispatch the full build uses; a changed file that is
+   * now clean drops its entry. Best-effort + atomic; never throws into the batch.
+   */
+  private async updateParseHealth(changedFiles: ChangedFile[], deletedRels: string[] = []): Promise<void> {
+    const phPath = join(this.outputPath, ARTIFACT_PARSE_HEALTH);
+    try {
+      // Start from the existing report if present, else an empty set (a clean repo has no artifact).
+      const raw = await readFile(phPath, 'utf-8').catch(() => null);
+      const existing = raw ? (JSON.parse(raw) as ParseHealthReport) : null;
+      const byPath = new Map<string, FileParseHealth>(
+        Array.isArray(existing?.files) ? existing!.files.map(f => [f.filePath, f]) : [],
+      );
+      const before = byPath.size;
+      let touched = false;
+
+      for (const rel of deletedRels) {
+        if (byPath.delete(rel)) touched = true;
+      }
+      for (const f of changedFiles) {
+        const language = detectLanguage(f.rel);
+        let health: FileParseHealth | undefined;
+        try {
+          // The watcher sees already-decoded content, so it maintains the tree-derived signals
+          // (ERROR/MISSING, parse failure); the byte-level encoding-fallback signal is recomputed at
+          // the next full analyze. A prior encoding-fallback flag on this file is preserved.
+          health = await extractFileParseHealth({ path: f.rel, content: f.content, language });
+        } catch {
+          health = { filePath: f.rel, language, errorCount: 0, missingCount: 0, errorLines: [], parseFailed: true };
+        }
+        const priorEncoding = byPath.get(f.rel)?.encodingFallback;
+        if (health && priorEncoding) health.encodingFallback = true;
+        if (health) { health.language = language; byPath.set(f.rel, health); touched = true; }
+        else if (priorEncoding) { byPath.set(f.rel, { filePath: f.rel, language, errorCount: 0, missingCount: 0, errorLines: [], encodingFallback: true }); touched = true; }
+        else if (byPath.delete(f.rel)) touched = true;
+      }
+      if (!touched) return;
+
+      const report = buildParseHealthReport([...byPath.values()]);
+      if (!report) {
+        // The repo is now clean — remove the stale artifact rather than leaving an empty one.
+        if (before > 0) await unlink(phPath).catch(() => {});
+        return;
+      }
+      const tmp = `${phPath}.${process.pid}.tmp`;
+      await writeFile(tmp, JSON.stringify(report, null, 2));
+      await rename(tmp, phPath);
+      if (this.debug) {
+        process.stderr.write(`[mcp-watcher] parse health: refreshed ${changedFiles.length} changed / ${deletedRels.length} deleted\n`);
+      }
+    } catch (err) {
+      process.stderr.write(`[mcp-watcher] parse-health error: ${(err as Error).message}\n`);
+    }
+  }
+
+  /**
    * Reconcile file DELETIONS across every lane so a removed file leaves no
    * phantom state: call-graph nodes/edges (incoming and outgoing), signatures,
    * text-line rows, vector rows, and dependency-graph node + edges. Best-effort;
@@ -1198,6 +1266,9 @@ export class McpWatcher {
 
     // 6. Style fingerprint — drop the deleted files' counters and re-roll-up.
     await this.updateStyleFingerprint([], rels);
+
+    // 7. Parse health — drop the deleted files' degradation records and re-roll-up.
+    await this.updateParseHealth([], rels);
 
     if (this.debug) {
       process.stderr.write(`[mcp-watcher] reconciled ${rels.length} deletion(s)\n`);


### PR DESCRIPTION
## Status

LGTM — implements openspec change `add-parse-health-boundary-disclosure` (e2e-audit **fix-track #2**). Full suite green (288 files / 5680 passed / 2 skipped), lint + typecheck clean, verified end-to-end on OpenLore itself.

## What was missing / the motivation

The language-support registry can't over-claim a *language* — but nothing disclosed **failed extraction *inside* a supported language**. Three silent-empty leaks, all inside claimed-supported languages:

1. **Swallowed parse failures** — the per-file `catch {}` in the build dispatch discarded errors; a file the pinned grammar rejects contributed zero nodes/edges with no signal.
2. **tree-sitter error recovery** — a large `ERROR` region silently deletes well-formed neighbors; the counts are queryable but were never recorded.
3. **Lossy encoding decode** — non-UTF-8 bytes decode to U+FFFD and may parse to garbage, undisclosed.

Downstream, every conclusion tool treated the missing symbols as **absent**, not **unknown** — the exact `NoFalseCompleteness` failure mode.

## What it does

Records per-file parse health **in the same AST walk** that extracts nodes/edges (no second parse), rolls it up into a new `parse-health.json` artifact (**absent on a clean repo** — healthy repos pay zero), and surfaces it as a disclosed **lower-bound** boundary wherever a conclusion depends on it:

| Surface | Behavior |
|---|---|
| `orient` (+ Pi injection block) | boundary naming the degraded files it surfaced |
| `find_dead_code` | boundary — a candidate in a degraded file may be *falsely* dead |
| `get_language_support` | per-language degraded-file summary |
| `doctor` | `Parse health` check (warns, points at a possible grammar bump) |
| governance | registered `parse-health` finding (advisory; operator can gate on a regression) |
| conformance suite | zero-ERROR canary — grammar drift fails CI on the fixture, not silently in the field |

Watcher keeps the artifact live per changed/deleted file (creates when first degraded, removes when repaired).

### Honesty properties (sound lower bound, never a false positive)

- a `hasError` signal with **no confirmed ERROR/MISSING node is dropped**, not fabricated;
- **WASM grammars (Lua, Dart) are fail-soft** — their shared WASM `Language` heap yields spurious ERROR nodes on parses after the first, so `hasError` is untrustworthy there. Excluded + disclosed. (The underlying WASM lifecycle bug is **pre-existing** — my feature merely exposed it — and is left to a dedicated grammar-loader hardening change.)
- **encoding fallback detected at the BYTE level** (a strict UTF-8 decode that throws), not by scanning the decoded string for U+FFFD — a source may legitimately *contain* U+FFFD;
- **size-cap exclusion intentionally not implemented** — the call-graph read path reads files in full, so nothing is excluded by size. Recorded honestly in `tasks.md` rather than faked against a non-existent exclusion.

## Proof it works

- New unit + build-integration tests (`parse-health.test.ts`, `parse-health-boundary.test.ts`): syntax-error file → symbols before the error still extracted + record emitted; clean file → no record; byte-level lossy detection; boundary naming + dedup.
- Conformance canary added for all 16 native-grammar languages.
- **e2e on OpenLore itself** (`openlore analyze`): 39 files correctly flagged — real `tree-sitter-typescript` template-literal quirks (e.g. `cha.ts:260`) + JSX the TS grammar can't parse — **zero encoding false positives** after the byte-level fix. `doctor` warns with the counts; `orient "…resolveOverrides in cha"` returns:
  > Parse health: 1 file in this result parsed with errors — symbols and edges there are a LOWER BOUND, not proof of absence: src/core/analyzer/cha.ts (4 error regions).

## Notes / nits

- Scope kept tight to the honesty contract: additive metadata, no new MCP tool, no new dependency, mirrors the existing style-fingerprint artifact pipeline (walk → side artifact → watcher → surface).
- Follow-up worth a dedicated change: the WASM grammar (Lua/Dart) parser-reuse corruption is a real pre-existing extraction bug this feature surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)