### PR TITLE
feat(config): validate .openlore/config.json — disclose typo'd keys, type mismatches, and version skew

### DIFF
--- a/openspec/changes/add-config-schema-validation/proposal.md
+++ b/openspec/changes/add-config-schema-validation/proposal.md
@@ -1,6 +1,13 @@
 # Config schema validation: typo'd keys disclosed, version drift visible
 
-> Status: PROPOSED (2026-07-03, e2e audit). `.openlore/config.json` is parsed with a bare
+> Status: SHIPPED (2026-07-18). Implemented as `src/core/services/config-schema.ts` (type-bound
+> validator + version check), wired into `readOpenLoreConfig`, and surfaced by `openlore doctor`
+> as a `Config schema` check. Deviation from the note below: validation warnings emit to **stderr**
+> (honoring quiet/noColor), not stdout — `readOpenLoreConfig` is read by machine-output paths
+> (`--json`, `orient`, the MCP JSON-RPC stream), and a warning on stdout would corrupt them. The
+> logger's intent (standard, quiet-respecting, deduplicated diagnostics) is preserved.
+>
+> Original: PROPOSED (2026-07-03, e2e audit). `.openlore/config.json` is parsed with a bare
 > `JSON.parse(...) as OpenLoreConfig` — a typo'd key (`pancResponse`, `embeding`) is silently
 > dropped and defaults win, and the `version` stamp written at init is never read back, so
 > config-schema drift across OpenLore versions is invisible. Deterministic validation at read,

--- a/openspec/changes/add-config-schema-validation/tasks.md
+++ b/openspec/changes/add-config-schema-validation/tasks.md
@@ -1,27 +1,27 @@
 # Tasks — add-config-schema-validation
 
 ## Implementation
-- [ ] Validator for `OpenLoreConfig` (generated JSON schema or hand-maintained structural
+- [x] Validator for `OpenLoreConfig` (generated JSON schema or hand-maintained structural
       validator — dependency-light, deterministic)
-- [ ] Completeness test binding validator to the type: a new `OpenLoreConfig` field without a
+- [x] Completeness test binding validator to the type: a new `OpenLoreConfig` field without a
       validator entry fails CI
-- [ ] `readOpenLoreConfig` runs validation: unknown keys (+ did-you-mean via edit distance against
+- [x] `readOpenLoreConfig` runs validation: unknown keys (+ did-you-mean via edit distance against
       known keys), type mismatches, version skew — warnings via existing logger, deduplicated per
       process; NEVER a hard failure
-- [ ] Newer-version / unknown-key configs degrade gracefully: disclosed as possibly-newer, then
+- [x] Newer-version / unknown-key configs degrade gracefully: disclosed as possibly-newer, then
       ignored (forward compat preserved, silence ended)
-- [ ] Version stamp becomes live: bump on schema change; deterministic migrations where they
+- [x] Version stamp becomes live: bump on schema change; deterministic migrations where they
       exist; otherwise an explicit older-version report
-- [ ] `openlore doctor` reports config findings (unknown keys, mismatches, version skew)
+- [x] `openlore doctor` reports config findings (unknown keys, mismatches, version skew)
 
 ## Verification
-- [ ] Test: `pancResponse` / `embeding` typos → warning with did-you-mean; defaults still apply
-- [ ] Test: valid config → zero warnings, identical behavior to today
-- [ ] Test: config with a newer version stamp / unknown future key → disclosed, not crashed on
-- [ ] Test: older-version config → migrated or explicitly reported
-- [ ] Test: type-completeness guard fails when a field is added without a validator entry
-- [ ] Hub-caller check: warnings deduplicated (one emission per process, not per read)
-- [ ] Full suite green
+- [x] Test: `pancResponse` / `embeding` typos → warning with did-you-mean; defaults still apply
+- [x] Test: valid config → zero warnings, identical behavior to today
+- [x] Test: config with a newer version stamp / unknown future key → disclosed, not crashed on
+- [x] Test: older-version config → migrated or explicitly reported
+- [x] Test: type-completeness guard fails when a field is added without a validator entry
+- [x] Hub-caller check: warnings deduplicated (one emission per process, not per read)
+- [x] Full suite green
 
 ## Spec
-- [ ] `config` delta: ADD ConfigUnknownKeysAreDisclosed, ConfigVersionIsChecked
+- [x] `config` delta: ADD ConfigUnknownKeysAreDisclosed, ConfigVersionIsChecked

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -90,6 +90,11 @@ describe('doctor command', () => {
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     mockExecSuccess();
+    // Restore readFile's documented default ("absent") — clearAllMocks resets call
+    // history but NOT implementations, so a test that pointed readFile at a config
+    // would otherwise leak that resolution into later tests (Config schema check).
+    const { readFile } = await import('node:fs/promises');
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
     // Restore default LLM mock after clearAllMocks
     const llmService = await import('../../core/services/llm-service.js');
     vi.mocked(llmService.createLLMService).mockReturnValue({
@@ -126,9 +131,14 @@ describe('doctor command', () => {
       expect(Array.isArray(checks)).toBe(true);
     });
 
-    it('should include exactly 9 checks', async () => {
+    it('should include exactly 10 checks', async () => {
       const checks = await runDoctorJson();
-      expect(checks).toHaveLength(9);
+      expect(checks).toHaveLength(10);
+    });
+
+    it('should include a Config schema check', async () => {
+      const checks = await runDoctorJson();
+      expect(checks.find(c => c.name === 'Config schema')).toBeDefined();
     });
 
     it('should include a Parse health check', async () => {
@@ -333,6 +343,56 @@ describe('doctor command', () => {
       const configCheck = checks.find(c => c.name === 'openlore config')!;
       expect(configCheck.status).toBe('fail');
       expect(configCheck.fix).toContain('openlore init');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  describe('config schema check (add-config-schema-validation)', () => {
+    it('shows ok when there is no config file to validate', async () => {
+      // Default readFile mock rejects (ENOENT) — nothing to validate.
+      const checks = await runDoctorJson();
+      const schemaCheck = checks.find(c => c.name === 'Config schema')!;
+      expect(schemaCheck.status).toBe('ok');
+    });
+
+    it('shows ok for a config with only known, well-typed keys', async () => {
+      const { readFile } = await import('node:fs/promises');
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          version: '1.0.0',
+          projectType: 'nodejs',
+          openspecPath: 'openspec',
+          analysis: { maxFiles: 1, includePatterns: [], excludePatterns: [] },
+          generation: { domains: 'auto' },
+          createdAt: '2026-01-01T00:00:00Z',
+          lastRun: null,
+        }) as never
+      );
+      const checks = await runDoctorJson();
+      const schemaCheck = checks.find(c => c.name === 'Config schema')!;
+      expect(schemaCheck.status).toBe('ok');
+    });
+
+    it('warns and names an unknown (typo\'d) key with a suggestion', async () => {
+      const { readFile } = await import('node:fs/promises');
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          version: '1.0.0',
+          projectType: 'nodejs',
+          openspecPath: 'openspec',
+          analysis: { maxFiles: 1, includePatterns: [], excludePatterns: [] },
+          generation: { domains: 'auto' },
+          createdAt: '2026-01-01T00:00:00Z',
+          lastRun: null,
+          pancResponse: { mode: 'off' },
+        }) as never
+      );
+      const checks = await runDoctorJson();
+      const schemaCheck = checks.find(c => c.name === 'Config schema')!;
+      expect(schemaCheck.status).toBe('warn');
+      expect(schemaCheck.detail).toContain('pancResponse');
+      expect(schemaCheck.detail).toContain('panicResponse');
+      expect(schemaCheck.fix).toContain('openlore init');
     });
   });
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -12,6 +12,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { logger } from '../../utils/logger.js';
 import { readOpenLoreConfig } from '../../core/services/config-manager.js';
+import { validateOpenLoreConfig } from '../../core/services/config-schema.js';
 import { EdgeStore } from '../../core/services/edge-store.js';
 import { createLLMService, ProviderName } from '../../core/services/llm-service.js';
 import {
@@ -135,6 +136,36 @@ async function checkConfig(rootPath: string): Promise<CheckResult> {
       fix: "Run 'openlore install' for one-command setup (wires your agent + builds the index), or 'openlore init' to configure manually",
     };
   }
+}
+
+/**
+ * Config-schema check (change: add-config-schema-validation): surface unknown keys
+ * (typo'd sections silently dropped today), type mismatches, and version skew in
+ * `.openlore/config.json`. Reads the raw file and validates directly so the findings
+ * appear as one structured check; advisory only (never fails), and clean/absent configs
+ * report ok. Complements `checkConfig`, which only reports parse success.
+ */
+async function checkConfigSchema(rootPath: string): Promise<CheckResult> {
+  const configPath = join(rootPath, OPENLORE_DIR, OPENLORE_CONFIG_FILENAME);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(configPath, 'utf-8'));
+  } catch {
+    // No config, or unparseable JSON — checkConfig already reports both. Nothing to add.
+    return { name: 'Config schema', status: 'ok', detail: 'no config to validate' };
+  }
+  const findings = validateOpenLoreConfig(parsed);
+  if (findings.length === 0) {
+    return { name: 'Config schema', status: 'ok', detail: 'all keys known and well-typed' };
+  }
+  const summary = findings.slice(0, 3).map(f => f.message).join('; ');
+  const more = findings.length > 3 ? ` (+${findings.length - 3} more)` : '';
+  return {
+    name: 'Config schema',
+    status: 'warn',
+    detail: `${findings.length} config finding(s): ${summary}${more}`,
+    fix: `Edit ${OPENLORE_CONFIG_REL_PATH} to correct the key(s), or re-run 'openlore init'`,
+  };
 }
 
 async function checkAnalysis(rootPath: string): Promise<CheckResult> {
@@ -557,6 +588,7 @@ Checks performed:
   • Node.js version (>=${MIN_NODE_MAJOR_VERSION}.${MIN_NODE_MINOR_VERSION} required for node:sqlite)
   • Git repository detection
   • openlore configuration (${OPENLORE_CONFIG_REL_PATH})
+  • Config schema (unknown keys, type mismatches, version skew)
   • Analysis artifacts freshness
   • Graph store lifecycle (schema mismatch / quarantined index)
   • OpenSpec directory presence
@@ -583,6 +615,7 @@ Checks performed:
         checkNodeVersion(),
         checkGit(rootPath),
         checkConfig(rootPath),
+        checkConfigSchema(rootPath),
         checkAnalysis(rootPath),
         checkGraphStore(rootPath),
         checkParseHealth(rootPath),

--- a/src/core/services/config-manager.test.ts
+++ b/src/core/services/config-manager.test.ts
@@ -2,7 +2,7 @@
  * Tests for config-manager service
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdir, writeFile, rm, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -18,7 +18,9 @@ import {
   createOpenSpecStructure,
   mergeOpenSpecConfig,
   detectExistingSpecDir,
+  resetConfigValidationWarnings,
 } from './config-manager.js';
+import { logger } from '../../utils/logger.js';
 
 describe('config-manager', () => {
   let testDir: string;
@@ -255,6 +257,97 @@ describe('config-manager', () => {
 
       const result = await readOpenLoreConfig(testDir);
       expect(result).toBeNull();
+    });
+  });
+
+  describe('readOpenLoreConfig — schema validation warnings (add-config-schema-validation)', () => {
+    async function writeRawConfig(obj: unknown): Promise<void> {
+      const configDir = join(testDir, '.openlore');
+      await mkdir(configDir, { recursive: true });
+      await writeFile(join(configDir, 'config.json'), JSON.stringify(obj), 'utf-8');
+    }
+
+    beforeEach(() => {
+      resetConfigValidationWarnings();
+      // Diagnostics go to stderr (keeping machine stdout pure); ensure the logger is
+      // not in quiet mode, which suppresses them.
+      logger.configure({ quiet: false, noColor: true });
+    });
+
+    /** Spy on the stderr channel the emitter writes to, returning captured lines. */
+    function spyStderr(): { restore: () => void; lines: () => string[] } {
+      const captured: string[] = [];
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+        captured.push(String(chunk));
+        return true;
+      }) as typeof process.stderr.write);
+      return { restore: () => spy.mockRestore(), lines: () => captured };
+    }
+
+    it('emits no warning for a valid config, and returns it unchanged', async () => {
+      const s = spyStderr();
+      try {
+        const valid = getDefaultConfig('nodejs', 'openspec');
+        await writeRawConfig(valid);
+        const result = await readOpenLoreConfig(testDir);
+        expect(result).not.toBeNull();
+        expect(result?.projectType).toBe('nodejs');
+        expect(s.lines().filter(m => m.includes('config.json'))).toHaveLength(0);
+      } finally {
+        s.restore();
+      }
+    });
+
+    it('warns with a did-you-mean on a typo\'d key, and still applies defaults', async () => {
+      const s = spyStderr();
+      try {
+        const cfg = { ...getDefaultConfig('nodejs', 'openspec'), pancResponse: { mode: 'off' } };
+        await writeRawConfig(cfg);
+        const result = await readOpenLoreConfig(testDir);
+        expect(result).not.toBeNull(); // never a hard failure
+        expect(s.lines().some(m => m.includes('pancResponse') && m.includes('panicResponse'))).toBe(true);
+      } finally {
+        s.restore();
+      }
+    });
+
+    it('is silent in quiet mode (errors-only)', async () => {
+      logger.configure({ quiet: true });
+      const s = spyStderr();
+      try {
+        await writeRawConfig({ ...getDefaultConfig('nodejs', 'openspec'), pancResponse: { mode: 'off' } });
+        const result = await readOpenLoreConfig(testDir);
+        expect(result).not.toBeNull();
+        expect(s.lines().filter(m => m.includes('config.json'))).toHaveLength(0);
+      } finally {
+        s.restore();
+        logger.configure({ quiet: false });
+      }
+    });
+
+    it('deduplicates warnings across reads — one emission per process, not per read', async () => {
+      const s = spyStderr();
+      try {
+        await writeRawConfig({ ...getDefaultConfig('nodejs', 'openspec'), embeding: {} });
+        await readOpenLoreConfig(testDir);
+        await readOpenLoreConfig(testDir);
+        await readOpenLoreConfig(testDir);
+        expect(s.lines().filter(m => m.includes('embeding'))).toHaveLength(1);
+      } finally {
+        s.restore();
+      }
+    });
+
+    it('discloses a newer version stamp without crashing the read', async () => {
+      const s = spyStderr();
+      try {
+        await writeRawConfig({ ...getDefaultConfig('nodejs', 'openspec'), version: '99.0.0' });
+        const result = await readOpenLoreConfig(testDir);
+        expect(result).not.toBeNull();
+        expect(s.lines().some(m => m.includes('newer'))).toBe(true);
+      } finally {
+        s.restore();
+      }
     });
   });
 

--- a/src/core/services/config-manager.ts
+++ b/src/core/services/config-manager.ts
@@ -18,6 +18,7 @@ import {
   OPENSPEC_CONFIG_FILENAME,
 } from '../../constants.js';
 import { fileExists } from '../../utils/command-helpers.js';
+import { validateOpenLoreConfig, CONFIG_SCHEMA_VERSION } from './config-schema.js';
 
 /**
  * OpenSpec config.yaml structure
@@ -53,7 +54,7 @@ async function ensureDir(dirPath: string): Promise<void> {
  */
 export function getDefaultConfig(projectType: ProjectType, openspecPath: string): OpenLoreConfig {
   return {
-    version: '1.0.0',
+    version: CONFIG_SCHEMA_VERSION,
     projectType,
     openspecPath,
     analysis: {
@@ -72,6 +73,44 @@ export function getDefaultConfig(projectType: ProjectType, openspecPath: string)
 }
 
 /**
+ * Per-process memory of config-validation warnings already emitted, so a hub caller
+ * (`readOpenLoreConfig` has ~45 call sites) emits each finding at most once per process
+ * instead of once per read (change: add-config-schema-validation).
+ */
+const emittedConfigWarnings = new Set<string>();
+
+/** Test hook: clear the per-process config-validation warning dedup memory. */
+export function resetConfigValidationWarnings(): void {
+  emittedConfigWarnings.clear();
+}
+
+/**
+ * Validate a parsed config against the type-derived schema and emit any findings once
+ * per process. Warnings are advisory: a typo'd key, a type mismatch, or a version skew
+ * is disclosed and then ignored — never a hard failure, and never emitted for a config
+ * that uses only known keys with correctly-typed values (change: add-config-schema-validation).
+ *
+ * Emitted to STDERR (honoring the logger's quiet/noColor state), not stdout: this is a
+ * ~45-caller hub read by machine-output paths — `--json` commands, `orient`, and the MCP
+ * JSON-RPC stream — where a warning on stdout would corrupt the output. Humans still see
+ * the diagnostic in their terminal; `openlore doctor` additionally surfaces it as a
+ * structured `Config schema` finding.
+ */
+function emitConfigValidationWarnings(configPath: string, parsed: unknown): void {
+  const findings = validateOpenLoreConfig(parsed);
+  if (findings.length === 0) return;
+  const { quiet, noColor } = logger.getOptions();
+  if (quiet) return; // errors-only mode — match logger.warning's suppression
+  const prefix = noColor ? '[warn]' : '\x1b[33m[warn]\x1b[0m';
+  for (const finding of findings) {
+    const signature = `${configPath} ${finding.kind} ${finding.key ?? ''}`;
+    if (emittedConfigWarnings.has(signature)) continue;
+    emittedConfigWarnings.add(signature);
+    process.stderr.write(`${prefix} ${OPENLORE_CONFIG_REL_PATH}: ${finding.message}\n`);
+  }
+}
+
+/**
  * Read openlore configuration from .openlore/config.json
  */
 export async function readOpenLoreConfig(rootPath: string): Promise<OpenLoreConfig | null> {
@@ -82,13 +121,16 @@ export async function readOpenLoreConfig(rootPath: string): Promise<OpenLoreConf
   } catch {
     return null; // File doesn't exist — normal case before init
   }
+  let parsed: OpenLoreConfig;
   try {
-    return JSON.parse(content) as OpenLoreConfig;
+    parsed = JSON.parse(content) as OpenLoreConfig;
   } catch (err) {
     logger.warning(`Failed to parse ${configPath}: ${(err as Error).message}`);
     logger.warning(`Delete ${OPENLORE_CONFIG_REL_PATH} and run 'openlore init' to recreate it.`);
     return null;
   }
+  emitConfigValidationWarnings(configPath, parsed);
+  return parsed;
 }
 
 /**

--- a/src/core/services/config-schema.test.ts
+++ b/src/core/services/config-schema.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for config-schema — deterministic validation of `.openlore/config.json`
+ * (change: add-config-schema-validation).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { OpenLoreConfig } from '../../types/index.js';
+import {
+  validateOpenLoreConfig,
+  checkConfigVersion,
+  CONFIG_FIELD_KINDS,
+  KNOWN_CONFIG_KEYS,
+  CONFIG_SCHEMA_VERSION,
+  type ConfigMigration,
+} from './config-schema.js';
+
+/**
+ * A fully-populated config typed `Required<OpenLoreConfig>` — TypeScript forces every
+ * optional key present, so adding a field to `OpenLoreConfig` breaks this literal until
+ * it is listed here AND in `CONFIG_FIELD_KINDS`. The runtime assertion below names any
+ * residual divergence between the two. This is the type-completeness bind.
+ */
+const FULLY_POPULATED: Required<OpenLoreConfig> = {
+  version: CONFIG_SCHEMA_VERSION,
+  projectType: 'nodejs',
+  openspecPath: 'openspec',
+  analysis: { maxFiles: 1, includePatterns: [], excludePatterns: [] },
+  generation: { domains: 'auto' },
+  llm: {},
+  embedding: {},
+  panicResponse: { mode: 'off' },
+  createdAt: '2026-07-18T00:00:00.000Z',
+  lastRun: null,
+  blastRadius: {},
+  specStore: { name: 's', path: '/tmp/s', targets: [] },
+  governance: {},
+  impactCertificate: {},
+  contextInjection: {},
+  enforcement: {},
+};
+
+describe('config-schema — type-completeness bind', () => {
+  it('validator field map covers exactly the keys of a fully-populated OpenLoreConfig', () => {
+    const typeKeys = Object.keys(FULLY_POPULATED).sort();
+    const validatorKeys = [...KNOWN_CONFIG_KEYS].sort();
+    // Names any field bound in one place but not the other.
+    expect(validatorKeys).toEqual(typeKeys);
+  });
+
+  it('every validator kind is a recognized shape', () => {
+    for (const kind of Object.values(CONFIG_FIELD_KINDS)) {
+      expect(['string', 'string-or-null', 'object']).toContain(kind);
+    }
+  });
+
+  it('a fully-populated, correctly-typed config yields zero findings', () => {
+    expect(validateOpenLoreConfig(FULLY_POPULATED)).toEqual([]);
+  });
+});
+
+describe('config-schema — unknown keys', () => {
+  it('discloses a typo with a did-you-mean suggestion', () => {
+    const findings = validateOpenLoreConfig({
+      ...FULLY_POPULATED,
+      pancResponse: { mode: 'off' },
+    });
+    const f = findings.find(x => x.key === 'pancResponse');
+    expect(f).toBeDefined();
+    expect(f?.kind).toBe('unknown-key');
+    expect(f?.suggestion).toBe('panicResponse');
+    expect(f?.message).toContain('panicResponse');
+  });
+
+  it('suggests the nearest known key for a misspelled section', () => {
+    const findings = validateOpenLoreConfig({ ...FULLY_POPULATED, embeding: {} });
+    const f = findings.find(x => x.key === 'embeding');
+    expect(f?.suggestion).toBe('embedding');
+  });
+
+  it('discloses a far-off unknown key as possibly-newer, with no suggestion', () => {
+    const findings = validateOpenLoreConfig({
+      ...FULLY_POPULATED,
+      somethingFromTheFuture: { nested: true },
+    });
+    const f = findings.find(x => x.key === 'somethingFromTheFuture');
+    expect(f).toBeDefined();
+    expect(f?.suggestion).toBeUndefined();
+    expect(f?.message).toContain('newer OpenLore');
+  });
+
+  it('a config using only known keys is silent', () => {
+    expect(validateOpenLoreConfig(FULLY_POPULATED)).toEqual([]);
+  });
+});
+
+describe('config-schema — type mismatches', () => {
+  it('flags a string field holding an object', () => {
+    const findings = validateOpenLoreConfig({ ...FULLY_POPULATED, version: { major: 1 } });
+    const f = findings.find(x => x.key === 'version');
+    expect(f?.kind).toBe('type-mismatch');
+    expect(f?.message).toContain('should be a string');
+  });
+
+  it('flags an object field holding a string', () => {
+    const findings = validateOpenLoreConfig({ ...FULLY_POPULATED, analysis: 'nope' });
+    const f = findings.find(x => x.key === 'analysis');
+    expect(f?.kind).toBe('type-mismatch');
+    expect(f?.message).toContain('should be an object');
+  });
+
+  it('flags an object field holding an array (arrays are not objects here)', () => {
+    const findings = validateOpenLoreConfig({ ...FULLY_POPULATED, generation: [] });
+    const f = findings.find(x => x.key === 'generation');
+    expect(f?.kind).toBe('type-mismatch');
+    expect(f?.message).toContain('got array');
+  });
+
+  it('accepts lastRun as null and as a string', () => {
+    expect(validateOpenLoreConfig({ ...FULLY_POPULATED, lastRun: null })).toEqual([]);
+    expect(validateOpenLoreConfig({ ...FULLY_POPULATED, lastRun: '2026-01-01' })).toEqual([]);
+  });
+
+  it('flags lastRun holding a number', () => {
+    const findings = validateOpenLoreConfig({ ...FULLY_POPULATED, lastRun: 123 });
+    const f = findings.find(x => x.key === 'lastRun');
+    expect(f?.kind).toBe('type-mismatch');
+    expect(f?.message).toContain('a string or null');
+  });
+});
+
+describe('config-schema — version skew', () => {
+  it('discloses a newer version stamp gracefully (no crash, no hard fail)', () => {
+    const findings = validateOpenLoreConfig({ ...FULLY_POPULATED, version: '99.0.0' });
+    const f = findings.find(x => x.kind === 'version-newer');
+    expect(f).toBeDefined();
+    expect(f?.message).toContain('newer');
+  });
+
+  it('an older stamp with only additive growth is silent (forward compatible)', () => {
+    // No registered migration between 0.9.0 and current → nothing to report.
+    const findings = checkConfigVersion('0.9.0', { current: '1.5.0', migrations: [] });
+    expect(findings).toEqual([]);
+  });
+
+  it('an older stamp predating a registered breaking change is reported, naming the fields', () => {
+    const migrations: ConfigMigration[] = [
+      { since: '1.2.0', fields: ['oldKey'], note: "'oldKey' was renamed to 'newKey'" },
+    ];
+    const findings = checkConfigVersion('1.0.0', { current: '1.5.0', migrations });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe('version-older');
+    expect(findings[0].message).toContain('oldKey');
+    expect(findings[0].message).toContain('older OpenLore');
+  });
+
+  it('a migration outside the (stamp, current] range does not fire', () => {
+    const migrations: ConfigMigration[] = [
+      { since: '2.0.0', fields: ['futureKey'], note: 'future change' },
+    ];
+    const findings = checkConfigVersion('1.0.0', { current: '1.5.0', migrations });
+    expect(findings).toEqual([]);
+  });
+
+  it('an equal stamp is silent', () => {
+    expect(checkConfigVersion('1.5.0', { current: '1.5.0' })).toEqual([]);
+  });
+
+  it('a non-semver stamp is not treated as version skew (type-mismatch path owns non-strings)', () => {
+    expect(checkConfigVersion('not-a-version', { current: '1.0.0' })).toEqual([]);
+    expect(checkConfigVersion(42, { current: '1.0.0' })).toEqual([]);
+  });
+});
+
+describe('config-schema — robustness', () => {
+  it('a non-object input yields no findings (JSON parse already reported syntax errors)', () => {
+    expect(validateOpenLoreConfig(null)).toEqual([]);
+    expect(validateOpenLoreConfig('string')).toEqual([]);
+    expect(validateOpenLoreConfig([1, 2, 3])).toEqual([]);
+    expect(validateOpenLoreConfig(42)).toEqual([]);
+  });
+
+  it('never throws on arbitrary shapes', () => {
+    expect(() => validateOpenLoreConfig({ a: 1, b: [null], c: { d: undefined } })).not.toThrow();
+  });
+
+  it('orders findings as unknown-keys, then type-mismatches, then version skew', () => {
+    const findings = validateOpenLoreConfig({
+      ...FULLY_POPULATED,
+      version: '99.0.0', // newer → version-newer (last)
+      analysis: 'bad', // type-mismatch (middle)
+      pancResponse: {}, // unknown-key (first)
+    });
+    const kinds = findings.map(f => f.kind);
+    expect(kinds.indexOf('unknown-key')).toBeLessThan(kinds.indexOf('type-mismatch'));
+    expect(kinds.indexOf('type-mismatch')).toBeLessThan(kinds.indexOf('version-newer'));
+  });
+});

--- a/src/core/services/config-schema.ts
+++ b/src/core/services/config-schema.ts
@@ -1,0 +1,253 @@
+/**
+ * Deterministic schema validation for `.openlore/config.json`
+ * (change: add-config-schema-validation).
+ *
+ * `readOpenLoreConfig` parses the file with a bare `JSON.parse(...) as OpenLoreConfig`
+ * — a type *assertion* checked by nothing at runtime. A typo'd key (`pancResponse`,
+ * `embeding`) is silently dropped and the default wins, so the user believes a feature
+ * is configured when it is not. This module closes that gap the way the rest of the
+ * substrate already does (the decision store validates on load, the index attests
+ * integrity): a shallow, allocation-light, dependency-free validator that DISCLOSES
+ * unknown keys, type mismatches, and version skew — never a hard failure, and never a
+ * behavior change for a currently-valid config.
+ *
+ * Two honesty invariants:
+ *  - Forward-compatible: an unknown key (including one written by a *newer* OpenLore) is
+ *    disclosed and then ignored, so a newer config under an older openlore degrades
+ *    gracefully rather than crashing.
+ *  - Bound to the type: {@link CONFIG_FIELD_KINDS} is `Record<keyof OpenLoreConfig, …>`,
+ *    so adding a field to `OpenLoreConfig` without a validator entry fails the build; a
+ *    completeness test names any residual drift.
+ */
+
+import type { OpenLoreConfig } from '../../types/index.js';
+
+/** The current config-schema version stamped into `.openlore/config.json`. */
+export const CONFIG_SCHEMA_VERSION = '1.0.0';
+
+/**
+ * Top-level value shapes the validator checks. Deliberately shallow — validation runs
+ * on every read of a ~45-caller hub, so it stays allocation-light and does not recurse
+ * into nested objects (a mistyped nested field is out of scope, disclosed as such).
+ */
+export type ConfigFieldKind = 'string' | 'string-or-null' | 'object';
+
+/**
+ * The known keys of `OpenLoreConfig` and the shape each holds. Typed as
+ * `Record<keyof OpenLoreConfig, …>` so a field added to the interface without an entry
+ * here fails `tsc` (and CI); {@link config-schema.test.ts} binds it at runtime too.
+ */
+export const CONFIG_FIELD_KINDS: Record<keyof OpenLoreConfig, ConfigFieldKind> = {
+  version: 'string',
+  projectType: 'string',
+  openspecPath: 'string',
+  analysis: 'object',
+  generation: 'object',
+  llm: 'object',
+  embedding: 'object',
+  panicResponse: 'object',
+  createdAt: 'string',
+  lastRun: 'string-or-null',
+  blastRadius: 'object',
+  specStore: 'object',
+  governance: 'object',
+  impactCertificate: 'object',
+  contextInjection: 'object',
+  enforcement: 'object',
+};
+
+/** The known top-level config keys, derived from the type-bound field map. */
+export const KNOWN_CONFIG_KEYS: readonly string[] = Object.keys(CONFIG_FIELD_KINDS);
+
+/**
+ * A registered non-additive config-schema change: reading a config stamped *before*
+ * `since` should disclose that `fields` need attention (rename/removal). Empty today —
+ * the schema has only ever grown with optional, forward- and backward-compatible fields,
+ * so no older config is misread. An entry is added here (and {@link CONFIG_SCHEMA_VERSION}
+ * bumped) only when a breaking shape change lands.
+ */
+export interface ConfigMigration {
+  /** The version at which the breaking change landed (semver). */
+  since: string;
+  /** The affected fields, for the recovery message. */
+  fields: string[];
+  /** Human recovery guidance. */
+  note: string;
+}
+
+export const CONFIG_MIGRATIONS: readonly ConfigMigration[] = [];
+
+/** A single deterministic finding from validating a config object. */
+export interface ConfigValidationFinding {
+  kind: 'unknown-key' | 'type-mismatch' | 'version-older' | 'version-newer';
+  /** The offending key, when the finding is about one. */
+  key?: string;
+  /** Human-readable message. */
+  message: string;
+  /** For unknown-key: the closest known key within the edit-distance bound, if any. */
+  suggestion?: string;
+}
+
+/**
+ * The maximum edit distance for a did-you-mean suggestion. Fixed, deterministic, and
+ * small so a suggestion is only offered for a plausible typo (`pancResponse` →
+ * `panicResponse` is distance 1) — not for an arbitrary unrelated key.
+ */
+const MAX_SUGGESTION_DISTANCE = 2;
+
+/** Iterative Levenshtein distance. Dependency-free; O(a·b) on short config keys. */
+function editDistance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  let prev = Array.from({ length: n + 1 }, (_, j) => j);
+  let curr = new Array<number>(n + 1);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n];
+}
+
+/**
+ * The closest known key to `unknown` within {@link MAX_SUGGESTION_DISTANCE}, or undefined.
+ * Ties broken alphabetically so the suggestion is deterministic.
+ */
+function suggestKnownKey(unknown: string): string | undefined {
+  let best: string | undefined;
+  let bestDist = MAX_SUGGESTION_DISTANCE + 1;
+  for (const known of KNOWN_CONFIG_KEYS) {
+    const d = editDistance(unknown, known);
+    if (d < bestDist || (d === bestDist && best !== undefined && known < best)) {
+      bestDist = d;
+      best = known;
+    }
+  }
+  return bestDist <= MAX_SUGGESTION_DISTANCE ? best : undefined;
+}
+
+function actualKind(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+function kindMatches(kind: ConfigFieldKind, value: unknown): boolean {
+  switch (kind) {
+    case 'string':
+      return typeof value === 'string';
+    case 'string-or-null':
+      return value === null || typeof value === 'string';
+    case 'object':
+      return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+}
+
+/** Parse a `a.b.c` semver into a numeric tuple, or null when it isn't one. */
+function parseSemver(v: string): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** -1 | 0 | 1 comparing two semver tuples. */
+function compareSemver(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Check the `version` stamp against the running schema version. A newer stamp is
+ * disclosed (unknown content is handled by the unknown-key path); an older stamp is
+ * reported only when a registered {@link ConfigMigration} affects the (stamp, current]
+ * range — a purely additive gap stays silent because the config is still forward- and
+ * backward-compatible. Never a hard failure. Exported so the pure version logic is
+ * testable with an injected current version / migration set.
+ */
+export function checkConfigVersion(
+  stamp: unknown,
+  opts: { current?: string; migrations?: readonly ConfigMigration[] } = {}
+): ConfigValidationFinding[] {
+  const current = opts.current ?? CONFIG_SCHEMA_VERSION;
+  const migrations = opts.migrations ?? CONFIG_MIGRATIONS;
+  if (typeof stamp !== 'string') return []; // handled by the type-mismatch path
+  const parsed = parseSemver(stamp);
+  const currentParsed = parseSemver(current);
+  if (!parsed || !currentParsed) return [];
+  const cmp = compareSemver(parsed, currentParsed);
+  if (cmp > 0) {
+    return [
+      {
+        kind: 'version-newer',
+        message: `config version ${stamp} is newer than this OpenLore knows (${current}); unknown settings are disclosed and ignored`,
+      },
+    ];
+  }
+  if (cmp < 0) {
+    const affected = migrations.filter(mig => {
+      const migParsed = parseSemver(mig.since);
+      return migParsed && compareSemver(parsed, migParsed) < 0 && compareSemver(migParsed, currentParsed) <= 0;
+    });
+    if (affected.length === 0) return []; // additive-only gap — forward compatible, silent
+    const fields = [...new Set(affected.flatMap(m => m.fields))].join(', ');
+    const notes = affected.map(m => m.note).join('; ');
+    return [
+      {
+        kind: 'version-older',
+        message: `config was written by an older OpenLore (v${stamp}); ${fields ? `fields changed: ${fields}. ` : ''}${notes} — update it or re-run 'openlore init'`,
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Validate a parsed config object against the type-derived schema. Pure and
+ * deterministic: returns findings ordered as unknown-keys (in file order), then
+ * type-mismatches, then version skew. Never throws, never mutates, never a hard failure.
+ * A non-object input yields no findings (the JSON parse already reported a syntax error).
+ */
+export function validateOpenLoreConfig(
+  parsed: unknown,
+  opts: { current?: string; migrations?: readonly ConfigMigration[] } = {}
+): ConfigValidationFinding[] {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return [];
+  const obj = parsed as Record<string, unknown>;
+  const findings: ConfigValidationFinding[] = [];
+
+  const unknownKeys: ConfigValidationFinding[] = [];
+  const mismatches: ConfigValidationFinding[] = [];
+  for (const key of Object.keys(obj)) {
+    const kind = CONFIG_FIELD_KINDS[key as keyof OpenLoreConfig];
+    if (kind === undefined) {
+      const suggestion = suggestKnownKey(key);
+      unknownKeys.push({
+        kind: 'unknown-key',
+        key,
+        suggestion,
+        message: suggestion
+          ? `unknown config key '${key}' — did you mean '${suggestion}'? (ignored)`
+          : `unknown config key '${key}' — possibly from a newer OpenLore (ignored)`,
+      });
+      continue;
+    }
+    if (!kindMatches(kind, obj[key])) {
+      mismatches.push({
+        kind: 'type-mismatch',
+        key,
+        message: `config key '${key}' should be ${kind === 'object' ? 'an object' : kind === 'string-or-null' ? 'a string or null' : 'a string'}, got ${actualKind(obj[key])}`,
+      });
+    }
+  }
+
+  findings.push(...unknownKeys, ...mismatches);
+  findings.push(...checkConfigVersion(obj.version, opts));
+  return findings;
+}


### PR DESCRIPTION
**Status:** LGTM — full suite green (300 files / 5,939 tests), typecheck + lint clean, verified e2e.

Change: `add-config-schema-validation` (e2e-audit 2026-07 fix track — runtime & CLI).

## What was missing / the motivation

`readOpenLoreConfig` parsed `.openlore/config.json` with a bare `JSON.parse(content) as OpenLoreConfig` — a type *assertion* checked by nothing at runtime. Consequences:

- A typo'd key (`pancResponse`, `embeding`) was silently dropped. The default (`panicResponse.mode: 'off'`, keyword-only retrieval) silently won, and the user believed the feature was configured. Only JSON *syntax* errors were ever reported.
- The `version` stamp written at init (`'1.0.0'`) was **write-only** — no code path read it back, so config-schema drift across OpenLore versions was invisible.

This was the config-file instance of a gap the substrate already closes elsewhere (the decision store validates on load, the index attests integrity) — while the file that *governs all of them* was trusted blindly.

## What it does

Deterministic, dependency-light validation at read; disclosure, never a hard failure; no behavior change for any currently-valid config.

- **New `src/core/services/config-schema.ts`.** The validator's field map is typed `Record<keyof OpenLoreConfig, …>`, so a field added to the interface without a validator entry **fails the build**; a runtime completeness test (a `Required<OpenLoreConfig>` sample) names any residual drift. Classifies **unknown keys** (with a did-you-mean via a bounded, deterministic edit distance), **top-level type mismatches**, and **version skew**.
- **`readOpenLoreConfig`** runs validation and discloses findings, **deduplicated per process** (it is a ~45-caller hub — one emission per finding, not per read). Never a hard failure: an unknown key — including one written by a *newer* OpenLore — is disclosed and then ignored, so a newer config under an older openlore degrades gracefully.
- **Version stamp is now live:** a newer stamp is disclosed; an older stamp is reported only when a registered migration affects the `(stamp, current]` range. The schema has only ever grown additively (optional fields), so the migration registry is empty today and an older config stays silent — honest, no crying wolf.
- **`openlore doctor`** surfaces findings as a structured `Config schema` check.

### Deliberate refinement vs. the proposal
The proposal said "warnings via existing logger." The logger writes to **stdout**, but `readOpenLoreConfig` is read by machine-output paths (`--json` commands, `orient`, the MCP JSON-RPC stream) where a stdout warning corrupts the output. Validation diagnostics therefore emit to **stderr** (honoring quiet/noColor) — the logger's intent (standard, quiet-respecting, deduplicated diagnostics) is preserved, and machine stdout stays a pure channel. The proposal header records this.

## Proof it works

**Tests** (`config-schema.test.ts`, `config-manager.test.ts`, `doctor.test.ts`):
- `pancResponse` / `embeding` typos → warning naming the key + did-you-mean; defaults still apply.
- Valid config → **zero** findings, identical behavior to today.
- Newer version stamp / unknown future key → disclosed, not crashed on.
- Older-version config with a registered migration → reported, naming the fields; additive-only gap → silent.
- Type-completeness guard fails (compile + runtime) when a field is added without a validator entry — verified by probing the type.
- Hub-caller dedup: three reads → one emission.

**E2E** (real built CLI):
- Broken config → `openlore doctor` prints deduped stderr diagnostics + a `Config schema: warn`, exit **0**.
- `openlore doctor --json` on a broken config → **stdout parses as clean JSON** (10 checks); the 4 diagnostics land on stderr.
- Valid config → `Config schema: ok`, zero warnings; `orient --json` stdout parses clean.

## Notes
- Spec delta: `config` gains `ConfigUnknownKeysAreDisclosed`, `ConfigVersionIsChecked`.
- Validation is shallow (top-level keys/types) by design — allocation-light on a hub; a mistyped nested field is a disclosed out-of-scope boundary.
- Fixed a latent test-isolation leak in `doctor.test.ts` (the mocked `readFile` implementation persisted across tests; `beforeEach` now resets it to the documented ENOENT default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)