### PR TITLE
fix(analyzer): string-literal-safe clone normalization — no false 1.0 verdicts from truncated literals

### DIFF
--- a/openspec/changes/fix-clone-string-normalization/proposal.md
+++ b/openspec/changes/fix-clone-string-normalization/proposal.md
@@ -1,10 +1,20 @@
 # Fix clone-detector string corruption: comment stripping truncates literals → false 1.0 clone verdicts
 
-> Status: PROPOSED (2026-07-08, e2e audit fifth pass). The duplicate detector's comment stripping
-> runs string-blind over raw text, so `//` inside a URL and `#` inside a hex color truncate the
-> literal — two functions differing ONLY in those constants normalize identical and are reported
-> as clones at similarity 1.0, exactly where an agent is told to trust the number (empirically
-> reproduced twice).
+> Status: SHIPPED (2026-07-19, PR fix-clone-string-normalization). `stripComments`
+> (`duplicate-detector.ts`) is now a single left-to-right scanner: it classifies each char as code,
+> string, or comment in one pass, so string-literal contents survive verbatim while comments are
+> removed. The `#` line-comment rule is language-selected (`hashStartsLineComment`); `findClones`
+> threads the query's language so query and candidates share one linguistic lens; the near-group
+> score is the all-pairs minimum (honest floor). Notes: (1) the string masking the proposal
+> described as a separate pass was folded into the scanner — equivalent result, no double-parse;
+> (2) both empirical repros and the language-selection/interpolation cases are pinned by tests in
+> `duplicate-detector.test.ts`; (3) no clone snapshots existed to re-baseline.
+>
+> Original status: PROPOSED (2026-07-08, e2e audit fifth pass). The duplicate detector's comment
+> stripping runs string-blind over raw text, so `//` inside a URL and `#` inside a hex color
+> truncate the literal — two functions differing ONLY in those constants normalize identical and
+> are reported as clones at similarity 1.0, exactly where an agent is told to trust the number
+> (empirically reproduced twice).
 
 ## The defect(s)
 

--- a/openspec/changes/fix-clone-string-normalization/tasks.md
+++ b/openspec/changes/fix-clone-string-normalization/tasks.md
@@ -1,29 +1,29 @@
 # Tasks — fix clone string normalization
 
 ## Implementation
-- [ ] String-aware comment stripping in `duplicate-detector.ts` (:126-137): mask string-literal
+- [x] String-aware comment stripping in `duplicate-detector.ts` (:126-137): mask string-literal
       contents (length-preserving, per the http-route-parser masking precedent) before applying
       comment rules, then strip the comment spans from the original text — literal contents
       still participate in normalization/shingling
-- [ ] Language-select the `#` line-comment rule: Python/Ruby only; never TS/JS/Go/Rust/Java;
+- [x] Language-select the `#` line-comment rule: Python/Ruby only; never TS/JS/Go/Rust/Java;
       Ruby `#{...}` interpolation protected by the string mask
-- [ ] Near-group score (:326-330): compute the group similarity floor all-pairs, or relabel the
+- [x] Near-group score (:326-330): compute the group similarity floor all-pairs, or relabel the
       seed-relative number honestly in the output field/docs — no silent overstatement
-- [ ] Confirm `normalizeType1`/`normalizeType2` (:140-157) and the shingle path all consume the
+- [x] Confirm `normalizeType1`/`normalizeType2` (:140-157) and the shingle path all consume the
       fixed stripper; `find_clones` inherits through the shared detector (no divergent copy)
 
 ## Verification
-- [ ] Repro fixtures pinned: two TS functions identical except a URL host/path inside a string →
+- [x] Repro fixtures pinned: two TS functions identical except a URL host/path inside a string →
       NOT exact/structural, similarity reported at its true value; two Python functions
       differing only in hex-color constants → same
-- [ ] `#`-in-TS fixture: a TS function whose strings contain `#` anchors normalizes without
+- [x] `#`-in-TS fixture: a TS function whose strings contain `#` anchors normalizes without
       truncation and does not falsely group
-- [ ] Ruby interpolation fixture: `"#{name}"` does not truncate its line
-- [ ] True clones still detected: an exact copy-paste pair (with differing comments) remains an
+- [x] Ruby interpolation fixture: `"#{name}"` does not truncate its line
+- [x] True clones still detected: an exact copy-paste pair (with differing comments) remains an
       exact clone at 1.0
-- [ ] Near-group fixture: a seed with two mutually dissimilar members reports the honest floor
+- [x] Near-group fixture: a seed with two mutually dissimilar members reports the honest floor
       (all-pairs) or the seed-relative label — per the implementation decision
-- [ ] Clone-report snapshot re-baseline reviewed against the fixtures; full suite green
+- [x] Clone-report snapshot re-baseline reviewed against the fixtures; full suite green
 
 ## Spec
-- [ ] `analyzer` delta: ADD StringLiteralSafeCloneNormalization
+- [x] `analyzer` delta: ADD StringLiteralSafeCloneNormalization

--- a/openspec/specs/analyzer/spec.md
+++ b/openspec/specs/analyzer/spec.md
@@ -5829,6 +5829,52 @@ SHALL NOT require any new persisted artifact.
 
 > Change: add-clone-query-tool
 > Date: 2026-06-26
+
+### Requirement: StringLiteralSafeCloneNormalization
+
+Clone-detection normalization SHALL NOT alter string-literal contents when stripping comments:
+comment rules SHALL be evaluated so a comment marker inside a literal (`//` in a URL, `#` in a hex
+color or anchor, Ruby `#{...}` interpolation, JS `#private` access) never truncates the literal;
+the `#` line-comment rule SHALL apply only to languages where `#` is a comment; and a reported
+clone-group similarity SHALL be what was computed — an all-pairs group floor, or a value explicitly
+labeled seed-relative — never a seed-relative number presented as group-wide.
+
+#### Scenario: Functions differing only in a URL are not identical clones
+
+- **GIVEN** two TypeScript functions identical except for the host and path inside a string
+  literal `"https://..."`
+- **WHEN** clone detection runs
+- **THEN** the pair is not reported as an exact or structural clone at similarity 1.0
+- **AND** any reported similarity reflects the literal difference
+
+#### Scenario: Functions differing only in constants are not identical clones
+
+- **GIVEN** two Python functions identical except for hex-color string constants (`"#ff0000"`
+  vs `"#00ff00"`)
+- **WHEN** clone detection runs
+- **THEN** the pair is not reported as an exact or structural clone at similarity 1.0
+
+#### Scenario: The hash-comment rule is language-selected
+
+- **GIVEN** a TypeScript function whose string literals contain `#`
+- **WHEN** normalization strips comments
+- **THEN** no text is removed by the `#` rule and the literals survive intact
+
+#### Scenario: True clones are still detected
+
+- **GIVEN** two copy-pasted functions that differ only in their comments
+- **WHEN** clone detection runs
+- **THEN** the pair is reported as an exact clone at similarity 1.0
+
+#### Scenario: Group similarity is honest
+
+- **GIVEN** a near-clone group whose members are closer to the seed than to each other
+- **WHEN** the group's similarity is reported
+- **THEN** the number is the all-pairs minimum, not a seed-relative value
+
+> Change: fix-clone-string-normalization
+> Date: 2026-07-19
+
 ### Requirement: FlipDefaultMcpSurfaceToTheSubstrateBothfacesPreset
 
 The system SHALL expose the substrate preset (navigation core plus recall, verify_claim, and blast_radius) as the default MCP tool surface.

--- a/src/core/analyzer/duplicate-detector.test.ts
+++ b/src/core/analyzer/duplicate-detector.test.ts
@@ -736,3 +736,200 @@ describe('findClones — one-vs-all query', () => {
     expect(cpp!.language).toBe('C++');
   });
 });
+
+// ---------------------------------------------------------------------------
+// String-literal-safe normalization (fix-clone-string-normalization)
+//
+// Comment stripping used to run string-blind, so a comment marker INSIDE a
+// literal (`//` in a URL, `#` in a hex color / anchor, Ruby `#{...}`) truncated
+// the literal — two bodies differing only there normalized identical and were
+// reported as clones at 1.0. These pin that the literal contents now survive.
+// ---------------------------------------------------------------------------
+
+describe('detectDuplicates — string-literal-safe normalization', () => {
+  /** Detect duplicates for a two-function fixture, one function per file. */
+  function pair(bodyA: string, bodyB: string, language = 'TypeScript') {
+    const fa = buildFile([bodyA]);
+    const fb = buildFile([bodyB]);
+    const nodes: FunctionNode[] = [
+      makeNode({ id: 'a', name: 'fa', filePath: '/a.ts', language, startIndex: fa.offsets[0].start, endIndex: fa.offsets[0].end }),
+      makeNode({ id: 'b', name: 'fb', filePath: '/b.ts', language, startIndex: fb.offsets[0].start, endIndex: fb.offsets[0].end }),
+    ];
+    return detectDuplicates(
+      [{ path: '/a.ts', content: fa.content }, { path: '/b.ts', content: fb.content }],
+      makeCallGraph(nodes),
+    );
+  }
+
+  it('two TS functions differing only in a URL inside a string are NOT exact/structural clones', () => {
+    // The `//` in the URL used to truncate both to `const url = "https:` → false exact clone.
+    const a = `function fetchUsers(client) {
+  const url = "https://api.example.com/users";
+  const res = client.get(url);
+  const parsed = parse(res.body);
+  return parsed.items;
+}`;
+    const b = `function fetchUsers(client) {
+  const url = "https://cdn.other.org/v2/data/records";
+  const res = client.get(url);
+  const parsed = parse(res.body);
+  return parsed.items;
+}`;
+    const result = pair(a, b);
+    expect(result.cloneGroups.filter(g => g.type === 'exact')).toHaveLength(0);
+    expect(result.cloneGroups.filter(g => g.type === 'structural')).toHaveLength(0);
+    // Any similarity that IS reported reflects the literal difference — strictly below 1.0.
+    for (const g of result.cloneGroups) expect(g.similarity).toBeLessThan(1.0);
+  });
+
+  it('two Python functions differing only in a hex-color string are NOT exact/structural clones', () => {
+    // The `#` in `"#ff0000"` used to truncate both to `color = "` → false exact clone.
+    const a = `def make_style():
+    color = "#ff0000"
+    border = solid(color)
+    fill = shade(color)
+    theme = build(border, fill)
+    return theme`;
+    const b = `def make_style():
+    color = "#00ff00"
+    border = solid(color)
+    fill = shade(color)
+    theme = build(border, fill)
+    return theme`;
+    const result = pair(a, b, 'Python');
+    expect(result.cloneGroups.filter(g => g.type === 'exact')).toHaveLength(0);
+    expect(result.cloneGroups.filter(g => g.type === 'structural')).toHaveLength(0);
+  });
+
+  it('the `#` rule is language-selected: a `#` inside a TS string literal survives', () => {
+    // TS: `#` is not a comment. The literal content after `#` (digits) must survive so the two
+    // bodies stay distinguishable (they would both collapse to `const a = "col` if `#` truncated).
+    const a = `function tag() {
+  const a = "col#100";
+  const b = combine(a);
+  const c = refine(b);
+  const d = finalize(c);
+  return d;
+}`;
+    const b = `function tag() {
+  const a = "col#200";
+  const b = combine(a);
+  const c = refine(b);
+  const d = finalize(c);
+  return d;
+}`;
+    const result = pair(a, b);
+    expect(result.cloneGroups.filter(g => g.type === 'exact')).toHaveLength(0);
+    expect(result.cloneGroups.filter(g => g.type === 'structural')).toHaveLength(0);
+  });
+
+  it('the `#` rule is language-selected: a TS `#private` field is not stripped', () => {
+    // Outside a string too: `this.#alpha` vs `this.#beta` used to both strip to `const v = this.`
+    // → false exact clone. TS `#` is code, so the field content must survive (not exact).
+    const a = `function read() {
+  const v = this.#alpha;
+  const w = wrap(v);
+  const x = scale(w);
+  const y = clamp(x);
+  return y;
+}`;
+    const b = `function read() {
+  const v = this.#beta;
+  const w = wrap(v);
+  const x = scale(w);
+  const y = clamp(x);
+  return y;
+}`;
+    const result = pair(a, b);
+    expect(result.cloneGroups.filter(g => g.type === 'exact')).toHaveLength(0);
+  });
+
+  it('Ruby `#{...}` interpolation does not truncate its line', () => {
+    // Ruby IS a `#`-comment language, but `#{...}` inside a string must be protected. Differing
+    // only in the digits after the interpolation, the pair must stay distinguishable (not exact).
+    const a = `def build(key)
+  value = "id-#{key}-100"
+  a = wrap(value)
+  b = scale(a)
+  c = clamp(b)
+  return c
+end`;
+    const b = `def build(key)
+  value = "id-#{key}-200"
+  a = wrap(value)
+  b = scale(a)
+  c = clamp(b)
+  return c
+end`;
+    const result = pair(a, b, 'Ruby');
+    expect(result.cloneGroups.filter(g => g.type === 'exact')).toHaveLength(0);
+    expect(result.cloneGroups.filter(g => g.type === 'structural')).toHaveLength(0);
+  });
+
+  it('true clones are still detected: identical Python bodies differing only in `#` comments', () => {
+    // The `#` rule STILL removes genuine Python comments, so a real copy-paste is still exact.
+    const a = `def total(items):
+    # sum the prices
+    s = 0
+    for it in items:
+        s = s + it.price
+    return s`;
+    const b = `def total(items):
+    # recompute total
+    s = 0
+    for it in items:
+        s = s + it.price
+    return s`;
+    const result = pair(a, b, 'Python');
+    const exact = result.cloneGroups.filter(g => g.type === 'exact');
+    expect(exact).toHaveLength(1);
+    expect(exact[0].similarity).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Near-group similarity honesty (fix-clone-string-normalization)
+//
+// A near group's reported similarity is the ALL-PAIRS minimum, not seed-vs-member —
+// so two members far apart from each other cannot be presented as a tight group.
+// ---------------------------------------------------------------------------
+
+describe('detectDuplicates — near-group similarity is the all-pairs floor', () => {
+  // A shared 14-statement core plus three DIFFERENTLY-SHAPED tails (so Type 2 does not collapse
+  // them): the seed is closer to each member than the two members are to each other.
+  const core = Array.from({ length: 14 }, (_, i) => `  const s${i} = op${i}(s${i > 0 ? i - 1 : 0});`).join('\n');
+  const seed = `function seed() {\n${core}\n  return s13;\n}`;
+  const bee = `function bee() {\n${core}\n  if (s13 > 0) { log(s13); }\n  return s13;\n}`;
+  const cee = `function cee() {\n${core}\n  for (const q of s13) { emit(q); trace(q); }\n  return s13;\n}`;
+
+  function nearSim(bodies: Array<{ name: string; body: string }>): { sim: number; members: string[] } {
+    const files = bodies.map(b => ({ path: `/${b.name}.ts`, content: b.body + '\n\n' }));
+    const nodes: FunctionNode[] = bodies.map(b =>
+      makeNode({ id: b.name, name: b.name, filePath: `/${b.name}.ts`, startIndex: 0, endIndex: b.body.length }),
+    );
+    const groups = detectDuplicates(files, makeCallGraph(nodes)).cloneGroups.filter(g => g.type === 'near');
+    expect(groups).toHaveLength(1);
+    return { sim: groups[0].similarity, members: groups[0].instances.map(i => i.functionName).sort() };
+  }
+
+  it('reports the minimum over ALL member pairs, including non-seed pairs', () => {
+    const S = { name: 'seed', body: seed };
+    const B = { name: 'bee', body: bee };
+    const C = { name: 'cee', body: cee };
+
+    // Each pairwise near-similarity, computed independently from a two-function run.
+    const seedBee = nearSim([S, B]).sim;
+    const seedCee = nearSim([S, C]).sim;
+    const beeCee = nearSim([B, C]).sim;
+
+    const combined = nearSim([S, B, C]);
+    expect(combined.members).toEqual(['bee', 'cee', 'seed']);
+
+    // The group score equals the all-pairs minimum — which here is the bee↔cee pair, NOT a
+    // seed-relative pair. A seed-relative floor would have reported min(seedBee, seedCee) instead.
+    const allPairsMin = Math.min(seedBee, seedCee, beeCee);
+    expect(combined.sim).toBe(allPairsMin);
+    expect(allPairsMin).toBe(beeCee);
+    expect(beeCee).toBeLessThan(Math.min(seedBee, seedCee));
+  });
+});

--- a/src/core/analyzer/duplicate-detector.ts
+++ b/src/core/analyzer/duplicate-detector.ts
@@ -123,30 +123,120 @@ const KEYWORDS = new Set([
 // NORMALIZATION
 // ============================================================================
 
-function stripComments(text: string): string {
-  // // single-line (JS/TS/Go/Rust/Java)
-  text = text.replace(/\/\/[^\n]*/g, '');
-  // # single-line (Python/Ruby)
-  text = text.replace(/#[^\n]*/g, '');
-  // /* */ multi-line
-  text = text.replace(/\/\*[\s\S]*?\*\//g, '');
-  // Python """ and ''' docstrings
-  text = text.replace(/"""[\s\S]*?"""/g, '');
-  text = text.replace(/'''[\s\S]*?'''/g, '');
-  return text;
+/**
+ * Languages where `#` begins a line comment. The `#` line-comment rule is applied
+ * ONLY for these; in C-family languages `#` is code (JS `#private` fields, C
+ * preprocessor `#include`, Rust `#[attr]`, Swift `#selector`, Lua `#len`), so
+ * stripping it there truncated real code. Matched case-insensitively against the
+ * call graph's language display names (`node.language`). An unknown/undefined
+ * language falls back to treating `#` as a comment — the pre-fix behavior, whose
+ * original target was Python/Ruby.
+ */
+const HASH_LINE_COMMENT_LANGUAGES = new Set([
+  'python', 'ruby', 'elixir', 'bash', 'shell', 'sh', 'zsh', 'php',
+  'perl', 'r', 'powershell', 'coffeescript', 'nim', 'crystal',
+  'toml', 'yaml', 'dockerfile', 'makefile', 'terraform', 'hcl',
+]);
+
+function hashStartsLineComment(language?: string): boolean {
+  if (!language) return true; // legacy default: `#` was Python/Ruby-targeted
+  return HASH_LINE_COMMENT_LANGUAGES.has(language.toLowerCase());
+}
+
+/**
+ * Strip comments from a function body WITHOUT corrupting string literals.
+ *
+ * A single left-to-right scan classifies each character as code, string, or
+ * comment. Comment/docstring characters are removed; string-literal CONTENTS are
+ * preserved verbatim, so two bodies differing only in a literal (a URL host, a
+ * hex color) stay distinguishable. This replaces the old string-blind regex
+ * passes, whose line- and block-comment rules ran over raw text and truncated a
+ * literal at the first comment-looking marker inside it (`//` in a URL, `#` in a
+ * hex color or anchor, Ruby `#{...}` interpolation, JS `#private`).
+ *
+ * `hashIsComment` selects the `#` line-comment rule (see `hashStartsLineComment`).
+ * Triple-quoted `"""`/`'''` blocks are removed as docstrings (unchanged
+ * behavior). Escapes inside a string are honored so `"\""` does not terminate
+ * early. An unterminated string or block comment runs to end-of-input —
+ * degrading to the old over-stripping, never to something worse.
+ */
+function stripComments(text: string, hashIsComment: boolean): string {
+  const n = text.length;
+  let out = '';
+  let i = 0;
+  while (i < n) {
+    const c = text[i];
+    const c2 = text[i + 1];
+
+    // Line comment: //
+    if (c === '/' && c2 === '/') {
+      let j = i + 2;
+      while (j < n && text[j] !== '\n') j++;
+      i = j;
+      continue;
+    }
+    // Block comment: /* ... */
+    if (c === '/' && c2 === '*') {
+      let j = i + 2;
+      while (j < n && !(text[j] === '*' && text[j + 1] === '/')) j++;
+      i = Math.min(n, j + 2); // consume the closing */
+      continue;
+    }
+    // Line comment: # (language-selected)
+    if (c === '#' && hashIsComment) {
+      let j = i + 1;
+      while (j < n && text[j] !== '\n') j++;
+      i = j;
+      continue;
+    }
+    // Triple-quoted docstring: """ ... """ or ''' ... ''' → removed
+    if ((c === '"' || c === "'") && text[i + 1] === c && text[i + 2] === c) {
+      const q = c;
+      let j = i + 3;
+      while (j < n && !(text[j] === q && text[j + 1] === q && text[j + 2] === q)) j++;
+      i = Math.min(n, j + 3); // consume the closing triple-quote
+      continue;
+    }
+    // String literal: " ... ", ' ... ', ` ... ` → contents preserved
+    if (c === '"' || c === "'" || c === '`') {
+      const q = c;
+      out += c;
+      let j = i + 1;
+      while (j < n) {
+        const cj = text[j];
+        if (cj === '\\') {
+          // Escape sequence: copy the backslash and the escaped char verbatim.
+          out += cj;
+          if (j + 1 < n) out += text[j + 1];
+          j += 2;
+          continue;
+        }
+        out += cj;
+        j++;
+        if (cj === q) break; // closing delimiter reached
+      }
+      i = j;
+      continue;
+    }
+
+    // Ordinary code character
+    out += c;
+    i++;
+  }
+  return out;
 }
 
 /** Type 1: strip comments + collapse whitespace */
-function normalizeType1(text: string): string {
-  return stripComments(text).replace(/\s+/g, ' ').trim();
+function normalizeType1(text: string, language?: string): string {
+  return stripComments(text, hashStartsLineComment(language)).replace(/\s+/g, ' ').trim();
 }
 
 /**
  * Type 2: Type 1 + replace non-keyword identifiers with sequential placeholders.
  * Same identifier name → same placeholder within the function scope.
  */
-function normalizeType2(text: string): string {
-  const base = normalizeType1(text);
+function normalizeType2(text: string, language?: string): string {
+  const base = normalizeType1(text, language);
   const seen = new Map<string, string>();
   let counter = 0;
   return base.replace(/\b([a-zA-Z_][a-zA-Z0-9_]*)\b/g, (match) => {
@@ -235,8 +325,8 @@ export function detectDuplicates(
     if (lineCount < MIN_LINES) continue;
 
     const body = content.slice(node.startIndex, node.endIndex);
-    const t1 = normalizeType1(body);
-    const t2 = normalizeType2(body);
+    const t1 = normalizeType1(body, node.language);
+    const t2 = normalizeType2(body, node.language);
     const tokens = tokenize(t2);
 
     if (tokens.length < MIN_TOKENS) continue;
@@ -323,10 +413,15 @@ export function detectDuplicates(
 
       if (group.length >= 2) {
         nearGrouped.add(i);
-        // Use minimum pairwise similarity as the group's score (conservative)
+        // Group score = the ALL-PAIRS minimum similarity (the honest floor). Computing it
+        // seed-vs-member only overstated cohesion: two members each 0.85-similar to the seed
+        // can be far less similar to each other. Groups are tiny (bounded by the near pass), so
+        // O(group²) is negligible.
         let minSim = 1.0;
-        for (let k = 1; k < group.length; k++) {
-          minSim = Math.min(minSim, jaccard(ungrouped[i].shingles, ungrouped[group[k]].shingles));
+        for (let a = 0; a < group.length; a++) {
+          for (let b = a + 1; b < group.length; b++) {
+            minSim = Math.min(minSim, jaccard(ungrouped[group[a]].shingles, ungrouped[group[b]].shingles));
+          }
         }
         const repIdx = group[0];
         cloneGroups.push({
@@ -430,6 +525,13 @@ export interface CloneQueryOptions {
    * never wrongly matched against itself and a different function is never wrongly excluded.
    */
   exclude?: { filePath: string; startIndex: number; endIndex: number };
+  /**
+   * The query's source language (symbol mode: the node's language; snippet mode: unknown). It
+   * governs the `#` line-comment rule for BOTH the query and every candidate, so the comparison is
+   * one consistent linguistic lens — a `#`-comment Python candidate is never spuriously matched to
+   * a `#`-code TS query. Undefined (snippet mode) falls back to the legacy `#`-as-comment default.
+   */
+  queryLanguage?: string;
 }
 
 export interface CloneQueryResult {
@@ -467,9 +569,13 @@ export function findClones(
     : NEAR_THRESHOLD;
   const floor = Math.min(1, Math.max(NEAR_FLOOR_MIN, requestedFloor));
 
+  // The query's language governs the `#` rule for the query AND every candidate, so both sides of
+  // each comparison share one linguistic lens (see `queryLanguage`).
+  const lang = options.queryLanguage;
+
   // ---- Fingerprint the query ----
-  const qT1 = normalizeType1(queryBody);
-  const qT2 = normalizeType2(queryBody);
+  const qT1 = normalizeType1(queryBody, lang);
+  const qT2 = normalizeType2(queryBody, lang);
   const qTokens = tokenize(qT2);
   if (queryLineCount < MIN_LINES || qTokens.length < MIN_TOKENS) {
     return { matches: [], belowThreshold: true, comparedAgainst: 0, similarityFloor: floor };
@@ -502,7 +608,7 @@ export function findClones(
     if (endLine - startLine + 1 < MIN_LINES) continue;
 
     const body = content.slice(node.startIndex, node.endIndex);
-    const tokens = tokenize(normalizeType2(body));
+    const tokens = tokenize(normalizeType2(body, lang));
     if (tokens.length < MIN_TOKENS) continue;
 
     comparedAgainst++;
@@ -516,9 +622,9 @@ export function findClones(
       language: node.language,
     };
 
-    if (sha16(normalizeType1(body)) === qT1Hash) {
+    if (sha16(normalizeType1(body, lang)) === qT1Hash) {
       matches.push({ type: 'exact', similarity: 1.0, ...base });
-    } else if (sha16(normalizeType2(body)) === qT2Hash) {
+    } else if (sha16(normalizeType2(body, lang)) === qT2Hash) {
       matches.push({ type: 'structural', similarity: 1.0, ...base });
     } else {
       const sim = jaccard(qShingles, getShingles(tokens));

--- a/src/core/services/mcp-handlers/clone-query.ts
+++ b/src/core/services/mcp-handlers/clone-query.ts
@@ -108,6 +108,7 @@ export async function handleFindClones(input: FindClonesInput): Promise<unknown>
   let queryBody: string;
   let queryLineCount: number;
   let exclude: { filePath: string; startIndex: number; endIndex: number } | undefined;
+  let queryLanguage: string | undefined;
   let queryLabel: Record<string, unknown>;
 
   if (hasSymbol) {
@@ -169,6 +170,7 @@ export async function handleFindClones(input: FindClonesInput): Promise<unknown>
     const endLine = node.endLine ?? startLine + queryBody.split('\n').length - 1;
     queryLineCount = endLine - startLine + 1;
     exclude = { filePath: node.filePath, startIndex: node.startIndex, endIndex: node.endIndex };
+    queryLanguage = node.language;
     queryLabel = {
       mode: 'symbol',
       symbol: `${node.name}::${node.filePath}`,
@@ -190,6 +192,7 @@ export async function handleFindClones(input: FindClonesInput): Promise<unknown>
     minSimilarity: input.minSimilarity,
     limit,
     exclude,
+    queryLanguage,
   });
 
   if (result.belowThreshold) {


### PR DESCRIPTION
**Status:** LGTM — implements the `fix-clone-string-normalization` proposal (e2e audit fifth pass). CI-equivalent green locally: lint + typecheck clean, **5,993 tests pass / 2 skipped** across 308 files, `npm run build` succeeds, and verified end-to-end on the compiled binary.

## What was wrong

`stripComments` in [duplicate-detector.ts](src/core/analyzer/duplicate-detector.ts) removed comments with string-blind regexes over raw text. A comment marker **inside a string literal** truncated the literal before hashing:

- `"https://api.example.com/users"` → the `//` truncates it to `"https:`
- `"#ff0000"` → the `#` truncates it to `"`

So two functions differing **only** in such a constant normalized identical and were reported as **exact clones at similarity 1.0** — precisely where `find_clones` and `get_duplicate_report` tell an agent to trust the number and reuse "the canonical implementation." Empirically reproduced for a URL-differing TS pair and a hex-color-differing Python pair.

Two smaller defects rode along: the `#` rule fired in C-family languages where `#` is code (JS `#private`, C preprocessor, Rust `#[attr]`, Swift `#selector`, Lua `#len`), and the near-group similarity was computed seed-vs-member, overstating group cohesion.

## How it was fixed

- **Single-pass scanner** replaces the regex passes: each character is classified as code, string, or comment in one left-to-right walk. String-literal contents survive verbatim; comments and triple-quoted docstrings are removed. Escapes are honored; an unterminated string/comment degrades to the old over-stripping, never worse.
- **Language-selected `#` rule** (`hashStartsLineComment`): applied only where `#` starts a comment.
- **`findClones` threads the query's language** so the query and every candidate are normalized under one consistent lens (no spurious cross-family exact matches; no snippet-mode regression).
- **All-pairs near-group floor**: the reported similarity is the minimum over every member pair, not seed-vs-member — a group whose members are far from each other can no longer be presented as tight.

`normalizeType1`/`normalizeType2`, the shingle path, `detectDuplicates`, and `findClones` all consume the one fixed stripper. No tool-surface change; no new tuning constant; no LLM.

## Proof it works

New tests in [duplicate-detector.test.ts](src/core/analyzer/duplicate-detector.test.ts) pin every case: URL-differing TS pair and hex-color Python pair are **not** exact/structural; TS `#`-in-string and `#private` survive; Ruby `#{...}` interpolation doesn't truncate; true copy-paste clones (differing only in comments) are still exact at 1.0; and the near-group score equals the independently-computed all-pairs minimum (a non-seed pair sets the floor).

End-to-end on the compiled binary: a temp repo whose two functions differ **only** in a URL inside a string now reports **0 clones** (`find-clones --symbol fetchUsers` → `exact 0, structural 0, near 0`); pre-fix they were a false exact clone at 1.0. A snippet query also ran clean against the real 2,598-function index.

## Notes

- Spec delta merged into [analyzer/spec.md](openspec/specs/analyzer/spec.md) as `StringLiteralSafeCloneNormalization`; proposal + tasks marked SHIPPED.
- The proposal floated masking as a separate pass; folding it into the scanner is equivalent with no double-parse.
- No clone snapshots existed, so nothing to re-baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)