### PR TITLE
fix(mcp-handlers): complete the epistemic-lease weight table and bind it to the registry

### DIFF
--- a/openspec/changes/fix-epistemic-lease-weights/tasks.md
+++ b/openspec/changes/fix-epistemic-lease-weights/tasks.md
@@ -2,10 +2,11 @@
 
 ## Implementation
 
-- [ ] Add the 27 missing entries to `TOOL_WEIGHTS` (epistemic-lease.ts:132-189) per the analogy
+- [x] Add the 27 missing entries to `TOOL_WEIGHTS` (epistemic-lease.ts:132-189) per the analogy
       table below — every weight is an existing entry's value, no new constants
-- [ ] Export `TOOL_WEIGHTS` (or a read-only accessor) so the completeness test can cross-check it;
+- [x] Export `TOOL_WEIGHTS` (or a read-only accessor) so the completeness test can cross-check it;
       keep the `?? 1` fallback (epistemic-lease.ts:617) as defense in depth
+      (exported as `TOOL_COGNITIVE_WEIGHTS`)
 
 ### Weight-by-analogy table (nearest weighted sibling, same traversal-depth class)
 
@@ -40,11 +41,12 @@
 | `sync_decisions` | 1 | `record_decision` (1) — decision lifecycle write |
 
 ## Verification
-- [ ] Completeness test mirroring tool-contract.test.ts:31-72: every `TOOL_DEFINITIONS` name has a
+- [x] Completeness test mirroring tool-contract.test.ts:31-72: every `TOOL_DEFINITIONS` name has a
       `TOOL_WEIGHTS` entry; no `TOOL_WEIGHTS` key names an unregistered tool
-- [ ] Mutation check: remove one entry → test fails naming the tool
-- [ ] Existing lease threshold tests stay green (thresholds unchanged)
-- [ ] Full suite green (`npm run test:run`)
+      (added to `tool-contract.test.ts` beside the sibling completeness cross-checks)
+- [x] Mutation check: remove one entry → test fails naming the tool
+- [x] Existing lease threshold tests stay green (thresholds unchanged)
+- [x] Full suite green (`npm run test:run`)
 
 ## Spec
-- [ ] `mcp-handlers` delta: ADD LeaseWeightTableIsComplete
+- [x] `mcp-handlers` delta: ADD LeaseWeightTableIsComplete

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -141,10 +141,17 @@ const TOOL_WEIGHTS: Record<string, number> = {
   list_spec_domains: 1,
   list_decisions: 1,
   record_decision: 1,
+  approve_decision: 1,     // ← record_decision (1) — decision lifecycle write
+  reject_decision: 1,      // ← record_decision (1) — decision lifecycle write
+  sync_decisions: 1,       // ← record_decision (1) — decision lifecycle write
   remember: 1,
   recall: 2,
+  verify_claim: 2,         // ← recall (2) — settle one fact against the graph/store
   get_env_vars: 1,
   get_external_packages: 1,
+  federation_status: 1,    // ← get_external_packages (1) — status/inventory read
+  spec_store_status: 1,    // ← get_external_packages (1) — binding health read
+  get_language_support: 1, // ← list_spec_domains (1) — pure registry lookup
 
   // Structural: function/file-level reads
   get_spec: 2,
@@ -157,6 +164,7 @@ const TOOL_WEIGHTS: Record<string, number> = {
   get_schema_inventory: 2,
   get_ui_component_inventory: 2,
   get_middleware_inventory: 2,
+  get_style_fingerprint: 2, // ← get_signatures (2) — precomputed per-file/region profile read
 
   // Structural-heavy: graph and architecture reads
   get_architecture_overview: 3,
@@ -174,6 +182,17 @@ const TOOL_WEIGHTS: Record<string, number> = {
   detect_changes: 3,
   audit_spec_coverage: 3,
   get_minimal_context: 3,
+  check_architecture: 3,          // ← get_architecture_overview (3) — architecture read
+  get_map: 3,                     // ← get_architecture_overview (3) — region view
+  get_health_map: 3,              // ← get_architecture_overview (3) — region health view
+  get_landmarks: 3,               // ← get_critical_hubs (3) — landmark/hub region read
+  get_surprising_connections: 3,  // ← get_critical_hubs (3) — cross-module edge read
+  get_change_coupling: 3,         // ← get_file_dependencies (3) — repo-wide co-change read
+  suggest_insertion_points: 3,    // ← get_minimal_context (3) — structural placement analysis
+  working_set_context: 3,         // ← get_minimal_context (3) — budgeted structural briefing
+  structural_diff: 3,             // ← detect_changes (3) — diff-scoped structural read
+  briefing_since: 3,              // ← detect_changes (3) — changed-symbols-since-ref read
+  certify_public_surface: 3,      // ← detect_changes (3) — diff-scoped export verdict
 
   // Graph traversal / cross-module
   get_subgraph: 5,
@@ -183,10 +202,27 @@ const TOOL_WEIGHTS: Record<string, number> = {
   annotate_story: 5,
   generate_tests: 4,
   get_low_risk_refactor_candidates: 4,
+  blast_radius: 5,              // ← analyze_impact (5) — callers/layers/tests briefing over the graph
+  select_tests: 5,             // ← analyze_impact (5) — backward reachability over the graph
+  report_coverage_gaps: 5,     // ← analyze_impact (5) — whole-graph reachability (inverse of select_tests)
+  find_dead_code: 5,           // ← analyze_impact (5) — whole-graph reachability sweep
+  change_impact_certificate: 5,// ← generate_change_proposal (5) — diff-scoped multi-source certificate
+  plan_parallel_work: 5,       // ← analyze_impact (5) — footprint + hazard graph over task seeds
+  map_in_flight_conflicts: 5,  // ← plan_parallel_work (5) — same hazard classifier, harvested inputs
 
   // Deep architectural tracing
   trace_execution_path: 8,
+  find_path: 8,  // ← trace_execution_path (8) — point-to-point path traversal, documented near-twin
 };
+
+/**
+ * Read-only view of the cognitive-weight table, exported so a completeness test can
+ * cross-check it against the live tool registry (`TOOL_DEFINITIONS`) in both directions —
+ * the same closed-table discipline `TOOL_OUTPUT_CLASS` and `TOOL_CAPABILITY_FAMILY` carry.
+ * The `?? 1` fallback in `updateTracker` remains as defense in depth, but the test ensures
+ * it is never the mechanism by which a *registered* tool is scored.
+ */
+export const TOOL_COGNITIVE_WEIGHTS: Readonly<Record<string, number>> = TOOL_WEIGHTS;
 
 // ============================================================================
 // THRESHOLDS

--- a/src/core/services/mcp-handlers/tool-contract.test.ts
+++ b/src/core/services/mcp-handlers/tool-contract.test.ts
@@ -24,6 +24,7 @@ import {
   groupToolsByFamily,
 } from './tool-contract.js';
 import { MAX_PROVENANCE_EDGES } from '../../../constants.js';
+import { TOOL_COGNITIVE_WEIGHTS } from './epistemic-lease.js';
 
 const registeredToolNames = TOOL_DEFINITIONS.map(t => t.name);
 const toolByName = new Map(TOOL_DEFINITIONS.map(t => [t.name, t]));
@@ -96,6 +97,42 @@ describe('groupToolsByFamily', () => {
     expect(grouped).toEqual([...registeredToolNames].sort());
     // An agent chooses among a handful of families, not the flat registry.
     expect(groups.length).toBeLessThanOrEqual(CAPABILITY_FAMILIES.length);
+  });
+});
+
+// ============================================================================
+// LeaseWeightTableIsComplete (mcp-handlers; change: fix-epistemic-lease-weights).
+// The epistemic lease weights each tool call to track per-session cognitive load.
+// Its weight table must cover the whole registry in both directions — the same
+// closed-table discipline TOOL_OUTPUT_CLASS and TOOL_CAPABILITY_FAMILY carry — so a
+// new tool without a declared weight fails CI rather than silently riding the `?? 1`
+// runtime fallback (a freshness signal computed from wrong inputs is a wrong signal).
+// ============================================================================
+describe('TOOL_COGNITIVE_WEIGHTS completeness', () => {
+  it('weights every registered tool (no tool falls to the runtime fallback)', () => {
+    const unweighted = registeredToolNames.filter(name => !(name in TOOL_COGNITIVE_WEIGHTS));
+    expect(unweighted).toEqual([]);
+  });
+
+  it('has no stale entries for tools that are no longer registered', () => {
+    const registered = new Set(registeredToolNames);
+    const stale = Object.keys(TOOL_COGNITIVE_WEIGHTS).filter(name => !registered.has(name));
+    expect(stale).toEqual([]);
+  });
+
+  it('assigns every weight from the existing tier set (no newly invented constant)', () => {
+    // Weights are assigned by analogy to an existing entry, never a fresh magnitude:
+    // 0 (reset), 1-2 (lightweight), 3-5 (structural/graph), 8 (deep architectural trace).
+    const allowed = new Set([0, 1, 2, 3, 4, 5, 8]);
+    for (const [name, weight] of Object.entries(TOOL_COGNITIVE_WEIGHTS)) {
+      expect(allowed.has(weight), `tool "${name}" has weight ${weight} outside the declared tier set`).toBe(true);
+    }
+  });
+
+  it('scores near-twin tools equally (find_path === trace_execution_path)', () => {
+    // Two point-to-point path traversals documented as near-twins accrue equal load —
+    // the 8× accounting gap the fix closes.
+    expect(TOOL_COGNITIVE_WEIGHTS.find_path).toBe(TOOL_COGNITIVE_WEIGHTS.trace_execution_path);
   });
 });
 


### PR DESCRIPTION
**Status:** LGTM — full suite green (295 files / 5,763 passed / 2 skipped), typecheck clean, mutation-verified.

Closes the fix-track item `fix-epistemic-lease-weights` (e2e audit 2026-07).

### What was wrong
The epistemic lease weights every tool call to track per-session cognitive load, then fires degrade/stale freshness thresholds on the accumulated total. Its weight table (`TOOL_WEIGHTS`, `epistemic-lease.ts`) listed only **45 of the 72 dispatched tools** — the other **27 silently scored the minimum** via the `TOOL_WEIGHTS[toolName] ?? 1` fallback:

- **Default-surface traversals were unweighted:** `find_path`, `blast_radius`, `verify_claim`, `suggest_insertion_points`, `get_landmarks`, `get_map`. Starkest case — `find_path` scored **1** while its documented near-twin `trace_execution_path` scored **8**: an 8× accounting gap decided by table membership, not by work done.
- **Whole families unweighted:** all of `coordinate`/`federate`, most of `change`.
- **No guard:** unlike `TOOL_OUTPUT_CLASS` and `TOOL_CAPABILITY_FAMILY`, nothing bound the table to the live registry — every one of the last ~14 tools shipped without a weight, and nothing stopped the next one.

A session of heavy unlisted traversals accrued load as if doing cheap lookups, so the freshness note the agent is told to trust arrived late or never. Per the honesty contract, a signal computed from wrong inputs is a wrong signal delivered with authority.

### How it was fixed
1. **Weighted all 27 missing tools by analogy** to the nearest weighted sibling in the same traversal-depth class — every weight is an existing value (`8/5/3/2/1`), **no new constants**. e.g. `find_path` ← `trace_execution_path` (8); `blast_radius`/`select_tests`/`find_dead_code` ← `analyze_impact` (5); `structural_diff`/`briefing_since` ← `detect_changes` (3); `verify_claim` ← `recall` (2); `approve/reject/sync_decisions` ← `record_decision` (1). Each entry carries an inline `← sibling (n)` provenance comment.
2. **Exported `TOOL_COGNITIVE_WEIGHTS`** (read-only) and added a **completeness cross-check** in `tool-contract.test.ts`, beside the sibling checks: every registered tool has a weight; no stale entry names an unregistered tool; every weight is from the existing tier set; near-twins accrue equal load. A new tool without a weight now **fails CI**. The `?? 1` fallback stays as defense in depth but can no longer mask a registry gap.

### Proof it works
- **Completeness:** the 27 additions are exactly the registered-minus-weighted set difference; no stale entries.
- **Mutation check:** removing `find_path: 8` fails the test naming `find_path` (both the completeness and near-twin assertions) — teeth confirmed, then restored.
- **Thresholds unchanged**, existing lease tests green. No payload/tool-surface change, so the tools/list budget guardrail is untouched.

### Notes
- Correction is behavioral-by-design: sessions heavy on formerly-unlisted tools now reach degrade/stale thresholds *sooner* — that's the fix, not a regression.
- Spec delta: `mcp-handlers` ADD `LeaseWeightTableIsComplete` (in the change dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)