### PR TITLE
test(project): defuse the test-suite time bombs — vi.mock hoisting + the watcher-parity flake

### DIFF
--- a/openspec/changes/fix-test-suite-hygiene/proposal.md
+++ b/openspec/changes/fix-test-suite-hygiene/proposal.md
@@ -1,7 +1,17 @@
 # Test-suite hygiene: eliminate deprecation time bombs and the known flake
 
-> Status: PROPOSED (2026-07-03, e2e audit). The suite is green (283 files / 5,589 tests) but
-> carries two liabilities that will bite on their own schedule rather than ours.
+> Status: SHIPPED (2026-07-19). Notes on how it landed: (1) the five `vi.mock` calls (four in
+> `unified-search.e2e.test.ts`, one in `gryph-bridge.test.ts`) moved to module top level — a
+> zero-behavior change since vitest already hoisted them. (2) The deprecation-warning escalation is
+> implemented as a deterministic guard test (`src/vitest-hygiene.test.ts`) that fails the moment any
+> `vi.mock` appears indented (inside a block) anywhere under `src`/`test`/`examples` — more robust
+> than scraping vitest's stderr, and it runs in the same CI `test:run` the repo already gates on.
+> (3) The `mcp-watcher-parity` flake was NOT reproducible on current main: the test is already
+> event-driven (it awaits `handleChange` → `handleBatch({ syncFlush: true })`, whose signature+vector
+> writes run inline and are fully awaited; every comparison is over a `.sort()`ed edge signature; each
+> test uses its own `mkdtemp` root). Intervening watcher hardening (the inline `syncFlush` path)
+> resolved it. Verified deterministic across 18 clean runs (12 isolated + 6 full-suite); a comment now
+> documents the guarantee so a future edit can't silently reintroduce a timer-based wait.
 
 ## The gap
 

--- a/openspec/changes/fix-test-suite-hygiene/tasks.md
+++ b/openspec/changes/fix-test-suite-hygiene/tasks.md
@@ -1,14 +1,14 @@
 # Tasks — test-suite hygiene
 
 ## Implementation
-- [ ] Hoist vi.mock calls to top level: unified-search.e2e.test.ts (4), gryph-bridge.test.ts (1)
-- [ ] CI: escalate vitest deprecation warnings for the mock-hoisting class to failures
-- [ ] mcp-watcher-parity flake: event-driven convergence assertion (or serial-pool isolation),
+- [x] Hoist vi.mock calls to top level: unified-search.e2e.test.ts (4), gryph-bridge.test.ts (1)
+- [x] CI: escalate vitest deprecation warnings for the mock-hoisting class to failures
+- [x] mcp-watcher-parity flake: event-driven convergence assertion (or serial-pool isolation),
       verified by a recorded loop-N run
 
 ## Verification
-- [ ] CI log free of vi.mock hoisting warnings
-- [ ] Watcher-parity green across N consecutive full-suite runs (N recorded in PR)
+- [x] CI log free of vi.mock hoisting warnings
+- [x] Watcher-parity green across N consecutive full-suite runs (N recorded in PR)
 
 ## Spec
-- [ ] `project` delta: ADD TestSuiteHasNoKnownTimeBombs
+- [x] `project` delta: ADD TestSuiteHasNoKnownTimeBombs

--- a/src/core/analyzer/__tests__/unified-search.e2e.test.ts
+++ b/src/core/analyzer/__tests__/unified-search.e2e.test.ts
@@ -10,6 +10,178 @@ import { join } from 'node:path';
 import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
+// vi.mock calls are hoisted to the top of the module by vitest regardless of where they
+// appear; keeping them at top level makes that behavior explicit and avoids the hoisting
+// deprecation warning that a future vitest will promote to an error (change: fix-test-suite-hygiene).
+// Mock the vector indexes
+vi.mock('../vector-index.js', async (importOriginal) => {
+  const actual = await importOriginal() as any;
+  return {
+    ...actual,
+    VectorIndex: {
+      ...actual.VectorIndex,
+      exists: vi.fn().mockReturnValue(true),
+      search: vi.fn().mockImplementation((_dir: string, query: string, _embed: any, opts: any) => {
+        // Simulate finding functions related to the query
+        const results = [];
+
+        if (query.includes('auth') || query.includes('validate') || query.includes('token')) {
+          results.push({
+            record: {
+              id: 'src/auth/jwt.ts::validateToken',
+              name: 'validateToken',
+              filePath: 'src/auth/jwt.ts',
+              className: '',
+              language: 'TypeScript',
+              signature: 'validateToken(token: string): boolean',
+              docstring: 'Validates JWT token',
+              fanIn: 5,
+              fanOut: 2,
+              isHub: false,
+              isEntryPoint: false,
+              text: '[TypeScript] src/auth/jwt.ts validateToken\nvalidateToken(token: string): boolean\nValidates JWT token'
+            },
+            score: 0.85
+          });
+
+          results.push({
+            record: {
+              id: 'src/auth/middleware.ts::authMiddleware',
+              name: 'authMiddleware',
+              filePath: 'src/auth/middleware.ts',
+              className: '',
+              language: 'TypeScript',
+              signature: 'authMiddleware(req, res, next): void',
+              docstring: 'Authentication middleware',
+              fanIn: 3,
+              fanOut: 1,
+              isHub: false,
+              isEntryPoint: true,
+              text: '[TypeScript] src/auth/middleware.ts authMiddleware\nauthMiddleware(req, res, next): void\nAuthentication middleware'
+            },
+            score: 0.75
+          });
+        }
+
+        if (query.includes('user') || query.includes('create')) {
+          results.push({
+            record: {
+              id: 'src/users/service.ts::createUser',
+              name: 'createUser',
+              filePath: 'src/users/service.ts',
+              className: 'UserService',
+              language: 'TypeScript',
+              signature: 'createUser(userData: UserInput): Promise<User>',
+              docstring: 'Creates a new user',
+              fanIn: 2,
+              fanOut: 3,
+              isHub: false,
+              isEntryPoint: false,
+              text: '[TypeScript] src/users/service.ts UserService.createUser\ncreateUser(userData: UserInput): Promise<User>\nCreates a new user'
+            },
+            score: 0.80
+          });
+        }
+
+        return Promise.resolve(results.slice(0, opts.limit));
+      })
+    }
+  };
+});
+
+vi.mock('../spec-vector-index.js', async (importOriginal) => {
+  const actual = await importOriginal() as any;
+  return {
+    ...actual,
+    SpecVectorIndex: {
+      ...actual.SpecVectorIndex,
+      exists: vi.fn().mockReturnValue(true),
+      search: vi.fn().mockImplementation((_dir: string, query: string, _embed: any, opts: any) => {
+        // Simulate finding spec requirements related to the query
+        const results = [];
+
+        if (query.includes('auth') || query.includes('validate') || query.includes('token')) {
+          results.push({
+            record: {
+              id: 'auth.validateToken',
+              domain: 'auth',
+              section: 'requirements',
+              title: 'Requirement: ValidateToken',
+              text: '[spec:auth] Requirement: ValidateToken\nThe system SHALL validate JWT tokens using HMAC-SHA256 signature verification.\n\n#### Scenario: ValidToken\n- **GIVEN** A valid JWT token with correct signature\n- **WHEN** validateToken() is called\n- **THEN** Returns true\n\n#### Scenario: InvalidToken\n- **GIVEN** A JWT token with incorrect signature\n- **WHEN** validateToken() is called\n- **THEN** Returns false',
+              linkedFiles: ['src/auth/jwt.ts', 'src/auth/middleware.ts']
+            },
+            score: 0.90
+          });
+
+          results.push({
+            record: {
+              id: 'auth.handleAuthentication',
+              domain: 'auth',
+              section: 'requirements',
+              title: 'Requirement: HandleAuthentication',
+              text: '[spec:auth] Requirement: HandleAuthentication\nThe system SHALL handle authentication requests with proper error handling and logging.\n\n#### Scenario: SuccessfulAuth\n- **GIVEN** Valid credentials\n- **WHEN** Authentication request is made\n- **THEN** Returns authenticated user with JWT token',
+              linkedFiles: ['src/auth/middleware.ts']
+            },
+            score: 0.85
+          });
+        }
+
+        if (query.includes('user') || query.includes('create')) {
+          results.push({
+            record: {
+              id: 'users.createUser',
+              domain: 'users',
+              section: 'requirements',
+              title: 'Requirement: CreateUser',
+              text: '[spec:users] Requirement: CreateUser\nThe system SHALL create users with email validation and password hashing.\n\n#### Scenario: ValidUserCreation\n- **GIVEN** Valid user data with unique email\n- **WHEN** createUser() is called\n- **THEN** User is created with hashed password\n\n#### Scenario: DuplicateEmail\n- **GIVEN** User data with existing email\n- **WHEN** createUser() is called\n- **THEN** Throws DuplicateEmailError',
+              linkedFiles: ['src/users/service.ts']
+            },
+            score: 0.88
+          });
+        }
+
+        return Promise.resolve(results.slice(0, opts.limit));
+      })
+    }
+  };
+});
+
+// Mock mapping.json (spread actual module to keep mkdir, writeFile, rm, readdir)
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal() as any;
+  return {
+    ...actual,
+    readFile: vi.fn().mockResolvedValue(
+      JSON.stringify({
+        mappings: [
+          {
+            domain: 'auth',
+            requirement: 'ValidateToken',
+            functions: [
+              { file: 'src/auth/jwt.ts', name: 'validateToken' },
+              { file: 'src/auth/middleware.ts', name: 'authMiddleware' }
+            ]
+          },
+          {
+            domain: 'auth',
+            requirement: 'HandleAuthentication',
+            functions: [
+              { file: 'src/auth/middleware.ts', name: 'authMiddleware' }
+            ]
+          },
+          {
+            domain: 'users',
+            requirement: 'CreateUser',
+            functions: [
+              { file: 'src/users/service.ts', name: 'createUser' }
+            ]
+          }
+        ]
+      })
+    ),
+  };
+});
+
 describe('UnifiedSearch E2E', () => {
   let testDir: string;
   let outputDir: string;
@@ -36,174 +208,6 @@ describe('UnifiedSearch E2E', () => {
       })
     };
 
-    // Mock the vector indexes
-    vi.mock('../vector-index.js', async (importOriginal) => {
-      const actual = await importOriginal() as any;
-      return {
-        ...actual,
-        VectorIndex: {
-          ...actual.VectorIndex,
-          exists: vi.fn().mockReturnValue(true),
-          search: vi.fn().mockImplementation((_dir: string, query: string, _embed: any, opts: any) => {
-            // Simulate finding functions related to the query
-            const results = [];
-
-            if (query.includes('auth') || query.includes('validate') || query.includes('token')) {
-              results.push({
-                record: {
-                  id: 'src/auth/jwt.ts::validateToken',
-                  name: 'validateToken',
-                  filePath: 'src/auth/jwt.ts',
-                  className: '',
-                  language: 'TypeScript',
-                  signature: 'validateToken(token: string): boolean',
-                  docstring: 'Validates JWT token',
-                  fanIn: 5,
-                  fanOut: 2,
-                  isHub: false,
-                  isEntryPoint: false,
-                  text: '[TypeScript] src/auth/jwt.ts validateToken\nvalidateToken(token: string): boolean\nValidates JWT token'
-                },
-                score: 0.85
-              });
-
-              results.push({
-                record: {
-                  id: 'src/auth/middleware.ts::authMiddleware',
-                  name: 'authMiddleware',
-                  filePath: 'src/auth/middleware.ts',
-                  className: '',
-                  language: 'TypeScript',
-                  signature: 'authMiddleware(req, res, next): void',
-                  docstring: 'Authentication middleware',
-                  fanIn: 3,
-                  fanOut: 1,
-                  isHub: false,
-                  isEntryPoint: true,
-                  text: '[TypeScript] src/auth/middleware.ts authMiddleware\nauthMiddleware(req, res, next): void\nAuthentication middleware'
-                },
-                score: 0.75
-              });
-            }
-
-            if (query.includes('user') || query.includes('create')) {
-              results.push({
-                record: {
-                  id: 'src/users/service.ts::createUser',
-                  name: 'createUser',
-                  filePath: 'src/users/service.ts',
-                  className: 'UserService',
-                  language: 'TypeScript',
-                  signature: 'createUser(userData: UserInput): Promise<User>',
-                  docstring: 'Creates a new user',
-                  fanIn: 2,
-                  fanOut: 3,
-                  isHub: false,
-                  isEntryPoint: false,
-                  text: '[TypeScript] src/users/service.ts UserService.createUser\ncreateUser(userData: UserInput): Promise<User>\nCreates a new user'
-                },
-                score: 0.80
-              });
-            }
-
-            return Promise.resolve(results.slice(0, opts.limit));
-          })
-        }
-      };
-    });
-
-    vi.mock('../spec-vector-index.js', async (importOriginal) => {
-      const actual = await importOriginal() as any;
-      return {
-        ...actual,
-        SpecVectorIndex: {
-          ...actual.SpecVectorIndex,
-          exists: vi.fn().mockReturnValue(true),
-          search: vi.fn().mockImplementation((_dir: string, query: string, _embed: any, opts: any) => {
-            // Simulate finding spec requirements related to the query
-            const results = [];
-
-            if (query.includes('auth') || query.includes('validate') || query.includes('token')) {
-              results.push({
-                record: {
-                  id: 'auth.validateToken',
-                  domain: 'auth',
-                  section: 'requirements',
-                  title: 'Requirement: ValidateToken',
-                  text: '[spec:auth] Requirement: ValidateToken\nThe system SHALL validate JWT tokens using HMAC-SHA256 signature verification.\n\n#### Scenario: ValidToken\n- **GIVEN** A valid JWT token with correct signature\n- **WHEN** validateToken() is called\n- **THEN** Returns true\n\n#### Scenario: InvalidToken\n- **GIVEN** A JWT token with incorrect signature\n- **WHEN** validateToken() is called\n- **THEN** Returns false',
-                  linkedFiles: ['src/auth/jwt.ts', 'src/auth/middleware.ts']
-                },
-                score: 0.90
-              });
-
-              results.push({
-                record: {
-                  id: 'auth.handleAuthentication',
-                  domain: 'auth',
-                  section: 'requirements',
-                  title: 'Requirement: HandleAuthentication',
-                  text: '[spec:auth] Requirement: HandleAuthentication\nThe system SHALL handle authentication requests with proper error handling and logging.\n\n#### Scenario: SuccessfulAuth\n- **GIVEN** Valid credentials\n- **WHEN** Authentication request is made\n- **THEN** Returns authenticated user with JWT token',
-                  linkedFiles: ['src/auth/middleware.ts']
-                },
-                score: 0.85
-              });
-            }
-
-            if (query.includes('user') || query.includes('create')) {
-              results.push({
-                record: {
-                  id: 'users.createUser',
-                  domain: 'users',
-                  section: 'requirements',
-                  title: 'Requirement: CreateUser',
-                  text: '[spec:users] Requirement: CreateUser\nThe system SHALL create users with email validation and password hashing.\n\n#### Scenario: ValidUserCreation\n- **GIVEN** Valid user data with unique email\n- **WHEN** createUser() is called\n- **THEN** User is created with hashed password\n\n#### Scenario: DuplicateEmail\n- **GIVEN** User data with existing email\n- **WHEN** createUser() is called\n- **THEN** Throws DuplicateEmailError',
-                  linkedFiles: ['src/users/service.ts']
-                },
-                score: 0.88
-              });
-            }
-
-            return Promise.resolve(results.slice(0, opts.limit));
-          })
-        }
-      };
-    });
-
-    // Mock mapping.json (spread actual module to keep mkdir, writeFile, rm, readdir)
-    vi.mock('node:fs/promises', async (importOriginal) => {
-      const actual = await importOriginal() as any;
-      return {
-        ...actual,
-        readFile: vi.fn().mockResolvedValue(
-          JSON.stringify({
-            mappings: [
-              {
-                domain: 'auth',
-                requirement: 'ValidateToken',
-                functions: [
-                  { file: 'src/auth/jwt.ts', name: 'validateToken' },
-                  { file: 'src/auth/middleware.ts', name: 'authMiddleware' }
-                ]
-              },
-              {
-                domain: 'auth',
-                requirement: 'HandleAuthentication',
-                functions: [
-                  { file: 'src/auth/middleware.ts', name: 'authMiddleware' }
-                ]
-              },
-              {
-                domain: 'users',
-                requirement: 'CreateUser',
-                functions: [
-                  { file: 'src/users/service.ts', name: 'createUser' }
-                ]
-              }
-            ]
-          })
-        ),
-      };
-    });
   });
 
   afterAll(async () => {

--- a/src/core/services/mcp-handlers/gryph-bridge.test.ts
+++ b/src/core/services/mcp-handlers/gryph-bridge.test.ts
@@ -27,6 +27,16 @@ import {
   PANIC_DECAY_PER_MIN,
 } from './panic-constants.js';
 
+// vitest hoists vi.mock to the top of the module regardless of where it is written, so
+// this mock already applied file-wide when it lived inside a test; declaring it at top
+// level makes that explicit and avoids the hoisting deprecation warning a future vitest
+// will promote to an error (change: fix-test-suite-hygiene). Gryph is treated as
+// unavailable (spawnSync exits non-zero) so the provider degrades rather than shelling out.
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(() => ({ status: 1, stdout: null })),
+  spawn: vi.fn(),
+}));
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -130,10 +140,6 @@ describe('applyGryphDelta', () => {
 
 describe('GryphBehaviorProvider', () => {
   it('returns null when gryph not available', async () => {
-    vi.mock('node:child_process', () => ({
-      spawnSync: vi.fn(() => ({ status: 1, stdout: null })),
-      spawn: vi.fn(),
-    }));
     const provider = new GryphBehaviorProvider();
     const result = await provider.collect(new Date().toISOString());
     // may return null (gryph unavailable) or a snapshot — just must not throw

--- a/src/core/services/mcp-watcher-parity.test.ts
+++ b/src/core/services/mcp-watcher-parity.test.ts
@@ -11,6 +11,14 @@
  *   • a newly-added symbol that a prior NON-caller should now resolve to is
  *     never re-resolved (getCallerFiles misses it — it was an `external` edge);
  *   • direct callers past CALLER_REPARSE_LIMIT are silently dropped.
+ *
+ * DETERMINISM (change: fix-test-suite-hygiene — the once-flaky guard): these tests
+ * await `handleChange`, which calls `handleBatch(..., { syncFlush: true })` — the
+ * signature AND vector writes run inline and are fully awaited, so convergence is
+ * complete when the promise resolves. Every comparison is over a `.sort()`ed edge
+ * signature, and each test runs in its own `mkdtemp` root. There is NO time-window
+ * or debounce wait, which is what made an earlier version flaky under full-suite
+ * load. Do not reintroduce one: assert on the awaited result, never on a timer.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/src/vitest-hygiene.test.ts
+++ b/src/vitest-hygiene.test.ts
@@ -1,0 +1,58 @@
+/**
+ * CI guard for the vi.mock hoisting deprecation (TestSuiteHasNoKnownTimeBombs,
+ * change: fix-test-suite-hygiene).
+ *
+ * vitest hoists every `vi.mock(...)` to the top of its module, so a call written
+ * inside `describe`/`it`/`beforeAll` runs earlier than it reads — vitest warns on
+ * every such call and has announced it "will become an error in a future version".
+ * A green suite would then flip red on a routine vitest upgrade.
+ *
+ * This test fails the moment such a call is introduced (the warning becomes a hard
+ * failure now, in plain unit-test CI, instead of at upgrade time). A top-level
+ * `vi.mock` starts at column 0; an indented one is inside a block — exactly the
+ * shape vitest warns about.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, statSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOTS = ['src', 'test', 'examples'];
+/** vi.mock preceded by whitespace on its line = not at module top level. */
+const INDENTED_VI_MOCK = /^[ \t]+vi\.mock\s*\(/m;
+
+function testFiles(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out; // an absent root (e.g. gitignored test/) is fine
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === 'node_modules') continue;
+      out.push(...testFiles(full));
+    } else if (entry.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('vitest hygiene', () => {
+  it('every vi.mock call is at module top level (no hoisting deprecation)', () => {
+    const offenders = testFiles('src')
+      .concat(ROOTS.slice(1).flatMap(testFiles))
+      // Exclude this guard's own explanatory regex literal.
+      .filter((f) => !f.endsWith('vitest-hygiene.test.ts'))
+      .filter((f) => INDENTED_VI_MOCK.test(readFileSync(f, 'utf-8')));
+
+    expect(
+      offenders,
+      `vi.mock must be at module top level (vitest hoists it and warns → future error). ` +
+        `Move it out of describe/it/beforeAll:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Status:** LGTM — ready. Full suite green (308 files, 5986 passed, 2 skipped), **zero vi.mock hoisting warnings** (was 4+), lint + typecheck clean. Implements the change `fix-test-suite-hygiene` (last item in the e2e-audit runtime & CLI fix track).

## What was wrong / the motivation

The suite was green but carried two liabilities that bite on their own schedule, not ours. CI green is a load-bearing claim in this repo (README badges it; the benchmark honesty contract leans on it).

## What it does

**1. vi.mock hoisting deprecation — defused.**
vitest hoists every `vi.mock` to the top of its module and warns *"this will become an error in a future version"* for calls written inside `describe`/`it`/`beforeAll`. Every CI run printed these; a routine vitest upgrade would flip the suite red.
- Moved the 5 offending calls (4 in `unified-search.e2e.test.ts`, 1 in `gryph-bridge.test.ts`) to module top level — **zero behavior change**, since vitest already hoisted them there.
- Added a guard test `src/vitest-hygiene.test.ts` that fails the moment an indented `vi.mock` is introduced anywhere under `src`/`test`/`examples`. This implements the proposal's *"escalate the warning to a CI failure"* as a deterministic unit test (runs in the same `test:run` CI already gates on) rather than brittle stderr scraping.

**2. mcp-watcher-parity flake — verified resolved, and locked.**
Not reproducible on current main. The test is already event-driven: it awaits `handleChange` → `handleBatch({ syncFlush: true })`, whose signature+vector writes run **inline and fully awaited**; every comparison is over a `.sort()`ed edge signature; each test uses its own `mkdtemp` root. Intervening watcher hardening (the inline `syncFlush` path) resolved the original timing race. Added a comment documenting the guarantee so a future edit can't silently reintroduce a timer-based wait.

Adds `project` requirement **TestSuiteHasNoKnownTimeBombs**.

## Proof it works

- **vi.mock**: full-suite output now contains **0** `"is not at the top level of the module"` warnings (was 4+). The new guard test passes and would fail on any regression.
- **Flake (recorded loop-N)**: `mcp-watcher-parity` green across **18 consecutive clean runs** — 12 isolated + 6 full-suite — 0 flakes.
- **Suite**: 308 files, 5986 passed, 2 skipped; lint + typecheck clean.

## Notes / nits

- The five moved `vi.mock` calls are behavior-identical (vitest hoisted them already); the diff just makes the code match its actual execution order.
- The flake task's outcome is "already event-driven + verified deterministic + documented," not a code change to the assertion mechanism — reported faithfully rather than inventing a fix for a race that no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)