### PR TITLE
fix(cli): uniform output contracts — color layer, fatal --config, honest summaries, one vocabulary

### DIFF
--- a/openspec/changes/fix-cli-output-hygiene/proposal.md
+++ b/openspec/changes/fix-cli-output-hygiene/proposal.md
@@ -1,9 +1,20 @@
 # CLI output hygiene: color contract, config errors, honest summaries, one vocabulary
 
-> Status: PROPOSED (2026-07-03, e2e audit). A live dogfood of all ~50 CLI commands surfaced a
-> batch of small output/UX defects — none dangerous alone, together they erode the polish the
-> happy-path work just shipped. One change, one review, all of them fixed, each with a regression
-> test.
+> Status: SHIPPED (2026-07-18). All six gaps fixed, each with a regression test. Notes on how it
+> landed: (1) color now flows through a shared layer `src/utils/colors.ts` (chalk-backed,
+> `--no-color`/non-TTY aware) — `decisions.ts` and the `--insecure` warning in `index.ts` moved off
+> raw ANSI, and the already-gated `doctor.ts`/`features.ts` were converted too so the repo-wide
+> guard (`src/cli/output-hygiene.test.ts`) needs only one exemption: the full-screen interactive
+> `tui-approval.ts`. (2) An explicit `--config` that can't be read is fatal (`src/cli/config-guard.ts`,
+> unit-tested); this scopes to fatal-on-missing — fully redirecting every `readOpenLoreConfig` call
+> site to an arbitrary path stays out of scope. (3) `doctor`'s summary now names the checks that
+> actually warned. (4) CLI hints translate MCP tool names to CLI commands via
+> `src/cli/surface-vocabulary.ts` (`analyze_codebase` → `openlore analyze`). (5) `decisions --list`
+> renders `verified` as `⧖` "awaiting review" with a legend, distinct from approved/synced.
+> (6) Cosmetics: the LanceDB native-log knob is `LANCEDB_LOG` (NOT `RUST_LOG`, verified empirically) —
+> defaulted to `error` before the first addon import at both call sites; export prints an absolute
+> path instead of a `../../..` chain when the artifact lands outside the repo; `init` detects a
+> pure-TS project (`tsconfig.json`, no `package.json`); `manifest emit` gains `--dry-run`.
 
 ## The gaps (all live-reproduced, v2.1.5)
 

--- a/openspec/changes/fix-cli-output-hygiene/tasks.md
+++ b/openspec/changes/fix-cli-output-hygiene/tasks.md
@@ -1,21 +1,21 @@
 # Tasks — CLI output hygiene
 
 ## Implementation
-- [ ] decisions --list via logger/chalk; guard test: no raw \x1b[ literals under src/cli
-- [ ] --config missing/unreadable → fatal error naming the path
-- [ ] doctor summary derived from emitted warnings (per-check fragments)
-- [ ] Surface-parameterized hint templates (CLI says `openlore analyze`, MCP says the tool name);
+- [x] decisions --list via logger/chalk; guard test: no raw \x1b[ literals under src/cli
+- [x] --config missing/unreadable → fatal error naming the path
+- [x] doctor summary derived from emitted warnings (per-check fragments)
+- [x] Surface-parameterized hint templates (CLI says `openlore analyze`, MCP says the tool name);
       guard test for MCP tool names in CLI hint strings
-- [ ] decisions --list glyph set + legend; `verified` rendered "awaiting review"
-- [ ] Cosmetics: scope lance WARN logging; absolute/repo-relative export paths; init detects
+- [x] decisions --list glyph set + legend; `verified` rendered "awaiting review"
+- [x] Cosmetics: scope lance WARN logging; absolute/repo-relative export paths; init detects
       plain-TS projects; manifest emit --dry-run
 
 ## Verification
-- [ ] `--no-color decisions --list | cat -v` shows zero escape bytes
-- [ ] `--config /nonexistent` exits non-zero naming the path
-- [ ] doctor with only a staleness warning summarizes staleness
-- [ ] find-clones unknown-symbol hint names `openlore analyze`
-- [ ] Full suite green
+- [x] `--no-color decisions --list | cat -v` shows zero escape bytes
+- [x] `--config /nonexistent` exits non-zero naming the path
+- [x] doctor with only a staleness warning summarizes staleness
+- [x] find-clones unknown-symbol hint names `openlore analyze`
+- [x] Full suite green
 
 ## Spec
-- [ ] `cli` delta: ADD OutputContractsAreUniform
+- [x] `cli` delta: ADD OutputContractsAreUniform

--- a/src/cli/commands/decisions-render.test.ts
+++ b/src/cli/commands/decisions-render.test.ts
@@ -1,0 +1,60 @@
+/**
+ * A gate-blocking `verified` decision must read as "awaiting review" — a glyph
+ * distinct from the done statuses (approved/synced), with a legend — and the row
+ * must carry no raw ANSI when color is off (OutputContractsAreUniform, change:
+ * fix-cli-output-hygiene).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { displayDecision, printDecisionLegend } from './decisions.js';
+import { configureLogger } from '../../utils/logger.js';
+import type { PendingDecision } from '../../types/index.js';
+
+function capture(fn: () => void): string {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((m?: unknown) => { lines.push(String(m ?? '')); });
+  try { fn(); } finally { spy.mockRestore(); }
+  return lines.join('\n');
+}
+
+function decision(status: PendingDecision['status']): PendingDecision {
+  return {
+    id: 'a1b2c3d4',
+    title: 'Use JWTs',
+    rationale: 'stateless',
+    status,
+    confidence: 'high',
+    affectedFiles: [],
+    affectedDomains: [],
+  } as unknown as PendingDecision;
+}
+
+describe('decisions rendering', () => {
+  beforeEach(() => configureLogger({ noColor: true }));
+  afterEach(() => { configureLogger({ noColor: false }); vi.restoreAllMocks(); });
+
+  it('renders a verified decision with the awaiting-review glyph, not a done checkmark', () => {
+    const out = capture(() => displayDecision(decision('verified')));
+    expect(out).toContain('⧖');
+    // Must not read as done (approved ● / synced ✔ / a bare ✓).
+    expect(out).not.toContain('✔');
+    expect(out).not.toMatch(/(^|[^⧖])✓/);
+  });
+
+  it('gives synced and approved distinct glyphs', () => {
+    expect(capture(() => displayDecision(decision('synced')))).toContain('✔');
+    expect(capture(() => displayDecision(decision('approved')))).toContain('●');
+  });
+
+  it('legend explains that verified means awaiting review', () => {
+    const legend = capture(() => printDecisionLegend());
+    expect(legend.toLowerCase()).toContain('awaiting review');
+    expect(legend).toContain('⧖');
+  });
+
+  it('emits no raw ANSI escape bytes when color is off', () => {
+    const out = capture(() => { displayDecision(decision('verified')); printDecisionLegend(); });
+    // eslint-disable-next-line no-control-regex
+    expect(/\x1b\[/.test(out)).toBe(false);
+  });
+});

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -16,6 +16,7 @@ const execFileAsync = promisify(execFile);
 import { join } from 'node:path';
 
 import { logger } from '../../utils/logger.js';
+import { colorForStdout } from '../../utils/colors.js';
 import { redirectConsoleToStderr } from '../../utils/quiet-stdout.js';
 import { fileExists, resolveLLMProvider } from '../../utils/command-helpers.js';
 import { readOpenLoreConfig } from '../../core/services/config-manager.js';
@@ -472,26 +473,31 @@ async function runAutopilotGate(
 // DISPLAY HELPERS
 // ============================================================================
 
-function displayDecision(d: PendingDecision, verbose = false): void {
+export function displayDecision(d: PendingDecision, verbose = false): void {
+  const c = colorForStdout();
+
+  // Glyphs are visually distinct across statuses AND across the "done vs not
+  // done" divide: `verified` gate-BLOCKS a commit awaiting human review, so it
+  // must never read as a done checkmark (✓/✔). See printDecisionLegend.
   const icon =
-    d.status === 'verified'      ? '✓' :
-    d.status === 'phantom'       ? '↗' :
-    d.status === 'approved'      ? '●' :
-    d.status === 'auto-approved' ? '◉' :
-    d.status === 'synced'        ? '✔' :
-    d.status === 'rejected'      ? '✗' : '○';
+    d.status === 'verified'      ? c.yellow('⧖') :   // awaiting review (blocks the gate)
+    d.status === 'phantom'       ? c.yellow('↗') :   // recorded but not in the diff
+    d.status === 'approved'      ? c.blue('●')   :
+    d.status === 'auto-approved' ? c.blue('◉')   :
+    d.status === 'synced'        ? c.green('✔')  :
+    d.status === 'rejected'      ? c.red('✗')    : c.dim('○');
 
   const confidence =
-    d.confidence === 'high'   ? '\x1b[32mhigh\x1b[0m' :
-    d.confidence === 'medium' ? '\x1b[33mmedium\x1b[0m' :
-                                '\x1b[31mlow\x1b[0m';
+    d.confidence === 'high'   ? c.green('high') :
+    d.confidence === 'medium' ? c.yellow('medium') :
+                                c.red('low');
 
   const scopeLabel = d.scope ?? 'component';
   const scopeBadge =
-    scopeLabel === 'system'       ? `\x1b[31m[${scopeLabel}]\x1b[0m` :
-    scopeLabel === 'cross-domain' ? `\x1b[33m[${scopeLabel}]\x1b[0m` :
-    scopeLabel === 'component'    ? `\x1b[34m[${scopeLabel}]\x1b[0m` :
-                                    `\x1b[90m[${scopeLabel}]\x1b[0m`;
+    scopeLabel === 'system'       ? c.red(`[${scopeLabel}]`) :
+    scopeLabel === 'cross-domain' ? c.yellow(`[${scopeLabel}]`) :
+    scopeLabel === 'component'    ? c.blue(`[${scopeLabel}]`) :
+                                    c.gray(`[${scopeLabel}]`);
 
   console.log(`${icon} [${d.id}] ${scopeBadge} ${d.title}`);
   if (verbose) {
@@ -501,6 +507,21 @@ function displayDecision(d: PendingDecision, verbose = false): void {
     if (d.proposedRequirement) console.log(`   Requirement: ${d.proposedRequirement}`);
     if (d.evidenceFile) console.log(`   Evidence   : ${d.evidenceFile}`);
   }
+}
+
+/**
+ * One-line glyph legend printed beneath any decision listing. Its job is to make
+ * a gate-blocking `verified` status legible as "awaiting review" — visually
+ * distinct from the done statuses (approved/synced) — rather than a bare glyph
+ * a reader has to guess at.
+ */
+export function printDecisionLegend(): void {
+  const c = colorForStdout();
+  console.log(
+    `\nLegend: ${c.yellow('⧖')} awaiting review   ${c.blue('●')} approved   ` +
+      `${c.blue('◉')} auto-accepted   ${c.green('✔')} synced   ${c.red('✗')} rejected   ` +
+      `${c.yellow('↗')} phantom`,
+  );
 }
 
 function displayMissing(missing: Array<{ file: string; description: string }>): void {
@@ -879,6 +900,8 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
         for (const d of phantom) displayDecision(d, options.verbose);
       }
 
+      if (verified.length > 0 || phantom.length > 0) printDecisionLegend();
+
       displayMissing(missing);
 
       console.log('\nApprove with: openlore decisions --approve <id>');
@@ -1135,6 +1158,7 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
 
     logger.section('Architectural Decisions');
     for (const d of all) displayDecision(d, options.verbose);
+    printDecisionLegend();
     console.log(`\nTotal: ${all.length}`);
     } catch (err) {
       logger.error(`decisions command failed: ${(err as Error).message}`);

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -542,6 +542,37 @@ describe('doctor command', () => {
       expect(vi.mocked(loggerModule.logger.error)).toHaveBeenCalled();
       expect(process.exitCode).toBe(1);
     });
+
+    it('non-JSON summary names the warned check, not a hardcoded "optional features" line (fix-cli-output-hygiene)', async () => {
+      doctorCommand.setOptionValue('json', false);
+
+      // Valid config so nothing FAILS; drop every provider key so the LLM check WARNS.
+      const configManager = await import('../../core/services/config-manager.js');
+      vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+        projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec', maxFiles: 500,
+      } as never);
+      const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'OPENAI_COMPAT_API_KEY'];
+      const saved: Record<string, string | undefined> = {};
+      for (const k of keyVars) { saved[k] = process.env[k]; delete process.env[k]; }
+
+      const llmService = await import('../../core/services/llm-service.js');
+      vi.mocked(llmService.createLLMService).mockImplementationOnce(() => { throw new Error('No API key'); });
+
+      const loggerModule = await import('../../utils/logger.js');
+      vi.mocked(loggerModule.logger.warning).mockClear();
+
+      try {
+        await doctorCommand.parseAsync(['node', 'doctor'], { from: 'user' });
+        const warnCalls = vi.mocked(loggerModule.logger.warning).mock.calls.map(c => String(c[0]));
+        const summary = warnCalls.find(m => /\d+ warning\(s\):/.test(m));
+        expect(summary, `expected a summary warning; got: ${JSON.stringify(warnCalls)}`).toBeTruthy();
+        // Derived from the actual warned checks, not the old hardcoded assumption.
+        expect(summary).toContain('LLM connection');
+        expect(summary).not.toContain('optional features (LLM generate, embeddings) may be limited');
+      } finally {
+        for (const k of keyVars) { if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k]; }
+      }
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { logger } from '../../utils/logger.js';
+import { palette } from '../../utils/colors.js';
 import { readOpenLoreConfig } from '../../core/services/config-manager.js';
 import { validateOpenLoreConfig } from '../../core/services/config-schema.js';
 import { EdgeStore } from '../../core/services/edge-store.js';
@@ -553,19 +554,18 @@ async function checkDiskSpace(rootPath: string): Promise<CheckResult> {
 // ============================================================================
 
 function printResult(r: CheckResult, useColor: boolean): void {
-  const icons: Record<CheckStatus, string> = { ok: '✓', warn: '⚠', fail: '✗' };
-  const colors: Record<CheckStatus, string> = {
-    ok: useColor ? '\x1b[32m' : '',
-    warn: useColor ? '\x1b[33m' : '',
-    fail: useColor ? '\x1b[31m' : '',
+  const c = palette(useColor);
+  const paint: Record<CheckStatus, (s: string) => string> = {
+    ok: (s) => c.green(s),
+    warn: (s) => c.yellow(s),
+    fail: (s) => c.red(s),
   };
-  const reset = useColor ? '\x1b[0m' : '';
-  const dim = useColor ? '\x1b[2m' : '';
+  const glyph: Record<CheckStatus, string> = { ok: '✓', warn: '⚠', fail: '✗' };
 
-  const icon = `${colors[r.status]}${icons[r.status]}${reset}`;
-  console.log(`  ${icon}  ${r.name.padEnd(22)} ${dim}${r.detail}${reset}`);
+  const icon = paint[r.status](glyph[r.status]);
+  console.log(`  ${icon}  ${r.name.padEnd(22)} ${c.dim(r.detail)}`);
   if (r.fix) {
-    console.log(`       ${' '.repeat(22)} ${colors.warn}→ ${r.fix}${reset}`);
+    console.log(`       ${' '.repeat(22)} ${c.yellow(`→ ${r.fix}`)}`);
   }
 }
 
@@ -655,7 +655,10 @@ Checks performed:
       logger.error(`${failures.length} check(s) failed${warnSuffix} — fix the failures above before proceeding`);
       process.exitCode = 1;
     } else if (warnings.length > 0) {
-      logger.warning(`${warnings.length} warning(s) — optional features (LLM generate, embeddings) may be limited`);
+      // Summarize the checks that actually warned, not a hardcoded assumption
+      // (a staleness warning must not read as "LLM/embeddings may be limited").
+      const warned = warnings.map(w => w.name).join(', ');
+      logger.warning(`${warnings.length} warning(s): ${warned} — see the details above`);
     } else {
       logger.success('All checks passed!');
     }

--- a/src/cli/commands/env-impact.ts
+++ b/src/cli/commands/env-impact.ts
@@ -15,6 +15,7 @@
 import { Command } from 'commander';
 import { logger, configureLogger } from '../../utils/logger.js';
 import { writeStdout } from '../output.js';
+import { toCliVocabulary } from '../surface-vocabulary.js';
 import { handleAnalyzeEnvImpact } from '../../core/services/mcp-handlers/env-impact.js';
 
 interface ReadSiteView {
@@ -121,15 +122,15 @@ export async function runEnvImpactCli(opts: EnvImpactCliOptions): Promise<number
     const r = result as EnvImpactView;
     if (opts.json) await writeStdout(JSON.stringify(result, null, 2) + '\n');
     else {
-      logger.warning(`env-impact: ${r.error}`);
+      logger.warning(`env-impact: ${toCliVocabulary(r.error ?? '')}`);
       if (r.candidates?.length) logger.info('candidates', r.candidates.join(', '));
-      if (r.hint) logger.info('hint', r.hint);
+      if (r.hint) logger.info('hint', toCliVocabulary(r.hint));
     }
     return 1;
   }
 
   if (opts.json) await writeStdout(JSON.stringify(result, null, 2) + '\n');
-  else await writeStdout(renderHuman(result as EnvImpactView) + '\n');
+  else await writeStdout(toCliVocabulary(renderHuman(result as EnvImpactView)) + '\n');
   return 0;
 }
 

--- a/src/cli/commands/error-propagation.ts
+++ b/src/cli/commands/error-propagation.ts
@@ -15,6 +15,7 @@
 import { Command } from 'commander';
 import { logger, configureLogger } from '../../utils/logger.js';
 import { writeStdout } from '../output.js';
+import { toCliVocabulary } from '../surface-vocabulary.js';
 import { handleAnalyzeErrorPropagation } from '../../core/services/mcp-handlers/error-propagation.js';
 
 interface EscapeView {
@@ -116,15 +117,15 @@ export async function runErrorPropagationCli(opts: ErrorPropagationCliOptions): 
     const r = result as ErrorPropagationView;
     if (opts.json) await writeStdout(JSON.stringify(result, null, 2) + '\n');
     else {
-      logger.warning(`error-propagation: ${r.error}`);
+      logger.warning(`error-propagation: ${toCliVocabulary(r.error ?? '')}`);
       if (r.candidates?.length) logger.info('candidates', r.candidates.join(', '));
-      if (r.hint) logger.info('hint', r.hint);
+      if (r.hint) logger.info('hint', toCliVocabulary(r.hint));
     }
     return 1;
   }
 
   if (opts.json) await writeStdout(JSON.stringify(result, null, 2) + '\n');
-  else await writeStdout(renderHuman(result as ErrorPropagationView) + '\n');
+  else await writeStdout(toCliVocabulary(renderHuman(result as ErrorPropagationView)) + '\n');
   return 0;
 }
 

--- a/src/cli/commands/features.ts
+++ b/src/cli/commands/features.ts
@@ -13,7 +13,9 @@
  */
 
 import { Command } from 'commander';
+import type { ChalkInstance } from 'chalk';
 import { logger } from '../../utils/logger.js';
+import { palette } from '../../utils/colors.js';
 import {
   collectFeatureInventory,
   type FeatureStatus,
@@ -26,39 +28,17 @@ const GROUP_ORDER: FeatureGroup[] = [
   'Multi-repo',
 ];
 
-interface Palette {
-  active: string;
-  inactive: string;
-  defaultOn: string;
-  hint: string;
-  dim: string;
-  reset: string;
-  bold: string;
-}
-
-function palette(useColor: boolean): Palette {
-  return {
-    active: useColor ? '\x1b[32m' : '', // green
-    inactive: useColor ? '\x1b[2m' : '', // dim
-    defaultOn: useColor ? '\x1b[36m' : '', // cyan
-    hint: useColor ? '\x1b[33m' : '', // yellow
-    dim: useColor ? '\x1b[2m' : '',
-    reset: useColor ? '\x1b[0m' : '',
-    bold: useColor ? '\x1b[1m' : '',
-  };
-}
-
-function printFeature(f: FeatureStatus, p: Palette): void {
+function printFeature(f: FeatureStatus, c: ChalkInstance): void {
   const icon =
     f.state === 'active'
-      ? `${p.active}✓${p.reset}`
+      ? c.green('✓')
       : f.state === 'default-on'
-        ? `${p.defaultOn}•${p.reset}`
-        : `${p.inactive}○${p.reset}`;
-  console.log(`  ${icon}  ${f.title.padEnd(38)} ${p.dim}${f.detail}${p.reset}`);
+        ? c.cyan('•')
+        : c.dim('○');
+  console.log(`  ${icon}  ${f.title.padEnd(38)} ${c.dim(f.detail)}`);
   // Show the activation hint only when there is an action to take.
   if (f.state === 'inactive' && f.activate) {
-    console.log(`         ${' '.repeat(38)} ${p.hint}→ ${f.activate}${p.reset}`);
+    console.log(`         ${' '.repeat(38)} ${c.yellow(`→ ${f.activate}`)}`);
   }
 }
 
@@ -88,7 +68,7 @@ the whole structural graph work with no keys set. The features below are all opt
     }
 
     const useColor = Boolean(process.stdout.isTTY);
-    const p = palette(useColor);
+    const c = palette(useColor);
 
     logger.section('openlore features');
     console.log('');
@@ -99,7 +79,7 @@ the whole structural graph work with no keys set. The features below are all opt
     }
 
     console.log(
-      `  ${p.dim}Core value needs zero config: orient, search, blast-radius, and the full graph work with no keys set.${p.reset}`
+      `  ${c.dim('Core value needs zero config: orient, search, blast-radius, and the full graph work with no keys set.')}`
     );
     console.log('');
 
@@ -110,8 +90,8 @@ the whole structural graph work with no keys set. The features below are all opt
     for (const group of GROUP_ORDER) {
       const inGroup = shown.filter((f) => f.group === group);
       if (inGroup.length === 0) continue;
-      console.log(`  ${p.bold}${group}${p.reset}`);
-      for (const f of inGroup) printFeature(f, p);
+      console.log(`  ${c.bold(group)}`);
+      for (const f of inGroup) printFeature(f, c);
       console.log('');
     }
 
@@ -121,7 +101,8 @@ the whole structural graph work with no keys set. The features below are all opt
     }
 
     console.log(
-      `  ${p.dim}${inventory.activeCount} of ${inventory.optInCount} opt-in features active · legend: ${p.reset}${p.active}✓ on${p.reset} ${p.defaultOn}• default-on${p.reset} ${p.inactive}○ off${p.reset}`
+      `  ${c.dim(`${inventory.activeCount} of ${inventory.optInCount} opt-in features active · legend:`)} ` +
+        `${c.green('✓ on')} ${c.cyan('• default-on')} ${c.dim('○ off')}`
     );
     console.log('');
   });

--- a/src/cli/commands/find-clones.ts
+++ b/src/cli/commands/find-clones.ts
@@ -13,6 +13,7 @@
 import { Command } from 'commander';
 import { logger, configureLogger } from '../../utils/logger.js';
 import { writeStdout } from '../output.js';
+import { toCliVocabulary } from '../surface-vocabulary.js';
 import { handleFindClones } from '../../core/services/mcp-handlers/clone-query.js';
 
 interface CloneMatchView {
@@ -103,15 +104,15 @@ export async function runFindClonesCli(opts: FindClonesCliOptions): Promise<numb
     const r = result as CloneQueryView;
     if (opts.json) await writeStdout(JSON.stringify(result, null, 2) + '\n');
     else {
-      logger.warning(`find-clones: ${r.error}`);
+      logger.warning(`find-clones: ${toCliVocabulary(r.error ?? '')}`);
       if (r.candidates?.length) logger.info('candidates', r.candidates.join(', '));
-      if (r.hint) logger.info('hint', r.hint);
+      if (r.hint) logger.info('hint', toCliVocabulary(r.hint));
     }
     return 1;
   }
 
   if (opts.json) await writeStdout(JSON.stringify(result, null, 2) + '\n');
-  else await writeStdout(renderHuman(result as CloneQueryView) + '\n');
+  else await writeStdout(toCliVocabulary(renderHuman(result as CloneQueryView)) + '\n');
   return 0;
 }
 

--- a/src/cli/config-guard.test.ts
+++ b/src/cli/config-guard.test.ts
@@ -1,0 +1,27 @@
+/**
+ * An explicit --config that does not resolve must be fatal, never a silent
+ * fallback to defaults (OutputContractsAreUniform, change: fix-cli-output-hygiene).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkExplicitConfig } from './config-guard.js';
+
+describe('checkExplicitConfig', () => {
+  const missing = () => false;
+  const present = () => true;
+
+  it('fails when a CLI-supplied config path is unreadable, naming the path', () => {
+    const r = checkExplicitConfig('cli', '/nope/config.json', missing);
+    expect(r.ok).toBe(false);
+    expect(r.message).toContain('/nope/config.json');
+  });
+
+  it('passes when a CLI-supplied config path is readable', () => {
+    expect(checkExplicitConfig('cli', '/exists/config.json', present).ok).toBe(true);
+  });
+
+  it('never fails on the built-in default source (pre-init repo is normal)', () => {
+    expect(checkExplicitConfig('default', '.openlore/config.json', missing).ok).toBe(true);
+    expect(checkExplicitConfig(undefined, '.openlore/config.json', missing).ok).toBe(true);
+  });
+});

--- a/src/cli/config-guard.ts
+++ b/src/cli/config-guard.ts
@@ -1,0 +1,50 @@
+/**
+ * Guard for an explicitly-passed global `--config` path.
+ *
+ * A `--config` value the user typed on the command line that does not resolve to
+ * a readable file is a fatal error naming the path — never a silent fallback to
+ * the default config (which would run, e.g., without the enforcement policy the
+ * user asked for). The built-in default value is exempt: a repo without an
+ * `.openlore/config.json` is the normal pre-init state (OutputContractsAreUniform,
+ * change: fix-cli-output-hygiene).
+ */
+
+import { accessSync, constants as fsConstants } from 'node:fs';
+
+/** How commander reported the option's value origin. */
+export type OptionValueSource = 'cli' | 'default' | 'env' | 'config' | 'implied' | undefined;
+
+export interface ConfigGuardResult {
+  ok: boolean;
+  /** Populated only when ok === false — the fatal message to print. */
+  message?: string;
+}
+
+/**
+ * Decide whether an explicit `--config` path is acceptable. Only a value that
+ * came from the CLI is checked; a `default`/unset source always passes.
+ *
+ * `readable` is injected so the decision is pure and unit-testable; the default
+ * probes the filesystem with `R_OK`.
+ */
+export function checkExplicitConfig(
+  source: OptionValueSource,
+  configPath: string | undefined,
+  readable: (p: string) => boolean = defaultReadable,
+): ConfigGuardResult {
+  if (source !== 'cli') return { ok: true };
+  if (typeof configPath === 'string' && readable(configPath)) return { ok: true };
+  return {
+    ok: false,
+    message: `--config: cannot read config file '${configPath}'. Check the path exists and is readable.`,
+  };
+}
+
+function defaultReadable(p: string): boolean {
+  try {
+    accessSync(p, fsConstants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/export/bundle.ts
+++ b/src/cli/export/bundle.ts
@@ -74,11 +74,14 @@ export async function runBundleExport(opts: BundleExportOptions): Promise<number
 
   const { manifest, buffer } = result;
   const sizeMb = (buffer.length / (1024 * 1024)).toFixed(2);
-  const relOut = relative(projectRoot, outPath) || outPath;
+  // Show a repo-relative path when the artifact lands inside the repo; otherwise
+  // show the absolute path, never a meaningless `../../../..` chain.
+  const rel = relative(projectRoot, outPath);
+  const insideRepo = rel !== '' && !rel.startsWith('..');
+  const relOut = insideRepo ? rel : outPath;
   // The .gitattributes hint only makes sense for an in-repo path; if the artifact was written
-  // outside the repo (relative path escapes with `..`), recommend the default glob instead of a
-  // meaningless `../…` pattern git can't apply.
-  const gitattrPath = relOut.startsWith('..') ? `*.olbundle` : (relOut || BUNDLE_DEFAULT_FILENAME);
+  // outside the repo, recommend the default glob instead of a pattern git can't apply.
+  const gitattrPath = insideRepo ? (rel || BUNDLE_DEFAULT_FILENAME) : `*.olbundle`;
   logger.success(
     `Exported graph bundle → ${relOut}\n` +
     `  ${manifest.files.length} files, ${sizeMb} MB, schema v${manifest.schemaVersion}, ` +

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -69,7 +69,9 @@ import { gryphWatchCommand } from './commands/gryph-watch.js';
 import { updateCommand } from './commands/update.js';
 import { featuresCommand } from './commands/features.js';
 import { groupedFormatHelp } from './help-groups.js';
-import { configureLogger } from '../utils/logger.js';
+import { configureLogger, logger } from '../utils/logger.js';
+import { colorForStderr } from '../utils/colors.js';
+import { checkExplicitConfig, type OptionValueSource } from './config-guard.js';
 import { notifyIfUpdateAvailable } from '../core/services/update-notifier.js';
 
 // Read version from package.json at runtime so it never drifts from the published version
@@ -97,6 +99,19 @@ program.hook('preAction', (thisCommand, actionCommand) => {
     timestamps: process.env.CI === 'true' || opts.color === false,
   });
 
+  // An explicitly-passed --config that does not resolve is a fatal error naming
+  // the path — never a silent fallback to the default config (which would run,
+  // e.g., without the enforcement policy the user asked for). Only fires when the
+  // value came from the CLI, not the built-in default (OutputContractsAreUniform).
+  const configGuard = checkExplicitConfig(
+    thisCommand.getOptionValueSource('config') as OptionValueSource,
+    opts.config as string | undefined,
+  );
+  if (!configGuard.ok) {
+    logger.error(configGuard.message!);
+    process.exit(1);
+  }
+
   // Passive update notifier — cached, non-blocking, fail-silent. Only for
   // human-interactive commands, and never when --quiet.
   if (!opts.quiet && UPDATE_NOTIFY_COMMANDS.has(actionCommand.name())) {
@@ -112,8 +127,9 @@ program.hook('preAction', (thisCommand, actionCommand) => {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
     // Only print if we're not in quiet mode
     if (!opts.quiet) {
+      const c = colorForStderr();
       process.stderr.write(
-        '\x1b[33m[warn]\x1b[0m --insecure: SSL certificate verification is disabled. ' +
+        `${c.yellow('[warn]')} --insecure: SSL certificate verification is disabled. ` +
         'Only use this on trusted networks.\n'
       );
     }

--- a/src/cli/manifest/emit-e2e.test.ts
+++ b/src/cli/manifest/emit-e2e.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { configureLogger } from '../../utils/logger.js';
@@ -116,6 +116,13 @@ describe('runManifestEmit (end-to-end)', () => {
     expect(validateManifest(manifest)).toEqual([]);
     expect(manifest.repo.git_commit).toBeNull();
     expect(manifest.links.repo).toBeNull();
+  });
+
+  it('--dry-run previews the destination without writing the file (fix-cli-output-hygiene)', async () => {
+    const out = join(dir, '.well-known', 'openlore.json');
+    const code = await runManifestEmit({ projectRoot: dir, dryRun: true });
+    expect(code).toBe(0);
+    expect(existsSync(out)).toBe(false);
   });
 
   it('--include-private widens the surface; --max-symbols truncates', async () => {

--- a/src/cli/manifest/emit.ts
+++ b/src/cli/manifest/emit.ts
@@ -44,6 +44,7 @@ export interface ManifestEmitOptions {
   projectRoot?: string;
   includePrivate?: boolean;
   maxSymbols?: number;
+  dryRun?: boolean;
 }
 
 export interface Manifest {
@@ -340,11 +341,17 @@ export async function runManifestEmit(opts: ManifestEmitOptions): Promise<number
   );
 
   const outPath = resolve(opts.out ?? join(projectRoot, '.well-known', 'openlore.json'));
-  await mkdir(dirname(outPath), { recursive: true });
   const bytes = serializeManifest(manifest);
-  await writeFile(outPath, bytes);
 
-  logger.success(`Wrote ${outPath} (${Buffer.byteLength(bytes)} bytes)`);
+  if (opts.dryRun) {
+    // Preview only: never touch the working tree (manifest emit writes into the
+    // repo, so a dry run lets a user see the destination and size first).
+    logger.success(`Dry run — would write ${outPath} (${Buffer.byteLength(bytes)} bytes); nothing written`);
+  } else {
+    await mkdir(dirname(outPath), { recursive: true });
+    await writeFile(outPath, bytes);
+    logger.success(`Wrote ${outPath} (${Buffer.byteLength(bytes)} bytes)`);
+  }
   logger.info('public symbols', manifest.exports.public_symbols.length + (manifest.exports.truncated ? ' (truncated)' : ''));
   logger.info('http routes', manifest.exports.http_routes.length);
   logger.info('external packages', manifest.imports.external_packages.length);

--- a/src/cli/manifest/index.ts
+++ b/src/cli/manifest/index.ts
@@ -17,6 +17,7 @@ const emitSubcommand = new Command('emit')
   .option('--project-root <path>', 'Project root to describe (default: current directory)')
   .option('--include-private', 'Include non-public symbols (produces a larger manifest)', false)
   .option('--max-symbols <int>', 'Truncate public_symbols to this many (sets "truncated": true)', (v) => parseInt(v, 10))
+  .option('--dry-run', 'Show the destination and manifest size without writing the file', false)
   .action(async (opts: ManifestEmitOptions) => {
     process.exit(await runManifestEmit(opts));
   });

--- a/src/cli/output-hygiene.test.ts
+++ b/src/cli/output-hygiene.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Guards for the uniform CLI output contracts (OutputContractsAreUniform,
+ * change: fix-cli-output-hygiene).
+ *
+ * 1. Raw-ANSI guard: no command module embeds `\x1b[…m` escape literals. Color
+ *    must flow through the shared color layer (src/utils/colors.ts) so it honors
+ *    --no-color and non-TTY streams. The one exception is the full-screen
+ *    interactive approval TUI, which needs cursor-control codes chalk cannot
+ *    express and never writes to a pipe.
+ * 2. Color layer: the shared helpers emit no escape bytes when color is off.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { palette } from '../utils/colors.js';
+
+/** Files that legitimately contain raw ANSI: interactive full-screen renderers. */
+const ANSI_ALLOWLIST = new Set(['tui-approval.ts']);
+
+function walkTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walkTsFiles(full));
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('CLI output hygiene — raw ANSI guard', () => {
+  it('no command module embeds raw ANSI escape literals', () => {
+    const cliDir = join(__dirname);
+    // Match the escape as it appears in source: \x1b[ , [ , or \033[ .
+    const rawAnsi = /\\x1b\[|\\u001b\[|\\033\[/;
+    const offenders: string[] = [];
+
+    for (const file of walkTsFiles(cliDir)) {
+      const base = file.split('/').pop()!;
+      if (ANSI_ALLOWLIST.has(base)) continue;
+      if (rawAnsi.test(readFileSync(file, 'utf-8'))) {
+        offenders.push(file);
+      }
+    }
+
+    expect(
+      offenders,
+      `Route color through src/utils/colors.ts instead of raw ANSI literals:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('CLI output hygiene — shared color layer', () => {
+  it('emits no escape bytes when color is disabled', () => {
+    const c = palette(false);
+    const painted = `${c.green('ok')} ${c.red('bad')} ${c.yellow('warn')} ${c.dim('x')}`;
+    expect(painted).toBe('ok bad warn x');
+    // eslint-disable-next-line no-control-regex
+    expect(/\x1b\[/.test(painted)).toBe(false);
+  });
+});

--- a/src/cli/surface-vocabulary.test.ts
+++ b/src/cli/surface-vocabulary.test.ts
@@ -1,0 +1,36 @@
+/**
+ * The CLI surface must name CLI commands, never MCP tool names, in the hints it
+ * relays from shared conclusion handlers (OutputContractsAreUniform, change:
+ * fix-cli-output-hygiene).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toCliVocabulary } from './surface-vocabulary.js';
+
+describe('toCliVocabulary', () => {
+  it('rewrites the analyze_codebase MCP tool name to `openlore analyze`', () => {
+    expect(toCliVocabulary('No analysis found. Run analyze_codebase first.')).toBe(
+      'No analysis found. Run openlore analyze first.',
+    );
+    expect(toCliVocabulary('re-run analyze_codebase after edits.')).toBe(
+      're-run openlore analyze after edits.',
+    );
+  });
+
+  it('leaves text without MCP tool names unchanged', () => {
+    const s = 'Did you mean one of these? Pass name::path to disambiguate.';
+    expect(toCliVocabulary(s)).toBe(s);
+  });
+
+  it('translated hints contain no bare MCP tool name', () => {
+    const hints = [
+      'No analysis found. Run analyze_codebase first.',
+      'Call graph not available. Re-run analyze_codebase.',
+      'If the code is new, run analyze_codebase — or use `snippet` mode.',
+    ];
+    for (const h of hints) {
+      expect(toCliVocabulary(h)).not.toMatch(/\banalyze_codebase\b/);
+      expect(toCliVocabulary(h)).toContain('openlore analyze');
+    }
+  });
+});

--- a/src/cli/surface-vocabulary.ts
+++ b/src/cli/surface-vocabulary.ts
@@ -1,0 +1,29 @@
+/**
+ * Translate MCP-surface vocabulary into CLI-surface vocabulary.
+ *
+ * The conclusion handlers (clone-query, error-propagation, env-impact, …) are
+ * shared by the MCP tools and their CLI mirror commands. Their not-found / stale
+ * hints name the MCP tool a human would re-run to refresh the index —
+ * `analyze_codebase`. On the CLI that tool name does not exist; the equivalent a
+ * user actually runs is `openlore analyze`. A CLI hint that names an MCP tool
+ * sends the reader to a command that isn't there.
+ *
+ * CLI output refers to CLI commands, MCP output refers to MCP tools
+ * (OutputContractsAreUniform, change: fix-cli-output-hygiene). CLI command
+ * modules pass every handler-produced hint / error / boundary string through
+ * here before printing.
+ */
+
+/** MCP tool name (word-bounded) → the CLI invocation that does the same thing. */
+const MCP_TO_CLI: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\banalyze_codebase\b/g, 'openlore analyze'],
+];
+
+/** Rewrite MCP tool names in a handler-produced string to their CLI equivalents. */
+export function toCliVocabulary(text: string): string {
+  let out = text;
+  for (const [pattern, replacement] of MCP_TO_CLI) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}

--- a/src/core/analyzer/lance-logging.test.ts
+++ b/src/core/analyzer/lance-logging.test.ts
@@ -1,0 +1,27 @@
+/**
+ * The native-LanceDB log level is quieted to errors by default, but a level the
+ * user set on purpose is never overridden (change: fix-cli-output-hygiene).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { quietNativeLoggingOnce } from './lance-logging.js';
+
+describe('quietNativeLoggingOnce', () => {
+  const saved = process.env.LANCEDB_LOG;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.LANCEDB_LOG;
+    else process.env.LANCEDB_LOG = saved;
+  });
+
+  it('sets LANCEDB_LOG=error when unset', () => {
+    delete process.env.LANCEDB_LOG;
+    quietNativeLoggingOnce();
+    expect(process.env.LANCEDB_LOG).toBe('error');
+  });
+
+  it('never overrides an explicit user setting', () => {
+    process.env.LANCEDB_LOG = 'debug';
+    quietNativeLoggingOnce();
+    expect(process.env.LANCEDB_LOG).toBe('debug');
+  });
+});

--- a/src/core/analyzer/lance-logging.ts
+++ b/src/core/analyzer/lance-logging.ts
@@ -1,0 +1,16 @@
+/**
+ * LanceDB's native (Rust) layer logs `WARN` lines (e.g. "No existing dataset …,
+ * it will be created") to stderr, polluting otherwise-clean `analyze` output.
+ * Its log level is read from the `LANCEDB_LOG` env var, NOT `RUST_LOG` — verified
+ * empirically against @lancedb/lancedb (RUST_LOG=off has no effect; LANCEDB_LOG=error
+ * drops the WARN lines while keeping genuine errors).
+ *
+ * Quiet it to errors only, but never override a level the user set on purpose so
+ * anyone debugging LanceDB can turn it back up. Idempotent, and must run before
+ * the FIRST `@lancedb/lancedb` import in the process initializes the native
+ * logger — every dynamic import of the addon calls this first
+ * (OutputContractsAreUniform, change: fix-cli-output-hygiene).
+ */
+export function quietNativeLoggingOnce(): void {
+  if (process.env.LANCEDB_LOG === undefined) process.env.LANCEDB_LOG = 'error';
+}

--- a/src/core/analyzer/text-line-index.ts
+++ b/src/core/analyzer/text-line-index.ts
@@ -26,6 +26,7 @@
 
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { quietNativeLoggingOnce } from './lance-logging.js';
 import {
   buildBm25Corpus,
   tokenize,
@@ -147,6 +148,7 @@ export class TextLineIndex {
     }
 
     const dbPath = join(outputDir, DB_FOLDER);
+    quietNativeLoggingOnce();
     const { connect } = await import('@lancedb/lancedb');
     const db = await connect(dbPath);
 
@@ -182,6 +184,7 @@ export class TextLineIndex {
     if (!TextLineIndex.exists(outputDir)) return { lines: 0 };
 
     const dbPath = join(outputDir, DB_FOLDER);
+    quietNativeLoggingOnce();
     const { connect } = await import('@lancedb/lancedb');
     const db = await connect(dbPath);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -229,6 +232,7 @@ export class TextLineIndex {
     const dbPath = join(outputDir, DB_FOLDER);
     let cached = _bm25Cache.get(dbPath);
     if (!cached) {
+      quietNativeLoggingOnce();
       const { connect } = await import('@lancedb/lancedb');
       const db = await connect(dbPath);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/core/analyzer/vector-index.ts
+++ b/src/core/analyzer/vector-index.ts
@@ -23,6 +23,7 @@ import type { FunctionNode } from './call-graph.js';
 import type { FileSignatureMap } from './signature-extractor.js';
 import type { Embedder } from './embedding-service.js';
 import { getSkeletonContent, isSkeletonWorthIncluding } from './code-shaper.js';
+import { quietNativeLoggingOnce } from './lance-logging.js';
 
 // ============================================================================
 // TYPES
@@ -496,6 +497,7 @@ export class VectorIndex {
     /** When true, reuse cached vectors for unchanged functions */
     incremental = false
   ): Promise<{ embedded: number; reused: number; total: number; hasEmbeddings: boolean }> {
+    quietNativeLoggingOnce();
     const { connect } = await import('@lancedb/lancedb');
 
     if (nodes.length === 0) {
@@ -801,6 +803,8 @@ export class VectorIndex {
       }
     }
 
+    quietNativeLoggingOnce();
+
     const { connect } = await import('@lancedb/lancedb');
     const db = await connect(dbPath);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -901,6 +905,7 @@ export class VectorIndex {
     const dbPath = join(outputDir, DB_FOLDER);
     let tableEntry = _tableCache.get(dbPath);
     if (!tableEntry) {
+      quietNativeLoggingOnce();
       const { connect } = await import('@lancedb/lancedb');
       const db = await connect(dbPath);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/core/services/project-detector.test.ts
+++ b/src/core/services/project-detector.test.ts
@@ -138,6 +138,23 @@ describe('project-detector', () => {
       expect(result.confidence).toBe('low');
     });
 
+    it('detects a pure-TS project (tsconfig.json, no package.json) as Node.js, not Unknown (fix-cli-output-hygiene)', async () => {
+      await writeFile(join(testDir, 'tsconfig.json'), '{}');
+      const result = await detectProjectType(testDir);
+
+      expect(result.projectType).toBe('nodejs');
+      expect(result.manifestFile).toBe('tsconfig.json');
+    });
+
+    it('prefers package.json over a co-located tsconfig.json', async () => {
+      await writeFile(join(testDir, 'package.json'), '{}');
+      await writeFile(join(testDir, 'tsconfig.json'), '{}');
+      const result = await detectProjectType(testDir);
+
+      expect(result.projectType).toBe('nodejs');
+      expect(result.manifestFile).toBe('package.json');
+    });
+
     it('should prefer higher priority manifest files', async () => {
       // pyproject.toml has higher priority than setup.py
       await writeFile(join(testDir, 'pyproject.toml'), '');

--- a/src/core/services/project-detector.ts
+++ b/src/core/services/project-detector.ts
@@ -39,6 +39,11 @@ const MANIFEST_MAP: { file: string; type: ProjectType; priority: number }[] = [
   { file: 'build.gradle.kts', type: 'java', priority: 2 },
   { file: 'Gemfile', type: 'ruby', priority: 1 },
   { file: 'composer.json', type: 'php', priority: 1 },
+  // A pure-TS/JS project (no package.json — e.g. a Deno or config-only repo) is
+  // still Node.js/TypeScript, not "Unknown". Lowest priority so a real language
+  // manifest above always wins when both are present.
+  { file: 'tsconfig.json', type: 'nodejs', priority: 9 },
+  { file: 'jsconfig.json', type: 'nodejs', priority: 9 },
 ];
 
 /**

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared color layer for CLI command modules.
+ *
+ * Every command that colorizes inline text (status glyphs, badges, confidence
+ * markers) routes through here instead of embedding raw `\x1b[…m` escape codes.
+ * Raw escapes ignore both `--no-color` and non-TTY streams, so they pollute
+ * pipes and CI logs (OutputContractsAreUniform, change: fix-cli-output-hygiene).
+ *
+ * The decision is centralized: color is emitted only when the global logger is
+ * not in `--no-color` mode AND the target stream is a color-capable TTY (chalk's
+ * own detection, which also honors the `NO_COLOR` / `FORCE_COLOR` env vars).
+ */
+
+import chalk, { Chalk, chalkStderr, type ChalkInstance } from 'chalk';
+import { logger } from './logger.js';
+
+/** A chalk instance with color forced off — every style method returns its input unchanged. */
+const plain = new Chalk({ level: 0 });
+
+/**
+ * Color helpers for stdout. Returns a chalk instance that respects `--no-color`
+ * (the global logger flag) and, when color is otherwise allowed, chalk's own
+ * TTY / NO_COLOR detection for stdout.
+ */
+export function colorForStdout(): ChalkInstance {
+  return logger.getOptions().noColor ? plain : chalk;
+}
+
+/** Color helpers for stderr, keyed off stderr's own TTY state. */
+export function colorForStderr(): ChalkInstance {
+  return logger.getOptions().noColor ? plain : chalkStderr;
+}
+
+/**
+ * Pick between the live chalk instance and a plain one from a caller-computed
+ * decision (e.g. a command that also disables color in `--json` mode).
+ */
+export function palette(useColor: boolean): ChalkInstance {
+  return useColor ? chalk : plain;
+}


### PR DESCRIPTION
**Status:** LGTM — ready. Full suite green (306 files, 5976 passed, 2 skipped), lint + typecheck clean, all six defects verified fixed end-to-end on the real CLI.

Implements change `fix-cli-output-hygiene` (e2e-audit runtime & CLI fix track, next after #243).

## What was missing / the motivation

A live dogfood of all ~50 CLI commands surfaced a batch of small output/UX defects — none dangerous alone, together they erode the polish the happy-path work shipped. All six were live-reproduced on v2.1.5.

## What it does

| # | Defect | Fix |
|---|--------|-----|
| 1 | `decisions --list` emitted raw `\x1b[…m` literals, ignoring `--no-color`/non-TTY | Color routes through a shared chalk-backed layer `src/utils/colors.ts` (honors `--no-color` + non-TTY). `decisions.ts` and the `--insecure` warning moved off raw ANSI; the already-gated `doctor.ts`/`features.ts` converted too, so the repo-wide guard exempts only the interactive `tui-approval.ts` |
| 2 | Global `--config <path>` at a missing file was **silently ignored** | An explicit (CLI-sourced) `--config` that can't be read is fatal, naming the path (`src/cli/config-guard.ts`) |
| 3 | `doctor`'s summary hardcoded "optional features … may be limited" for any warning | Summary now names the checks that actually warned |
| 4 | CLI hints leaked MCP vocabulary (`Run analyze_codebase first` — no such CLI command) | CLI hints translate MCP tool names to CLI commands (`src/cli/surface-vocabulary.ts`): `analyze_codebase` → `openlore analyze` |
| 5 | `verified` (gate-blocking, awaiting review) rendered with a done-reading `✓` | `verified` now renders `⧖` "awaiting review" with a legend, distinct from approved/synced |
| 6 | Cosmetics: lance `WARN` noise; `../../..` export path; `init` "Unknown" on pure-TS; no `manifest emit --dry-run` | LanceDB noise quieted via `LANCEDB_LOG=error` (the real knob — `RUST_LOG` has no effect, verified empirically); export prints an absolute path when the artifact lands outside the repo; `init` detects `tsconfig.json`-only projects as Node.js/TypeScript; `manifest emit --dry-run` added |

Adds one `cli` requirement: **OutputContractsAreUniform**.

## Proof it works

New/updated regression tests (all green):
- `src/cli/output-hygiene.test.ts` — repo-wide guard: no raw ANSI literals in command modules (except the interactive TUI) + color-off emits no escape bytes
- `src/cli/config-guard.test.ts` — explicit missing `--config` is fatal; default source never fails
- `src/cli/surface-vocabulary.test.ts` — `analyze_codebase` → `openlore analyze`, no MCP names leak
- `src/cli/commands/decisions-render.test.ts` — `verified` = `⧖` awaiting-review glyph + legend, no raw ANSI
- `src/cli/commands/doctor.test.ts` — summary names the warned check, not the hardcoded line
- `src/core/services/project-detector.test.ts` — pure-TS (`tsconfig.json`) → `nodejs`; `package.json` still wins
- `src/cli/manifest/emit-e2e.test.ts` — `--dry-run` writes nothing
- `src/core/analyzer/lance-logging.test.ts` — `LANCEDB_LOG` defaulted, user setting respected

End-to-end on the real CLI:
```
$ openlore --config /nonexistent/config.json decisions --list
[error] --config: cannot read config file '/nonexistent/config.json'. …   (exit 1)

$ openlore --no-color decisions --list | grep -c $'\x1b'      → 0
$ openlore decisions --list        → ⧖ [id] … + "Legend: ⧖ awaiting review …"
$ openlore find-clones --symbol NoSuch  → hint: … run openlore analyze …
$ openlore manifest emit --dry-run  → "Dry run — would write … nothing written" (file absent)
$ openlore init  (pure-TS dir)      → "Detected Node.js/TypeScript project"
$ openlore analyze --no-embed       → 0 lance WARN lines
```

## Notes / nits

- `--config` fix is scoped to fatal-on-missing for CLI-sourced values; fully redirecting every `readOpenLoreConfig` call site to an arbitrary path stays out of scope (disclosed in the proposal).
- Change dir kept in `openspec/changes/` (proposal marked `SHIPPED`, tasks checked) — matches how recent siblings (#242/#243) are tracked; spec-delta merges into the main corpus at the next bulk archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)