### PR TITLE
fix(cli): uniform conclusion honesty — base-ref resolve-or-disclose, staleness, unknown inputs

### DIFF
--- a/openspec/changes/fix-cli-conclusion-honesty/proposal.md
+++ b/openspec/changes/fix-cli-conclusion-honesty/proposal.md
@@ -1,10 +1,13 @@
 # Uniform conclusion honesty across CLI commands: base-ref fallback, staleness, unknown inputs
 
-> Status: PROPOSED (2026-07-03, e2e audit). The honesty disciplines exist — some commands apply
+> Status: SHIPPED (2026-07-18). The honesty disciplines exist — some commands apply
 > them, siblings don't. A live dogfood of all ~50 CLI commands found four places where a
 > conclusion-shaped command answers confidently over an undisclosed defect in its own inputs,
 > while a sibling command discloses the identical defect. This change makes the disciplines
 > uniform and adds the guard that keeps a new conclusion command from shipping without them.
+> Shipped as one shared `resolveBaseRefDisclosed` helper + the existing staleness boundary,
+> adopted across certify-public-surface, impact-certificate, blast-radius, briefing-since, and
+> coverage-gaps, plus the style-fingerprint and features fixes and a source-level parity guard.
 
 ## The gap (all live-reproduced on this repo, v2.1.5)
 

--- a/openspec/changes/fix-cli-conclusion-honesty/tasks.md
+++ b/openspec/changes/fix-cli-conclusion-honesty/tasks.md
@@ -1,22 +1,22 @@
 # Tasks — uniform CLI conclusion honesty
 
 ## Implementation
-- [ ] Shared base-ref helper: resolve-or-disclose with structured baseRefFallback; certification
+- [x] Shared base-ref helper: resolve-or-disclose with structured baseRefFallback; certification
       commands (certify-public-surface, impact-certificate) error on unresolvable requested ref
       unless --allow-base-fallback
-- [ ] Shared staleness helper (index commit + changed-file count); adopt in blast-radius and
+- [x] Shared staleness helper (index commit + changed-file count); adopt in blast-radius and
       briefing-since (certify-public-surface already emits it)
-- [ ] style-fingerprint --language <unknown>: not-found shape, exit 1, known languages listed
-- [ ] features: federation health from resolvability verdicts, not registry count
-- [ ] Parity guard test: every --base / cached-graph command routes through the helpers
+- [x] style-fingerprint --language <unknown>: not-found shape, exit 1, known languages listed
+- [x] features: federation health from resolvability verdicts, not registry count
+- [x] Parity guard test: every --base / cached-graph command routes through the helpers
 
 ## Verification
-- [ ] certify-public-surface --base not-a-ref exits non-zero naming the ref; with
+- [x] certify-public-surface --base not-a-ref exits non-zero naming the ref; with
       --allow-base-fallback returns disclosed fallback
-- [ ] blast-radius/briefing-since on a stale index carry the staleness boundary (live repro from
+- [x] blast-radius/briefing-since on a stale index carry the staleness boundary (live repro from
       the audit re-run)
-- [ ] features shows degraded federation when peers unresolvable
-- [ ] Full suite green
+- [x] features shows degraded federation when peers unresolvable
+- [x] Full suite green
 
 ## Spec
-- [ ] `cli` delta: ADD BaseRefResolutionIsDisclosedOrFatal, ConclusionCommandsDiscloseIndexStaleness
+- [x] `cli` delta: ADD BaseRefResolutionIsDisclosedOrFatal, ConclusionCommandsDiscloseIndexStaleness

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -1110,3 +1110,53 @@ but unreachable — not when keyword mode is simply the unconfigured default.
 Benchmark-cleared. The DefaultSurfaceRevealsAllFaces gate ran all three quantities and none regressed: (1) token economy — substrate ~4.5k tokens, +1.2k over navigation, within the ~10k tool-search threshold; (2) face coverage — substrate exposes navigate+change+remember+verify, navigation only navigate; (3) selection accuracy — substrate 90% vs navigation 80% on shared tool selection (no regression) and 100% vs 0% on governance, plus end-to-end task COMPLETION on the pinned real-repo corpus across TWO models (sonnet + haiku) on BOTH tiers: 100% correctness everywhere, substrate cheaper on 3 of 4 model×tier cells. The lean navigation default under-sold the substrate: agents installed the documented way never discovered recall/verify_claim/blast_radius.
 
 **Consequences:** The out-of-box default install now exposes the substrate preset (navigation core + recall + verify_claim + blast_radius, 13 tools) instead of navigation (10). No tool removed; navigation stays a named preset and is a one-flag reversible escape (--preset navigation). Reverses ADR-0022 (a6c916ed). Lean-default payload budget rises ~13.2KB to ~17.7KB. The BREADTH_POINTER now describes the substrate default and points to full/federation/navigation. Docs/guards updated to the 13-tool default.
+
+### Requirement: BaseRefResolutionIsDisclosedOrFatal
+
+Every CLI command accepting a `--base` ref SHALL resolve it through one shared helper
+(`resolveBaseRefDisclosed`). When the requested ref does not resolve, an advisory command (blast
+radius, briefing, coverage-gaps) SHALL return a structured fallback disclosure (`requested`,
+`resolved`) alongside its conclusion, and a certification command (`certify-public-surface`,
+`impact-certificate`) SHALL fail with a non-zero exit naming the unresolvable ref — a verdict
+computed against a base the user did not ask for is never presented as a certificate — unless the
+user explicitly opts into disclosed fallback with `--allow-base-fallback`. A composer that forwards
+`--base` to a helper-routed handler inherits the disclosure. A parity test SHALL fail when a
+`--base` command does not route through the helper.
+
+#### Scenario: A typo'd tag cannot produce a clean certificate
+
+- **GIVEN** `openlore certify-public-surface --base v2.1.5-typo`
+- **WHEN** the ref does not resolve
+- **THEN** the command exits non-zero naming the ref, and no verdict is printed
+
+#### Scenario: An advisory command falls back with a receipt
+
+- **GIVEN** `openlore blast-radius --base not-a-ref`
+- **WHEN** the ref does not resolve and the fallback chain selects `main`
+- **THEN** the output carries the structured fallback disclosure naming both refs
+
+#### Scenario: The opt-in flag restores disclosed fallback for a certificate
+
+- **GIVEN** `openlore certify-public-surface --base not-a-ref --allow-base-fallback`
+- **WHEN** the ref does not resolve
+- **THEN** the certificate is computed against the fallback base and carries the `baseRefFallback` disclosure
+
+### Requirement: ConclusionCommandsDiscloseIndexStaleness
+
+Every CLI command whose conclusion is computed from the cached graph SHALL disclose index
+staleness through one shared boundary shape (the index's build commit and the count of source files
+changed since) whenever the working tree has moved past the index. No conclusion command may present
+a risk headline or ranked briefing over a stale graph without the disclosure. A parity test SHALL
+enumerate cached-graph commands and fail when one lacks the boundary path.
+
+#### Scenario: A stale blast radius says so
+
+- **GIVEN** an index built 90 commits ago and a `blast-radius` invocation
+- **WHEN** the conclusion is printed
+- **THEN** it carries the staleness boundary (build commit, changed-file count) alongside the risk headline
+
+#### Scenario: Unknown enum inputs are not quiet-empty
+
+- **GIVEN** `openlore style-fingerprint --language <unrecognized>`
+- **WHEN** the language matches no known language
+- **THEN** the command exits non-zero with a not-found shape listing the known languages, matching the honesty of its file-path counterpart

--- a/src/cli/commands/blast-radius.test.ts
+++ b/src/cli/commands/blast-radius.test.ts
@@ -165,9 +165,10 @@ describe('runBlastRadiusCli (advisory posture & exit codes)', () => {
     expect(await runBlastRadiusCli({ cwd: '/p', hook: true })).toBe(0);
   });
 
-  it('human render surfaces a silent base-ref fallback (resolvedBaseRef ≠ baseRef)', async () => {
+  it('human render surfaces a disclosed base-ref fallback (baseRefFallback set)', async () => {
     const fellBack = {
       headline: 'h', posture: 'advisory', baseRef: 'totally-bogus-ref', resolvedBaseRef: 'main',
+      baseRefFallback: { requested: 'totally-bogus-ref', resolved: 'main' },
       impact: { hubsTouched: [], layersCrossed: [], governingDecisions: [] },
       tests: { count: 0, toRun: [] },
       memory: { orphaned: 0, drifted: 0, willDrift: [] },

--- a/src/cli/commands/blast-radius.ts
+++ b/src/cli/commands/blast-radius.ts
@@ -121,8 +121,12 @@ function renderHuman(b: BlastRadiusBriefing): string {
   lines.push('   ' + b.headline);
   // Surface a silent base-ref fallback here too (not only in the JSON caveats), so a
   // typo'd --base never makes the human briefing misrepresent what it diffed.
-  if (b.resolvedBaseRef !== b.baseRef) {
-    lines.push(`   ⚠ base ref "${b.baseRef}" did not resolve — diffed against "${b.resolvedBaseRef}" instead.`);
+  if (b.baseRefFallback) {
+    lines.push(`   ⚠ base ref "${b.baseRefFallback.requested}" did not resolve — diffed against "${b.baseRefFallback.resolved}" instead.`);
+  }
+  // Index staleness: a risk headline over a graph that predates the working tree must say so.
+  if (b.confidenceBoundary?.staleness?.detail) {
+    lines.push(`   ⚠ ${b.confidenceBoundary.staleness.detail}`);
   }
   if (b.impact.hubsTouched.length > 0) {
     lines.push('   Hubs: ' + b.impact.hubsTouched.map(h => `${h.symbol} (${h.fanIn} callers)`).join(', '));

--- a/src/cli/commands/certify-public-surface.ts
+++ b/src/cli/commands/certify-public-surface.ts
@@ -37,6 +37,7 @@ interface DiffResult {
   mode: 'diff';
   base: string;
   head: string;
+  baseRefFallback?: { requested: string; resolved: string };
   overall: 'breaking' | 'non-breaking' | 'potentially-breaking';
   summary: { breaking: number; potentiallyBreaking: number; nonBreaking: number };
   changes: SurfaceChangeOut[];
@@ -60,6 +61,7 @@ function renderSurface(r: SurfaceResult): string {
 function renderDiff(r: DiffResult): string {
   const lines: string[] = ['', `📐 Public API surface contract — verdict: ${ICON[r.overall]} ${r.overall.toUpperCase()}`];
   lines.push(`   base: ${r.base} → ${r.head}`);
+  if (r.baseRefFallback) lines.push(`   ⚠ requested base "${r.baseRefFallback.requested}" did not resolve — certified against "${r.baseRefFallback.resolved}" (--allow-base-fallback)`);
   lines.push(`   ${r.summary.breaking} breaking · ${r.summary.potentiallyBreaking} potentially-breaking · ${r.summary.nonBreaking} non-breaking`);
   if (r.confidenceBoundary?.integrity?.detail) lines.push(`   ⚠ index integrity ${r.confidenceBoundary.integrity.verdict}: ${r.confidenceBoundary.integrity.detail}`);
   if (r.confidenceBoundary?.staleness?.detail) lines.push(`   ⚠ ${r.confidenceBoundary.staleness.detail}`);
@@ -86,6 +88,7 @@ export interface CertifyPublicSurfaceCliOptions {
   base?: string;
   max?: number;
   json?: boolean;
+  allowBaseFallback?: boolean;
 }
 
 export async function runCertifyPublicSurfaceCli(opts: CertifyPublicSurfaceCliOptions): Promise<number> {
@@ -93,7 +96,7 @@ export async function runCertifyPublicSurfaceCli(opts: CertifyPublicSurfaceCliOp
   configureLogger({ quiet: true });
   let result: unknown;
   try {
-    result = await handleCertifyPublicSurface({ directory: cwd, baseRef: opts.base, maxResults: opts.max });
+    result = await handleCertifyPublicSurface({ directory: cwd, baseRef: opts.base, maxResults: opts.max, allowBaseFallback: opts.allowBaseFallback });
   } catch (err) {
     result = { error: err instanceof Error ? err.message : String(err) };
   } finally {
@@ -120,8 +123,9 @@ export const certifyPublicSurfaceCommand = new Command('certify-public-surface')
   .description('Certify the public API surface (no --base) or the breaking-change verdict for the working-tree diff (--base <ref>): removed/renamed exports, incompatible signatures, each breaking change with its in-repo consumers. Read-only, deterministic, never blocks.')
   .option('--base <ref>', 'Diff the working tree\'s public surface against this git ref (e.g. HEAD, main) for a breaking-change verdict')
   .option('--max <n>', 'Limit the surface listing in surface mode (default 200, capped 500)', (v) => parseInt(v, 10))
+  .option('--allow-base-fallback', 'Accept the disclosed main → master → HEAD~1 fallback when --base does not resolve, instead of erroring', false)
   .option('--json', 'Emit the result as JSON', false)
-  .action(async (opts: { base?: string; max?: number; json?: boolean }) => {
-    const code = await runCertifyPublicSurfaceCli({ base: opts.base, max: opts.max, json: opts.json });
+  .action(async (opts: { base?: string; max?: number; json?: boolean; allowBaseFallback?: boolean }) => {
+    const code = await runCertifyPublicSurfaceCli({ base: opts.base, max: opts.max, json: opts.json, allowBaseFallback: opts.allowBaseFallback });
     process.exit(code);
   });

--- a/src/cli/commands/conclusion-honesty-parity.test.ts
+++ b/src/cli/commands/conclusion-honesty-parity.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Conclusion-honesty parity guard (change: fix-cli-conclusion-honesty).
+ *
+ * The honesty disciplines — resolve-or-disclose a `--base` ref, disclose index
+ * staleness on a cached-graph conclusion — are only worth anything if EVERY command
+ * applies them. The v2.1.5 audit found the opposite: some commands disclosed, their
+ * siblings silently answered over the same defect. This test is the CLAUDE.md
+ * MCP↔CLI parity doctrine applied inside the CLI: it enumerates every command taking
+ * `--base` (or reading the cached graph) and fails when one drops off the shared path.
+ *
+ * It is a SOURCE-level guard on purpose: a new `--base` command that forgets the
+ * helper fails here, at authoring time, instead of shipping a silent fallback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const COMMANDS_DIR = join(process.cwd(), 'src', 'cli', 'commands');
+const read = (rel: string): string => readFileSync(join(process.cwd(), rel), 'utf-8');
+
+/**
+ * Every `--base` command and HOW it satisfies the resolve-or-disclose contract:
+ *  - `handler`: the command resolves the base itself, in this handler, which MUST
+ *    reference the one shared helper `resolveBaseRefDisclosed`.
+ *  - `delegatesTo`: the command does not resolve a base itself; it forwards the ref
+ *    to a composed handler that does (so the disclosure flows up transitively).
+ *
+ * A NEW `--base` command that is not registered here fails `enumerates every --base
+ * command` below — forcing its author to declare, and wire, its compliance.
+ */
+const BASE_REF_COMMANDS: Record<string, { handler: string } | { delegatesTo: string[] }> = {
+  'certify-public-surface': { handler: 'src/core/services/mcp-handlers/public-surface.ts' },
+  'impact-certificate': { handler: 'src/core/services/mcp-handlers/impact-certificate.ts' },
+  'blast-radius': { handler: 'src/core/services/mcp-handlers/blast-radius.ts' },
+  'briefing-since': { handler: 'src/core/services/mcp-handlers/briefing-since.ts' },
+  'coverage-gaps': { handler: 'src/core/services/mcp-handlers/coverage-gaps.ts' },
+  // enforce + review are composers: they forward `--base` to computeBlastRadius /
+  // computeImpactCertificate, which resolve-or-disclose through the shared helper.
+  enforce: { delegatesTo: ['src/core/services/mcp-handlers/blast-radius.ts'] },
+  review: { delegatesTo: ['src/core/services/mcp-handlers/blast-radius.ts'] },
+};
+
+/**
+ * Cached-graph conclusion commands that must disclose index staleness through the one
+ * shared boundary shape (`computeStaleness` + `assembleBoundary`). certify-public-surface
+ * already emitted it pre-change; blast-radius and briefing-since adopted it here.
+ */
+const STALENESS_HANDLERS: Record<string, string> = {
+  'blast-radius': 'src/core/services/mcp-handlers/blast-radius.ts',
+  'briefing-since': 'src/core/services/mcp-handlers/briefing-since.ts',
+  'certify-public-surface': 'src/core/services/mcp-handlers/public-surface.ts',
+  'coverage-gaps': 'src/core/services/mcp-handlers/coverage-gaps.ts',
+};
+
+/** Command files that declare a `--base <ref>` option. */
+function commandsDeclaringBase(): string[] {
+  return readdirSync(COMMANDS_DIR)
+    .filter(f => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    .filter(f => /\.option\('--base/.test(readFileSync(join(COMMANDS_DIR, f), 'utf-8')))
+    .map(f => f.replace(/\.ts$/, ''));
+}
+
+describe('conclusion-honesty parity: base-ref resolution', () => {
+  it('enumerates every --base command (a new one must register its compliance)', () => {
+    const declared = commandsDeclaringBase().sort();
+    const registered = Object.keys(BASE_REF_COMMANDS).sort();
+    expect(declared).toEqual(registered);
+  });
+
+  it('every direct-resolving --base handler routes through the shared resolveBaseRefDisclosed helper', () => {
+    for (const [cmd, how] of Object.entries(BASE_REF_COMMANDS)) {
+      if (!('handler' in how)) continue;
+      const src = read(how.handler);
+      expect(src, `${cmd} (${how.handler}) must call resolveBaseRefDisclosed`).toMatch(/resolveBaseRefDisclosed/);
+    }
+  });
+
+  it('every delegating --base command forwards to a helper-compliant handler', () => {
+    for (const [cmd, how] of Object.entries(BASE_REF_COMMANDS)) {
+      if (!('delegatesTo' in how)) continue;
+      for (const delegate of how.delegatesTo) {
+        expect(read(delegate), `${cmd} delegates to ${delegate}, which must call resolveBaseRefDisclosed`).toMatch(/resolveBaseRefDisclosed/);
+      }
+    }
+  });
+});
+
+describe('conclusion-honesty parity: index-staleness disclosure', () => {
+  it('every cached-graph conclusion handler discloses staleness via the shared boundary shape', () => {
+    for (const [cmd, handler] of Object.entries(STALENESS_HANDLERS)) {
+      const src = read(handler);
+      expect(src, `${cmd} (${handler}) must compute staleness`).toMatch(/computeStaleness/);
+      expect(src, `${cmd} (${handler}) must assemble the confidence boundary`).toMatch(/assembleBoundary/);
+    }
+  });
+});

--- a/src/cli/commands/impact-certificate.test.ts
+++ b/src/cli/commands/impact-certificate.test.ts
@@ -143,6 +143,29 @@ describe('runImpactCertificateCli (advisory posture & exit codes)', () => {
     expect(await runImpactCertificateCli({ cwd: '/p', hook: true })).toBe(0);
   });
 
+  it('a DIRECT invocation fails non-zero on an unresolvable base (a typo cannot yield a clean cert)', async () => {
+    // computeImpactCertificate tags the fatal-base error so the CLI can distinguish it
+    // from infrastructure failure and exit non-zero (fix-cli-conclusion-honesty).
+    vi.mocked(computeImpactCertificate).mockResolvedValue({ error: 'base ref "bogus" did not resolve', baseUnresolved: true });
+    const code = await runImpactCertificateCli({ cwd: '/p', base: 'bogus', json: true });
+    expect(code).toBe(1);
+  });
+
+  it('the HOOK never blocks on a bad base: it passes allowBaseFallback and stays exit 0', async () => {
+    // In hook mode the CLI opts into the disclosed fallback, so compute never returns the
+    // fatal-base error; even if it did, the hook must not block. Assert both.
+    vi.mocked(computeImpactCertificate).mockResolvedValue(cert([]));
+    const code = await runImpactCertificateCli({ cwd: '/p', base: 'bogus', hook: true });
+    expect(code).toBe(0);
+    expect(vi.mocked(computeImpactCertificate).mock.calls[0][0]).toMatchObject({ allowBaseFallback: true });
+  });
+
+  it('--allow-base-fallback on a direct invocation is forwarded to compute', async () => {
+    vi.mocked(computeImpactCertificate).mockResolvedValue(cert([]));
+    await runImpactCertificateCli({ cwd: '/p', base: 'bogus', allowBaseFallback: true, json: true });
+    expect(vi.mocked(computeImpactCertificate).mock.calls[0][0]).toMatchObject({ allowBaseFallback: true });
+  });
+
   it('blocks (exit 1) in --hook mode only when a configured surface severity fires', async () => {
     vi.mocked(computeImpactCertificate).mockResolvedValue(cert([CRIT_PATH]));
     vi.mocked(readOpenLoreConfig).mockResolvedValue({ impactCertificate: { block: ['critical'] } } as never);

--- a/src/cli/commands/impact-certificate.ts
+++ b/src/cli/commands/impact-certificate.ts
@@ -112,8 +112,8 @@ export function triggeredBlockSeverities(
 /** Compact human rendering of the certificate (to stderr in hook mode). */
 function renderHuman(c: ImpactCertificate): string {
   const lines: string[] = ['', '📜 Change-impact certificate (advisory)', '   ' + c.headline];
-  if (c.resolvedBaseRef !== c.baseRef) {
-    lines.push(`   ⚠ base ref "${c.baseRef}" did not resolve — diffed against "${c.resolvedBaseRef}".`);
+  if (c.baseRefFallback) {
+    lines.push(`   ⚠ base ref "${c.baseRefFallback.requested}" did not resolve — certified against "${c.baseRefFallback.resolved}" (--allow-base-fallback).`);
   }
   if (c.surfaces.length > 0) {
     lines.push('   Surfaces: ' + c.surfaces.map(s => `${s.name} (${s.resolvedSymbols} sym, ${s.severity})`).join(', '));
@@ -144,6 +144,7 @@ export interface ImpactCertificateCliOptions {
   save?: boolean;
   installHook?: boolean;
   uninstallHook?: boolean;
+  allowBaseFallback?: boolean;
 }
 
 export async function runImpactCertificateCli(opts: ImpactCertificateCliOptions): Promise<number> {
@@ -155,10 +156,14 @@ export async function runImpactCertificateCli(opts: ImpactCertificateCliOptions)
   // Hook mode persists by default so the certificate decays and the spec-store
   // health check can re-fire it; an explicit --save forces it elsewhere too.
   const persist = opts.save || opts.hook;
+  // The hook is advisory and must never block a commit — so a bogus --base there
+  // falls back (disclosed) rather than erroring. A direct invocation stays fatal on
+  // an unresolvable base (fix-cli-conclusion-honesty) unless --allow-base-fallback.
+  const allowBaseFallback = opts.allowBaseFallback || opts.hook === true;
   configureLogger({ quiet: true });
   let result: Awaited<ReturnType<typeof computeImpactCertificate>>;
   try {
-    result = await computeImpactCertificate({ directory: cwd, baseRef: opts.base, change: opts.change, persist });
+    result = await computeImpactCertificate({ directory: cwd, baseRef: opts.base, change: opts.change, persist, allowBaseFallback });
   } catch (err) {
     // Final advisory safety net: a throw must NEVER block a commit.
     result = { error: err instanceof Error ? err.message : String(err) };
@@ -169,6 +174,10 @@ export async function runImpactCertificateCli(opts: ImpactCertificateCliOptions)
   if ('error' in result) {
     if (opts.json) await writeStdout(JSON.stringify({ status: 'unavailable', error: result.error }, null, 2) + '\n');
     else logger.warning(`impact-certificate: ${result.error}`);
+    // A caller-supplied unresolvable base is a usage error, not infrastructure failure:
+    // fail non-zero for a direct invocation so a typo'd ref can't yield a clean-looking
+    // certificate. In hook mode allowBaseFallback is on, so this branch is unreachable there.
+    if ('baseUnresolved' in result && result.baseUnresolved && !opts.hook) return 1;
     return 0; // infrastructure failure never blocks
   }
 
@@ -204,15 +213,16 @@ export const impactCertificateCommand = new Command('impact-certificate')
   .description('Change-impact certificate for the current diff (advisory): blast radius, newly-opened paths into declared covering surfaces, drifted specs, and tests to run.')
   .option('--base <ref>', 'Git ref to diff the working tree against (default HEAD)')
   .option('--change <id>', 'Change id to record on the certificate (spec-store context)')
+  .option('--allow-base-fallback', 'Accept the disclosed main → master → HEAD~1 fallback when --base does not resolve, instead of erroring (direct invocation only; the hook always falls back)', false)
   .option('--json', 'Emit the certificate as JSON', false)
   .option('--hook', 'Hook mode: print to stderr, persist, and block only on a configured surface severity', false)
   .option('--save', 'Persist the certificate under .openlore/impact-certificates/ for later decay re-checks', false)
   .option('--install-hook', 'Install the advisory pre-commit hook', false)
   .option('--uninstall-hook', 'Remove the advisory pre-commit hook', false)
-  .action(async (opts: { base?: string; change?: string; json?: boolean; hook?: boolean; save?: boolean; installHook?: boolean; uninstallHook?: boolean }) => {
+  .action(async (opts: { base?: string; change?: string; json?: boolean; hook?: boolean; save?: boolean; installHook?: boolean; uninstallHook?: boolean; allowBaseFallback?: boolean }) => {
     const code = await runImpactCertificateCli({
       base: opts.base, change: opts.change, json: opts.json, hook: opts.hook, save: opts.save,
-      installHook: opts.installHook, uninstallHook: opts.uninstallHook,
+      installHook: opts.installHook, uninstallHook: opts.uninstallHook, allowBaseFallback: opts.allowBaseFallback,
     });
     process.exit(code);
   });

--- a/src/core/drift/git-diff.test.ts
+++ b/src/core/drift/git-diff.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { classifyFile, isSkippableFile, validateGitRef,
   isGitRepository, getCurrentBranch, resolveBaseRef, refExists,
-  getFileDiff, getChangedFiles } from './git-diff.js';
+  resolveBaseRefDisclosed, getFileDiff, getChangedFiles } from './git-diff.js';
 import { execFile } from 'node:child_process';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -369,6 +369,56 @@ describe('refExists', () => {
     } finally {
       await rm(nonRepo, { recursive: true, force: true });
     }
+  });
+});
+
+// ============================================================================
+// resolveBaseRefDisclosed — the shared resolve-or-disclose helper every --base
+// command routes through (fix-cli-conclusion-honesty). This is the ONE home of
+// the fallback-detection logic; the commands only surface/act on its verdict.
+// ============================================================================
+
+describe('resolveBaseRefDisclosed', () => {
+  const EMPTY_TREE = '4b825dc642cb6eb9a060e54bf899d15f71049056';
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'openlore-disclosed-'));
+    await initRepo(tmpDir);
+    await writeFile(join(tmpDir, 'a.ts'), 'v1', 'utf-8');
+    await commit(tmpDir, 'initial');
+  });
+  afterEach(async () => { await rm(tmpDir, { recursive: true, force: true }); });
+
+  it('an explicit ref that resolves is NOT a fallback', async () => {
+    const r = await resolveBaseRefDisclosed(tmpDir, 'HEAD');
+    expect(r).toEqual({ requested: 'HEAD', resolved: 'HEAD', fellBack: false });
+  });
+
+  it('an explicit ref that does NOT resolve falls back and discloses both refs', async () => {
+    const r = await resolveBaseRefDisclosed(tmpDir, 'totally-bogus-ref-xyz');
+    expect(r.requested).toBe('totally-bogus-ref-xyz');
+    expect(r.resolved).toBe('main'); // main → master → HEAD~1 fallback
+    expect(r.fellBack).toBe(true);
+  });
+
+  it('the "auto" default explicitly requests the fallback chain and is never a fallback', async () => {
+    const r = await resolveBaseRefDisclosed(tmpDir, 'auto');
+    expect(r.resolved).toBe('main');
+    expect(r.fellBack).toBe(false);
+  });
+
+  it('an empty request is treated as auto (no fallback flag)', async () => {
+    const r = await resolveBaseRefDisclosed(tmpDir, '');
+    expect(r.fellBack).toBe(false);
+  });
+
+  it('does NOT false-flag a usable base that resolves to itself but is not a commit (empty-tree SHA)', async () => {
+    // resolveBaseRef returns the empty-tree SHA verbatim (it is a valid diff base), so the
+    // helper must NOT call it a fallback even though refExists (which peels ^{commit}) is false.
+    const r = await resolveBaseRefDisclosed(tmpDir, EMPTY_TREE);
+    expect(r.resolved).toBe(EMPTY_TREE);
+    expect(r.fellBack).toBe(false);
   });
 });
 

--- a/src/core/drift/git-diff.ts
+++ b/src/core/drift/git-diff.ts
@@ -231,6 +231,42 @@ export async function resolveBaseRef(rootPath: string, preferredRef: string): Pr
 }
 
 /**
+ * The disclosed resolution of a `--base` ref. `requested` is what the caller asked
+ * for (verbatim, or the command's default sentinel); `resolved` is the ref git will
+ * actually diff against after {@link resolveBaseRef}'s main → master → HEAD~1 fallback.
+ * `fellBack` is true exactly when the caller passed an EXPLICIT ref that git could not
+ * resolve — so `resolved` is a base the caller did not ask for. A conclusion command
+ * must never present a verdict over a fallback base without disclosing this.
+ */
+export interface BaseRefResolution {
+  requested: string;
+  resolved: string;
+  fellBack: boolean;
+}
+
+/**
+ * Resolve a base ref AND disclose whether the caller's requested ref actually
+ * resolved — the single "resolve-or-disclose" point every `--base` command shares
+ * (fix-cli-conclusion-honesty). Advisory commands surface `fellBack` as a caveat;
+ * certification commands treat it as fatal unless the caller opts into fallback.
+ *
+ * The `auto`/empty sentinel (the briefing default that explicitly REQUESTS the
+ * fallback chain) never counts as a fallback. For an explicit ref we confirm the
+ * fallback with {@link refExists}, so a ref that resolves to a differently-spelled
+ * commit (e.g. a short SHA, a tag) is correctly reported as resolved, not fallen-back.
+ */
+export async function resolveBaseRefDisclosed(
+  rootPath: string,
+  requestedRef: string,
+): Promise<BaseRefResolution> {
+  const resolved = await resolveBaseRef(rootPath, requestedRef);
+  const isAuto = !requestedRef || requestedRef === 'auto';
+  const fellBack =
+    !isAuto && resolved !== requestedRef && !(await refExists(rootPath, requestedRef));
+  return { requested: requestedRef, resolved, fellBack };
+}
+
+/**
  * Parse a git status character into a ChangedFile status
  */
 function parseGitStatus(statusChar: string): ChangedFile['status'] {

--- a/src/core/services/feature-inventory.test.ts
+++ b/src/core/services/feature-inventory.test.ts
@@ -185,16 +185,40 @@ describe('feature-inventory', () => {
     expect(ss.detail).toMatch(/2 target/);
   });
 
-  it('detects federation peers from .openlore/federation.json', async () => {
+  it('reports federation active when its peers are reachable', async () => {
     await mkdir(join(dir, '.openlore'), { recursive: true });
+    await mkdir(join(dir, 'peer-a'), { recursive: true });
+    await mkdir(join(dir, 'peer-b'), { recursive: true });
     await writeFile(
       join(dir, '.openlore', 'federation.json'),
-      JSON.stringify({ schemaVersion: 1, repos: [{ name: 'a' }, { name: 'b' }] })
+      JSON.stringify({ schemaVersion: 1, repos: [
+        { name: 'a', path: join(dir, 'peer-a') },
+        { name: 'b', path: join(dir, 'peer-b') },
+      ] })
     );
     const inv = await collectFeatureInventory(dir);
     const fed = byId(inv.features, 'federation');
     expect(fed.state).toBe('active');
     expect(fed.detail).toMatch(/2 peer/);
+    expect(fed.detail).toMatch(/reachable/);
+  });
+
+  it('reports federation as degraded (not active ✓) when its peers are unreachable (finding #4)', async () => {
+    // The old inventory counted registry ROWS as health, so a registry of missing peers
+    // showed as active ✓ while `federation list` reported every one "✗ missing path".
+    // Health now reflects resolvability: all-unreachable is inactive, and says why.
+    await mkdir(join(dir, '.openlore'), { recursive: true });
+    await writeFile(
+      join(dir, '.openlore', 'federation.json'),
+      JSON.stringify({ schemaVersion: 1, repos: [
+        { name: 'a', path: join(dir, 'no-such-peer-a') },
+        { name: 'b', path: join(dir, 'no-such-peer-b') },
+      ] })
+    );
+    const inv = await collectFeatureInventory(dir);
+    const fed = byId(inv.features, 'federation');
+    expect(fed.state).toBe('inactive');
+    expect(fed.detail).toMatch(/2 peer.*unreachable/i);
   });
 
   it('is fail-soft: malformed marker files degrade to inactive, never throw', async () => {
@@ -219,9 +243,10 @@ describe('feature-inventory', () => {
     await writeFile(join(dir, '.openlore', 'architecture.json'), '{}');
     await mkdir(join(dir, '.git', 'hooks'), { recursive: true });
     await writeFile(join(dir, '.git', 'hooks', 'pre-commit'), 'openlore enforce --hook');
+    await mkdir(join(dir, 'peer-a'), { recursive: true });
     await writeFile(
       join(dir, '.openlore', 'federation.json'),
-      JSON.stringify({ repos: [{ name: 'a' }] })
+      JSON.stringify({ repos: [{ name: 'a', path: join(dir, 'peer-a') }] })
     );
     const inv = await collectFeatureInventory(dir);
     // 10 opt-in features, all active (decision autopilot added the 10th).

--- a/src/core/services/feature-inventory.ts
+++ b/src/core/services/feature-inventory.ts
@@ -94,12 +94,22 @@ async function detectWiredPreset(rootPath: string): Promise<string | null> {
   return null;
 }
 
-/** Count federation-registered peer repos in `.openlore/federation.json`. */
-async function countFederationRepos(rootPath: string): Promise<number> {
-  const fed = (await readJsonSoft(join(rootPath, '.openlore', 'federation.json'))) as
-    | { repos?: unknown[] }
-    | null;
-  return Array.isArray(fed?.repos) ? fed!.repos!.length : 0;
+/**
+ * Federation health, not a registry row count (fix-cli-conclusion-honesty). Reuses the SAME
+ * `evaluateRepoState` verdicts `federation list` shows, so `features` and `federation list` can
+ * never disagree: a peer whose path no longer exists is `missing` (unreachable), not "registered
+ * and healthy". Fail-soft — a corrupt/absent registry reports zero peers rather than throwing.
+ */
+async function federationHealth(rootPath: string): Promise<{ registered: number; reachable: number; unreachable: number }> {
+  try {
+    const { listRepos, evaluateRepoState } = await import('../federation/registry.js');
+    const repos = listRepos(rootPath);
+    let reachable = 0;
+    for (const r of repos) if (evaluateRepoState(r) !== 'missing') reachable++;
+    return { registered: repos.length, reachable, unreachable: repos.length - reachable };
+  } catch {
+    return { registered: 0, reachable: 0, unreachable: 0 };
+  }
 }
 
 /** Detect whether a git pre-commit hook wired to OpenLore is installed. */
@@ -309,19 +319,31 @@ export async function collectFeatureInventory(rootPath: string): Promise<Feature
     docs: 'docs/federation.md',
   });
 
-  // Federation registry.
-  const repoCount = await countFederationRepos(rootPath);
+  // Federation registry — reported by peer RESOLVABILITY, not registry row count. A registry with
+  // peers but none reachable is degraded, not active: it counts as inactive (no ✓) and says why, so
+  // `features` never disagrees with `federation list` (fix-cli-conclusion-honesty).
+  const fed = await federationHealth(rootPath);
+  const anyReachable = fed.reachable > 0;
   features.push({
     id: 'federation',
     title: 'Federation registry',
     group: 'Multi-repo',
-    state: repoCount > 0 ? 'active' : 'inactive',
+    // Active only when at least one peer is actually reachable; a registry whose peers are all
+    // missing provides no cross-repo value, so it is not shown as on.
+    state: anyReachable ? 'active' : 'inactive',
     optIn: true,
     detail:
-      repoCount > 0
-        ? `${repoCount} peer repo(s) registered`
-        : 'single-repository mode — no peers registered',
-    activate: repoCount > 0 ? '' : 'openlore federation add <path> --name <name>',
+      fed.registered === 0
+        ? 'single-repository mode — no peers registered'
+        : fed.unreachable === 0
+          ? `${fed.registered} peer repo(s) registered, all reachable`
+          : `${fed.registered} peer(s) registered, ${fed.unreachable} unreachable (✗ missing path)`,
+    activate:
+      fed.registered === 0
+        ? 'openlore federation add <path> --name <name>'
+        : anyReachable
+          ? ''
+          : 'openlore federation list  # then fix or re-add the unreachable peer path(s)',
     docs: 'docs/federation.md',
   });
 

--- a/src/core/services/mcp-handlers/blast-radius.test.ts
+++ b/src/core/services/mcp-handlers/blast-radius.test.ts
@@ -14,6 +14,13 @@ vi.mock('./utils.js', () => ({
 
 vi.mock('../../drift/git-diff.js', () => ({
   getChangedFiles: vi.fn(async () => ({ files: [{ path: 'src/utils.ts' }], resolvedBase: 'HEAD' })),
+  // The shared resolve-or-disclose helper (fix-cli-conclusion-honesty). Default: the ref
+  // resolves as-is (no fallback); individual tests override to force a disclosed fallback.
+  resolveBaseRefDisclosed: vi.fn(async (_d: string, requested: string) => ({
+    requested,
+    resolved: !requested || requested === 'auto' ? 'HEAD' : requested,
+    fellBack: false,
+  })),
 }));
 
 // Partial mock: stub handleAnalyzeImpact but keep buildAdjacency real (select_tests needs it).
@@ -26,11 +33,21 @@ vi.mock('./analysis.js', () => ({
   handleCheckSpecDrift: vi.fn(),
 }));
 
+// Real staleness reads disk; stub ONLY computeStaleness so we can drive it
+// deterministically, keeping every other confidence-boundary export (assembleBoundary,
+// edgeBasisWithinSet, …) real — other reachable handlers depend on them. Default: index
+// current (undefined) so the confidenceBoundary is omitted (existing assertions unaffected).
+vi.mock('./confidence-boundary.js', async (importActual) => {
+  const actual = await importActual<typeof import('./confidence-boundary.js')>();
+  return { ...actual, computeStaleness: vi.fn(async () => undefined) };
+});
+
 import { computeBlastRadius, type BlastRadiusBriefing } from './blast-radius.js';
 import { triggeredBlockPatterns } from '../../../cli/commands/blast-radius.js';
 import { readCachedContext } from './utils.js';
 import { handleAnalyzeImpact } from './graph.js';
 import { handleCheckSpecDrift } from './analysis.js';
+import { computeStaleness } from './confidence-boundary.js';
 import { assertConclusionShape } from './tool-contract.js';
 import type { FunctionNode, SerializedCallGraph, CallEdge } from '../../analyzer/call-graph.js';
 import type { DriftResult } from '../../../types/index.js';
@@ -83,6 +100,9 @@ describe('computeBlastRadius', () => {
       { id: 's1', kind: 'stale', severity: 'warning', message: 'mcp-handlers spec describes removed behavior', filePath: 'src/utils.ts', domain: 'mcp-handlers', specPath: 'openspec/specs/mcp-handlers/spec.md', suggestion: '' },
       { id: 'a1', kind: 'adr-orphaned', severity: 'warning', message: 'ADR references a domain that no longer exists', filePath: 'src/utils.ts', domain: 'mcp-handlers', specPath: null, suggestion: '' },
     ]));
+    // Default: index current. Composed handlers (select_tests) also call computeStaleness,
+    // so use a persistent value (not Once) — a fresh default is set every beforeEach.
+    vi.mocked(computeStaleness).mockResolvedValue(undefined);
   });
 
   it('briefs a hub change: callers, layers, tests, and anchored drift, as one conclusion', async () => {
@@ -138,13 +158,15 @@ describe('computeBlastRadius', () => {
   });
 
   it('reports the resolved base ref (and caveats the fallback) when the requested ref does not resolve', async () => {
-    // resolveBaseRef silently falls back to main when the requested ref is bogus;
-    // the briefing must report what git ACTUALLY diffed against, not the typo.
-    const { getChangedFiles } = await import('../../drift/git-diff.js');
+    // The shared helper falls back to main when the requested ref is bogus; the briefing
+    // must report what git ACTUALLY diffed against (and disclose it), not the typo.
+    const { getChangedFiles, resolveBaseRefDisclosed } = await import('../../drift/git-diff.js');
+    vi.mocked(resolveBaseRefDisclosed).mockResolvedValueOnce({ requested: 'totally-bogus-ref', resolved: 'main', fellBack: true });
     vi.mocked(getChangedFiles).mockResolvedValueOnce({ files: [{ path: 'src/utils.ts' }], resolvedBase: 'main' } as never);
     const b = await computeBlastRadius({ directory: '/p', baseRef: 'totally-bogus-ref' }) as BlastRadiusBriefing;
     expect(b.baseRef).toBe('totally-bogus-ref');     // what the caller asked for
     expect(b.resolvedBaseRef).toBe('main');          // what git actually diffed
+    expect(b.baseRefFallback).toEqual({ requested: 'totally-bogus-ref', resolved: 'main' });
     expect(b.caveats.join(' ')).toMatch(/Requested base ref "totally-bogus-ref" did not resolve.*diffed against "main"/i);
   });
 
@@ -153,6 +175,20 @@ describe('computeBlastRadius', () => {
     const b = await computeBlastRadius({ directory: '/p' }) as BlastRadiusBriefing;
     expect(b.resolvedBaseRef).toBe('HEAD');
     expect(b.caveats.join(' ')).not.toMatch(/did not resolve/i);
+  });
+
+  it('discloses index staleness when the graph predates the working tree (finding #2)', async () => {
+    // A risk headline computed over a stale graph must say so — the same boundary shape
+    // certify-public-surface already emits.
+    const marker = { indexCommit: 'abc1234', filesChangedSince: 42, detail: '42 source file(s) changed since abc1234.' };
+    vi.mocked(computeStaleness).mockResolvedValue(marker);
+    const b = await computeBlastRadius({ directory: '/p' }) as BlastRadiusBriefing;
+    expect(b.confidenceBoundary?.staleness).toEqual(marker);
+  });
+
+  it('omits the confidence boundary when the index is current (no false staleness noise)', async () => {
+    const b = await computeBlastRadius({ directory: '/p' }) as BlastRadiusBriefing;
+    expect(b.confidenceBoundary).toBeUndefined();
   });
 
   it('errors clearly when no analysis exists', async () => {

--- a/src/core/services/mcp-handlers/blast-radius.ts
+++ b/src/core/services/mcp-handlers/blast-radius.ts
@@ -22,6 +22,8 @@ import { validateDirectory, readCachedContext } from './utils.js';
 import { seedsFromFiles, handleSelectTests } from './test-impact.js';
 import { handleAnalyzeImpact } from './graph.js';
 import { handleCheckSpecDrift } from './analysis.js';
+import { assembleBoundary, computeStaleness } from './confidence-boundary.js';
+import type { ConfidenceBoundary } from './confidence-boundary.js';
 import type { SerializedCallGraph } from '../../analyzer/call-graph.js';
 import type { DriftIssue, DriftResult } from '../../../types/index.js';
 
@@ -105,6 +107,11 @@ export interface BlastRadiusBriefing {
     items: Array<{ kind: string; message: string; domain: string | null }>;
   };
   federation: { evaluated: false; note: string };
+  /** Present only when the requested base did not resolve; names both refs (fix-cli-conclusion-honesty). */
+  baseRefFallback?: { requested: string; resolved: string };
+  /** Index-staleness disclosure: a risk headline computed over a graph that predates the
+   * working tree must say so (fix-cli-conclusion-honesty). Absent when the index is current. */
+  confidenceBoundary?: ConfidenceBoundary;
   headline: string;
   posture: 'advisory';
   caveats: string[];
@@ -145,15 +152,18 @@ export async function computeBlastRadius(
 
   // ── 1. Resolve the diff → changed files → seed production symbols ───────────
   let changedFiles: string[] = [];
-  // resolveBaseRef silently falls back (main → master → HEAD~1) when the requested
-  // ref does not resolve; capture what git ACTUALLY diffed against so the briefing
-  // never misrepresents its base (honest-scope; mirrors no-silent-truncation).
+  // Resolve-or-disclose through the one shared helper (fix-cli-conclusion-honesty):
+  // an explicit ref that git can't resolve falls back (main → master → HEAD~1) and is
+  // disclosed, so the advisory briefing never misrepresents the base it diffed against.
   let resolvedBaseRef = baseRef;
+  let baseFellBack = false;
   try {
-    const { getChangedFiles } = await import('../../drift/git-diff.js');
-    const diff = await getChangedFiles({ rootPath: absDir, baseRef, includeUnstaged: true });
+    const { getChangedFiles, resolveBaseRefDisclosed } = await import('../../drift/git-diff.js');
+    const base = await resolveBaseRefDisclosed(absDir, baseRef);
+    resolvedBaseRef = base.resolved;
+    baseFellBack = base.fellBack;
+    const diff = await getChangedFiles({ rootPath: absDir, baseRef: resolvedBaseRef, includeUnstaged: true });
     changedFiles = diff.files.map(f => f.path);
-    resolvedBaseRef = diff.resolvedBase ?? baseRef;
   } catch (err) {
     return { error: `git diff failed (base ${baseRef}): ${err instanceof Error ? err.message : String(err)}` };
   }
@@ -205,7 +215,7 @@ export async function computeBlastRadius(
   let testToRun: Array<{ test: string; file: string; confidence: string }> = [];
   let testSoundness: unknown;
   try {
-    const sel = await handleSelectTests({ directory: absDir, diffRef: baseRef }) as {
+    const sel = await handleSelectTests({ directory: absDir, diffRef: resolvedBaseRef }) as {
       selectedTests?: Array<{ test: string; file: string; confidence: string }>;
       soundness?: unknown;
     };
@@ -225,7 +235,7 @@ export async function computeBlastRadius(
   let driftUnavailable: string | null = null;
   let driftRaw: unknown;
   try {
-    driftRaw = await handleCheckSpecDrift(absDir, baseRef, changedFiles, [], 'warning');
+    driftRaw = await handleCheckSpecDrift(absDir, resolvedBaseRef, changedFiles, [], 'warning');
   } catch (err) {
     // Drift is best-effort: a throw degrades to "unavailable" (reported as a
     // caveat), it never aborts the briefing (advisory — never block).
@@ -250,7 +260,7 @@ export async function computeBlastRadius(
     'Blast radius is an over-approximate structural prioritizer, not a behavioral test outcome.',
     'Impact and test selection can under-select through dynamic dispatch, reflection, and DI.',
   ];
-  if (resolvedBaseRef !== baseRef) {
+  if (baseFellBack) {
     caveats.push(`Requested base ref "${baseRef}" did not resolve; diffed against "${resolvedBaseRef}" instead (main → master → HEAD~1 fallback).`);
   }
   if (seeds.length > analyzed.length) {
@@ -276,9 +286,17 @@ export async function computeBlastRadius(
     caveats.push(`Detail lists truncated for brevity: ${capped.join(', ')} — see the counts for totals.`);
   }
 
+  // Index-staleness disclosure: a risk headline computed from a graph that predates
+  // the working tree must say so (fix-cli-conclusion-honesty). Same shared shape the
+  // certification commands emit; absent when the index is current.
+  const staleness = await computeStaleness(absDir);
+  const confidenceBoundary = assembleBoundary({ staleness, integrity: ctx.integrity });
+
   const briefing: BlastRadiusBriefing = {
     baseRef,
     resolvedBaseRef,
+    ...(baseFellBack ? { baseRefFallback: { requested: baseRef, resolved: resolvedBaseRef } } : {}),
+    ...(confidenceBoundary.complete ? {} : { confidenceBoundary }),
     changed: {
       files: changedFiles.length,
       symbols: seeds.length,

--- a/src/core/services/mcp-handlers/briefing-since.test.ts
+++ b/src/core/services/mcp-handlers/briefing-since.test.ts
@@ -16,8 +16,8 @@ vi.mock('./utils.js', () => ({
 
 vi.mock('../../drift/git-diff.js', () => ({
   getChangedFiles: vi.fn(),
-  // Default: any explicit ref resolves; individual tests override to force a fallback.
-  refExists: vi.fn(async () => true),
+  // The shared resolve-or-disclose helper; a per-test default is set in beforeEach.
+  resolveBaseRefDisclosed: vi.fn(),
 }));
 
 // Keep volatilityLevel real; stub only the git-history miner.
@@ -44,7 +44,7 @@ vi.mock('./confidence-boundary.js', () => ({
 
 import { handleBriefingSince } from './briefing-since.js';
 import { readCachedContext } from './utils.js';
-import { getChangedFiles, refExists } from '../../drift/git-diff.js';
+import { getChangedFiles, resolveBaseRefDisclosed } from '../../drift/git-diff.js';
 import { analyzeChangeCoupling } from '../../provenance/change-coupling.js';
 import type { FunctionNode, SerializedCallGraph, CallEdge } from '../../analyzer/call-graph.js';
 
@@ -95,7 +95,7 @@ interface BriefingResult {
 const mockedReadCtx = vi.mocked(readCachedContext);
 const mockedDiff = vi.mocked(getChangedFiles);
 const mockedCoupling = vi.mocked(analyzeChangeCoupling);
-const mockedRefExists = vi.mocked(refExists);
+const mockedResolve = vi.mocked(resolveBaseRefDisclosed);
 
 function diffFiles(paths: string[], resolvedBase = 'mainsha') {
   return {
@@ -116,7 +116,13 @@ function coupling(churn: Record<string, number>, commitsScanned: number) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockedReadCtx.mockResolvedValue({ callGraph: FIXTURE() } as unknown as Awaited<ReturnType<typeof readCachedContext>>);
-  mockedRefExists.mockResolvedValue(true); // explicit refs resolve unless a test overrides
+  // Default: the requested ref resolves as-is (explicit) or to 'mainsha' (auto), no fallback.
+  // Tests that exercise a fallback override this.
+  mockedResolve.mockImplementation(async (_dir: string, requested: string) => ({
+    requested,
+    resolved: !requested || requested === 'auto' ? 'mainsha' : requested,
+    fellBack: false,
+  }));
 });
 
 describe('handleBriefingSince', () => {
@@ -196,9 +202,12 @@ describe('handleBriefingSince', () => {
     expect(core(a)).toBe(core(b));
   });
 
-  it('discloses a SILENT base-ref fallback when an explicit ref cannot be resolved', async () => {
-    mockedRefExists.mockResolvedValue(false); // git can't resolve the requested ref
-    mockedDiff.mockResolvedValue(diffFiles(['src/core.ts'], 'main')); // resolveBaseRef fell back to main
+  it('surfaces the base-ref fallback the shared helper discloses', async () => {
+    // The fallback DETECTION is the helper's job (unit-tested in git-diff.test.ts); here we
+    // assert the briefing SURFACES it — structured field + leading caveat — so a typo'd
+    // --base never makes every number below authoritative-looking but wrong.
+    mockedResolve.mockResolvedValue({ requested: 'totally-bogus-ref', resolved: 'main', fellBack: true });
+    mockedDiff.mockResolvedValue(diffFiles(['src/core.ts'], 'main'));
     mockedCoupling.mockResolvedValue(coupling({ 'src/core.ts': 1 }, 40));
 
     const r = (await handleBriefingSince({ directory: '/repo', baseRef: 'totally-bogus-ref' })) as BriefingResult;
@@ -206,29 +215,12 @@ describe('handleBriefingSince', () => {
     expect(r.caveats[0]).toMatch(/could not be resolved.*briefed against "main"/i);
   });
 
-  it('does NOT report a fallback when the explicit ref resolves', async () => {
-    mockedRefExists.mockResolvedValue(true);
+  it('does NOT report a fallback when the helper resolves the ref as-is', async () => {
+    mockedResolve.mockResolvedValue({ requested: 'abc123', resolved: 'abc123', fellBack: false });
     mockedDiff.mockResolvedValue(diffFiles(['src/core.ts'], 'abc123'));
     mockedCoupling.mockResolvedValue(coupling({ 'src/core.ts': 1 }, 40));
 
     const r = (await handleBriefingSince({ directory: '/repo', baseRef: 'abc123' })) as BriefingResult;
-    expect(r.baseRefFallback).toBeUndefined();
-    // 'auto' base never triggers a resolve-check at all
-    mockedRefExists.mockClear();
-    await handleBriefingSince({ directory: '/repo' });
-    expect(mockedRefExists).not.toHaveBeenCalled();
-  });
-
-  it('does NOT false-flag a fallback for a usable base that resolves to itself (e.g. empty-tree SHA)', async () => {
-    // The empty-tree SHA is a valid git-diff base but is not a commit, so refExists
-    // (which peels ^{commit}) is false — yet resolveBaseRef returns it verbatim, so it
-    // is NOT a fallback. The resolvedBase===input short-circuit must suppress the flag.
-    const EMPTY_TREE = '4b825dc642cb6eb9a060e54bf899d15f71049056';
-    mockedRefExists.mockResolvedValue(false);
-    mockedDiff.mockResolvedValue(diffFiles(['src/core.ts'], EMPTY_TREE)); // resolved === requested
-    mockedCoupling.mockResolvedValue(coupling({ 'src/core.ts': 1 }, 40));
-
-    const r = (await handleBriefingSince({ directory: '/repo', baseRef: EMPTY_TREE })) as BriefingResult;
     expect(r.baseRefFallback).toBeUndefined();
     expect(r.caveats.some(c => /could not be resolved/i.test(c))).toBe(false);
   });

--- a/src/core/services/mcp-handlers/briefing-since.ts
+++ b/src/core/services/mcp-handlers/briefing-since.ts
@@ -28,7 +28,6 @@ import { seedsFromFiles, handleSelectTests } from './test-impact.js';
 import { isCodeNode, isExcludedPath } from './code-node.js';
 import { computeLandmarkSignals } from '../../analyzer/landmark-signals.js';
 import { analyzeChangeCoupling } from '../../provenance/change-coupling.js';
-import { refExists } from '../../drift/git-diff.js';
 import { assembleBoundary, computeStaleness } from './confidence-boundary.js';
 import {
   labelChangeSignificance,
@@ -82,29 +81,26 @@ export async function handleBriefingSince(input: BriefingSinceInput): Promise<un
   const baseRefInput = input.baseRef && input.baseRef.length > 0 ? input.baseRef : 'auto';
 
   // ── 1. Changed files since the base ref ─────────────────────────────────────
+  // Resolve-or-disclose through the one shared helper (fix-cli-conclusion-honesty):
+  // it returns the ref git actually diffs against (post main → master → HEAD~1
+  // fallback) AND whether the caller's explicit ref was genuinely unresolvable — so a
+  // typo'd `--base` is disclosed rather than silently briefing against a base the
+  // caller never asked for. The `auto` default explicitly requests the fallback chain.
   let resolvedBase: string;
+  let requestedRefUnresolved: boolean;
   let changedFiles: string[];
   try {
-    const { getChangedFiles } = await import('../../drift/git-diff.js');
-    const diff = await getChangedFiles({ rootPath: absDir, baseRef: baseRefInput, includeUnstaged: true });
-    resolvedBase = diff.resolvedBase;
+    const { getChangedFiles, resolveBaseRefDisclosed } = await import('../../drift/git-diff.js');
+    const base = await resolveBaseRefDisclosed(absDir, baseRefInput);
+    resolvedBase = base.resolved;
+    requestedRefUnresolved = base.fellBack;
+    const diff = await getChangedFiles({ rootPath: absDir, baseRef: resolvedBase, includeUnstaged: true });
     // Production code files only — tests/config/generated are not "changes that matter"
     // to rank; they still drive the tests-to-run selection below.
     changedFiles = diff.files.filter(f => !f.isTest).map(f => f.path);
   } catch (err) {
     return { error: `git diff failed (base ${baseRefInput}): ${err instanceof Error ? err.message : String(err)}` };
   }
-
-  // ── Honesty: detect a SILENT base-ref fallback ──────────────────────────────
-  // `resolveBaseRef` (inside getChangedFiles) returns an explicit ref verbatim when
-  // it verifies, and SILENTLY substitutes main → master → HEAD~1 → empty-tree when it
-  // does not — so `resolvedBase !== baseRefInput` is exactly "a fallback happened".
-  // We additionally confirm the requested ref is genuinely unresolvable, so a valid
-  // base that simply isn't a commit (e.g. the empty-tree SHA, which resolves to
-  // itself) is never mis-flagged. Briefing against a base the caller never asked for
-  // (a typo'd `--base`) would make every number below authoritative-looking but wrong.
-  const requestedRefUnresolved =
-    baseRefInput !== 'auto' && resolvedBase !== baseRefInput && !(await refExists(absDir, baseRefInput));
 
   // ── 2. Changed production symbols (file-level granularity) ──────────────────
   // A region scope (filePattern) narrows BOTH the briefed symbols and the file

--- a/src/core/services/mcp-handlers/coverage-gaps.ts
+++ b/src/core/services/mcp-handlers/coverage-gaps.ts
@@ -143,6 +143,7 @@ export async function handleReportCoverageGaps(input: ReportCoverageGapsInput): 
   let scopeIds: Set<string> | null = null;
   let changedDescriptor: string[] = [];
   let baseRefUsed: string | undefined;
+  let baseRefFallback: { requested: string; resolved: string } | undefined;
   let diffError: string | undefined;
   if (wantsDiff) {
     scope = 'diff';
@@ -153,8 +154,14 @@ export async function handleReportCoverageGaps(input: ReportCoverageGapsInput): 
       changedDescriptor = input.changedSymbols!;
     } else {
       try {
-        const { getChangedFiles } = await import('../../drift/git-diff.js');
-        const diff = await getChangedFiles({ rootPath: absDir, baseRef: baseRefUsed, includeUnstaged: true });
+        // Resolve-or-disclose through the one shared helper (fix-cli-conclusion-honesty): a
+        // typo'd diffRef silently falls back inside getChangedFiles, which would report gaps
+        // scoped to the wrong diff. Resolve first, disclose the fallback, diff the real base.
+        const { getChangedFiles, resolveBaseRefDisclosed } = await import('../../drift/git-diff.js');
+        const base = await resolveBaseRefDisclosed(absDir, baseRefUsed);
+        if (base.fellBack) baseRefFallback = { requested: baseRefUsed, resolved: base.resolved };
+        baseRefUsed = base.resolved;
+        const diff = await getChangedFiles({ rootPath: absDir, baseRef: base.resolved, includeUnstaged: true });
         const files = diff.files.map(f => f.path);
         changedDescriptor = files;
         scopeIds = new Set(seedsFromFiles(cg, files).map(s => s.id));
@@ -270,9 +277,16 @@ export async function handleReportCoverageGaps(input: ReportCoverageGapsInput): 
 
   const testedCount = inScope.filter(n => reachedByTest.has(n.id)).length;
 
+  // The unresolved-ref disclosure leads the caveats — it changes which base the diff
+  // scope was computed against, so it must not be buried under the gaps-only caveats.
+  if (baseRefFallback) {
+    caveats.unshift(`Requested base ref "${baseRefFallback.requested}" did not resolve; scoped gaps to the diff vs "${baseRefFallback.resolved}" instead (git's silent fallback). Pass a ref that exists to target the base you meant.`);
+  }
+
   return {
     scope,
     ...(scope === 'diff' ? { changed: changedDescriptor } : {}),
+    ...(baseRefFallback ? { baseRefFallback } : {}),
     ...(input.filePattern ? { filePattern: input.filePattern } : {}),
     analyzedSymbols: inScope.length,
     reachableFromTest: testedCount,

--- a/src/core/services/mcp-handlers/impact-certificate.ts
+++ b/src/core/services/mcp-handlers/impact-certificate.ts
@@ -110,6 +110,8 @@ export interface ImpactCertificate {
   /** The base ref the diff was computed against (post-fallback). */
   baseRef: string;
   resolvedBaseRef: string;
+  /** Present only when the requested base did not resolve and --allow-base-fallback accepted the fallback. */
+  baseRefFallback?: { requested: string; resolved: string };
   /** The change id, when assessed in a spec-store context; else 'working-tree'. */
   change: string;
   changed: { files: number; symbols: number };
@@ -141,6 +143,11 @@ export interface ImpactCertificateInput {
   change?: string;
   /** Persist the certificate under `.openlore/impact-certificates/` for later decay re-checks. */
   persist?: boolean;
+  /**
+   * Certification is fatal on an unresolvable base by default (fix-cli-conclusion-honesty).
+   * Set this to accept the disclosed main → master → HEAD~1 fallback instead.
+   */
+  allowBaseFallback?: boolean;
 }
 
 const SEVERITY_RANK: Record<CoveringSurfaceSeverity, number> = { info: 1, warn: 2, critical: 3 };
@@ -251,12 +258,6 @@ async function fileAtRef(rootPath: string, ref: string, path: string): Promise<s
   } catch {
     return '';
   }
-}
-
-/** The ref git actually diffs against once `baseRef` is resolved (main → master → HEAD~1 fallback). */
-async function resolveDiffBase(rootPath: string, baseRef: string): Promise<string | undefined> {
-  const { resolveBaseRef } = await import('../../drift/git-diff.js');
-  try { return await resolveBaseRef(rootPath, baseRef); } catch { return undefined; }
 }
 
 /**
@@ -781,7 +782,7 @@ function renderHeadline(cert: ImpactCertificate): string {
  */
 export async function computeImpactCertificate(
   input: ImpactCertificateInput,
-): Promise<ImpactCertificate | { error: string }> {
+): Promise<ImpactCertificate | { error: string; baseUnresolved?: boolean }> {
   const absDir = await validateDirectory(input.directory);
   const ctx = await readCachedContext(absDir);
   if (!ctx) return { error: 'No analysis found. Run analyze_codebase first.' };
@@ -789,6 +790,16 @@ export async function computeImpactCertificate(
   const cg = ctx.callGraph as SerializedCallGraph;
   const baseRef = input.baseRef && input.baseRef.length > 0 ? input.baseRef : 'HEAD';
   const change = input.change && input.change.trim() ? input.change.trim() : 'working-tree';
+
+  // Certification is fatal on an unresolvable base (fix-cli-conclusion-honesty): a
+  // certificate against a base the caller did not ask for is not a certificate.
+  const { resolveBaseRefDisclosed } = await import('../../drift/git-diff.js');
+  let baseResolution: Awaited<ReturnType<typeof resolveBaseRefDisclosed>>;
+  try { baseResolution = await resolveBaseRefDisclosed(absDir, baseRef); }
+  catch (e) { return { error: `cannot resolve base ref: ${e instanceof Error ? e.message : String(e)}` }; }
+  if (baseResolution.fellBack && !input.allowBaseFallback) {
+    return { error: `base ref "${baseResolution.requested}" did not resolve — refusing to certify against a fallback base ("${baseResolution.resolved}"). Pass an existing ref, or --allow-base-fallback to accept the disclosed fallback.`, baseUnresolved: true };
+  }
 
   // ── 1. Declared surfaces config (additive; absent = nothing to assess against) ─
   let surfaceCfg: CoveringSurfaceConfig[] = [];
@@ -802,11 +813,11 @@ export async function computeImpactCertificate(
 
   // ── 3. Changed files → edge delta (the differential's authoritative input) ───
   let changedEntries: ChangedFileEntry[] = [];
-  let resolvedBaseRef = baseRef;
+  let resolvedBaseRef = baseResolution.resolved;
   let diffError: string | null = null;
   try {
     changedEntries = await collectChangedFiles(absDir, baseRef);
-    resolvedBaseRef = (await resolveDiffBase(absDir, baseRef)) ?? baseRef;
+    resolvedBaseRef = baseResolution.resolved;
   } catch (err) {
     diffError = err instanceof Error ? err.message : String(err);
   }
@@ -895,7 +906,8 @@ export async function computeImpactCertificate(
     'A surface is the declared boundary; symbols outside every declared surface are not assessed.',
   ];
   if (diffError) caveats.push(`The change diff could not be read (base ${baseRef}): ${diffError}. Newly-opened paths were not computed.`);
-  if (resolvedBaseRef !== baseRef) caveats.push(`Requested base ref "${baseRef}" did not resolve; diffed against "${resolvedBaseRef}".`);
+  // Only reachable when --allow-base-fallback was set (an unresolvable base is otherwise fatal).
+  if (baseResolution.fellBack) caveats.push(`Requested base ref "${baseResolution.requested}" did not resolve; certified against "${resolvedBaseRef}" (--allow-base-fallback).`);
   if (unresolvedAdded.length > 10) caveats.push(`${unresolvedAdded.length} added calls had ambiguous callees and were not assessed (first 10 listed as findings).`);
   for (const t of truncatedSurfaces) {
     caveats.push(`Surface "${t.surface}" had ${t.total} newly-opened paths; the certificate lists the ${t.shown} shortest (count is authoritative in the finding).`);
@@ -911,6 +923,7 @@ export async function computeImpactCertificate(
   const cert: ImpactCertificate = {
     kind: 'impact-certificate', version: 1,
     baseRef, resolvedBaseRef, change,
+    ...(baseResolution.fellBack ? { baseRefFallback: { requested: baseResolution.requested, resolved: resolvedBaseRef } } : {}),
     changed: { files: changedFiles.length, symbols: symbolCount },
     surfaces: surfaceViews,
     newlyOpenedPaths,

--- a/src/core/services/mcp-handlers/public-surface.test.ts
+++ b/src/core/services/mcp-handlers/public-surface.test.ts
@@ -1,5 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import { assembleSurfaceDiff } from './public-surface.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assembleSurfaceDiff, computeCertifyPublicSurface } from './public-surface.js';
+
+// Mock only the two utils the handler reads; the pure assembleSurfaceDiff core below
+// does not touch them, so the existing suite is unaffected. git-diff is imported
+// dynamically inside the handler, so vi.mock still intercepts it.
+vi.mock('./utils.js', () => ({
+  validateDirectory: vi.fn(async (d: string) => d),
+  readCachedContext: vi.fn(async () => ({ callGraph: { nodes: [] } })),
+}));
+vi.mock('../../drift/git-diff.js', () => ({
+  validateGitRef: vi.fn(() => {}),
+  getChangedFiles: vi.fn(async () => ({ files: [], resolvedBase: 'main' })),
+  resolveBaseRefDisclosed: vi.fn(async (_d: string, requested: string) => ({
+    requested,
+    resolved: 'main',
+    fellBack: requested === 'bogus-ref',
+  })),
+}));
 
 type File = { path: string; content: string; language: string };
 const ts = (path: string, content: string): File => ({ path, content, language: 'TypeScript' });
@@ -254,5 +274,32 @@ describe('assembleSurfaceDiff — breaking-change classification over file conte
     const r = await assembleSurfaceDiff(base, head, noRename);
     expect(r.extraCrossings.length).toBe(1);
     expect(r.extraCrossings[0].kind).toBe('unindexed-repo');
+  });
+});
+
+describe('handleCertifyPublicSurface — base-ref is fatal on non-resolution (fix-cli-conclusion-honesty)', () => {
+  let dir: string;
+  beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), 'openlore-certbase-')); });
+  afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it('a typo\'d --base cannot produce a clean certificate — it errors, no verdict', async () => {
+    const r = (await computeCertifyPublicSurface({ directory: dir, baseRef: 'bogus-ref' })) as Record<string, unknown>;
+    expect(r.error).toMatch(/base ref "bogus-ref" did not resolve/i);
+    expect(r.error).toMatch(/refusing to certify/i);
+    expect(r.mode).toBeUndefined(); // no diff verdict was produced
+  });
+
+  it('--allow-base-fallback opts back into the disclosed fallback (verdict against main, disclosed)', async () => {
+    const r = (await computeCertifyPublicSurface({ directory: dir, baseRef: 'bogus-ref', allowBaseFallback: true })) as Record<string, unknown>;
+    expect(r.error).toBeUndefined();
+    expect(r.mode).toBe('diff');
+    expect(r.baseRefFallback).toEqual({ requested: 'bogus-ref', resolved: 'main' });
+  });
+
+  it('a resolvable --base produces a verdict with no fallback disclosure', async () => {
+    const r = (await computeCertifyPublicSurface({ directory: dir, baseRef: 'HEAD' })) as Record<string, unknown>;
+    expect(r.error).toBeUndefined();
+    expect(r.mode).toBe('diff');
+    expect(r.baseRefFallback).toBeUndefined();
   });
 });

--- a/src/core/services/mcp-handlers/public-surface.ts
+++ b/src/core/services/mcp-handlers/public-surface.ts
@@ -54,6 +54,12 @@ export interface CertifyPublicSurfaceInput {
   baseRef?: string;
   /** Cap the surface listing (surface mode). */
   maxResults?: number;
+  /**
+   * Certification is fatal on an unresolvable base by default: a verdict computed
+   * against a base the caller did not ask for is not a certificate. Set this to accept
+   * the disclosed main → master → HEAD~1 fallback instead (fix-cli-conclusion-honesty).
+   */
+  allowBaseFallback?: boolean;
 }
 
 // ── exported-name extraction (the surface predicate, computable on any content) ──
@@ -387,11 +393,18 @@ async function diffSurface(
   absDir: string,
   ctx: Awaited<ReturnType<typeof readCachedContext>>,
   baseRef: string,
+  allowBaseFallback: boolean,
 ): Promise<unknown> {
-  const { resolveBaseRef, validateGitRef } = await import('../../drift/git-diff.js');
+  const { resolveBaseRefDisclosed, validateGitRef } = await import('../../drift/git-diff.js');
   try { validateGitRef(baseRef); } catch (e) { return { error: (e as Error).message }; }
-  let resolvedBase: string;
-  try { resolvedBase = await resolveBaseRef(absDir, baseRef); } catch (e) { return { error: `cannot resolve base ref: ${(e as Error).message}` }; }
+  let base: Awaited<ReturnType<typeof resolveBaseRefDisclosed>>;
+  try { base = await resolveBaseRefDisclosed(absDir, baseRef); } catch (e) { return { error: `cannot resolve base ref: ${(e as Error).message}` }; }
+  // Certification is fatal on an unresolvable base: never certify against a base the
+  // caller did not ask for (fix-cli-conclusion-honesty). --allow-base-fallback opts in.
+  if (base.fellBack && !allowBaseFallback) {
+    return { error: `base ref "${base.requested}" did not resolve — refusing to certify the public surface against a fallback base ("${base.resolved}"). Pass an existing ref, or --allow-base-fallback to accept the disclosed fallback.` };
+  }
+  const resolvedBase = base.resolved;
   const oldRef = await mergeBase(absDir, resolvedBase);
 
   const changed = await changedSourceFiles(absDir, resolvedBase);
@@ -414,6 +427,9 @@ async function diffSurface(
     mode: 'diff',
     base: resolvedBase,
     head: 'working tree',
+    // An allowed fallback (base.fellBack was true but --allow-base-fallback was set)
+    // is disclosed structurally so the verdict never hides the base it actually used.
+    ...(base.fellBack ? { baseRefFallback: { requested: base.requested, resolved: resolvedBase } } : {}),
     ...diff,
     confidenceBoundary: assembleBoundary({ staleness: await computeStaleness(absDir), integrity: ctx?.integrity, extraCrossings }),
   };
@@ -630,7 +646,7 @@ export async function computeCertifyPublicSurface(input: CertifyPublicSurfaceInp
     return { error: 'No analysis found. Run analyze_codebase first.' };
   }
   if (input.baseRef && input.baseRef.trim().length > 0) {
-    return diffSurface(absDir, ctx, input.baseRef.trim());
+    return diffSurface(absDir, ctx, input.baseRef.trim(), input.allowBaseFallback ?? false);
   }
   return listSurface(absDir, ctx, input.maxResults ?? 200);
 }

--- a/src/core/services/mcp-handlers/style-fingerprint.test.ts
+++ b/src/core/services/mcp-handlers/style-fingerprint.test.ts
@@ -62,6 +62,25 @@ describe('handleGetStyleFingerprint', () => {
     expect(go.idioms.functionNaming).toEqual({ signal: null, reason: 'enforced' });
   });
 
+  it('an unrecognized --language is a not-found error, never a quiet empty (finding #3)', async () => {
+    // The tool family whose selling point is "a null signal, never a quiet empty" must
+    // not answer a typo'd language with byLanguage: []; it errors and lists the known set.
+    const res = (await handleGetStyleFingerprint({ directory: dir, language: 'Klingon' })) as Record<string, unknown>;
+    expect(res.error).toMatch(/No style fingerprint for language "Klingon"/);
+    expect(res.error).toMatch(/TypeScript/);
+    expect(res.knownLanguages).toEqual(['Go', 'JavaScript', 'Python', 'TypeScript']);
+    expect(res.byLanguage).toBeUndefined();
+  });
+
+  it('a supported-but-absent language returns an honest note, not a silent empty', async () => {
+    // Python IS a supported style-fingerprint language, just not present in this fixture.
+    // That is a legitimate empty — but disclosed with a note, never a bare byLanguage: [].
+    const res = (await handleGetStyleFingerprint({ directory: dir, language: 'python' })) as Record<string, unknown>;
+    expect(res.error).toBeUndefined();
+    expect(res.byLanguage).toEqual([]);
+    expect(res.note).toMatch(/Python is a supported language but no functions were sampled/i);
+  });
+
   it('region scope returns one community profile', async () => {
     const res = (await handleGetStyleFingerprint({ directory: dir, communityId: 'reg2' })) as Record<string, unknown>;
     expect(res.scope).toBe('region');

--- a/src/core/services/mcp-handlers/style-fingerprint.ts
+++ b/src/core/services/mcp-handlers/style-fingerprint.ts
@@ -17,9 +17,25 @@ import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_STYLE_FINGERPRINT } fr
 import {
   fileProfile,
   STYLE_SCHEMA_VERSION,
+  STYLE_FINGERPRINT_LANGUAGES,
   type StyleFingerprint,
   type LanguageProfile,
 } from '../../analyzer/style-fingerprint.js';
+
+/** The style-fingerprint-supported languages, canonical-cased and sorted, for disclosure. */
+const KNOWN_STYLE_LANGUAGES = [...STYLE_FINGERPRINT_LANGUAGES].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+/**
+ * Resolve a requested language name (case-insensitive) to its canonical style-fingerprint
+ * language, or null when it is not a language style fingerprints are computed for. Lets the
+ * handler reject an unrecognized `--language` with a not-found shape instead of a quiet empty —
+ * matching the honesty of the `--file` path and `get_language_support`.
+ */
+function resolveStyleLanguage(language: string): string | null {
+  const want = language.trim().toLowerCase();
+  for (const l of STYLE_FINGERPRINT_LANGUAGES) if (l.toLowerCase() === want) return l;
+  return null;
+}
 
 export interface GetStyleFingerprintInput {
   directory: string;
@@ -118,6 +134,19 @@ export async function handleGetStyleFingerprint(input: GetStyleFingerprintInput)
     };
   }
 
+  // An unrecognized `--language` is a not-found, never a quiet empty (fix-cli-conclusion-honesty):
+  // the tool family whose selling point is "a null signal, never a quiet empty" must not answer a
+  // typo'd language with `byLanguage: []`. A language that IS supported but absent from this repo
+  // is a legitimate empty (handled per-scope below with a note), so gate the error on the
+  // capability set, not on presence in this repo.
+  const requestedLanguage = input.language?.trim();
+  if (requestedLanguage && !resolveStyleLanguage(requestedLanguage)) {
+    return {
+      error: `No style fingerprint for language "${input.language}". Style fingerprints are computed only for: ${KNOWN_STYLE_LANGUAGES.join(', ')}.`,
+      knownLanguages: KNOWN_STYLE_LANGUAGES,
+    };
+  }
+
   // Single file.
   if (input.filePath) return resolveFileProfile(fp, input.filePath);
 
@@ -130,23 +159,36 @@ export async function handleGetStyleFingerprint(input: GetStyleFingerprintInput)
         availableRegions: fp.regions.slice(0, 25).map(r => ({ communityId: r.communityId, label: r.label })),
       };
     }
+    const byLanguage = filterByLanguage(region.byLanguage, input.language);
     return {
       scope: 'region',
       communityId: region.communityId,
       label: region.label,
       evidenceFloor: fp.evidenceFloor,
-      byLanguage: filterByLanguage(region.byLanguage, input.language),
-      note: DESCRIPTIVE_NOTE,
+      byLanguage,
+      note: emptyLanguageNote(requestedLanguage, byLanguage) ?? DESCRIPTIVE_NOTE,
     };
   }
 
   // Default: the whole repository, sliced per language.
+  const byLanguage = filterByLanguage(fp.byLanguage, input.language);
   return {
     scope: 'repository',
     evidenceFloor: fp.evidenceFloor,
     languagesAnalyzed: fp.generatedLanguages,
-    byLanguage: filterByLanguage(fp.byLanguage, input.language),
+    byLanguage,
     regionCount: fp.regions.length,
-    note: DESCRIPTIVE_NOTE,
+    note: emptyLanguageNote(requestedLanguage, byLanguage) ?? DESCRIPTIVE_NOTE,
   };
+}
+
+/**
+ * A supported language that produced no profile in this scope is a legitimate empty — but not a
+ * SILENT one. Return a note distinguishing "supported here, but no functions sampled" from the
+ * unrecognized-language error above; null when there is a profile (the descriptive note applies).
+ */
+function emptyLanguageNote(requestedLanguage: string | undefined, byLanguage: LanguageProfile[]): string | undefined {
+  if (!requestedLanguage || byLanguage.length > 0) return undefined;
+  const canonical = resolveStyleLanguage(requestedLanguage) ?? requestedLanguage;
+  return `${canonical} is a supported language but no functions were sampled in this scope (nothing above the evidence floor). ${DESCRIPTIVE_NOTE}`;
 }


### PR DESCRIPTION
**Status:** LGTM — full suite green (5958 passed, 2 skipped), typecheck + lint clean, E2E-verified on built dist. Ships `fix-cli-conclusion-honesty` from the 2026-07 e2e audit.

## What was wrong

The honesty contract's own disciplines — resolve-or-disclose a `--base` ref, disclose index staleness, never quiet-empty on an unknown input — were applied by some conclusion commands and silently skipped by their siblings. A live dogfood of ~50 CLI commands (v2.1.5) found four such gaps, each already implemented correctly once elsewhere:

1. **Silent base-ref fallback.** `certify-public-surface --base not-a-ref` → exit 0, a clean `non-breaking` verdict against `main`, with no disclosure the requested ref never resolved — the worst failure for a certification tool.
2. **Missing staleness disclosure.** `blast-radius` printed `highest risk: critical` over a graph that predated the very commits being briefed, with no mention it was stale.
3. **Quiet-empty on unknown enum.** `style-fingerprint --language Klingon` → exit 0, `byLanguage: []` — from the tool family whose selling point is "a null signal, never a quiet empty."
4. **Health conflation.** `features` showed Federation as active ✓ while `federation list` reported every peer `✗ missing path` — counting registry rows as health.

## What it does

- **One shared `resolveBaseRefDisclosed` helper** (`git-diff.ts`) that every `--base` command routes through. Certification commands (`certify-public-surface`, `impact-certificate`) now **fail non-zero** on an unresolvable base — `--allow-base-fallback` opts back into disclosed fallback. Advisory commands (`blast-radius`, `briefing-since`, `coverage-gaps`) attach a structured `baseRefFallback`. `enforce`/`review` inherit it via their delegates. The impact-certificate **hook** stays advisory (never blocks a commit) by opting into fallback.
- **blast-radius** now emits the shared staleness `confidenceBoundary` (build commit + changed-file count), the same shape `certify-public-surface` already emitted.
- **style-fingerprint** `--language <unknown>` returns a not-found shape (exit 1, known languages listed); a supported-but-absent language returns an honest note instead of a bare `[]`.
- **features** reports federation health by peer **resolvability**, reusing `federation list`'s `evaluateRepoState` verdicts, so the two can never disagree.
- **Parity guard** (`conclusion-honesty-parity.test.ts`): a source-level test enumerates every `--base` / cached-graph command and fails when a new one forgets the helper.

## Proof it works

- New unit tests: `resolveBaseRefDisclosed` (detection: explicit-unresolvable → fallback, resolvable → not, empty-tree resolves-to-itself → not, auto → not); certify-public-surface fatal + opt-in fallback; impact-certificate CLI hook-vs-direct exit codes; blast-radius staleness surfacing; style-fingerprint unknown/absent language; features degraded federation.
- Parity guard passes and is self-enforcing.
- E2E on built dist (`node dist/cli/index.js`): certify/impact-cert bogus base → exit 1; valid base → exit 0; impact-cert `--hook` bogus base → exit 0 (advisory); style-fingerprint Klingon → exit 1; blast-radius prints the staleness line; briefing-since/coverage-gaps disclose `baseRefFallback`; `features` and the MCP server boot clean.

## Notes

- **Behavior change:** certification commands newly error on a bogus `--base` (the correct behavior); opt-out is `--allow-base-fallback`.
- Scope grew by one command beyond the four findings: `coverage-gaps` also resolves `--base` directly, so it was wired through the same helper to keep the parity guard honest (no exemptions).
- Specs: `cli` ADDs `BaseRefResolutionIsDisclosedOrFatal` and `ConclusionCommandsDiscloseIndexStaleness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)