### PR TITLE
feat(analyzer): harden call resolution — never bind by first-match on ambiguity

### DIFF
--- a/openspec/changes/harden-call-resolution-ambiguity/proposal.md
+++ b/openspec/changes/harden-call-resolution-ambiguity/proposal.md
@@ -46,10 +46,15 @@ lower-confidence edge or no edge — never an arbitrary first match.**
   duplicating it.
 - `type_name` resolution binds only a unique match; multiple same-named types → unresolved-ambiguous
   (same disposition as above).
-- Overloads: the trie gains an **arity** discriminator where the language exposes it (parameter
-  count is already in every signature). Exact-arity match binds; ambiguous arity falls into the same
-  ambiguity handling. No type-based overload resolution is attempted (that would need a type
-  checker — out of scope, disclosed).
+- Overloads: **deferred to a follow-up (disclosed).** The audit assumed overload siblings survive as
+  distinct nodes "orphaned at fan-in 0"; the measured behavior is different and more consequential —
+  same-name/different-arity overloads share the node id `file::Class.method`, so one is silently
+  DROPPED at node identity before the resolution ladder runs. The ladder therefore never sees a
+  multi-candidate overload set, and this change's ambiguity guards cannot reach it. Recovering
+  overloads requires arity-qualified node identity plus call-site argument-count capture across the
+  extractors — a node-identity change whose blast radius (stable ids, the CFG side-table, symbol
+  continuity, every node-count consumer) is different and larger than the resolution-ladder guesses
+  this change targets. It is carved into a dedicated follow-up rather than bundled here.
 - Conformance suite gains the missing adversarial fixtures: a cross-file **name-collision** fixture
   per resolution strategy (bare call, self/cls, type_name, overload pair), asserting the ambiguous
   case does NOT bind arbitrarily, plus cross-file happy-path fixtures for all 18 callGraph languages
@@ -72,8 +77,10 @@ substrate's authority. This change makes the ladder's documented discipline true
 
 ## Impact
 
-- `src/core/analyzer/call-graph.ts` (Strategy 1/1b/4 sites above), the symbol trie (arity
-  dimension), `call-graph-types.ts` (ambiguous disposition), conformance suite fixtures.
+- `src/core/analyzer/call-graph.ts` (Strategy 1/1a/1b/4 sites above), `call-graph-types.ts`
+  (ambiguous disposition), the resident-graph serializer + the three conclusion consumers
+  (`find_dead_code`, `analyze_error_propagation`, `analyze_impact`), conformance suite fixtures.
+  (The symbol-trie arity dimension moves to the deferred overload follow-up.)
 - Specs: `analyzer` — 1 ADDED requirement (NoFirstMatchBindingOnAmbiguity), 1 MODIFIED
   (CapabilityMatrixIsConformanceVerified gains the collision/cross-file-breadth scenarios).
 - Archive-order dependency: `CapabilityMatrixIsConformanceVerified` is ADDED by

--- a/openspec/changes/harden-call-resolution-ambiguity/specs/analyzer/spec.md
+++ b/openspec/changes/harden-call-resolution-ambiguity/specs/analyzer/spec.md
@@ -5,15 +5,25 @@
 ### Requirement: NoFirstMatchBindingOnAmbiguity
 
 The call-resolution ladder SHALL never bind a call edge by arbitrary first-match when more than one
-candidate definition is viable. Every resolution strategy — bare-name (`name_only`), Python
-`self.`/`cls.` method dispatch, capitalized-receiver (`type_name`), and overloaded names — SHALL
-either single out a unique candidate via a defined affinity ladder (own-file containment →
-import/package binding → single remaining candidate → arity match where the language exposes
-parameter counts) or record the call site as **unresolved-ambiguous**, carrying a bounded candidate
-list, instead of emitting an edge. A unique candidate MAY still bind at the strategy's declared
-confidence. Conclusion tools whose soundness depends on edge precision (`find_dead_code`,
+candidate definition is viable. Every resolution strategy that resolves against a multi-candidate
+symbol set — bare-name (`name_only`), Python `self.`/`cls.` method dispatch, and capitalized-receiver
+(`type_name`) — SHALL either single out a unique candidate via a defined affinity ladder (own-file
+containment → the file the caller imports the qualifier from → a single remaining candidate) or
+record the call site as **unresolved-ambiguous**, carrying a bounded candidate list, instead of
+emitting an edge. A unique candidate MAY still bind at the strategy's declared confidence.
+Conclusion tools whose soundness depends on edge precision (`find_dead_code`,
 `analyze_error_propagation`, `analyze_impact`, `select_tests`) SHALL disclose relevant
 unresolved-ambiguous sites as boundaries rather than silently treating them as resolved or absent.
+
+> **Overloaded names are out of scope for this requirement and tracked separately.** Same-name,
+> different-arity overloads (Java/C#/Scala/C++) do not reach the resolution ladder as a multi-candidate
+> set: they collapse earlier, at *node identity* — two overloads share the id `file::Class.method`, so
+> only one survives in the graph and the resolution ladder sees a single candidate. Making overloads
+> distinct nodes (arity-qualified identity) and resolving them by call-site argument count is a
+> node-identity change with a different, larger blast radius (stable ids, the CFG side-table, symbol
+> continuity, every node-count consumer) and is deferred to a dedicated follow-up. This requirement
+> therefore governs the three resolution-ladder strategies that genuinely bound by first-match; the
+> overload collapse is a disclosed known limitation, not a first-match guess this change introduces.
 
 #### Scenario: An ambiguous bare cross-file call is not bound arbitrarily
 
@@ -36,14 +46,6 @@ unresolved-ambiguous sites as boundaries rather than silently treating them as r
 - **WHEN** `self.process()` is resolved inside one of them
 - **THEN** the edge binds to the method in the caller's own file, not to whichever candidate sorts
   first
-
-#### Scenario: Overloaded names do not collapse onto one node
-
-- **GIVEN** a language with arity-distinguishable overloads (e.g. Java `f(int)` and `f(int, int)`)
-- **WHEN** a call `f(1, 2)` is resolved
-- **THEN** the edge binds to the arity-matching overload
-- **AND** an arity-ambiguous call falls into the unresolved-ambiguous disposition rather than
-  binding to the first overload
 
 #### Scenario: Dead-code confidence respects ambiguity
 
@@ -73,10 +75,11 @@ leaving them implicit. For every capability with a closed claimed-language set, 
 if that set grows without a corresponding fixture, so no capability can silently over-claim.
 
 The suite SHALL further verify **cross-file resolution for every claimed callGraph language** (not a
-sample), and SHALL include **adversarial name-collision fixtures** for each resolution strategy
-(bare cross-file call, `self`/`cls` dispatch, capitalized-receiver, overload pair) asserting that an
-ambiguous candidate set yields the unresolved-ambiguous disposition, never an arbitrary first-match
-edge.
+sample), and SHALL include **adversarial name-collision fixtures** for each first-match-prone
+resolution strategy (bare cross-file call, `self`/`cls` dispatch, capitalized-receiver) asserting
+that an ambiguous candidate set yields the unresolved-ambiguous disposition, never an arbitrary
+first-match edge. (Overload-arity disambiguation is a node-identity concern tracked by a separate
+change and is not required here.)
 
 #### Scenario: A claimed callGraph language is proven on real code
 

--- a/openspec/changes/harden-call-resolution-ambiguity/tasks.md
+++ b/openspec/changes/harden-call-resolution-ambiguity/tasks.md
@@ -1,28 +1,35 @@
 # Tasks — harden call resolution ambiguity
 
 ## Implementation
-- [ ] Add `ambiguous` call-site disposition to `call-graph-types.ts` (candidate list, bounded to a
+- [x] Add `ambiguous` call-site disposition to `call-graph-types.ts` (candidate list, bounded to a
       fixed cap; count disclosed when truncated)
-- [ ] `name_only` ambiguity guard: >1 cross-file candidate, no affinity → record ambiguous site, do
+- [x] `name_only` ambiguity guard: >1 cross-file candidate, no affinity → record ambiguous site, do
       not bind (`call-graph.ts` Strategy 4); unique candidate still binds as `name_only`
-- [ ] Python `self.`/`cls.` path adopts `resolveSelfMethod`'s affinity ladder (share, don't copy)
-- [ ] `type_name` strategy binds only a unique type match; else ambiguous site
-- [ ] Symbol trie arity discriminator; exact-arity bind, ambiguous arity → ambiguous site
-- [ ] `find_dead_code`: a function reachable only via an ambiguous site's candidate list is reported
+- [x] Python `self.`/`cls.` path adopts `resolveSelfMethod`'s affinity ladder (share, don't copy)
+- [x] `type_name` strategy binds only a unique type match; else ambiguous site
+- [~] Symbol trie arity discriminator; exact-arity bind, ambiguous arity → ambiguous site —
+      **DEFERRED to a follow-up.** Overloads collapse at *node identity* (two overloads share the id
+      `file::Class.method`, one is dropped before resolution), so the ladder never sees a
+      multi-candidate overload set. Splitting overloads into arity-qualified nodes + resolving by
+      call-site arg count is a node-identity change (stable ids, CFG side-table, symbol continuity,
+      node-count consumers) — a different, larger blast radius, tracked separately. Disclosed in the
+      spec delta and the proposal.
+- [x] `find_dead_code`: a function reachable only via an ambiguous site's candidate list is reported
       at reduced confidence, never `confident`-dead
-- [ ] `analyze_error_propagation` / `analyze_impact`: surface ambiguous sites in `boundaries`
+- [x] `analyze_error_propagation` / `analyze_impact`: surface ambiguous sites in `boundaries`
 
 ## Conformance
-- [ ] Name-collision fixture per strategy (bare cross-file, self/cls, type_name, overload pair):
-      ambiguous case does NOT bind arbitrarily
-- [ ] Cross-file happy-path fixture for all 18 callGraph languages (today 3) + coverage guard
-- [ ] Recursion / nested-shadowing regressions stay green (stable-nested-function-identity suite)
+- [x] Name-collision fixture per first-match-prone strategy (bare cross-file, self/cls, type_name):
+      ambiguous case does NOT bind arbitrarily (overload pair deferred with the arity work)
+- [x] Cross-file happy-path fixture for all 18 callGraph languages (was 3) + coverage guard
+- [x] Recursion / nested-shadowing regressions stay green (stable-nested-function-identity suite)
 
 ## Verification
-- [ ] Before/after structural diff on this repo: every removed edge has ≥2 candidates or arity
-      mismatch; confidence distribution shift reported in the PR
-- [ ] Full suite green
+- [x] Before/after structural diff on this repo: every removed edge has ≥2 candidates;
+      confidence distribution shift reported in the PR
+- [x] Full suite green
 
 ## Spec
-- [ ] `analyzer` delta: ADD NoFirstMatchBindingOnAmbiguity; MODIFY
+- [x] `analyzer` delta: ADD NoFirstMatchBindingOnAmbiguity (scoped to the three resolution-ladder
+      strategies; overload arity disclosed as a follow-up); MODIFY
       CapabilityMatrixIsConformanceVerified (collision + cross-file breadth scenarios)

--- a/src/core/analyzer/call-graph-types.ts
+++ b/src/core/analyzer/call-graph-types.ts
@@ -100,6 +100,47 @@ export interface FunctionNode {
 /** Broad category of an external (unresolved) call */
 export type ExternalKind = 'http' | 'database' | 'filesystem' | 'stdlib' | 'unknown';
 
+/**
+ * Maximum number of candidate ids retained on an {@link AmbiguousCallSite}. An
+ * ambiguous name can in pathological cases match many definitions; the list is
+ * bounded so the persisted graph and tool payloads stay small. When the true
+ * candidate count exceeds the cap, `candidateCount` records the full total while
+ * `candidateIds` holds the first {@link AMBIGUOUS_CANDIDATE_CAP} (id-sorted, so the
+ * truncation is deterministic).
+ */
+export const AMBIGUOUS_CANDIDATE_CAP = 8;
+
+/** Which resolution strategy refused to bind because the candidate set was ambiguous. */
+export type AmbiguousStrategy = 'name_only' | 'self_cls' | 'type_name' | 'overload';
+
+/**
+ * A call site the resolution ladder refused to bind because more than one candidate
+ * definition was viable and no affinity/arity signal singled one out (change:
+ * harden-call-resolution-ambiguity; analyzer: NoFirstMatchBindingOnAmbiguity).
+ *
+ * Recorded INSTEAD of emitting an arbitrary first-match edge, so precision-sensitive
+ * consumers (find_dead_code, analyze_error_propagation, analyze_impact, select_tests)
+ * can disclose the ambiguity as a boundary rather than trusting a guess or assuming
+ * absence. A UNIQUE candidate still binds at the strategy's declared confidence — an
+ * ambiguous site is only recorded when the ladder would otherwise have guessed.
+ */
+export interface AmbiguousCallSite {
+  /** Node id of the calling function. */
+  callerId: string;
+  /** Callee name as written at the call site. */
+  calleeName: string;
+  /** Receiver in `obj.method()` calls, if any. */
+  calleeObject?: string;
+  /** 1-based call-site line, when known. */
+  line?: number;
+  /** Which strategy hit the ambiguity. */
+  strategy: AmbiguousStrategy;
+  /** Candidate node ids (id-sorted, bounded to {@link AMBIGUOUS_CANDIDATE_CAP}). */
+  candidateIds: string[];
+  /** Total viable candidates before capping (equals candidateIds.length when not truncated). */
+  candidateCount: number;
+}
+
 export interface CallEdge {
   callerId: string;
   /** Resolved callee ID */
@@ -319,6 +360,14 @@ export interface CallGraphResult {
    * {@link SerializedCallGraph}.
    */
   parseHealthByFile?: Map<string, FileParseHealth>;
+  /**
+   * Call sites the resolution ladder refused to bind because the candidate set was
+   * ambiguous (change: harden-call-resolution-ambiguity). NOT edges — these are the
+   * disclosed alternative to an arbitrary first-match guess. Carried through
+   * serialization so serve-time consumers can surface them as boundaries. Absent
+   * (undefined) when the graph has no ambiguous sites.
+   */
+  ambiguousSites?: AmbiguousCallSite[];
 }
 
 /** Serializable version (Maps replaced by arrays) for JSON storage */
@@ -331,4 +380,6 @@ export interface SerializedCallGraph {
   entryPoints: FunctionNode[];
   layerViolations: LayerViolation[];
   stats: CallGraphResult['stats'];
+  /** Unresolved-ambiguous call sites (change: harden-call-resolution-ambiguity). Omitted when empty. */
+  ambiguousSites?: AmbiguousCallSite[];
 }

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -55,8 +55,10 @@ import type {
   InheritanceEdge,
   CallGraphResult,
   SerializedCallGraph,
+  AmbiguousCallSite,
+  AmbiguousStrategy,
 } from './call-graph-types.js';
-import { classifyLayerEdge } from './call-graph-types.js';
+import { classifyLayerEdge, AMBIGUOUS_CANDIDATE_CAP } from './call-graph-types.js';
 
 // Docstring/declaration extraction helpers — extracted to ./call-graph-extract.ts
 // (internal, not re-exported; see the banner at the original section site below).
@@ -91,8 +93,10 @@ export type {
   InheritanceEdge,
   CallGraphResult,
   SerializedCallGraph,
+  AmbiguousCallSite,
+  AmbiguousStrategy,
 } from './call-graph-types.js';
-export { CALL_DISTANCE_COSTS, callDistance, layerOf, classifyLayerEdge } from './call-graph-types.js';
+export { CALL_DISTANCE_COSTS, callDistance, layerOf, classifyLayerEdge, AMBIGUOUS_CANDIDATE_CAP } from './call-graph-types.js';
 // Re-export the extracted complexity estimator so it stays importable from call-graph.ts.
 export { computeCyclomaticComplexity } from './call-graph-complexity.js';
 
@@ -4073,31 +4077,53 @@ export class CallGraphBuilder {
      *  (the same-class / same-file family — the dominant case), then the file the
      *  caller imports the class from (cross-file parent); a single candidate is
      *  unambiguous; an ambiguous match with no affinity is SKIPPED, never guessed. */
+    /** Outcome of an affinity-based candidate pick: a unique target, a genuinely
+     *  ambiguous candidate set (≥2, no affinity signal — never guessed), or none.
+     *  (change: harden-call-resolution-ambiguity). */
+    type AffinityPick =
+      | { kind: 'unique'; node: FunctionNode }
+      | { kind: 'ambiguous'; candidates: FunctionNode[] }
+      | { kind: 'none' };
+
+    /** The one affinity ladder shared by self/cls, this/super and type-name
+     *  resolution: own-file containment → the file the caller imports the qualifier
+     *  from → a single remaining candidate. A candidate set that survives all three
+     *  with >1 member is ambiguous and is NEVER bound to an arbitrary first match. */
+    const pickByAffinity = (
+      cands: FunctionNode[],
+      callerFile: string,
+      qualifier: string,
+    ): AffinityPick => {
+      if (cands.length === 0) return { kind: 'none' };
+      const own = cands.find(c => c.filePath === callerFile);
+      if (own) return { kind: 'unique', node: own };
+      const importedFrom = callImportMap.get(callerFile)?.get(qualifier);
+      if (importedFrom) {
+        const m = cands.find(
+          c =>
+            c.filePath === importedFrom ||
+            c.filePath.startsWith(`${importedFrom}.`) ||
+            c.filePath.startsWith(`${importedFrom}/`),
+        );
+        if (m) return { kind: 'unique', node: m };
+      }
+      // Unambiguous single target → safe; ambiguous with no affinity → do not guess.
+      return cands.length === 1
+        ? { kind: 'unique', node: cands[0] }
+        : { kind: 'ambiguous', candidates: cands };
+    };
+
+    /** Resolve an intra-object method call by walking the enclosing class chain,
+     *  disambiguating each hop with {@link pickByAffinity}. Returns the resolved node,
+     *  or — when the first class with candidates was ambiguous with no affinity and no
+     *  ancestor resolved — the ambiguous candidate set so the caller can disclose it. */
     const resolveSelfMethod = (
       callerNode: FunctionNode,
       methodName: string,
       includeSelf: boolean,
-    ): FunctionNode | undefined => {
-      if (!callerNode.className) return undefined;
-      const pick = (cls: string): FunctionNode | undefined => {
-        const cands = trie.findByQualifiedName(cls, methodName);
-        if (cands.length === 0) return undefined;
-        const own = cands.find(c => c.filePath === callerNode.filePath);
-        if (own) return own;
-        const importedFrom = callImportMap.get(callerNode.filePath)?.get(cls);
-        if (importedFrom) {
-          const m = cands.find(
-            c =>
-              c.filePath === importedFrom ||
-              c.filePath.startsWith(`${importedFrom}.`) ||
-              c.filePath.startsWith(`${importedFrom}/`),
-          );
-          if (m) return m;
-        }
-        // Unambiguous single target → safe; ambiguous with no affinity → skip (the
-        // wrong-file guess was the source of false cross-file edges).
-        return cands.length === 1 ? cands[0] : undefined;
-      };
+    ): { node?: FunctionNode; ambiguous?: FunctionNode[] } => {
+      if (!callerNode.className) return {};
+      let firstAmbiguous: FunctionNode[] | undefined;
       const seen = new Set<string>();
       const queue: string[] = includeSelf
         ? [callerNode.className]
@@ -4106,17 +4132,40 @@ export class CallGraphBuilder {
         const cls = queue.shift()!;
         if (seen.has(cls)) continue;
         seen.add(cls);
-        const hit = pick(cls);
-        if (hit) return hit;
+        const picked = pickByAffinity(trie.findByQualifiedName(cls, methodName), callerNode.filePath, cls);
+        if (picked.kind === 'unique') return { node: picked.node };
+        if (picked.kind === 'ambiguous' && !firstAmbiguous) firstAmbiguous = picked.candidates;
         // Walk to this class's parents. The relationship map is keyed by file::Class;
         // probe the caller's file key (same-file class families — the common case).
         const rel = relationships.get(`${callerNode.filePath}::${cls}`);
         for (const p of rel?.parentClasses ?? []) if (!seen.has(p)) queue.push(p);
       }
-      return undefined;
+      return firstAmbiguous ? { ambiguous: firstAmbiguous } : {};
     };
 
     const edges: CallEdge[] = [];
+    // Call sites the ladder refused to bind because the candidate set was ambiguous
+    // (change: harden-call-resolution-ambiguity). Recorded instead of an arbitrary
+    // first-match edge so precision-sensitive consumers can disclose the ambiguity.
+    const ambiguousSites: AmbiguousCallSite[] = [];
+    const recordAmbiguous = (
+      r: RawEdge,
+      strategy: AmbiguousStrategy,
+      candidates: FunctionNode[],
+    ): void => {
+      const ids = candidates
+        .map(c => c.id)
+        .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+      ambiguousSites.push({
+        callerId: r.callerId,
+        calleeName: r.calleeName,
+        calleeObject: r.calleeObject,
+        line: r.line,
+        strategy,
+        candidateIds: ids.slice(0, AMBIGUOUS_CANDIDATE_CAP),
+        candidateCount: ids.length,
+      });
+    };
     for (const raw of allRawEdges) {
       const callerNode = allNodes.get(raw.callerId);
       if (!callerNode) continue;
@@ -4124,11 +4173,17 @@ export class CallGraphBuilder {
       let calleeNode: FunctionNode | undefined;
       let confidence: EdgeConfidence = 'name_only';
 
-      // Strategy 1 — self/cls intra-class (Python self.*, cls.* or same-class method)
+      // Strategy 1 — self/cls intra-class (Python self.*, cls.* or same-class method).
+      // Shares the this/super affinity ladder (own-file → imported-from → single
+      // candidate), walking ancestors so an inherited method still resolves. Two
+      // same-named classes in different files no longer bind by insertion order:
+      // the caller's own class wins, and a genuinely ambiguous set is disclosed, never
+      // guessed (change: harden-call-resolution-ambiguity).
       if (raw.calleeObject === 'self' || raw.calleeObject === 'cls') {
         if (callerNode.className) {
-          const candidates = trie.findByQualifiedName(callerNode.className, raw.calleeName);
-          if (candidates.length > 0) { calleeNode = candidates[0]; confidence = 'self_cls'; }
+          const res = resolveSelfMethod(callerNode, raw.calleeName, true);
+          if (res.node) { calleeNode = res.node; confidence = 'self_cls'; }
+          else if (res.ambiguous) { recordAmbiguous(raw, 'self_cls', res.ambiguous); continue; }
         }
       }
 
@@ -4139,8 +4194,9 @@ export class CallGraphBuilder {
       // resolved nor external — because the call query historically only captured an
       // `(identifier)` receiver. (change: add-this-super-method-resolution)
       if (!calleeNode && (raw.calleeObject === 'this' || raw.calleeObject === 'super')) {
-        const resolved = resolveSelfMethod(callerNode, raw.calleeName, raw.calleeObject === 'this');
-        if (resolved) { calleeNode = resolved; confidence = 'self_cls'; }
+        const res = resolveSelfMethod(callerNode, raw.calleeName, raw.calleeObject === 'this');
+        if (res.node) { calleeNode = res.node; confidence = 'self_cls'; }
+        else if (res.ambiguous) { recordAmbiguous(raw, 'self_cls', res.ambiguous); continue; }
       }
 
       // Strategy 1b — type-name resolution (capitalized receiver = type/class reference).
@@ -4150,6 +4206,9 @@ export class CallGraphBuilder {
       // don't cover. A capitalized receiver is a reliable signal for a class reference
       // in these languages (variables are conventionally lower-case), so resolve it to
       // the matching internal type member before falling back to import/external.
+      // A unique type match (or one singled out by file/import affinity) binds; two
+      // same-named types with no affinity are disclosed as ambiguous, never guessed
+      // (change: harden-call-resolution-ambiguity).
       if (
         !calleeNode && raw.calleeObject &&
         (callerNode.language === 'Swift' || callerNode.language === 'C++' || callerNode.language === 'Java')
@@ -4157,8 +4216,13 @@ export class CallGraphBuilder {
         const ch = raw.calleeObject.charCodeAt(0);
         const isCapitalized = ch >= 65 && ch <= 90; // A-Z
         if (isCapitalized) {
-          const candidates = trie.findByQualifiedName(raw.calleeObject, raw.calleeName);
-          if (candidates.length > 0) { calleeNode = candidates[0]; confidence = 'type_name'; }
+          const picked = pickByAffinity(
+            trie.findByQualifiedName(raw.calleeObject, raw.calleeName),
+            callerNode.filePath,
+            raw.calleeObject,
+          );
+          if (picked.kind === 'unique') { calleeNode = picked.node; confidence = 'type_name'; }
+          else if (picked.kind === 'ambiguous') { recordAmbiguous(raw, 'type_name', picked.candidates); continue; }
         }
       }
 
@@ -4249,7 +4313,16 @@ export class CallGraphBuilder {
           const recursive = sameFileCands.find(c => c === callerNode);
           const sameFile = nested[0] ?? recursive ?? sameFileCands[0];
           if (sameFile) { calleeNode = sameFile; confidence = 'same_file'; }
-          else { calleeNode = candidates[0]; confidence = 'name_only'; }
+          else if (candidates.length === 1) {
+            // A UNIQUE cross-file candidate still binds at name_only, exactly as before.
+            calleeNode = candidates[0]; confidence = 'name_only';
+          } else {
+            // >1 cross-file candidate and no same-file / import affinity (Strategy 3
+            // already ran): binding candidates[0] here was the highest-impact guess —
+            // an arbitrary sort-order match carrying the substrate's authority. Refuse
+            // it; disclose the ambiguity instead (change: harden-call-resolution-ambiguity).
+            recordAmbiguous(raw, 'name_only', candidates); continue;
+          }
         }
       }
 
@@ -4667,6 +4740,7 @@ export class CallGraphBuilder {
       },
       styleByFile: styleByFile.size > 0 ? styleByFile : undefined,
       parseHealthByFile: parseHealthByFile.size > 0 ? parseHealthByFile : undefined,
+      ambiguousSites: ambiguousSites.length > 0 ? ambiguousSites : undefined,
     };
   }
 
@@ -4812,5 +4886,11 @@ export function serializeCallGraph(result: CallGraphResult): SerializedCallGraph
     entryPoints: result.entryPoints,
     layerViolations: result.layerViolations,
     stats: result.stats,
+    // Unresolved-ambiguous call sites survive into llm-context.json so serve-time
+    // consumers (find_dead_code, analyze_error_propagation, analyze_impact) can
+    // disclose them (change: harden-call-resolution-ambiguity). Omitted when empty.
+    ...(result.ambiguousSites && result.ambiguousSites.length > 0
+      ? { ambiguousSites: result.ambiguousSites }
+      : {}),
   };
 }

--- a/src/core/analyzer/language-capability-conformance.test.ts
+++ b/src/core/analyzer/language-capability-conformance.test.ts
@@ -323,3 +323,153 @@ describe('grammar-drift canary — every claimed callGraph language parses its f
     });
   }
 });
+
+// ── (9) Cross-file resolution for EVERY claimed callGraph language + precision ─────────────────────
+// The resolver's discipline is only proven where it is exercised. Section (3) sampled 3 languages;
+// this sweep drives a caller→callee split across two files for every claimed callGraph language and
+// asserts the edge resolves AND its provenance is the confidence expected for that language — so a
+// cross-language precision difference (import-precise TS/JS, capitalized-receiver Java, name-only for
+// the rest) is asserted, never hidden (change: harden-call-resolution-ambiguity).
+//
+// Documented exclusions (proven cross-file elsewhere or a disclosed extractor limitation, NOT a
+// resolver guess):
+//  - Bash: a bare command call (`helper`) is lexically indistinguishable from an external command
+//    across files, so the extractor deliberately does not bind it cross-file. Asserted explicitly below.
+//  - Lua, Dart: WASM-loaded grammars whose shared WASM Language heap yields spurious ERROR nodes on
+//    parses AFTER the first in a process (the same limitation the grammar-drift canary excludes them
+//    for). Their callGraph support — including cross-file name resolution on a first parse — is proven
+//    by the standalone build in section (1); a second in-process build (this sweep) is unreliable, so
+//    they are excluded here rather than asserted flakily.
+const CROSS_FILE_EXCLUDED = new Set(['Bash', 'Lua', 'Dart']);
+interface CrossFile { language: string; a: { path: string; content: string }; b: { path: string; content: string }; caller: string; callee: string; confidence: string }
+const CROSS_FILE: CrossFile[] = [
+  { language: 'TypeScript', confidence: 'import',    caller: 'main', callee: 'helper', a: { path: 'a.ts', content: `import { helper } from './b';\nexport function main(){ helper(); }` }, b: { path: 'b.ts', content: `export function helper(){ return 1; }` } },
+  { language: 'JavaScript', confidence: 'import',    caller: 'main', callee: 'helper', a: { path: 'a.js', content: `import { helper } from './b';\nexport function main(){ helper(); }` }, b: { path: 'b.js', content: `export function helper(){ return 1; }` } },
+  { language: 'Python',     confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'a.py', content: `from b import helper\n\ndef main():\n    helper()\n` }, b: { path: 'b.py', content: `def helper():\n    return 1\n` } },
+  { language: 'Go',         confidence: 'name_only', caller: 'Main', callee: 'Helper', a: { path: 'a.go', content: `package m\nfunc Main(){ Helper() }\n` }, b: { path: 'b.go', content: `package m\nfunc Helper() int { return 1 }\n` } },
+  { language: 'Rust',       confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'a.rs', content: `fn main(){ helper(); }\n` }, b: { path: 'b.rs', content: `fn helper() -> i32 { 1 }\n` } },
+  { language: 'Ruby',       confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'a.rb', content: `def main\n  helper\nend\n` }, b: { path: 'b.rb', content: `def helper\n  1\nend\n` } },
+  { language: 'Java',       confidence: 'type_name', caller: 'main', callee: 'helper', a: { path: 'A.java', content: `class A {\n  void main() { B.helper(); }\n}` }, b: { path: 'B.java', content: `class B {\n  static void helper() {}\n}` } },
+  { language: 'Kotlin',     confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'a.kt', content: `fun main() { helper() }\n` }, b: { path: 'b.kt', content: `fun helper(): Int { return 1 }\n` } },
+  { language: 'PHP',        confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'a.php', content: `<?php\nfunction main() { helper(); }\n` }, b: { path: 'b.php', content: `<?php\nfunction helper() { return 1; }\n` } },
+  { language: 'C#',         confidence: 'name_only', caller: 'Main', callee: 'Helper', a: { path: 'A.cs', content: `class A {\n  void Main() { B.Helper(); }\n}` }, b: { path: 'B.cs', content: `class B {\n  public static void Helper() {}\n}` } },
+  { language: 'C++',        confidence: 'name_only', caller: 'mainFn', callee: 'helper', a: { path: 'a.cpp', content: `void mainFn() { helper(); }\n` }, b: { path: 'b.cpp', content: `void helper() {}\n` } },
+  { language: 'C',          confidence: 'name_only', caller: 'mainFn', callee: 'helper', a: { path: 'a.c', content: `void mainFn() { helper(); }\n` }, b: { path: 'b.c', content: `void helper() {}\n` } },
+  { language: 'Swift',      confidence: 'name_only', caller: 'mainFn', callee: 'helper', a: { path: 'a.swift', content: `func mainFn() { helper() }\n` }, b: { path: 'b.swift', content: `func helper() -> Int { return 1 }\n` } },
+  { language: 'Scala',      confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'A.scala', content: `object A {\n  def main(): Unit = { B.helper() }\n}` }, b: { path: 'B.scala', content: `object B {\n  def helper(): Int = 1\n}` } },
+  { language: 'Elixir',     confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'a.ex', content: `defmodule A do\n  def main(), do: B.helper()\nend\n` }, b: { path: 'b.ex', content: `defmodule B do\n  def helper(), do: 1\nend\n` } },
+];
+
+describe('language conformance — cross-file resolution for EVERY claimed callGraph language', () => {
+  it('covers every claimed callGraph language (except the documented Bash exclusion)', () => {
+    const claimed = [...CALLGRAPH_LANGUAGES].filter((l) => !CROSS_FILE_EXCLUDED.has(l));
+    const covered = new Set(CROSS_FILE.map((f) => f.language));
+    const uncovered = claimed.filter((l) => !covered.has(l));
+    expect(uncovered, `callGraph languages with no cross-file fixture: ${uncovered.join(', ')}`).toEqual([]);
+  });
+
+  for (const f of CROSS_FILE) {
+    it(`${f.language}: resolves a cross-file ${f.caller}→${f.callee} at ${f.confidence} confidence`, async () => {
+      const r = await build([
+        { path: f.a.path, language: f.language, content: f.a.content },
+        { path: f.b.path, language: f.language, content: f.b.content },
+      ]);
+      const e = hasEdge(r, f.caller, f.callee);
+      expect(e, `${f.language} cross-file edge`).toBeTruthy();
+      // The callee must live in the OTHER file (a genuine cross-file bind, not a same-file homonym).
+      expect(r.nodes.get(e!.calleeId)?.filePath, `${f.language} callee file`).toBe(f.b.path);
+      expect(e!.confidence, `${f.language} cross-file provenance`).toBe(f.confidence);
+    });
+  }
+
+  it('Bash cross-file is a documented limitation: a bare command call is not bound across files', async () => {
+    const r = await build([
+      { path: 'a.sh', language: 'Bash', content: `main() { helper; }\n` },
+      { path: 'b.sh', language: 'Bash', content: `helper() { echo hi; }\n` },
+    ]);
+    const e = hasEdge(r, 'main', 'helper');
+    expect(e, 'Bash bare command calls are indistinguishable from external commands across files').toBeFalsy();
+  });
+});
+
+// ── (10) Adversarial name-collision fixtures — the resolver refuses to guess ───────────────────────
+// For each first-match-prone strategy, an ambiguous candidate set must yield the unresolved-ambiguous
+// disposition (recorded on `result.ambiguousSites`), never an arbitrary first-match edge. A UNIQUE
+// candidate still binds at the strategy's declared confidence. Overload-arity disambiguation is a
+// node-identity concern tracked by a separate change and is intentionally not covered here.
+// (change: harden-call-resolution-ambiguity; analyzer: NoFirstMatchBindingOnAmbiguity)
+describe('language conformance — resolver refuses to guess on ambiguity', () => {
+  const boundEdgesFrom = (r: Awaited<ReturnType<typeof build>>, caller: string) =>
+    r.edges.filter((e) => r.nodes.get(e.callerId)?.name === caller && !r.nodes.get(e.calleeId)?.isExternal);
+
+  it('name_only: a bare cross-file call matching two definitions is not bound arbitrarily', async () => {
+    const r = await build([
+      { path: 'caller.py', language: 'Python', content: `def main():\n    run()\n` },
+      { path: 'a.py', language: 'Python', content: `def run():\n    return 1\n` },
+      { path: 'b.py', language: 'Python', content: `def run():\n    return 2\n` },
+    ]);
+    // No name_only edge to either candidate.
+    expect(boundEdgesFrom(r, 'main').some((e) => e.confidence === 'name_only')).toBe(false);
+    const site = (r.ambiguousSites ?? []).find((s) => s.calleeName === 'run' && s.strategy === 'name_only');
+    expect(site, 'ambiguous site recorded').toBeTruthy();
+    expect(site!.candidateCount).toBe(2);
+    expect(site!.candidateIds.sort()).toEqual(['a.py::run', 'b.py::run']);
+  });
+
+  it('name_only: a UNIQUE cross-file candidate still binds', async () => {
+    const r = await build([
+      { path: 'caller.py', language: 'Python', content: `def main():\n    run()\n` },
+      { path: 'a.py', language: 'Python', content: `def run():\n    return 1\n` },
+    ]);
+    const edge = boundEdgesFrom(r, 'main').find((e) => e.confidence === 'name_only');
+    expect(edge, 'unique cross-file name_only edge').toBeTruthy();
+    expect(r.ambiguousSites, 'no ambiguity for a unique candidate').toBeUndefined();
+  });
+
+  it('self/cls: dispatch resolves to the caller\'s OWN class, not whichever sorts first', async () => {
+    // Both files declare `Handler` with `process`; the caller is in a1.py.
+    const r = await build([
+      { path: 'a1.py', language: 'Python', content: `class Handler:\n    def run(self):\n        self.process()\n    def process(self):\n        return 1\n` },
+      { path: 'a2.py', language: 'Python', content: `class Handler:\n    def process(self):\n        return 2\n` },
+    ]);
+    const edge = boundEdgesFrom(r, 'run').find((e) => e.confidence === 'self_cls');
+    expect(edge, 'self_cls edge to own class').toBeTruthy();
+    expect(r.nodes.get(edge!.calleeId)?.filePath).toBe('a1.py');
+    expect(r.ambiguousSites, 'own-file affinity resolves it, no ambiguity').toBeUndefined();
+  });
+
+  it('self/cls: a self-call whose method lives only in two OTHER same-named classes is ambiguous', async () => {
+    const r = await build([
+      { path: 'a1.py', language: 'Python', content: `class Handler:\n    def run(self):\n        self.process()\n` },
+      { path: 'a2.py', language: 'Python', content: `class Handler:\n    def process(self):\n        return 2\n` },
+      { path: 'a3.py', language: 'Python', content: `class Handler:\n    def process(self):\n        return 3\n` },
+    ]);
+    expect(boundEdgesFrom(r, 'run').some((e) => e.confidence === 'self_cls')).toBe(false);
+    const site = (r.ambiguousSites ?? []).find((s) => s.calleeName === 'process' && s.strategy === 'self_cls');
+    expect(site, 'ambiguous self_cls site recorded').toBeTruthy();
+    expect(site!.candidateCount).toBe(2);
+  });
+
+  it('type_name: two same-named types with no affinity yield an ambiguous site, not a type_name edge', async () => {
+    const r = await build([
+      { path: 'A.java', language: 'Java', content: `class A {\n  void use() { Money.of(1); }\n}` },
+      { path: 'Money1.java', language: 'Java', content: `class Money {\n  static int of(int x) { return x; }\n}` },
+      { path: 'Money2.java', language: 'Java', content: `class Money {\n  static int of(int x) { return x + 1; }\n}` },
+    ]);
+    // No confident type_name edge (a synthesized over-approximation to both is a separate,
+    // provenance-labeled mechanism — never a confident first-match).
+    expect(boundEdgesFrom(r, 'use').some((e) => e.confidence === 'type_name')).toBe(false);
+    const site = (r.ambiguousSites ?? []).find((s) => s.calleeName === 'of' && s.strategy === 'type_name');
+    expect(site, 'ambiguous type_name site recorded').toBeTruthy();
+    expect(site!.candidateCount).toBe(2);
+  });
+
+  it('type_name: a UNIQUE type match still binds', async () => {
+    const r = await build([
+      { path: 'A.java', language: 'Java', content: `class A {\n  void use() { Money.of(1); }\n}` },
+      { path: 'Money.java', language: 'Java', content: `class Money {\n  static int of(int x) { return x; }\n}` },
+    ]);
+    const edge = boundEdgesFrom(r, 'use').find((e) => e.confidence === 'type_name');
+    expect(edge, 'unique type_name edge').toBeTruthy();
+  });
+});

--- a/src/core/services/mcp-handlers/error-propagation.test.ts
+++ b/src/core/services/mcp-handlers/error-propagation.test.ts
@@ -17,6 +17,7 @@ const CALLER = `function caller() {\n  helper();\n}\n`;
 const GUARDED = `function guarded() {\n  try {\n    helper();\n  } catch (e) {\n    return;\n  }\n}\n`;
 const EXTCALLER = `function extCaller() {\n  fetch();\n}\n`;
 const GOFN = `func goFn() error {\n  return nil\n}\n`;
+const AMBIGCALLER = `function ambigCaller() {\n  run();\n}\n`;
 
 interface Node {
   id: string;
@@ -44,6 +45,7 @@ beforeEach(() => {
   writeFileSync(join(dir, 'guarded.ts'), GUARDED, 'utf-8');
   writeFileSync(join(dir, 'extcaller.ts'), EXTCALLER, 'utf-8');
   writeFileSync(join(dir, 'gofn.go'), GOFN, 'utf-8');
+  writeFileSync(join(dir, 'ambigcaller.ts'), AMBIGCALLER, 'utf-8');
 
   const nodes: Node[] = [
     node('helper', 'helper', 'helper.ts', HELPER),
@@ -51,6 +53,7 @@ beforeEach(() => {
     node('guarded', 'guarded', 'guarded.ts', GUARDED),
     node('extCaller', 'extCaller', 'extcaller.ts', EXTCALLER),
     node('goFn', 'goFn', 'gofn.go', GOFN, 'Go'),
+    node('ambigCaller', 'ambigCaller', 'ambigcaller.ts', AMBIGCALLER),
     { id: 'fetchExt', name: 'fetch', filePath: 'lib.ts', startIndex: 0, endIndex: 0, startLine: 0, endLine: 0, language: 'TypeScript', isExternal: true },
   ];
   const edges = [
@@ -58,10 +61,15 @@ beforeEach(() => {
     { callerId: 'guarded', calleeId: 'helper', calleeName: 'helper', line: 3, confidence: 'import' },
     { callerId: 'extCaller', calleeId: 'fetchExt', calleeName: 'fetch', line: 2, confidence: 'external' },
   ];
+  // An unresolved-ambiguous call site at ambigCaller (change: harden-call-resolution-ambiguity):
+  // `run()` matched two definitions, so no edge was bound.
+  const ambiguousSites = [
+    { callerId: 'ambigCaller', calleeName: 'run', line: 2, strategy: 'name_only', candidateIds: ['a.ts::run', 'b.ts::run'], candidateCount: 2 },
+  ];
 
   const analysisDir = join(dir, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
   mkdirSync(analysisDir, { recursive: true });
-  writeFileSync(join(analysisDir, ARTIFACT_LLM_CONTEXT), JSON.stringify({ callGraph: { nodes, edges } }), 'utf-8');
+  writeFileSync(join(analysisDir, ARTIFACT_LLM_CONTEXT), JSON.stringify({ callGraph: { nodes, edges, ambiguousSites } }), 'utf-8');
 });
 
 afterEach(() => {
@@ -73,12 +81,13 @@ interface Result {
   unsupported?: boolean;
   error?: string;
   candidates?: string[];
-  summary: { escapes: number; direct: number; propagated: number; handledInternally: number; unresolvedSelfCalls: number };
+  summary: { escapes: number; direct: number; propagated: number; handledInternally: number; unresolvedSelfCalls: number; ambiguousCallSites: number };
   escapes: Array<{ type: string; kind: string; originFunction: string; path: string[] }>;
   handledInternally: Array<{ type: string; caughtIn: string; fromCallee: string }>;
   boundaries: string[];
   externalCalleesNotAnalyzed?: { count: number; sample: string[] };
   unresolvedSelfCalls?: { count: number; sample: string[] };
+  ambiguousCallSites?: { count: number; sample: string[] };
 }
 
 describe('handleAnalyzeErrorPropagation', () => {
@@ -125,6 +134,16 @@ describe('handleAnalyzeErrorPropagation', () => {
     const res = (await handleAnalyzeErrorPropagation({ directory: dir, symbol: 'help' })) as Result;
     expect(res.error).toMatch(/No indexed function/);
     expect(res.candidates).toContain('helper');
+  });
+
+  it('discloses an unresolved-ambiguous call site as a boundary, never assumed exception-free', async () => {
+    const res = (await handleAnalyzeErrorPropagation({ directory: dir, symbol: 'ambigCaller' })) as Result;
+    // The ambiguous call `run()` was not bound, so no escape is claimed — but the
+    // uncertainty is disclosed, not silently treated as exception-free.
+    expect(res.summary.ambiguousCallSites).toBe(1);
+    expect(res.ambiguousCallSites?.count).toBe(1);
+    expect(res.ambiguousCallSites?.sample.some(s => /run/.test(s))).toBe(true);
+    expect(res.boundaries.some(b => /unresolved-ambiguous call site/.test(b))).toBe(true);
   });
 
   it('errors cleanly when no analysis exists', async () => {

--- a/src/core/services/mcp-handlers/error-propagation.ts
+++ b/src/core/services/mcp-handlers/error-propagation.ts
@@ -31,7 +31,7 @@ import {
   DYNAMIC_TYPE,
   type FunctionExceptionFacts,
 } from '../../analyzer/exception-flow.js';
-import type { SerializedCallGraph, FunctionNode, CallEdge } from '../../analyzer/call-graph.js';
+import type { SerializedCallGraph, FunctionNode, CallEdge, AmbiguousCallSite } from '../../analyzer/call-graph.js';
 
 export interface AnalyzeErrorPropagationInput {
   directory: string;
@@ -152,6 +152,16 @@ export async function handleAnalyzeErrorPropagation(
     if (arr) arr.push(e);
     else calleesByCaller.set(e.callerId, [e]);
   }
+  // Unresolved-ambiguous call sites indexed by caller (change:
+  // harden-call-resolution-ambiguity) — a call the resolver refused to bind because
+  // >1 candidate was viable. Like an unresolved self-call, its callees' exceptions are
+  // out of scope: disclosed as a boundary, never assumed none.
+  const ambiguousByCaller = new Map<string, AmbiguousCallSite[]>();
+  for (const site of cg.ambiguousSites ?? []) {
+    const arr = ambiguousByCaller.get(site.callerId);
+    if (arr) arr.push(site);
+    else ambiguousByCaller.set(site.callerId, [site]);
+  }
 
   const depthBound = Number.isFinite(input.maxDepth as number)
     ? Math.max(MIN_DEPTH, Math.min(input.maxDepth as number, MAX_DEPTH))
@@ -170,6 +180,10 @@ export async function handleAnalyzeErrorPropagation(
   // resolved nor an `external::` edge, so without this it would be silently
   // assumed exception-free. Disclosed, never dropped. Keyed by caller+line+name.
   const unresolvedSelfCalls = new Map<string, string>();
+  // Unresolved-ambiguous call sites reached during the traversal (change:
+  // harden-call-resolution-ambiguity). Keyed by caller+line+name so a site is
+  // disclosed once regardless of how often the node is revisited.
+  const ambiguousCallSites = new Map<string, string>();
   let parsedCount = 0;
   let capHit = false;
   // Set true by factsFor ONLY when it returned null because the parse cap was hit
@@ -281,6 +295,18 @@ export async function handleAnalyzeErrorPropagation(
       unresolvedSelfCalls.set(`${n.id}@${cs.line}@${cs.calleeName}`, `${selfLabel}:${cs.line} (${cs.calleeName})`);
     }
 
+    // Disclose unresolved-ambiguous call sites at this node: a call the resolver
+    // refused to bind because >1 candidate was viable with no affinity. Its callees'
+    // exceptions are out of scope — a clean escape set does not clear these paths
+    // (change: harden-call-resolution-ambiguity).
+    for (const site of ambiguousByCaller.get(n.id) ?? []) {
+      const recv = site.calleeObject ? `${site.calleeObject}.` : '';
+      ambiguousCallSites.set(
+        `${n.id}@${site.line ?? -1}@${site.calleeName}`,
+        `${selfLabel}:${site.line ?? '?'} (${recv}${site.calleeName} → ${site.candidateCount} candidates)`,
+      );
+    }
+
     // Direct throws that escape this function.
     for (const ts of facts.throwSites) {
       if (ts.locallyHandled) continue;
@@ -379,6 +405,15 @@ export async function handleAnalyzeErrorPropagation(
         'scope, NEVER assumed none. A clean escape set does not clear these paths.',
     );
   }
+  const ambiguousSample = [...ambiguousCallSites.values()].sort();
+  if (ambiguousCallSites.size > 0) {
+    boundaries.add(
+      `${ambiguousCallSites.size} unresolved-ambiguous call site(s) (a bare/self/type-name call whose ` +
+        'name matched more than one candidate with no affinity) were NOT bound to an edge — their ' +
+        "callees' exceptions are out of scope, NEVER assumed none. A clean escape set does not clear " +
+        'these paths.',
+    );
+  }
 
   const directCount = escapeList.filter(e => e.kind === 'direct').length;
   const dynamicCount = escapeList.filter(e => e.type === DYNAMIC_TYPE).length;
@@ -394,6 +429,7 @@ export async function handleAnalyzeErrorPropagation(
       functionsAnalyzed: parsedCount,
       externalCalleesNotAnalyzed: externalCallees.size,
       unresolvedSelfCalls: unresolvedSelfCalls.size,
+      ambiguousCallSites: ambiguousCallSites.size,
     },
     escapes: escapeList,
     handledInternally: handledList,
@@ -403,6 +439,9 @@ export async function handleAnalyzeErrorPropagation(
       : {}),
     ...(unresolvedSelfCalls.size > 0
       ? { unresolvedSelfCalls: { count: unresolvedSelfCalls.size, sample: unresolvedSelfSample.slice(0, 15) } }
+      : {}),
+    ...(ambiguousCallSites.size > 0
+      ? { ambiguousCallSites: { count: ambiguousCallSites.size, sample: ambiguousSample.slice(0, 15) } }
       : {}),
     note:
       'escapes = exception types that can propagate OUT of this function to its callers (each with ' +

--- a/src/core/services/mcp-handlers/graph.test.ts
+++ b/src/core/services/mcp-handlers/graph.test.ts
@@ -817,6 +817,37 @@ describe('handleAnalyzeImpact — edgeStore fast path', () => {
     expect(['low', 'medium', 'high', 'critical']).toContain(result.riskLevel);
   });
 
+  // Ambiguity disclosure (change: harden-call-resolution-ambiguity): a site whose caller is
+  // in the impact set means downstream is under-counted; the blast radius is a lower bound.
+  it('surfaces unresolved-ambiguous call sites touching the impact set', async () => {
+    vi.mocked(readCachedContext).mockResolvedValueOnce({
+      edgeStore: store,
+      callGraph: {
+        ambiguousSites: [
+          { callerId: 'src/a.ts::entry', calleeName: 'run', line: 3, strategy: 'name_only', candidateIds: ['x.ts::run', 'y.ts::run'], candidateCount: 2 },
+        ],
+      },
+    } as never);
+    const result = await handleAnalyzeImpact(dir, 'entry', 2) as {
+      ambiguousCallSites?: { count: number; sample: Array<{ caller: string; callee: string; strategy: string; candidates: number }> };
+    };
+    expect(result.ambiguousCallSites?.count).toBe(1);
+    expect(result.ambiguousCallSites?.sample[0]).toMatchObject({ caller: 'entry', callee: 'run', strategy: 'name_only', candidates: 2 });
+  });
+
+  it('omits the ambiguous block when no ambiguous site touches the impact set', async () => {
+    vi.mocked(readCachedContext).mockResolvedValueOnce({
+      edgeStore: store,
+      callGraph: {
+        ambiguousSites: [
+          { callerId: 'unrelated.ts::other', calleeName: 'run', line: 3, strategy: 'name_only', candidateIds: ['x.ts::run', 'y.ts::run'], candidateCount: 2 },
+        ],
+      },
+    } as never);
+    const result = await handleAnalyzeImpact(dir, 'entry', 2) as { ambiguousCallSites?: unknown };
+    expect(result.ambiguousCallSites).toBeUndefined();
+  });
+
   // Regression: `symbol` is required by the MCP inputSchema, but dispatchTool enforces
   // nothing — a non-conformant caller reaching the handler with an undefined/blank
   // symbol must get a clean error, not an uncaught `undefined.toLowerCase()` crash.

--- a/src/core/services/mcp-handlers/graph.ts
+++ b/src/core/services/mcp-handlers/graph.ts
@@ -39,7 +39,7 @@ import {
   TRACE_PATH_DEFAULT_MAX_DEPTH,
   TRACE_PATH_MAX_PATHS,
 } from '../../../constants.js';
-import type { SerializedCallGraph, FunctionNode } from '../../analyzer/call-graph.js';
+import type { SerializedCallGraph, FunctionNode, AmbiguousCallSite } from '../../analyzer/call-graph.js';
 import { callDistance } from '../../analyzer/call-graph.js';
 import type { DecisionNode } from '../../decisions/project.js';
 import { isIacLanguage } from '../../analyzer/iac/types.js';
@@ -707,6 +707,32 @@ export async function handleAnalyzeImpact(
   }
   const confidenceBoundary = assembleBoundary({ basis: edgeBasis(impactEdges), staleness: await computeStaleness(absDir), integrity: ctx?.integrity, repair: repairDisclosure(absDir) });
 
+  // Unresolved-ambiguous call sites touching the impact set (change:
+  // harden-call-resolution-ambiguity). A site whose CALLER is in-scope is an outbound
+  // call the resolver refused to bind (downstream is under-counted); a site listing a
+  // SEED among its candidates is a potential hidden upstream caller (upstream is
+  // under-counted). Disclosed so the blast radius reads as a sound lower bound.
+  const ambiguousInScope = (ctx.callGraph?.ambiguousSites ?? []).filter(
+    (s: AmbiguousCallSite) => involvedIds.has(s.callerId) || s.candidateIds.some(id => seedIds.includes(id)),
+  );
+  const ambiguousBlock = ambiguousInScope.length > 0
+    ? {
+        ambiguousCallSites: {
+          count: ambiguousInScope.length,
+          note:
+            'Call sites the resolver refused to bind because >1 candidate was viable. A caller ' +
+            'in-scope means downstream is under-counted; a seed among the candidates means a ' +
+            'potential hidden upstream caller. The blast radius is a lower bound here.',
+          sample: ambiguousInScope.slice(0, 10).map((s: AmbiguousCallSite) => ({
+            caller: ctx.edgeStore!.getNode(s.callerId)?.name ?? s.callerId,
+            callee: s.calleeObject ? `${s.calleeObject}.${s.calleeName}` : s.calleeName,
+            strategy: s.strategy,
+            candidates: s.candidateCount,
+          })),
+        },
+      }
+    : {};
+
   const results = seeds.map(seed => {
     const isHub     = hubIds.has(seed.id);
     const riskScore = computeRiskScore(seed, blastRadius, isHub);
@@ -775,9 +801,9 @@ export async function handleAnalyzeImpact(
   const fedOut = federationBlock ? { federation: federationBlock } : {};
 
   if (seeds.length === 1) {
-    return { ...results[0], confidenceBoundary, ...fedOut };
+    return { ...results[0], confidenceBoundary, ...ambiguousBlock, ...fedOut };
   }
-  return { matches: results, confidenceBoundary, ...fedOut };
+  return { matches: results, confidenceBoundary, ...ambiguousBlock, ...fedOut };
 }
 
 /**

--- a/src/core/services/mcp-handlers/reachability-ambiguity.test.ts
+++ b/src/core/services/mcp-handlers/reachability-ambiguity.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Ambiguity-aware reachability (change: harden-call-resolution-ambiguity).
+ * Verifies that find_dead_code never reports a function as HIGH-confidence dead when
+ * a potential caller was left unbound as an unresolved-ambiguous call site — the
+ * caller may well be live via that call. Drives the real handler over an
+ * llm-context fixture that carries `ambiguousSites`. Plain .test.ts so CI runs it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_LLM_CONTEXT } from '../../../constants.js';
+import { handleFindDeadCode } from './reachability.js';
+import type { FunctionNode, CallEdge, AmbiguousCallSite } from '../../analyzer/call-graph.js';
+
+let root: string;
+
+function node(id: string, name: string, extra: Partial<FunctionNode> = {}): FunctionNode {
+  return {
+    id, name, filePath: id.split('::')[0], isAsync: false, language: 'TypeScript',
+    startIndex: 0, endIndex: 10, fanIn: 0, fanOut: 0, ...extra,
+  };
+}
+
+async function writeContext(
+  nodes: FunctionNode[],
+  edges: CallEdge[],
+  ambiguousSites?: AmbiguousCallSite[],
+): Promise<void> {
+  for (const n of nodes) { n.fanIn = 0; n.fanOut = 0; }
+  for (const e of edges) {
+    const c = nodes.find(n => n.id === e.callerId); if (c) c.fanOut++;
+    const t = nodes.find(n => n.id === e.calleeId); if (t) t.fanIn++;
+  }
+  const callGraph = {
+    nodes, edges, classes: [], inheritanceEdges: [],
+    hubFunctions: [], entryPoints: [], layerViolations: [],
+    stats: { totalNodes: nodes.length, totalEdges: edges.length, avgFanIn: 0, avgFanOut: 0 },
+    ...(ambiguousSites ? { ambiguousSites } : {}),
+  };
+  const dir = join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, ARTIFACT_LLM_CONTEXT), JSON.stringify({ callGraph }), 'utf-8');
+}
+
+beforeEach(async () => { root = await mkdtemp(join(tmpdir(), 'ol-reach-ambig-')); });
+afterEach(async () => { await rm(root, { recursive: true, force: true }); });
+
+describe('ambiguity-aware reachability', () => {
+  it('a candidate named by an unresolved-ambiguous site is not high-confidence dead', async () => {
+    // test → caller; caller has an ambiguous call whose candidates are handlerA/handlerB.
+    // Neither handler has a resolved caller, so both are candidate-dead — but each is a
+    // potential target of the unbound ambiguous call, so neither is HIGH-confidence dead.
+    const nodes = [
+      node('x.test.ts::test_x', 'test_x', { isTest: true }),
+      node('a.ts::caller', 'caller'),
+      node('a.ts::handlerA', 'handlerA'),
+      node('b.ts::handlerB', 'handlerB'),
+    ];
+    const edges: CallEdge[] = [
+      { callerId: 'x.test.ts::test_x', calleeId: 'a.ts::caller', calleeName: 'caller', confidence: 'import', kind: 'calls' },
+    ];
+    const ambiguousSites: AmbiguousCallSite[] = [
+      { callerId: 'a.ts::caller', calleeName: 'handler', line: 2, strategy: 'name_only', candidateIds: ['a.ts::handlerA', 'b.ts::handlerB'], candidateCount: 2 },
+    ];
+    await writeContext(nodes, edges, ambiguousSites);
+    const r = (await handleFindDeadCode({ directory: root })) as {
+      candidateDead: Array<{ name: string; confidence: string; reason: string }>;
+    };
+    for (const name of ['handlerA', 'handlerB']) {
+      const c = r.candidateDead.find(x => x.name === name);
+      expect(c, `${name} is still a candidate`).toBeDefined();
+      expect(c!.confidence, `${name} downgraded`).not.toBe('high');
+      expect(c!.reason).toMatch(/unresolved-ambiguous call site/);
+    }
+  });
+
+  it('without any ambiguous site, an uncalled non-exported symbol is still high-confidence dead', async () => {
+    // Control: same shape, no ambiguousSites → the classic high-confidence dead verdict stands.
+    const nodes = [
+      node('x.test.ts::test_x', 'test_x', { isTest: true }),
+      node('a.ts::caller', 'caller'),
+      node('a.ts::orphan', 'orphan'),
+    ];
+    const edges: CallEdge[] = [
+      { callerId: 'x.test.ts::test_x', calleeId: 'a.ts::caller', calleeName: 'caller', confidence: 'import', kind: 'calls' },
+    ];
+    await writeContext(nodes, edges);
+    const r = (await handleFindDeadCode({ directory: root })) as {
+      candidateDead: Array<{ name: string; confidence: string; reason: string }>;
+    };
+    const orphan = r.candidateDead.find(x => x.name === 'orphan');
+    expect(orphan).toBeDefined();
+    // No ambiguity → the ambiguous-site downgrade/reason is never applied.
+    expect(orphan!.reason).not.toMatch(/unresolved-ambiguous call site/);
+  });
+});

--- a/src/core/services/mcp-handlers/reachability.ts
+++ b/src/core/services/mcp-handlers/reachability.ts
@@ -224,6 +224,17 @@ export async function handleFindDeadCode(input: FindDeadCodeInput): Promise<unkn
     }
   }
 
+  // Nodes named as a candidate by an unresolved-ambiguous call site (change:
+  // harden-call-resolution-ambiguity). Such a node has a *potential* caller the
+  // resolver refused to bind — it may well be live via that call. It is therefore
+  // never reported as high-confidence dead, mirroring the synthesized-edge downgrade.
+  // Applies in both strict and non-strict mode (ambiguity is a resolution gap, not a
+  // synthesized-edge artifact).
+  const ambiguousCandidateIds = new Set<string>();
+  for (const site of cg.ambiguousSites ?? []) {
+    for (const id of site.candidateIds) ambiguousCandidateIds.add(id);
+  }
+
   // ── Roots (liveness seeds) — conservative: prefer false-live over false-dead ──
   // tests (they invoke code) · symbols imported by another file · HTTP route
   // handlers · synthesized route handlers (framework-invoked entry points; omitted
@@ -316,6 +327,14 @@ export async function handleFindDeadCode(input: FindDeadCodeInput): Promise<unkn
       if (synthRule) {
         confidence = 'low';
         reasons.push(`reachable via a synthesized ${synthRule} edge whose dispatcher is not itself reached — likely live through dynamic dispatch`);
+      }
+
+      // A node named by an unresolved-ambiguous call site has a potential caller the
+      // resolver refused to bind — never high-confidence dead (change:
+      // harden-call-resolution-ambiguity).
+      if (ambiguousCandidateIds.has(n.id)) {
+        confidence = 'low';
+        reasons.push('listed as a candidate by an unresolved-ambiguous call site — a potential caller was not bound, so it may be live');
       }
 
       return {

--- a/src/core/services/mcp-watcher-parity.test.ts
+++ b/src/core/services/mcp-watcher-parity.test.ts
@@ -374,56 +374,56 @@ describe('adversarial regressions (PR #189 review findings)', () => {
     s.close();
   });
 
-  it('round2: adding a symbol that LOSES the name_only tiebreak does not needlessly stale-flag its consumers', async () => {
-    // zzz defines foo; 5 consumers resolve foo -> zzz (lowest id). Adding foo in
-    // zzzz (sorts AFTER zzz) cannot become the winner, so NONE of the 5 consumers
-    // change — they must not be re-resolved or marked stale, even under a tiny budget.
-    const v1: Files = { 'src/zzz.ts': 'export function foo() { return 9; }\n' };
-    for (let i = 0; i < 5; i++) v1[`src/w${i}.ts`] = `export function use${i}() { return foo(); }\n`;
-    await writeFiles(v1);
-    const store = EdgeStore.open(EdgeStore.dbPath(outputPath));
-    seedStore(store, v1, await fullBuild(v1));
-    store.close();
+  // With the resolver's refuse-to-guess discipline (change: harden-call-resolution-ambiguity),
+  // adding a SECOND cross-file definition of a bare-called name makes every such call
+  // AMBIGUOUS — the edge disappears — regardless of the added symbol's id sort order.
+  // So the old "name_only tiebreak winner" model is gone: a higher-id add is no longer a
+  // no-op, and a lower-id add no longer produces a new winner. Both must converge every
+  // consumer to "no foo edge" within budget and flag the overflow stale.
+  for (const variant of [
+    { name: 'higher-id', file: 'src/zzzz.ts' }, // sorts AFTER zzz (was the "LOSES" no-op case)
+    { name: 'lower-id', file: 'src/aaa.ts' },   // sorts BEFORE zzz (was the "WINS" case)
+  ]) {
+    it(`round2: adding a ${variant.name} second definition makes bare callers ambiguous, converging within budget and flagging the overflow stale`, async () => {
+      const v1: Files = { 'src/zzz.ts': 'export function foo() { return 9; }\n' };
+      for (let i = 0; i < 5; i++) v1[`src/w${i}.ts`] = `export function use${i}() { return foo(); }\n`;
+      await writeFiles(v1);
+      const store = EdgeStore.open(EdgeStore.dbPath(outputPath));
+      seedStore(store, v1, await fullBuild(v1));
+      // Seeded state: each consumer resolves foo -> zzz uniquely (name_only).
+      for (let i = 0; i < 5; i++) {
+        expect(outgoingSig(store, `src/w${i}.ts`).join('\n')).toContain('src/zzz.ts::foo');
+      }
+      store.close();
 
-    await writeFiles({ 'src/zzzz.ts': 'export function foo() { return 1; }\n' });
-    const { McpWatcher } = await import('./mcp-watcher.js');
-    await new McpWatcher({ rootPath: root, outputPath, embed: false, closureBudget: 2 })
-      .handleChange(join(root, 'src/zzzz.ts'));
+      await writeFiles({ [variant.file]: 'export function foo() { return 1; }\n' });
+      const { McpWatcher } = await import('./mcp-watcher.js');
+      await new McpWatcher({ rootPath: root, outputPath, embed: false, closureBudget: 2 })
+        .handleChange(join(root, variant.file));
 
-    const s = EdgeStore.open(EdgeStore.dbPath(outputPath));
-    // The prune: zero needless stale flags (without it, 5 consumers − budget 2 = 3 stale).
-    expect(s.getStaleFiles().filter((f) => f.startsWith('src/w'))).toHaveLength(0);
-    // And every consumer still correctly resolves to zzz (matches analyze --force).
-    for (let i = 0; i < 5; i++) {
-      expect(outgoingSig(s, `src/w${i}.ts`).join('\n')).toContain('src/zzz.ts::foo');
-    }
-    s.close();
-  });
+      const s = EdgeStore.open(EdgeStore.dbPath(outputPath));
+      const stale = s.getStaleFiles().filter((f) => f.startsWith('src/w'));
+      // 5 consumers all diverge (unique -> ambiguous); budget 2 recomputes 2, flags 3 stale.
+      expect(stale).toHaveLength(3);
+      // The 2 recomputed consumers converged to NO foo edge (ambiguous), matching a full
+      // rebuild — never a guessed edge to either candidate.
+      for (let i = 0; i < 5; i++) {
+        const rel = `src/w${i}.ts`;
+        if (!stale.includes(rel)) {
+          const sig = outgoingSig(s, rel).join('\n');
+          expect(sig).not.toContain('::foo');
+        }
+      }
+      s.close();
 
-  it('round2: adding a symbol that WINS the tiebreak converges consumers within budget and flags the overflow stale', async () => {
-    const v1: Files = { 'src/zzz.ts': 'export function foo() { return 9; }\n' };
-    for (let i = 0; i < 5; i++) v1[`src/w${i}.ts`] = `export function use${i}() { return foo(); }\n`;
-    await writeFiles(v1);
-    const store = EdgeStore.open(EdgeStore.dbPath(outputPath));
-    seedStore(store, v1, await fullBuild(v1));
-    store.close();
-
-    // aaa sorts BEFORE zzz → becomes the new winner for every consumer.
-    await writeFiles({ 'src/aaa.ts': 'export function foo() { return 1; }\n' });
-    const { McpWatcher } = await import('./mcp-watcher.js');
-    await new McpWatcher({ rootPath: root, outputPath, embed: false, closureBudget: 2 })
-      .handleChange(join(root, 'src/aaa.ts'));
-
-    const s = EdgeStore.open(EdgeStore.dbPath(outputPath));
-    const stale = s.getStaleFiles().filter((f) => f.startsWith('src/w'));
-    expect(stale).toHaveLength(3); // 5 consumers − budget 2 = 3 over budget → stale
-    // The 2 recomputed consumers converged to aaa (the new winner).
-    for (let i = 0; i < 5; i++) {
-      const rel = `src/w${i}.ts`;
-      if (!stale.includes(rel)) expect(outgoingSig(s, rel).join('\n')).toContain('src/aaa.ts::foo');
-    }
-    s.close();
-  });
+      // Oracle: a full rebuild resolves NO consumer's foo (two candidates = ambiguous).
+      const v2: Files = { ...v1, [variant.file]: 'export function foo() { return 1; }\n' };
+      const oracle = await fullBuild(v2);
+      for (let i = 0; i < 5; i++) {
+        expect(oracleOutgoingSig(oracle.edges, `src/w${i}.ts`).join('\n')).not.toContain('::foo');
+      }
+    });
+  }
 
   it('round2: a present-but-unreadable consumer file is marked stale (not silently emptied + asserted fresh)', async () => {
     const v1: Files = {

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -541,13 +541,13 @@ export class McpWatcher {
           let sub = await buildGraphSubset(f.rel, f.content, recompute, this.rootPath, resolutionNodes);
 
           // Class-P closure: a symbol this edit ADDED can newly bind a previously-
-          // `external` call site, or flip the lowest-id `name_only` winner, in a
-          // file that is NOT a caller of this one (getCallerFiles misses it).
-          // Discovery runs even when direct callers already filled the budget —
-          // these consumers must never be left silently divergent: re-resolve
-          // within the remaining budget, mark the rest stale. Re-resolving runs
-          // them alongside the changed file so the new edge resolves internally —
-          // exactly as `analyze --force` would.
+          // `external` call site, or turn a previously-UNIQUE `name_only` bind into
+          // an ambiguous (unbound) one, in a file that is NOT a caller of this one
+          // (getCallerFiles misses it). Discovery runs even when direct callers
+          // already filled the budget — these consumers must never be left silently
+          // divergent: re-resolve within the remaining budget, mark the rest stale.
+          // Re-resolving runs them alongside the changed file so the new edge (or the
+          // new ambiguity) resolves exactly as `analyze --force` would.
           const addedIdByName = new Map<string, string>(); // added name → lowest new id
           for (const n of sub.nodes) {
             if (oldNames.has(n.name)) continue;
@@ -561,14 +561,16 @@ export class McpWatcher {
               for (const cf of store.getExternalConsumerFiles(name)) {
                 if (cf !== f.rel && cf !== 'external' && !recompute.includes(cf)) extra.add(cf);
               }
-              // `name_only` consumers already resolve the name to another file by
-              // lowest candidate id; the added symbol only flips that pick when its
-              // id sorts BEFORE the consumer's current target. Re-resolving the rest
-              // is a verified no-op (and a needless stale flag), so prune them — this
-              // is what keeps a common-name add (`get`/`run`) from re-parsing and
-              // stale-flagging dozens of unaffected files.
+              // `name_only` consumers currently resolve the name to a UNIQUE cross-file
+              // definition. Adding a SECOND definition of that name makes the bare call
+              // ambiguous — the resolver refuses to guess, so the edge disappears —
+              // REGARDLESS of id sort order (change: harden-call-resolution-ambiguity).
+              // Every such consumer therefore diverges from a full rebuild and must be
+              // re-resolved (the pre-ambiguity `addedId < calleeId` prune, which assumed
+              // only a lower-id add flipped the pick, would now leave higher-id adds
+              // silently holding a stale unique edge). `!==` guards the same-node no-op.
               for (const { file: cf, calleeId } of store.getNameOnlyConsumers(name)) {
-                if (cf !== f.rel && cf !== 'external' && !recompute.includes(cf) && addedId < calleeId) extra.add(cf);
+                if (cf !== f.rel && cf !== 'external' && !recompute.includes(cf) && addedId !== calleeId) extra.add(cf);
               }
             }
             if (extra.size > 0) {


### PR DESCRIPTION
**Status:** LGTM — full suite green (293 files / 5738 tests), lint + typecheck + build clean, verified end-to-end on real `openlore analyze` output.

Implements the #1 fix-track item from the e2e audit (`harden-call-resolution-ambiguity`).

## What was wrong
The resolution ladder documents "prefer false-negatives over false-positives," but enforced it everywhere **except** three spots that took `candidates[0]`:
- **`name_only`** (highest impact): a bare cross-file call matching >1 definition bound to whichever node sorted first — an arbitrary guess carrying the substrate's authority. Since import-precise resolution exists only for TS/JS/Python, all other languages ride this path for every cross-file call.
- **Python `self.`/`cls.` dispatch**: took `candidates[0]` with no file affinity (unlike `this`/`super`), so two same-named classes could bind to the wrong one — correct only by insertion-order luck.
- **`type_name`** (capitalized receiver): first-match across same-named types.

Every consumer downstream (`find_path`, `select_tests`, `find_dead_code`, blast radius) inherited the wrong edge, and no fixture exercised name-collision, so the guess was invisible to CI.

## What it does
One rule, applied uniformly: **a strategy that cannot single out a candidate emits a disclosed `unresolved-ambiguous` site (bounded candidate list) instead of an arbitrary edge. A unique candidate still binds at its declared confidence.**

- New `AmbiguousCallSite` disposition on `CallGraphResult`/`SerializedCallGraph`, carried through `serializeCallGraph` into the resident graph (`llm-context.json`).
- `name_only` / `self_cls` / `type_name` share one affinity ladder (own-file → the file the caller imports the qualifier from → single remaining candidate); `self`/`cls` now reuse `resolveSelfMethod` (with ancestor walking) rather than a first-match copy.
- **Consumers disclose, never silently trust or drop:**
  - `find_dead_code`: a function named by an ambiguous site is never high-confidence dead (mirrors the synthesized-edge downgrade).
  - `analyze_error_propagation`: ambiguous call sites become a disclosed boundary (mirrors the unresolved-self-call disclosure).
  - `analyze_impact`: ambiguous sites touching the impact set are surfaced with a "blast radius is a lower bound" note.
- **Watcher convergence fix** (`mcp-watcher` Class-P closure): a same-named addition flips a previously-unique `name_only` bind to ambiguous **regardless of id sort order**, so all such consumers must be re-resolved. The pre-existing `addedId < calleeId` prune (correct under the old lowest-id-winner model) would have left higher-id additions silently holding a stale unique edge — fixed to `addedId !== calleeId`.

## Proof it works
Before/after structural diff on this repo, **identical 328-file / 5159-node corpus** (changed files excluded to isolate the resolver):

| Metric | Before (main) | After | Δ |
|---|---|---|---|
| `name_only` edges | 113 | 94 | **−19** |
| unresolved-ambiguous sites | 0 | 19 | **+19** |
| total edges | 13257 | 13238 | −19 |
| `self_cls` / `import` / `external` / `same_file` | unchanged | unchanged | 0 |

Exactly 19 first-match guesses replaced by 19 ambiguous sites (each ≥2 candidates, e.g. `lineOf` ×6 IaC files, `visit` ×7); every other tier untouched, no external-leaf inflation. Recall drops only where the resolver was guessing; precision rises — as intended and disclosed.

Tests added:
- Conformance: cross-file resolution proven for **every claimed callGraph language** (+ coverage guard) with per-language provenance asserted; adversarial name-collision fixtures per strategy (refuse-to-guess + unique-still-binds).
- Consumer tests for `find_dead_code` downgrade, `analyze_error_propagation` boundary, `analyze_impact` disclosure.
- Watcher-parity tests rewritten to the ambiguity model (id-order-independent) with a full-rebuild oracle.

E2E on a real `openlore analyze`: `ambiguousSites` persist in `llm-context.json`; `error-propagation`, `find_dead_code`, and `analyze_impact` all disclose the collision correctly.

## Notes / scope
- **Overload-arity disambiguation is descoped to a follow-up** (disclosed in the spec delta, proposal, and tasks). Measured behavior differs from the audit's premise: same-name/different-arity overloads collapse at **node identity** (they share `file::Class.method`, so one is dropped *before* the resolution ladder runs) — not "orphaned at fan-in 0." Splitting overloads into arity-qualified nodes + resolving by call-site arg count is a node-identity change (stable ids, CFG side-table, symbol continuity, node-count consumers) with a different, larger blast radius, so it is not bundled here.
- Documented conformance exclusions (not resolver guesses): **Bash** cross-file (a bare command call is indistinguishable from an external command), and **Lua/Dart** in the multi-build sweep (WASM shared-heap flakiness on second in-process parse — same limitation the grammar-drift canary already excludes them for; their callGraph support is proven by the standalone section).
- Spec delta lives in the change dir; base-spec merge is an archive-time step (matches the parse-health #227 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)