### PR TITLE
fix(mcp-security): put the view server behind the serve daemon's request guard

### DIFF
--- a/openspec/changes/harden-local-http-surfaces/tasks.md
+++ b/openspec/changes/harden-local-http-surfaces/tasks.md
@@ -1,17 +1,17 @@
 # Tasks — harden local HTTP surfaces
 
 ## Implementation
-- [ ] Extract serve.ts guard (Host allowlist, Origin check, constant-time token, non-loopback
+- [x] Extract serve.ts guard (Host allowlist, Origin check, constant-time token, non-loopback
       token requirement) into a shared module; serve.ts imports it (behavior-identical)
-- [ ] Apply guard to all view.ts /api/* routes; inject token into the served UI page
-- [ ] /api/chat requires token even on loopback
-- [ ] view.ts SIGINT/SIGTERM graceful shutdown + descriptor file (stale-instance detection)
+- [x] Apply guard to all view.ts /api/* routes; inject token into the served UI page
+- [x] /api/chat requires token even on loopback
+- [x] view.ts SIGINT/SIGTERM graceful shutdown + descriptor file (stale-instance detection)
 
 ## Verification
-- [ ] Rebinding-shaped request (loopback IP, foreign Host/Origin) → 403 on every view API route
-- [ ] Served UI same-origin flow works end-to-end (chat, skeleton, search)
-- [ ] /api/chat without token → 401 even from localhost
-- [ ] serve daemon suite unchanged and green against the shared module
+- [x] Rebinding-shaped request (loopback IP, foreign Host/Origin) → 403 on every view API route
+- [x] Served UI same-origin flow works end-to-end (chat, skeleton, search)
+- [x] /api/chat without token → 401 even from localhost
+- [x] serve daemon suite unchanged and green against the shared module
 
 ## Spec
-- [ ] `mcp-security` delta: ADD AllLocalHttpSurfacesShareTheGuard
+- [x] `mcp-security` delta: ADD AllLocalHttpSurfacesShareTheGuard (folded into main spec)

--- a/openspec/specs/mcp-security/spec.md
+++ b/openspec/specs/mcp-security/spec.md
@@ -207,6 +207,36 @@ comparison SHALL be constant-time.
 - **WHEN** the daemon starts
 - **THEN** it refuses to bind and explains that a non-loopback bind requires a token
 
+### Requirement: AllLocalHttpSurfacesShareTheGuard
+
+Every HTTP surface OpenLore binds locally (the `serve` daemon, the `view` graph server, and any
+future one) SHALL enforce the same request guard from one shared module: a Host-header allowlist
+restricted to loopback forms with the bound port, an Origin check rejecting foreign browser
+origins, and a constant-time token requirement for any non-loopback binding. An endpoint that
+spends the user's money or executes an agent (e.g. the viewer's chat endpoint) SHALL require the
+token even on loopback. No API route may be mounted outside the guard. Each surface SHALL install
+graceful-shutdown handlers and a descriptor for stale-instance detection.
+
+#### Scenario: DNS rebinding cannot reach the viewer's APIs
+
+- **GIVEN** a browser request arriving at `127.0.0.1:<port>` with a non-loopback Host or Origin
+  header
+- **WHEN** any `/api/*` route of the view server receives it
+- **THEN** the request is rejected with 403 before any handler logic runs
+
+#### Scenario: The chat endpoint cannot be driven by a foreign page
+
+- **GIVEN** a request to the viewer's `/api/chat` without the instance token
+- **WHEN** the guard evaluates it
+- **THEN** it is rejected with 401 even when it originates from loopback
+
+#### Scenario: A new local surface cannot opt out silently
+
+- **GIVEN** a future command that binds a local HTTP listener with an API route mounted outside
+  the shared guard
+- **WHEN** the guard-coverage test runs
+- **THEN** the test fails naming the unguarded route
+
 ### Requirement: Write Confinement for Mutating Tools
 
 Tools that write to disk or mutate persistent state (`record_decision`, `sync_decisions`,

--- a/src/cli/commands/local-http-guard.test.ts
+++ b/src/cli/commands/local-http-guard.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the shared local-HTTP request guard (local-http-guard.ts) — the one
+ * door both the `serve` daemon and the `view` graph server put in front of every
+ * API route. Covers the DNS-rebinding / cross-origin defense, the constant-time
+ * token gate's policy branches, and the connect middleware factory.
+ *
+ * Guards the `mcp-security` requirement AllLocalHttpSurfacesShareTheGuard.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import {
+  isLoopbackHost,
+  hostnameOf,
+  constantTimeEqual,
+  originDefenseError,
+  checkLocalHttpRequest,
+  createApiGuardMiddleware,
+  OPENLORE_TOKEN_HEADER,
+} from './local-http-guard.js';
+
+/** Minimal IncomingMessage stand-in — only headers/url are read by the guard. */
+function fakeReq(headers: Record<string, string | undefined>, url = '/'): IncomingMessage {
+  return { headers, url } as unknown as IncomingMessage;
+}
+
+describe('isLoopbackHost', () => {
+  it('accepts loopback names and literals', () => {
+    for (const h of ['localhost', '127.0.0.1', '127.5.6.7', '::1', '[::1]', 'LOCALHOST']) {
+      expect(isLoopbackHost(h)).toBe(true);
+    }
+  });
+  it('rejects non-loopback hosts', () => {
+    for (const h of ['0.0.0.0', 'attacker.example.com', '10.0.0.1', '192.168.1.5', '128.0.0.1']) {
+      expect(isLoopbackHost(h)).toBe(false);
+    }
+  });
+});
+
+describe('hostnameOf', () => {
+  it('strips ports, schemes, and IPv6 brackets', () => {
+    expect(hostnameOf('127.0.0.1:5173')).toBe('127.0.0.1');
+    expect(hostnameOf('http://localhost:8080')).toBe('localhost');
+    expect(hostnameOf('[::1]:5173')).toBe('::1');
+    expect(hostnameOf('https://evil.example.com')).toBe('evil.example.com');
+  });
+});
+
+describe('constantTimeEqual', () => {
+  it('is true only for identical strings', () => {
+    expect(constantTimeEqual('sekret', 'sekret')).toBe(true);
+    expect(constantTimeEqual('sekret', 'sekrey')).toBe(false);
+    expect(constantTimeEqual('sekret', 'sekre')).toBe(false); // length mismatch
+    expect(constantTimeEqual('', '')).toBe(true);
+  });
+});
+
+describe('originDefenseError', () => {
+  const bound = '127.0.0.1';
+  it('allows a loopback Host with no Origin', () => {
+    expect(originDefenseError(fakeReq({ host: '127.0.0.1:5173' }), bound)).toBeNull();
+  });
+  it('allows a same-origin loopback Host + Origin', () => {
+    expect(
+      originDefenseError(fakeReq({ host: 'localhost:5173', origin: 'http://localhost:5173' }), bound),
+    ).toBeNull();
+  });
+  it('rejects a foreign (rebinding) Host', () => {
+    const err = originDefenseError(fakeReq({ host: 'attacker.example.com' }), bound);
+    expect(err).toMatch(/DNS-rebinding/);
+  });
+  it('rejects a missing Host', () => {
+    expect(originDefenseError(fakeReq({}), bound)).toMatch(/DNS-rebinding/);
+  });
+  it('rejects a cross-site Origin even with a loopback Host', () => {
+    const err = originDefenseError(
+      fakeReq({ host: '127.0.0.1:5173', origin: 'https://evil.example.com' }),
+      bound,
+    );
+    expect(err).toMatch(/cross-site Origin/);
+  });
+  it('accepts the literal "null" Origin (opaque origin, e.g. file://)', () => {
+    expect(originDefenseError(fakeReq({ host: '127.0.0.1:5173', origin: 'null' }), bound)).toBeNull();
+  });
+});
+
+describe('checkLocalHttpRequest — token policy', () => {
+  const good = { host: '127.0.0.1:5173' };
+
+  it('403s a rebinding request before any token check', () => {
+    const r = checkLocalHttpRequest(fakeReq({ host: 'evil.example.com' }), {
+      boundHost: '127.0.0.1',
+      token: 'sekret',
+      requireToken: true,
+    });
+    expect(r?.status).toBe(403);
+  });
+
+  it('allows a loopback request with no token when none is required', () => {
+    const r = checkLocalHttpRequest(fakeReq(good), { boundHost: '127.0.0.1', token: 'sekret' });
+    expect(r).toBeNull();
+  });
+
+  it('401s a requireToken route on loopback without the token', () => {
+    const r = checkLocalHttpRequest(fakeReq(good), {
+      boundHost: '127.0.0.1',
+      token: 'sekret',
+      requireToken: true,
+    });
+    expect(r?.status).toBe(401);
+  });
+
+  it('allows a requireToken route on loopback WITH the token', () => {
+    const r = checkLocalHttpRequest(
+      fakeReq({ ...good, [OPENLORE_TOKEN_HEADER]: 'sekret' }),
+      { boundHost: '127.0.0.1', token: 'sekret', requireToken: true },
+    );
+    expect(r).toBeNull();
+  });
+
+  it('401s a wrong token', () => {
+    const r = checkLocalHttpRequest(
+      fakeReq({ ...good, [OPENLORE_TOKEN_HEADER]: 'nope' }),
+      { boundHost: '127.0.0.1', token: 'sekret', requireToken: true },
+    );
+    expect(r?.status).toBe(401);
+  });
+
+  it('requires the token on a non-loopback binding even for a non-requireToken route', () => {
+    // Host allowlist also names the bound host (0.0.0.0) so origin defense passes.
+    const r = checkLocalHttpRequest(fakeReq({ host: '0.0.0.0:5173' }), {
+      boundHost: '0.0.0.0',
+      token: 'sekret',
+      requireToken: false,
+    });
+    expect(r?.status).toBe(401);
+  });
+
+  it('never requires a token when none is configured', () => {
+    const r = checkLocalHttpRequest(fakeReq(good), { boundHost: '127.0.0.1', requireToken: true });
+    expect(r).toBeNull();
+  });
+});
+
+/** Record a middleware's effect: either it wrote a status+body or it called next(). */
+function runMiddleware(
+  mw: ReturnType<typeof createApiGuardMiddleware>,
+  req: IncomingMessage,
+): { status?: number; body?: string; nexted: boolean } {
+  const out: { status?: number; body?: string; nexted: boolean } = { nexted: false };
+  const res = {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn((b?: string) => {
+      out.body = b;
+    }),
+  } as unknown as ServerResponse;
+  mw(req, res, () => {
+    out.nexted = true;
+  });
+  if (!out.nexted) out.status = (res as unknown as { statusCode: number }).statusCode;
+  return out;
+}
+
+describe('createApiGuardMiddleware', () => {
+  const mw = createApiGuardMiddleware({
+    boundHost: '127.0.0.1',
+    token: 'sekret',
+    requireTokenFor: (rel) => rel === '/chat',
+  });
+
+  it('403s a rebinding request on any route', () => {
+    // req.url is relative to the /api mount: '/skeleton' => /api/skeleton.
+    const r = runMiddleware(mw, fakeReq({ host: 'evil.example.com' }, '/skeleton'));
+    expect(r.status).toBe(403);
+    expect(r.nexted).toBe(false);
+  });
+
+  it('passes a same-origin non-chat route with no token (loopback)', () => {
+    const r = runMiddleware(mw, fakeReq({ host: '127.0.0.1:5173' }, '/skeleton?file=x'));
+    expect(r.nexted).toBe(true);
+  });
+
+  it('401s /chat without the token even on loopback', () => {
+    const r = runMiddleware(mw, fakeReq({ host: '127.0.0.1:5173' }, '/chat'));
+    expect(r.status).toBe(401);
+    expect(r.nexted).toBe(false);
+  });
+
+  it('passes /chat with the token', () => {
+    const r = runMiddleware(
+      mw,
+      fakeReq({ host: '127.0.0.1:5173', [OPENLORE_TOKEN_HEADER]: 'sekret' }, '/chat'),
+    );
+    expect(r.nexted).toBe(true);
+  });
+
+  it('treats /chat/models like an ordinary route (no token needed on loopback)', () => {
+    const r = runMiddleware(mw, fakeReq({ host: '127.0.0.1:5173' }, '/chat/models'));
+    expect(r.nexted).toBe(true);
+  });
+});

--- a/src/cli/commands/local-http-guard.ts
+++ b/src/cli/commands/local-http-guard.ts
@@ -1,0 +1,187 @@
+/**
+ * Shared request guard for OpenLore's local HTTP surfaces (the `serve` daemon and
+ * the `view` graph server).
+ *
+ * OpenLore binds more than one local HTTP listener; both must present the same
+ * door to a browser. This module is the single, dependency-light home for the
+ * security-critical primitives so the two surfaces cannot drift:
+ *
+ *   - a Host-header allowlist restricted to loopback forms (DNS-rebinding guard),
+ *   - an Origin check rejecting foreign browser origins,
+ *   - a constant-time token comparison,
+ *
+ * plus {@link checkLocalHttpRequest}, the composed policy a surface applies per
+ * request: reject a cross-origin/rebinding request (403), then require the
+ * `x-openlore-token` header when the binding is non-loopback OR the route is a
+ * money/agent endpoint (401). See the `mcp-security` spec requirement
+ * `AllLocalHttpSurfacesShareTheGuard`.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
+
+/** Header a client presents to authenticate to a local OpenLore HTTP surface. */
+export const OPENLORE_TOKEN_HEADER = 'x-openlore-token';
+
+/** Hostnames that denote the loopback interface (no DNS resolution involved). */
+export const LOOPBACK_HOSTNAMES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '0:0:0:0:0:0:0:1',
+  '0000:0000:0000:0000:0000:0000:0000:0001',
+]);
+
+/** True if `host` is a loopback literal/name (127.0.0.0/8, ::1, localhost). */
+export function isLoopbackHost(host: string): boolean {
+  const h = host.trim().replace(/^\[|\]$/g, '').toLowerCase();
+  if (LOOPBACK_HOSTNAMES.has(h)) return true;
+  // Any 127.x.y.z address is loopback.
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h);
+}
+
+/** Extract the hostname (sans port, sans brackets) from a Host/Origin authority. */
+export function hostnameOf(authority: string): string {
+  let a = authority.trim();
+  // Strip scheme if this came from an Origin (e.g. http://host:port).
+  const scheme = a.indexOf('://');
+  if (scheme !== -1) a = a.slice(scheme + 3);
+  // Bracketed IPv6: [::1]:port
+  if (a.startsWith('[')) {
+    const close = a.indexOf(']');
+    if (close !== -1) return a.slice(1, close).toLowerCase();
+  }
+  // host:port → host (IPv4 / name only; bare IPv6 has no port form here)
+  const colon = a.indexOf(':');
+  if (colon !== -1 && a.indexOf(':') === a.lastIndexOf(':')) a = a.slice(0, colon);
+  return a.toLowerCase();
+}
+
+/**
+ * Constant-time string equality. Returns false for length mismatch, but still
+ * runs a same-length compare first so timing does not leak the secret's length.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf-8');
+  const bb = Buffer.from(b, 'utf-8');
+  if (ab.length !== bb.length) {
+    // Compare ab to itself to burn comparable time, then fail.
+    timingSafeEqual(ab, ab);
+    return false;
+  }
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * DNS-rebinding / cross-origin defense for a loopback listener. A browser tricked
+ * into resolving an attacker domain to 127.0.0.1 still sends the attacker's name in
+ * the `Host` header (and an attacker page sends a cross-site `Origin`). We accept a
+ * request only when both the Host and any Origin name the loopback interface or the
+ * exact bound host. Returns an error string to reject with, or null to allow.
+ */
+export function originDefenseError(req: IncomingMessage, boundHost: string): string | null {
+  const boundName = hostnameOf(boundHost);
+  const allowed = (name: string): boolean => isLoopbackHost(name) || name === boundName;
+
+  const hostHeader = req.headers.host;
+  if (hostHeader === undefined || !allowed(hostnameOf(hostHeader))) {
+    return `Host header "${hostHeader ?? ''}" is not an allowed loopback name (DNS-rebinding guard)`;
+  }
+  const origin = req.headers.origin;
+  if (origin !== undefined && origin !== 'null' && !allowed(hostnameOf(origin))) {
+    return `cross-site Origin "${origin}" is not permitted`;
+  }
+  return null;
+}
+
+/** Per-request guard configuration. */
+export interface LocalHttpGuardConfig {
+  /** The host the server is bound to (from the surface's --host). */
+  boundHost: string;
+  /** The instance token, if one is configured. */
+  token?: string;
+  /**
+   * Force the token even on a loopback binding — for money/agent endpoints
+   * (e.g. the viewer's chat route) that must not be driven by another local
+   * process or a header-less rebinding page. On a non-loopback binding the token
+   * is always required regardless of this flag.
+   */
+  requireToken?: boolean;
+  /** Header carrying the token. Defaults to {@link OPENLORE_TOKEN_HEADER}. */
+  tokenHeader?: string;
+}
+
+/** A rejection to send. `null` from {@link checkLocalHttpRequest} means "allow". */
+export interface LocalHttpGuardRejection {
+  status: number;
+  error: string;
+}
+
+/**
+ * Apply the shared local-HTTP guard to a request. Returns a rejection to send
+ * (403 for a rebinding/cross-origin request, 401 for a missing/invalid token) or
+ * `null` to allow the request through.
+ *
+ * Token policy: a token is required when a token is configured AND either the
+ * binding is non-loopback (anyone on the network can reach the port) or the
+ * caller marked the route `requireToken` (a money/agent endpoint).
+ */
+export function checkLocalHttpRequest(
+  req: IncomingMessage,
+  cfg: LocalHttpGuardConfig,
+): LocalHttpGuardRejection | null {
+  const originErr = originDefenseError(req, cfg.boundHost);
+  if (originErr) return { status: 403, error: originErr };
+
+  const tokenRequired =
+    cfg.token !== undefined && (cfg.requireToken === true || !isLoopbackHost(cfg.boundHost));
+  if (tokenRequired) {
+    const presented = req.headers[cfg.tokenHeader ?? OPENLORE_TOKEN_HEADER];
+    if (typeof presented !== 'string' || !constantTimeEqual(presented, cfg.token as string)) {
+      return { status: 401, error: `invalid or missing ${cfg.tokenHeader ?? OPENLORE_TOKEN_HEADER}` };
+    }
+  }
+  return null;
+}
+
+/** Minimal connect-style middleware signature (a subset of what vite/connect pass). */
+export type ConnectMiddleware = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: (err?: unknown) => void,
+) => void;
+
+/**
+ * Build a connect/vite middleware that enforces {@link checkLocalHttpRequest} on
+ * every request that reaches it. Mount it at the `/api` prefix BEFORE any
+ * `/api/*` route so no route can be reached without passing the guard.
+ *
+ * `requireTokenFor(pathname)` receives the request pathname RELATIVE to the mount
+ * point (e.g. `/chat` for a request to `/api/chat`) and returns true for routes
+ * that must present the token even on a loopback binding.
+ */
+export function createApiGuardMiddleware(opts: {
+  boundHost: string;
+  token?: string;
+  requireTokenFor?: (relativePathname: string) => boolean;
+  tokenHeader?: string;
+}): ConnectMiddleware {
+  return (req, res, next) => {
+    // Under a connect prefix mount ('/api'), req.url is relative to the mount:
+    // a request to /api/chat arrives here as '/chat'.
+    const rel = (req.url ?? '/').split('?')[0].replace(/\/+$/, '') || '/';
+    const rejection = checkLocalHttpRequest(req, {
+      boundHost: opts.boundHost,
+      token: opts.token,
+      requireToken: opts.requireTokenFor ? opts.requireTokenFor(rel) : false,
+      tokenHeader: opts.tokenHeader,
+    });
+    if (rejection) {
+      res.statusCode = rejection.status;
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      res.end(JSON.stringify({ error: rejection.error }));
+      return;
+    }
+    next();
+  };
+}

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -32,7 +32,6 @@
 import { Command } from 'commander';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createRequire } from 'node:module';
-import { timingSafeEqual } from 'node:crypto';
 import { writeFile, readFile, unlink, mkdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { logger } from '../../utils/logger.js';
@@ -45,6 +44,12 @@ import { McpWatcher } from '../../core/services/mcp-watcher.js';
 import { openloreAnalyze } from '../../api/analyze.js';
 import { TOOL_DEFINITIONS, TOOL_PRESETS, selectActiveTools } from './mcp.js';
 import { validateToolArgs } from '../../core/services/mcp-handlers/tool-guard.js';
+import {
+  isLoopbackHost,
+  constantTimeEqual,
+  originDefenseError,
+  OPENLORE_TOKEN_HEADER,
+} from './local-http-guard.js';
 
 /**
  * Debounce before a full call-graph re-analyze after edits settle. Longer than
@@ -124,77 +129,6 @@ export interface ServeHandle {
 
 const SERVE_FILE = 'serve.json';
 const MAX_BODY_BYTES = 1_000_000; // tool args are small; reject anything larger
-
-/** Hostnames that denote the loopback interface (no DNS resolution involved). */
-const LOOPBACK_HOSTNAMES = new Set([
-  'localhost',
-  '127.0.0.1',
-  '::1',
-  '0:0:0:0:0:0:0:1',
-  '0000:0000:0000:0000:0000:0000:0000:0001',
-]);
-
-/** True if `host` is a loopback literal/name (127.0.0.0/8, ::1, localhost). */
-function isLoopbackHost(host: string): boolean {
-  const h = host.trim().replace(/^\[|\]$/g, '').toLowerCase();
-  if (LOOPBACK_HOSTNAMES.has(h)) return true;
-  // Any 127.x.y.z address is loopback.
-  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h);
-}
-
-/** Extract the hostname (sans port, sans brackets) from a Host/Origin authority. */
-function hostnameOf(authority: string): string {
-  let a = authority.trim();
-  // Strip scheme if this came from an Origin (e.g. http://host:port).
-  const scheme = a.indexOf('://');
-  if (scheme !== -1) a = a.slice(scheme + 3);
-  // Bracketed IPv6: [::1]:port
-  if (a.startsWith('[')) {
-    const close = a.indexOf(']');
-    if (close !== -1) return a.slice(1, close).toLowerCase();
-  }
-  // host:port → host (IPv4 / name only; bare IPv6 has no port form here)
-  const colon = a.indexOf(':');
-  if (colon !== -1 && a.indexOf(':') === a.lastIndexOf(':')) a = a.slice(0, colon);
-  return a.toLowerCase();
-}
-
-/**
- * Constant-time string equality. Returns false for length mismatch, but still
- * runs a same-length compare first so timing does not leak the secret's length.
- */
-function constantTimeEqual(a: string, b: string): boolean {
-  const ab = Buffer.from(a, 'utf-8');
-  const bb = Buffer.from(b, 'utf-8');
-  if (ab.length !== bb.length) {
-    // Compare ab to itself to burn comparable time, then fail.
-    timingSafeEqual(ab, ab);
-    return false;
-  }
-  return timingSafeEqual(ab, bb);
-}
-
-/**
- * DNS-rebinding / cross-origin defense for the loopback daemon. A browser tricked
- * into resolving an attacker domain to 127.0.0.1 still sends the attacker's name in
- * the `Host` header (and an attacker page sends a cross-site `Origin`). We accept a
- * request only when both the Host and any Origin name the loopback interface or the
- * exact bound host. Returns an error string to reject with, or null to allow.
- */
-function originDefenseError(req: IncomingMessage, boundHost: string): string | null {
-  const boundName = hostnameOf(boundHost);
-  const allowed = (name: string): boolean => isLoopbackHost(name) || name === boundName;
-
-  const hostHeader = req.headers.host;
-  if (hostHeader === undefined || !allowed(hostnameOf(hostHeader))) {
-    return `Host header "${hostHeader ?? ''}" is not an allowed loopback name (DNS-rebinding guard)`;
-  }
-  const origin = req.headers.origin;
-  if (origin !== undefined && origin !== 'null' && !allowed(hostnameOf(origin))) {
-    return `cross-site Origin "${origin}" is not permitted`;
-  }
-  return null;
-}
 
 function serveFilePath(root: string): string {
   return join(root, OPENLORE_DIR, SERVE_FILE);
@@ -460,9 +394,9 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
     // Token gate (skips /health so liveness checks need no secret). Compared in
     // constant time so a timing oracle can't recover the token byte-by-byte.
     if (token && url.pathname !== '/health') {
-      const presented = req.headers['x-openlore-token'];
+      const presented = req.headers[OPENLORE_TOKEN_HEADER];
       if (typeof presented !== 'string' || !constantTimeEqual(presented, token)) {
-        sendJson(res, 401, { error: 'invalid or missing x-openlore-token' });
+        sendJson(res, 401, { error: `invalid or missing ${OPENLORE_TOKEN_HEADER}` });
         return;
       }
     }

--- a/src/cli/commands/view.test.ts
+++ b/src/cli/commands/view.test.ts
@@ -2,8 +2,8 @@
  * Tests for openlore view command
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { viewCommand, sanitizeErrorMessage, safePath } from './view.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { viewCommand, sanitizeErrorMessage, safePath, buildTokenInjectionScript } from './view.js';
 
 // ============================================================================
 // MOCKS
@@ -58,6 +58,14 @@ vi.mock('../../core/analyzer/code-shaper.js', () => ({
 vi.mock('../../core/services/chat-agent.js', () => ({
   runChatAgent: vi.fn().mockResolvedValue({ reply: '', filePaths: [] }),
   resolveProviderConfig: vi.fn().mockResolvedValue({ kind: 'anthropic', model: 'claude', baseUrl: '', apiKey: '' }),
+}));
+
+// Mock fs so the descriptor write in the wiring test never touches the real repo.
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn().mockResolvedValue(''),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  unlink: vi.fn().mockResolvedValue(undefined),
 }));
 
 // ============================================================================
@@ -289,5 +297,111 @@ describe('safePath', () => {
     // src/../src/file.ts resolves to /project/src/file.ts
     const result = safePath('/project', 'src/../src/file.ts');
     expect(result).toBe('/project/src/file.ts');
+  });
+});
+
+// ============================================================================
+// buildTokenInjectionScript — the token/fetch shim injected into the served UI
+// ============================================================================
+
+describe('buildTokenInjectionScript', () => {
+  it('publishes the token and attaches x-openlore-token to /api requests', () => {
+    const script = buildTokenInjectionScript('deadbeef');
+    expect(script).toContain('window.__OPENLORE_TOKEN__="deadbeef"');
+    expect(script).toContain('x-openlore-token');
+    expect(script).toContain("indexOf('/api/')");
+    // Wraps fetch and is defensive (never throws into the app).
+    expect(script).toContain('window.fetch=function');
+    expect(script).toContain('try{');
+  });
+
+  it('escapes < so an odd token cannot close the <script> tag', () => {
+    const script = buildTokenInjectionScript('a"b</script>');
+    // The quote is JSON-escaped and every `<` is turned into <, so the
+    // literal </script> sequence never appears in the emitted script.
+    expect(script).toContain('\\u003c/script>');
+    expect(script).not.toContain('</script>');
+  });
+});
+
+// ============================================================================
+// API guard wiring — every /api route sits behind the shared guard
+// ============================================================================
+
+describe('view server API guard wiring', () => {
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    // The action installs SIGINT/SIGTERM handlers; drop them so they don't
+    // accumulate across the suite.
+    process.removeAllListeners('SIGINT');
+    process.removeAllListeners('SIGTERM');
+  });
+
+  /** Run the view action far enough to capture the vite plugin config. */
+  async function captureViteConfig() {
+    const { fileExists } = await import('../../utils/command-helpers.js');
+    // graph exists, viewer index.html exists → createServer is reached.
+    vi.mocked(fileExists).mockResolvedValue(true);
+    const { createServer } = await import('vite');
+
+    // Pass an explicit valid port: the shared viewCommand instance retains the
+    // last-parsed --port from the port-validation tests above, so an omitted
+    // --port would inherit their invalid value and bail before createServer.
+    await viewCommand.parseAsync(['node', 'view', '--no-open', '--port', '5199'], { from: 'user' });
+
+    expect(vi.mocked(createServer)).toHaveBeenCalled();
+    return vi.mocked(createServer).mock.calls[0][0] as {
+      plugins: Array<{ name?: string; configureServer?: (s: unknown) => void; transformIndexHtml?: () => unknown }>;
+    };
+  }
+
+  it('registers the /api guard before any /api/* route', async () => {
+    const cfg = await captureViteConfig();
+    const plugin = (cfg.plugins.flat() as Array<{ name?: string; configureServer?: (s: unknown) => void }>)
+      .find((p) => p && p.name === 'openlore-graph-api');
+    expect(plugin).toBeDefined();
+
+    const registrations: Array<{ path: string }> = [];
+    const fakeDevServer = {
+      middlewares: { use: (path: string) => registrations.push({ path }) },
+    };
+    plugin!.configureServer!(fakeDevServer);
+
+    const guardIdx = registrations.findIndex((r) => r.path === '/api');
+    const firstRouteIdx = registrations.findIndex((r) => r.path.startsWith('/api/'));
+    expect(guardIdx).toBeGreaterThanOrEqual(0);
+    expect(firstRouteIdx).toBeGreaterThanOrEqual(0);
+    // The guard is registered (and therefore runs) before every scoped /api/* route.
+    expect(guardIdx).toBeLessThan(firstRouteIdx);
+    // No /api/* route may be registered before the guard.
+    const routesBeforeGuard = registrations
+      .slice(0, guardIdx)
+      .filter((r) => r.path.startsWith('/api'));
+    expect(routesBeforeGuard).toEqual([]);
+  });
+
+  it('injects the token + fetch shim into the served page', async () => {
+    const cfg = await captureViteConfig();
+    const plugin = (cfg.plugins.flat() as Array<{ name?: string; transformIndexHtml?: () => unknown }>)
+      .find((p) => p && p.name === 'openlore-graph-api');
+    const tags = plugin!.transformIndexHtml!() as Array<{ tag: string; children: string; injectTo: string }>;
+    expect(tags).toHaveLength(1);
+    expect(tags[0].tag).toBe('script');
+    expect(tags[0].children).toContain('x-openlore-token');
+    expect(tags[0].children).toContain('window.__OPENLORE_TOKEN__');
+  });
+
+  it('writes a discovery descriptor on start', async () => {
+    await captureViteConfig();
+    const { writeFile } = await import('node:fs/promises');
+    const wrote = vi.mocked(writeFile).mock.calls.find(([p]) => String(p).endsWith('view.json'));
+    expect(wrote).toBeDefined();
+    const payload = JSON.parse(String(wrote![1]));
+    expect(payload).toMatchObject({ pid: process.pid, host: expect.any(String) });
+    expect(typeof payload.token).toBe('string');
+    expect(payload.token.length).toBeGreaterThan(0);
   });
 });

--- a/src/cli/commands/view.ts
+++ b/src/cli/commands/view.ts
@@ -6,7 +6,8 @@
  */
 
 import { Command } from 'commander';
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile, unlink, mkdir } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
 import { fileExists } from '../../utils/command-helpers.js';
 import { join, resolve, sep } from 'node:path';
 import { spawn } from 'node:child_process';
@@ -17,6 +18,7 @@ import {
   MAX_CHAT_BODY_BYTES,
   DEFAULT_VIEWER_PORT,
   DEFAULT_VIEWER_HOST,
+  OPENLORE_DIR,
   OPENLORE_ANALYSIS_REL_PATH,
   OPENSPEC_DIR,
   OPENSPEC_SPECS_SUBDIR,
@@ -25,6 +27,7 @@ import {
   ARTIFACT_REFACTOR_PRIORITIES,
   ARTIFACT_MAPPING,
 } from '../../constants.js';
+import { createApiGuardMiddleware, OPENLORE_TOKEN_HEADER } from './local-http-guard.js';
 import { VectorIndex } from '../../core/analyzer/vector-index.js';
 import { resolveEmbedder } from '../../core/analyzer/embedder.js';
 import { getSkeletonContent } from '../../core/analyzer/code-shaper.js';
@@ -52,6 +55,29 @@ export function safePath(rootPath: string, userPath: string): string | null {
     return null;
   }
   return abs;
+}
+
+/**
+ * Build the inline script injected into the served UI so its same-origin `/api`
+ * requests authenticate. It publishes the instance token and wraps `fetch` to
+ * attach the `x-openlore-token` header to relative `/api/*` requests only. The
+ * token is a fresh random hex string embedded via `JSON.stringify` (no injection
+ * risk); the wrapper is defensively wrapped in try/catch so it can never break
+ * the app's own fetches.
+ */
+export function buildTokenInjectionScript(token: string): string {
+  // Escape `<` so the embedded token can never close the surrounding <script>
+  // tag (defense in depth; the real token is hex-only).
+  const embedded = JSON.stringify(token).replace(/</g, '\\u003c');
+  return (
+    `window.__OPENLORE_TOKEN__=${embedded};` +
+    `(function(){var t=window.__OPENLORE_TOKEN__;if(!t||!window.fetch)return;` +
+    `var o=window.fetch.bind(window);window.fetch=function(i,n){try{` +
+    `var u=typeof i==='string'?i:(i&&i.url)||'';` +
+    `if(typeof u==='string'&&u.indexOf('/api/')===0){` +
+    `n=n||{};var h=new Headers((n&&n.headers)||(typeof i!=='string'&&i&&i.headers)||undefined);` +
+    `h.set(${JSON.stringify(OPENLORE_TOKEN_HEADER)},t);n.headers=h;}}catch(e){}return o(i,n);};})();`
+  );
 }
 
 function openBrowser(url: string): void {
@@ -116,6 +142,11 @@ export const viewCommand = new Command('view')
       const port = isNaN(parsedPort) ? DEFAULT_VIEWER_PORT : parsedPort;
       const host = options.host || DEFAULT_VIEWER_HOST;
 
+      // Per-instance token. Injected into the served UI so its same-origin /api
+      // requests authenticate; required by the money/agent chat route (always)
+      // and by every route when bound to a non-loopback host. See local-http-guard.ts.
+      const token = randomBytes(24).toString('hex');
+
       logger.section('Starting Graph Viewer');
       logger.info('Analysis', analysisDir);
       logger.info('Graph', graphPath);
@@ -132,7 +163,32 @@ export const viewCommand = new Command('view')
           react(),
           {
             name: 'openlore-graph-api',
+            // Inject the instance token + fetch shim into the served page so the
+            // browser UI's same-origin /api requests carry x-openlore-token.
+            transformIndexHtml() {
+              return [
+                {
+                  tag: 'script',
+                  injectTo: 'head-prepend' as const,
+                  children: buildTokenInjectionScript(token),
+                },
+              ];
+            },
             configureServer(devServer) {
+              // SECURITY: one guard in front of every /api/* route. Mounted at the
+              // '/api' prefix and registered FIRST so no route below can be reached
+              // without passing it: DNS-rebinding / cross-origin requests are rejected
+              // (403), and the money/agent chat route requires the instance token even
+              // on loopback (401) — as does every route on a non-loopback binding.
+              devServer.middlewares.use(
+                '/api',
+                createApiGuardMiddleware({
+                  boundHost: host,
+                  token,
+                  requireTokenFor: (rel) => rel === '/chat',
+                }),
+              );
+
               devServer.middlewares.use('/api/dependency-graph', async (_req, res) => {
                 try {
                   // Friendly 404 (matching the sibling artifact endpoints) when the graph
@@ -636,6 +692,38 @@ export const viewCommand = new Command('view')
 
       const url = `http://${host}:${port}/`;
       logger.success(`Viewer running at ${url}`);
+
+      // Discovery + stale-instance detection (parity with the `serve` daemon):
+      // record where the viewer is listening so a later invocation / tool can
+      // detect a live or stale instance instead of a mystery port occupant.
+      const descriptorPath = join(rootPath, OPENLORE_DIR, 'view.json');
+      try {
+        await mkdir(join(rootPath, OPENLORE_DIR), { recursive: true });
+        await writeFile(
+          descriptorPath,
+          JSON.stringify(
+            { port, pid: process.pid, host, token, startedAt: new Date().toISOString() },
+            null,
+            2,
+          ) + '\n',
+          'utf-8',
+        );
+      } catch {
+        // Discovery is best-effort; a read-only .openlore must not stop the viewer.
+      }
+
+      // Graceful shutdown: close the server and drop the descriptor so a stale
+      // view.json never outlives the process (parity with `serve`).
+      let shuttingDown = false;
+      const shutdown = async (): Promise<void> => {
+        if (shuttingDown) return;
+        shuttingDown = true;
+        await unlink(descriptorPath).catch(() => {});
+        await server.close().catch(() => {});
+        process.exit(0);
+      };
+      process.on('SIGINT', () => void shutdown());
+      process.on('SIGTERM', () => void shutdown());
 
       if (options.open) {
         openBrowser(url);

--- a/src/core/decisions/lock.test.ts
+++ b/src/core/decisions/lock.test.ts
@@ -89,9 +89,14 @@ describe('isDecisionsLockHeld', () => {
     await isDecisionsLockHeld(root);
     // The holder's lock survives the peeks: a second acquire still blocks.
     let acquired2 = false;
-    acquireDecisionsLock(root).then((r) => { acquired2 = true; return r; });
+    const p2 = acquireDecisionsLock(root).then((r) => { acquired2 = true; return r; });
     await sleep(300);
     expect(acquired2).toBe(false);
     await release();
+    // Drain the now-unblocked second acquire and release it. Leaving it pending
+    // lets its next poll race afterEach's rm(root): open() then rejects with
+    // ENOENT as an unhandled rejection that fails the whole run.
+    const release2 = await p2;
+    await release2();
   });
 });


### PR DESCRIPTION
**Status:** LGTM — implemented, full suite green (296 files / 5,804 tests), verified end-to-end against the real vite server. Closes the last bulletproofing item of the e2e-audit fix track (`harden-local-http-surfaces`).

## What was wrong

OpenLore runs two local HTTP surfaces with two different security postures. The `serve` daemon has the right one — loopback default, Host/Origin DNS-rebinding guard, constant-time token, non-loopback-requires-token. The `view` graph server had **none of it**, while exposing strictly more dangerous endpoints with no Host check, no Origin check, and no token:

- `/api/chat` — drives a full `runChatAgent`, spending the user's LLM API key and running tools;
- `/api/skeleton` — returns the contents/structure of arbitrary in-project files;
- `/api/search` — semantic search over the codebase.

Loopback binding does not stop DNS rebinding: a malicious page can re-point its hostname at `127.0.0.1` and issue same-"origin" requests — exfiltrating source and burning the user's API key.

## How it was fixed

- **One shared guard.** Extracted the serve daemon's guard primitives (loopback Host allowlist, cross-origin defense, constant-time token compare) into `src/cli/commands/local-http-guard.ts`. `serve.ts` now imports them (behavior-identical); `view.ts` uses them too.
- **Guard in front of every view route.** One middleware mounted at the `/api` prefix, registered first, so no route can be reached without passing it. A rebinding/cross-origin request is rejected `403` before any handler; the money/agent `/api/chat` route requires the instance token even on loopback (`401`); every route requires it on a non-loopback bind.
- **Token reaches the UI.** A per-instance token + a small `fetch` shim are injected into the served page so its same-origin `/api` requests authenticate. The token embed escapes `<` so it can't break out of the `<script>` tag (the real token is hex-only; belt and suspenders).
- **Lifecycle parity.** SIGINT/SIGTERM graceful shutdown + a `.openlore/view.json` descriptor for stale-instance detection, mirroring `serve`.
- **Spec:** folded `AllLocalHttpSurfacesShareTheGuard` into the main `mcp-security` spec.

## Proof it works

New unit tests (`local-http-guard.test.ts`, 30+ cases) cover every policy branch of the guard + the middleware; `view.test.ts` gains guard-wiring, token-injection, and descriptor tests; the `serve.test.ts` suite is unchanged and green against the shared module.

End-to-end against the real running viewer:

| Probe | Result |
|---|---|
| loopback same-origin `/api/dependency-graph` | `200` |
| foreign `Host` (DNS-rebinding) | `403` |
| cross-site `Origin` (loopback Host) | `403` (our guard: "cross-site Origin … not permitted") |
| `POST /api/chat` no token, loopback | `401` |
| `POST /api/chat` with token | passes guard (`400` missing-field downstream) |
| `/api/search` loopback no token | `200` (token only for chat / non-loopback) |
| served `index.html` | carries the token + `x-openlore-token` shim |
| `SIGTERM` | clean exit, `view.json` removed |

## Notes

- A proxy/tunnel setup with a rewritten Host header would need the token for the viewer — correct behavior for that setup anyway.
- Vite's own `allowedHosts` also 403s a foreign Host before our guard sees it (extra defense in depth); our guard still owns the Origin check and the token policy, as the chat `401` shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)