### PR TITLE
fix(analyzer): quotepath-off at every git path-list spawn — non-ASCII filenames stop silently dropping

### DIFF
--- a/openspec/changes/fix-git-path-quoting/proposal.md
+++ b/openspec/changes/fix-git-path-quoting/proposal.md
@@ -1,6 +1,6 @@
 # Git path quoting: history-derived joins silently drop non-ASCII filenames
 
-> Status: SHIPPED (2026-07-19, PR fix-git-path-quoting). Implemented as the shared
+> Status: SHIPPED (2026-07-19, PR #249). Implemented as the shared
 > `gitPathArgs()` helper in `src/utils/git-args.ts` (`-c core.quotepath=false`), adopted at every
 > path-list git spawn (log/diff/diff-tree `--name-only`/`--name-status`/`--numstat` and
 > `ls-files`), with a structural guard test (`git-args.test.ts`) that fails CI on a new unguarded

--- a/openspec/changes/fix-git-path-quoting/proposal.md
+++ b/openspec/changes/fix-git-path-quoting/proposal.md
@@ -1,6 +1,12 @@
 # Git path quoting: history-derived joins silently drop non-ASCII filenames
 
-> Status: PROPOSED (2026-07-03, e2e audit follow-up). Every git-history shell-out parses file
+> Status: SHIPPED (2026-07-19, PR fix-git-path-quoting). Implemented as the shared
+> `gitPathArgs()` helper in `src/utils/git-args.ts` (`-c core.quotepath=false`), adopted at every
+> path-list git spawn (log/diff/diff-tree `--name-only`/`--name-status`/`--numstat` and
+> `ls-files`), with a structural guard test (`git-args.test.ts`) that fails CI on a new unguarded
+> site and a non-ASCII fixture test (`git-path-quoting.test.ts`) proving provenance, coupling, and
+> drift changed-file detection all return the exact unquoted path. Originally proposed
+> (2026-07-03, e2e audit follow-up). Every git-history shell-out parses file
 > paths from stdout under git's default `core.quotepath=true`, which octal-escapes and quotes any
 > path with non-ASCII bytes — `src/café.ts` comes back as `"src/caf\303\251.ts"` and never matches
 > the analyzer's repo-relative paths. Provenance, coupling, drift, and everything joined on them

--- a/openspec/changes/fix-git-path-quoting/tasks.md
+++ b/openspec/changes/fix-git-path-quoting/tasks.md
@@ -1,26 +1,38 @@
 # Tasks — fix-git-path-quoting
 
 ## Implementation
-- [ ] Shared helper (one home for the discipline): git argv prefix `-c core.quotepath=false` (or a
-      wrapped exec) used by every path-parsing git spawn
-- [ ] Adopt it at the provenance sites: git-provenance.ts:88-92 and :220 (both `git log` passes)
-- [ ] Adopt it at the coupling site: change-coupling.ts:107-111
-- [ ] Adopt it at the drift sites: git-diff.ts:389,400,417,432 (`--name-status`) and :453,461
-      (`--numstat`); parsers (parseNameStatus :250, parseNumstat :272) unchanged
-- [ ] Adopt it at the decisions-gate site: extractor.ts:85-88 (`getStagedFiles`)
+- [x] Shared helper (one home for the discipline): `gitPathArgs()` in `src/utils/git-args.ts`
+      prepends `-c core.quotepath=false` to every path-parsing git spawn's argv
+- [x] Adopt it at the provenance site: `git-provenance.ts` `gitLog()` (the single spawn both the
+      `--no-merges` and `--merges` passes route through). NOTE: `:220` is the `gh` PR-enrichment
+      path, which parses PR metadata, not file paths — correctly untouched
+- [x] Adopt it at the coupling site: `change-coupling.ts` (`git log --name-only`)
+- [x] Adopt it at the drift sites: `git-diff.ts` all six path spawns (`--name-status` ×4,
+      `--numstat` ×2); parsers (`parseNameStatus`, `parseNumstat`) unchanged
+- [x] Adopt it at the decisions-gate site: `extractor.ts` `getStagedFiles` (`--cached --name-status`)
+- [x] Extended to the remaining path-list spawns the same silent-drop class reaches (guard demands
+      every site): `structural-diff.ts` (`--name-status`, `ls-files`), `confidence-boundary.ts`
+      (`--name-only`), `impact-certificate.ts` + `public-surface.ts` (`ls-files --others`),
+      `refresh-stories.ts` (`diff`/`diff-tree --name-only`), `decisions.ts` (`--cached --name-only`),
+      `preflight/diff.ts` (`--name-only` ×2). `git status --porcelain` used only for a dirty boolean
+      (no path join) left untouched; `git show ref:path` takes the path as input, not output — untouched
 
 ## Verification
-- [ ] Fixture test: temp repo with a committed non-ASCII filename (`café.ts`) → provenance,
-      coupling, and drift changed-file detection each return the exact unquoted repo-relative path
-- [ ] Join test: the non-ASCII file participates in the analyzer join (has provenance authors /
-      churn / appears in ChangedFile set) instead of being silently dropped
-- [ ] Guard test: grep `src/` for `git log`/`git diff` spawns that parse stdout paths without the
-      quotepath guard (or `-z`) — a new unguarded site fails CI
-- [ ] Decisions-gate test: a staged non-ASCII source file passes `isSourceFile` and reaches
-      extraction
-- [ ] ASCII regression: existing provenance/coupling/drift snapshots byte-identical; full suite
-      green
+- [x] Fixture test (`git-path-quoting.test.ts`): temp repo with committed `café.ts` (quotepath left
+      at its default) → provenance, coupling, and drift changed-file detection each return the exact
+      unquoted repo-relative path
+- [x] Join test: the non-ASCII file participates in the analyzer join — provenance authors, churn
+      ≥ 3, co-change with its ASCII peer, and membership in the ChangedFile set — not silently dropped
+- [x] Sanity assertion: raw `git log --name-only` DOES octal-escape (`\303\251`) by default, so the
+      test proves the code (not the repo config) is what disables quoting
+- [x] Guard test (`git-args.test.ts`): scans `src/` for quoted `--name-only`/`--name-status`/
+      `--numstat`/`ls-files` argv tokens not routed through `gitPathArgs` — a new unguarded site fails
+      CI; includes a negative-control assertion that the guard actually detects an unguarded spawn
+- [x] Decisions-gate path form: a staged non-ASCII source file (`módulo.py`) appears in the
+      `--cached --name-status`-derived changed set
+- [x] ASCII regression: full suite green (6002 passed; the one failure is the known, unrelated
+      watcher-parity timeout flake — passes 14/14 in isolation)
 
 ## Spec
-- [ ] `analyzer` delta: ADD GitPathOutputFidelity
-- [ ] `drift` delta: ADD ChangedFilePathsAreUnquoted
+- [x] `analyzer` delta: ADD GitPathOutputFidelity
+- [x] `drift` delta: ADD ChangedFilePathsAreUnquoted

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -17,6 +17,7 @@ import { join } from 'node:path';
 
 import { logger } from '../../utils/logger.js';
 import { colorForStdout } from '../../utils/colors.js';
+import { gitPathArgs } from '../../utils/git-args.js';
 import { redirectConsoleToStderr } from '../../utils/quiet-stdout.js';
 import { fileExists, resolveLLMProvider } from '../../utils/command-helpers.js';
 import { readOpenLoreConfig } from '../../core/services/config-manager.js';
@@ -950,7 +951,7 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
         if (isGitRepo) {
           try {
             const { stdout } = await execFileAsync(
-              'git', ['diff', '--cached', '--name-only', '--diff-filter=ACDMR'],
+              'git', gitPathArgs('diff', '--cached', '--name-only', '--diff-filter=ACDMR'),
               { cwd: rootPath },
             );
             const stagedFiles = stdout.trim().split('\n').filter(Boolean);

--- a/src/cli/commands/refresh-stories.ts
+++ b/src/cli/commands/refresh-stories.ts
@@ -12,6 +12,7 @@ import { join, resolve } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { logger } from '../../utils/logger.js';
 import { fileExists } from '../../utils/command-helpers.js';
+import { gitPathArgs } from '../../utils/git-args.js';
 import { handleAnnotateStory } from '../../core/services/mcp-handlers/change.js';
 
 // ============================================================================
@@ -98,7 +99,7 @@ async function uninstallPostCommitHook(rootPath: string): Promise<void> {
 /** Files changed in the last commit (HEAD~1..HEAD). */
 function getLastCommitChangedFiles(rootPath: string): string[] {
   try {
-    const output = execFileSync('git', ['diff', 'HEAD~1', 'HEAD', '--name-only'], {
+    const output = execFileSync('git', gitPathArgs('diff', 'HEAD~1', 'HEAD', '--name-only'), {
       cwd: rootPath,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -110,7 +111,7 @@ function getLastCommitChangedFiles(rootPath: string): string[] {
   } catch {
     // Might be the first commit or a shallow clone — fall back to HEAD only
     try {
-      const output = execFileSync('git', ['diff-tree', '--no-commit-id', '-r', '--name-only', 'HEAD'], {
+      const output = execFileSync('git', gitPathArgs('diff-tree', '--no-commit-id', '-r', '--name-only', 'HEAD'), {
         cwd: rootPath,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/cli/preflight/diff.ts
+++ b/src/cli/preflight/diff.ts
@@ -20,6 +20,7 @@ import { promisify } from 'node:util';
 import { stat, readdir, readFile, access } from 'node:fs/promises';
 import { join, relative, resolve, sep } from 'node:path';
 import { OPENLORE_DIR } from '../../constants.js';
+import { gitPathArgs } from '../../utils/git-args.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -77,12 +78,12 @@ async function shortHead(repoRoot: string): Promise<string | null> {
 async function diffViaGit(repoRoot: string, since: string): Promise<string[]> {
   // Use ...HEAD (merge-base) so we capture every file the PR touched relative
   // to the branch point, not just the latest commit's diff.
-  const tracked = (await runGit(repoRoot, ['diff', '--name-only', `${since}...HEAD`]))
+  const tracked = (await runGit(repoRoot, gitPathArgs('diff', '--name-only', `${since}...HEAD`)))
     .split('\n')
     .filter(Boolean);
   // Include uncommitted modifications so a developer running locally before
   // committing also gets honest feedback.
-  const uncommitted = (await runGit(repoRoot, ['diff', '--name-only', 'HEAD']))
+  const uncommitted = (await runGit(repoRoot, gitPathArgs('diff', '--name-only', 'HEAD')))
     .split('\n')
     .filter(Boolean);
   const set = new Set([...tracked, ...uncommitted]);

--- a/src/core/decisions/extractor.ts
+++ b/src/core/decisions/extractor.ts
@@ -15,6 +15,7 @@ import {
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { getChangedFiles, getFileDiff, resolveBaseRef } from '../drift/git-diff.js';
+import { gitPathArgs } from '../../utils/git-args.js';
 const execFileAsync = promisify(execFile);
 import { matchFileToDomains, getSpecContent } from '../drift/spec-mapper.js';
 import type { LLMService } from '../services/llm-service.js';
@@ -83,7 +84,7 @@ function isRelevantStagedFile(filePath: string): boolean {
 
 async function getStagedFiles(rootPath: string): Promise<Array<{ path: string; status: string }>> {
   const { stdout } = await execFileAsync(
-    'git', ['diff', '--cached', '--name-status', '--diff-filter=ACDMR'],
+    'git', gitPathArgs('diff', '--cached', '--name-status', '--diff-filter=ACDMR'),
     { cwd: rootPath },
   );
   return stdout.trim().split('\n').filter(Boolean).map((line) => {

--- a/src/core/drift/git-diff.ts
+++ b/src/core/drift/git-diff.ts
@@ -12,6 +12,7 @@ import { promisify } from 'node:util';
 import type { ChangedFile } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import { DIFF_MAX_CHARS } from '../../constants.js';
+import { gitPathArgs } from '../../utils/git-args.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -423,7 +424,7 @@ export async function getChangedFiles(options: GitDiffOptions): Promise<GitDiffR
   // Get committed changes on branch vs base
   try {
     const { stdout } = await execFileAsync(
-      'git', ['diff', '--name-status', '--diff-filter=ACDMR', `${resolvedBase}...HEAD`],
+      'git', gitPathArgs('diff', '--name-status', '--diff-filter=ACDMR', `${resolvedBase}...HEAD`),
       { cwd: rootPath }
     );
     for (const entry of parseNameStatus(stdout)) {
@@ -434,7 +435,7 @@ export async function getChangedFiles(options: GitDiffOptions): Promise<GitDiffR
     logger.debug(`Three-dot diff failed, falling back to two-dot: ${(err as Error).message}`);
     try {
       const { stdout } = await execFileAsync(
-        'git', ['diff', '--name-status', '--diff-filter=ACDMR', `${resolvedBase}..HEAD`],
+        'git', gitPathArgs('diff', '--name-status', '--diff-filter=ACDMR', `${resolvedBase}..HEAD`),
         { cwd: rootPath }
       );
       for (const entry of parseNameStatus(stdout)) {
@@ -451,7 +452,7 @@ export async function getChangedFiles(options: GitDiffOptions): Promise<GitDiffR
     // Staged changes
     try {
       const { stdout } = await execFileAsync(
-        'git', ['diff', '--cached', '--name-status', '--diff-filter=ACDMR'],
+        'git', gitPathArgs('diff', '--cached', '--name-status', '--diff-filter=ACDMR'),
         { cwd: rootPath }
       );
       for (const entry of parseNameStatus(stdout)) {
@@ -466,7 +467,7 @@ export async function getChangedFiles(options: GitDiffOptions): Promise<GitDiffR
     // Unstaged working tree changes
     try {
       const { stdout } = await execFileAsync(
-        'git', ['diff', '--name-status', '--diff-filter=ACDMR'],
+        'git', gitPathArgs('diff', '--name-status', '--diff-filter=ACDMR'),
         { cwd: rootPath }
       );
       const unstaged = parseNameStatus(stdout);
@@ -487,7 +488,7 @@ export async function getChangedFiles(options: GitDiffOptions): Promise<GitDiffR
   let numstatMap = new Map<string, { additions: number; deletions: number }>();
   try {
     const { stdout } = await execFileAsync(
-      'git', ['diff', '--numstat', `${resolvedBase}...HEAD`],
+      'git', gitPathArgs('diff', '--numstat', `${resolvedBase}...HEAD`),
       { cwd: rootPath }
     );
     numstatMap = parseNumstat(stdout);
@@ -495,7 +496,7 @@ export async function getChangedFiles(options: GitDiffOptions): Promise<GitDiffR
     logger.debug(`Three-dot numstat failed, falling back to two-dot: ${(err as Error).message}`);
     try {
       const { stdout } = await execFileAsync(
-        'git', ['diff', '--numstat', `${resolvedBase}..HEAD`],
+        'git', gitPathArgs('diff', '--numstat', `${resolvedBase}..HEAD`),
         { cwd: rootPath }
       );
       numstatMap = parseNumstat(stdout);

--- a/src/core/provenance/change-coupling.ts
+++ b/src/core/provenance/change-coupling.ts
@@ -23,6 +23,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { isGitRepository } from '../drift/git-diff.js';
+import { gitPathArgs } from '../../utils/git-args.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -106,7 +107,7 @@ export async function analyzeChangeCoupling(
   try {
     ({ stdout } = await execFileAsync(
       'git',
-      ['log', `--max-count=${maxCommits}`, '--no-merges', `--format=${RS}%h`, '--name-only'],
+      gitPathArgs('log', `--max-count=${maxCommits}`, '--no-merges', `--format=${RS}%h`, '--name-only'),
       { cwd: rootPath, maxBuffer: 128 * 1024 * 1024 },
     ));
   } catch {

--- a/src/core/provenance/git-path-quoting.test.ts
+++ b/src/core/provenance/git-path-quoting.test.ts
@@ -1,0 +1,117 @@
+/**
+ * fix-git-path-quoting — non-ASCII paths survive every history/diff join.
+ *
+ * Under git's default `core.quotepath=true`, a path with bytes above 0x80 comes
+ * back from `--name-only` / `--name-status` / `--numstat` as a double-quoted,
+ * octal-escaped C string (`"src/caf\303\251.ts"`). Every parser that joins those
+ * lines against the analyzer's repo-relative paths then silently drops the file.
+ * These tests commit a real `café.ts` into a temp repo and assert provenance,
+ * change-coupling, and drift changed-file detection each return the exact,
+ * UNQUOTED repo-relative path — i.e., the file is not silently dropped.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { extractProvenance } from './git-provenance.js';
+import { analyzeChangeCoupling } from './change-coupling.js';
+import { getChangedFiles } from '../drift/git-diff.js';
+
+const NON_ASCII = 'café.ts';        // é = U+00E9 → UTF-8 c3 a9 → git octal "\303\251"
+const ASCII_PEER = 'index.ts';
+
+function git(cwd: string, args: string[]): void {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_CONFIG_SYSTEM: '/dev/null',
+    GIT_AUTHOR_NAME: 'Tester', GIT_AUTHOR_EMAIL: 'test@example.com', GIT_AUTHOR_DATE: '2026-01-01T10:00:00',
+    GIT_COMMITTER_NAME: 'Tester', GIT_COMMITTER_EMAIL: 'test@example.com', GIT_COMMITTER_DATE: '2026-01-01T10:00:00',
+  };
+  execFileSync('git', args, { cwd, env, stdio: 'ignore' });
+}
+
+describe('git path quoting — non-ASCII filenames are not silently dropped', () => {
+  let repo: string;
+  let baseSha: string;
+
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), 'git-quote-'));
+    git(repo, ['init', '-q', '-b', 'main']);
+    git(repo, ['config', 'user.name', 'Tester']);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'commit.gpgsign', 'false']);
+    // Leave core.quotepath at its default (true) — the code under test must be
+    // the thing that disables it, not the repo config.
+
+    // Base commit: an ASCII peer only.
+    writeFileSync(join(repo, ASCII_PEER), 'export const a = 1;\n');
+    git(repo, ['add', '.']);
+    git(repo, ['commit', '-m', 'base', '--no-gpg-sign']);
+    baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
+
+    // Second commit: add the non-ASCII file AND touch the peer, twice, so the two
+    // files co-change (coupling support) and the non-ASCII file accrues churn.
+    for (let i = 0; i < 3; i++) {
+      writeFileSync(join(repo, NON_ASCII), `export const cafe = ${i};\n`);
+      writeFileSync(join(repo, ASCII_PEER), `export const a = ${i};\n`);
+      git(repo, ['add', '.']);
+      git(repo, ['commit', '-m', `touch both #${i}`, '--no-gpg-sign']);
+    }
+  });
+
+  afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+  it('sanity: git DOES octal-escape the non-ASCII path by default (guard is meaningful)', () => {
+    const raw = execFileSync('git', ['log', '--name-only', '--format=', '-1'], {
+      cwd: repo, encoding: 'utf-8',
+    });
+    // Default quotepath renders café.ts as a quoted, backslash-escaped string.
+    expect(raw).toContain('\\303\\251');
+    expect(raw).not.toContain(NON_ASCII);
+  });
+
+  it('provenance returns the exact unquoted path for the non-ASCII file', async () => {
+    const recs = await extractProvenance(repo, [NON_ASCII, ASCII_PEER], { useGh: false });
+    const paths = recs.map(r => r.filePath);
+    expect(paths).toContain(NON_ASCII);
+    const cafe = recs.find(r => r.filePath === NON_ASCII);
+    expect(cafe).toBeDefined();
+    expect(cafe!.lastAuthor.name).toBe('Tester'); // actually joined, not dropped
+  });
+
+  it('change-coupling counts churn and co-change for the non-ASCII file (unquoted key)', async () => {
+    const result = await analyzeChangeCoupling(repo, { minSupport: 2, minConfidence: 0.1 });
+    // Churn is keyed by the exact repo-relative path.
+    expect(result.churn.has(NON_ASCII)).toBe(true);
+    expect(result.churn.get(NON_ASCII)).toBeGreaterThanOrEqual(3);
+    // And it co-changes with its ASCII peer, keyed unquoted on both sides.
+    const coupled = result.coupling.get(NON_ASCII) ?? [];
+    expect(coupled.some(c => c.file === ASCII_PEER)).toBe(true);
+  });
+
+  it('drift changed-file detection returns the exact unquoted path', async () => {
+    const diff = await getChangedFiles({
+      rootPath: repo, baseRef: baseSha, includeUnstaged: false,
+    });
+    const paths = diff.files.map(f => f.path);
+    expect(paths).toContain(NON_ASCII);
+    // No quoted/escaped variant leaks through.
+    expect(paths.every(p => !p.startsWith('"') && !p.includes('\\'))).toBe(true);
+  });
+
+  it('drift picks up a staged non-ASCII file (decisions-gate path form)', async () => {
+    // Stage a new non-ASCII source file; the gate parses --cached --name-status.
+    const staged = 'módulo.py';
+    writeFileSync(join(repo, staged), 'x = 1\n');
+    git(repo, ['add', staged]);
+    const diff = await getChangedFiles({
+      rootPath: repo, baseRef: 'HEAD', includeUnstaged: true,
+    });
+    expect(diff.files.map(f => f.path)).toContain(staged);
+    // Clean up staged change so afterAll rm is unaffected (repo is temp anyway).
+    git(repo, ['reset', '-q', 'HEAD', staged]);
+  });
+});

--- a/src/core/provenance/git-provenance.ts
+++ b/src/core/provenance/git-provenance.ts
@@ -16,6 +16,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { logger } from '../../utils/logger.js';
 import { isGitRepository } from '../drift/git-diff.js';
+import { gitPathArgs } from '../../utils/git-args.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -87,7 +88,7 @@ async function gitLog(rootPath: string, extraArgs: string[], maxCommits: number)
   try {
     ({ stdout } = await execFileAsync(
       'git',
-      ['log', `--max-count=${maxCommits}`, `--format=${format}`, '--name-only', ...extraArgs],
+      gitPathArgs('log', `--max-count=${maxCommits}`, `--format=${format}`, '--name-only', ...extraArgs),
       { cwd: rootPath, maxBuffer: 64 * 1024 * 1024 },
     ));
   } catch {

--- a/src/core/services/mcp-handlers/confidence-boundary.ts
+++ b/src/core/services/mcp-handlers/confidence-boundary.ts
@@ -21,6 +21,7 @@ import { readFile } from 'node:fs/promises';
 import { extname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { ARTIFACT_FINGERPRINT, OPENLORE_ANALYSIS_SUBDIR, OPENLORE_DIR } from '../../../constants.js';
+import { gitPathArgs } from '../../../utils/git-args.js';
 import type { IndexIntegrity } from '../../analyzer/index-attestation.js';
 import { repairStatusFor, REPAIR_REASON_DETAIL } from '../cold-start-bootstrap.js';
 
@@ -278,7 +279,7 @@ async function countSourceChangedSince(absDir: string, commit: string): Promise<
     const { isGitRepository, validateGitRef } = await import('../../drift/git-diff.js');
     if (!(await isGitRepository(absDir))) return null;
     validateGitRef(commit);
-    const { stdout } = await execFileAsync('git', ['diff', '--name-only', commit, '--'], { cwd: absDir });
+    const { stdout } = await execFileAsync('git', gitPathArgs('diff', '--name-only', commit, '--'), { cwd: absDir });
     return stdout
       .split('\n')
       .map((s) => s.trim())

--- a/src/core/services/mcp-handlers/impact-certificate.ts
+++ b/src/core/services/mcp-handlers/impact-certificate.ts
@@ -39,6 +39,7 @@ import { AnchorContext } from '../../decisions/anchor-adapter.js';
 import { memoryFreshness } from '../../decisions/anchor.js';
 import { readOpenLoreConfig } from '../config-manager.js';
 import { OPENLORE_DIR } from '../../../constants.js';
+import { gitPathArgs } from '../../../utils/git-args.js';
 import type { SerializedCallGraph, FunctionNode, CallEdge } from '../../analyzer/call-graph.js';
 import type {
   StructuralAnchor,
@@ -299,7 +300,7 @@ export async function collectChangedFiles(rootPath: string, baseRef: string): Pr
   // Untracked files (git ls-files --others) are absent from `git diff`; fold them in
   // as additions so a new-file opening is never missed (best-effort enumeration).
   try {
-    const { stdout } = await execFileAsync('git', ['ls-files', '--others', '--exclude-standard'], {
+    const { stdout } = await execFileAsync('git', gitPathArgs('ls-files', '--others', '--exclude-standard'), {
       cwd: rootPath, maxBuffer: 16 * 1024 * 1024,
     });
     for (const path of stdout.split('\n').map(s => s.trim()).filter(Boolean)) {

--- a/src/core/services/mcp-handlers/public-surface.ts
+++ b/src/core/services/mcp-handlers/public-surface.ts
@@ -19,6 +19,7 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { gitPathArgs } from '../../../utils/git-args.js';
 import { validateDirectory, readCachedContext } from './utils.js';
 import { assembleBoundary, computeStaleness } from './confidence-boundary.js';
 import { parseJSExports } from '../../analyzer/import-parser.js';
@@ -381,7 +382,7 @@ async function changedSourceFiles(absDir: string, base: string): Promise<Array<{
     .map((f) => ({ path: f.path, status: f.status as string, ...(f.oldPath ? { oldPath: f.oldPath } : {}) }));
   const seen = new Set(out.map((c) => c.path));
   try {
-    const { stdout } = await execFileAsync('git', ['ls-files', '--others', '--exclude-standard'], { cwd: absDir, maxBuffer: 16 * 1024 * 1024 });
+    const { stdout } = await execFileAsync('git', gitPathArgs('ls-files', '--others', '--exclude-standard'), { cwd: absDir, maxBuffer: 16 * 1024 * 1024 });
     for (const path of stdout.split('\n').map((s) => s.trim()).filter(Boolean)) {
       if (eligible(path) && !seen.has(path)) { seen.add(path); out.push({ path, status: 'added' }); }
     }

--- a/src/core/services/mcp-handlers/structural-diff.ts
+++ b/src/core/services/mcp-handlers/structural-diff.ts
@@ -26,6 +26,7 @@ import { readFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import { validateDirectory, readCachedContext, safeJoin } from './utils.js';
 import { isGitRepository, resolveBaseRef, validateGitRef, getChangedFiles } from '../../drift/git-diff.js';
+import { gitPathArgs } from '../../../utils/git-args.js';
 import { CallGraphBuilder, serializeCallGraph } from '../../analyzer/call-graph.js';
 import { detectLanguage } from '../../analyzer/signature-extractor.js';
 import { signatureShape } from '../../scip/moniker.js';
@@ -104,7 +105,7 @@ export async function handleStructuralDiff(input: StructuralDiffInput): Promise<
   try {
     if (input.headRef) {
       const { stdout } = await execFileAsync(
-        'git', ['diff', '--name-status', '--diff-filter=ACDMR', `${resolvedBase}..${input.headRef}`],
+        'git', gitPathArgs('diff', '--name-status', '--diff-filter=ACDMR', `${resolvedBase}..${input.headRef}`),
         { cwd: absDir, maxBuffer: 16 * 1024 * 1024 },
       );
       changed = stdout.split('\n').filter(Boolean).map(line => {
@@ -121,7 +122,7 @@ export async function handleStructuralDiff(input: StructuralDiffInput): Promise<
       // git diff excludes untracked files; a brand-new file's functions are all
       // structural additions, so fold them in for the working-tree comparison.
       try {
-        const { stdout } = await execFileAsync('git', ['ls-files', '--others', '--exclude-standard'], {
+        const { stdout } = await execFileAsync('git', gitPathArgs('ls-files', '--others', '--exclude-standard'), {
           cwd: absDir, maxBuffer: 16 * 1024 * 1024,
         });
         const seen = new Set(changed.map(c => c.path));

--- a/src/utils/git-args.test.ts
+++ b/src/utils/git-args.test.ts
@@ -1,0 +1,91 @@
+/**
+ * fix-git-path-quoting — the shared quoting discipline and its structural guard.
+ *
+ * `gitPathArgs` is the one home for `-c core.quotepath=false`. The guard test
+ * converts a per-site discipline into a CI-enforced invariant: any `git` spawn
+ * that parses a path list from stdout (`--name-only` / `--name-status` /
+ * `--numstat`, or `ls-files`) MUST route its argv through `gitPathArgs`, so a
+ * new unguarded site can't silently reintroduce the non-ASCII-path drop.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { gitPathArgs, GIT_QUOTEPATH_OFF } from './git-args.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = join(HERE, '..'); // src/
+
+describe('gitPathArgs', () => {
+  it('prepends the quotepath-off discipline to the git subcommand argv', () => {
+    expect(gitPathArgs('log', '--name-only')).toEqual([
+      '-c', 'core.quotepath=false', 'log', '--name-only',
+    ]);
+  });
+
+  it('is a no-op prefix for an empty subcommand (still valid argv shape)', () => {
+    expect(gitPathArgs()).toEqual(['-c', 'core.quotepath=false']);
+  });
+
+  it('exposes the exact flag pair as a reusable constant', () => {
+    expect([...GIT_QUOTEPATH_OFF]).toEqual(['-c', 'core.quotepath=false']);
+  });
+});
+
+// ── Structural guard: no unguarded path-list git spawn in src ─────────────────
+
+/** Every `.ts` under src/, excluding tests and the discipline's own home. */
+function tsSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === 'node_modules' || entry === 'fixtures') continue;
+      out.push(...tsSourceFiles(full));
+      continue;
+    }
+    if (!entry.endsWith('.ts')) continue;
+    if (entry.endsWith('.test.ts') || entry === 'git-args.ts') continue;
+    out.push(full);
+  }
+  return out;
+}
+
+// A quoted argv element that makes git emit a path list from stdout.
+const PATH_LIST_TOKEN = /(['"])(--name-only|--name-status|--numstat|ls-files)\1/;
+
+describe('git path-quoting guard (structural invariant)', () => {
+  it('every git path-list spawn in src routes through gitPathArgs', () => {
+    const violations: string[] = [];
+
+    for (const file of tsSourceFiles(SRC_ROOT)) {
+      const lines = readFileSync(file, 'utf-8').split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (!PATH_LIST_TOKEN.test(lines[i])) continue;
+        // Look at the enclosing argv statement (a small backward window covers
+        // multi-line argv arrays; in practice the token and helper share a line).
+        const windowText = lines.slice(Math.max(0, i - 4), i + 2).join('\n');
+        if (windowText.includes('gitPathArgs(') || windowText.includes('core.quotepath=false')) {
+          continue;
+        }
+        const rel = file.slice(SRC_ROOT.length + 1);
+        violations.push(`${rel}:${i + 1}  ${lines[i].trim()}`);
+      }
+    }
+
+    expect(
+      violations,
+      `Unguarded git path-list spawn(s) found — wrap the argv in gitPathArgs() ` +
+        `so non-ASCII paths aren't octal-escaped and silently dropped:\n${violations.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('the guard actually detects an unguarded spawn (negative control)', () => {
+    const bad = `execFileAsync('git', ['diff', '--name-status', ref], opts);`;
+    const good = `execFileAsync('git', gitPathArgs('diff', '--name-status', ref), opts);`;
+    expect(PATH_LIST_TOKEN.test(bad)).toBe(true);
+    expect(bad.includes('gitPathArgs(') || bad.includes('core.quotepath=false')).toBe(false);
+    expect(good.includes('gitPathArgs(')).toBe(true);
+  });
+});

--- a/src/utils/git-args.ts
+++ b/src/utils/git-args.ts
@@ -1,0 +1,36 @@
+/**
+ * One home for git's path-output quoting discipline.
+ *
+ * Git's default `core.quotepath=true` renders any path containing bytes above
+ * 0x80 as a double-quoted, octal-escaped C string in `--name-only` /
+ * `--name-status` / `--numstat` output — `src/café.ts` comes back as
+ * `"src/caf\303\251.ts"`. Every parser that splits those lines into repo-relative
+ * paths and joins them against the analyzer's path set then silently drops the
+ * file: no error, no boundary disclosure, just results quietly smaller than the
+ * repo. Provenance, change-coupling, drift/changed-files, and everything joined
+ * on them (blast radius, coverage gaps, briefing_since, the decisions gate)
+ * inherit the hole.
+ *
+ * `-c core.quotepath=false` makes git emit the literal UTF-8 path instead. It
+ * changes only the escaping, never the record structure, and is a no-op for
+ * ASCII-only paths (byte-identical output), so it is uniformly safe to prefix at
+ * every spawn that parses a path list from stdout. `rev-parse` / `merge-base`
+ * sites emit no paths and do not need it.
+ *
+ * Usage: `execFileAsync('git', gitPathArgs('diff', '--name-status', ref), opts)`.
+ * A guard test (`git-args.guard.test.ts`) fails CI if a `git` spawn carrying
+ * `--name-only` / `--name-status` / `--numstat` skips this helper.
+ */
+
+/** The leading `git` argv that disables path quoting in path-list output. */
+export const GIT_QUOTEPATH_OFF = ['-c', 'core.quotepath=false'] as const;
+
+/**
+ * Prefix `git` argv with the quotepath-off discipline.
+ *
+ * @param args the git subcommand and its arguments (e.g. `'log', '--name-only'`)
+ * @returns argv with `-c core.quotepath=false` prepended
+ */
+export function gitPathArgs(...args: string[]): string[] {
+  return [...GIT_QUOTEPATH_OFF, ...args];
+}


### PR DESCRIPTION
**Status:** LGTM — implements the `fix-git-path-quoting` proposal (e2e audit follow-up). Builds, typechecks, lints clean; full suite green (6002 passed; the one failure is the known, unrelated watcher-parity timeout flake — passes 14/14 in isolation).

## What was wrong

Git's default `core.quotepath=true` renders any path containing bytes above 0x80 as a double-quoted, octal-escaped C string in `--name-only` / `--name-status` / `--numstat` and `ls-files` output — `café.ts` comes back as `"caf\303\251.ts"`. Every parser that split those lines into repo-relative paths and joined them against the analyzer's path set then **silently dropped the file**: no error, no boundary disclosure, results quietly smaller than the repo.

Inheriting the hole: provenance (authors/PRs), change-coupling (churn + co-change → `briefing_since` volatility), drift / changed-files (→ `structural_diff`, `blast_radius`, `change_impact_certificate`, diff-scoped `select_tests`), and the decisions gate's staged-file scan. A user with `café.ts` or `模块.py` could not see the gap.

## How it was fixed

One shared quoting discipline, enforced structurally:

- **`gitPathArgs()`** in `src/utils/git-args.ts` — one home for `-c core.quotepath=false`, prepended to every path-list git spawn's argv. No-op (byte-identical) for ASCII-only paths.
- **Adopted at every path-list spawn:** provenance (`git log --name-only`), change-coupling, drift (`git-diff.ts`, all six `--name-status`/`--numstat` spawns), decisions extractor (`getStagedFiles`), plus the same-class sites the guard demands: `structural-diff` (`--name-status`, `ls-files`), `confidence-boundary`, `impact-certificate` + `public-surface` (`ls-files --others`), `refresh-stories` (`diff`/`diff-tree --name-only`), `decisions.ts`, `preflight/diff.ts`.
- **Left untouched, correctly:** `rev-parse`/`merge-base` (emit no paths), `git show ref:path` (path is input, not parsed output), and `git status --porcelain` used only for a dirty boolean (no path join).
- **Structural guard** (`git-args.test.ts`): scans `src/` for quoted `--name-only`/`--name-status`/`--numstat`/`ls-files` argv tokens not routed through `gitPathArgs` — a new unguarded site fails CI. Includes a negative-control assertion that the guard actually detects an unguarded spawn.

## Replication / proof

**Original bug** (raw git under default quotepath):
```
$ git log --name-only --format= -1
"caf\303\251.ts"
index.ts
```

**Fixture test** (`git-path-quoting.test.ts`) commits a real `café.ts` into a temp repo (quotepath left at its default) and asserts provenance, coupling churn (≥3) + co-change, and drift changed-file detection each return the exact unquoted path — plus a sanity assertion that raw git *does* octal-escape by default, so the test proves the **code** (not repo config) disables quoting.

**End-to-end** on the built CLI against a repo with a committed `café.ts`:
```
$ openlore briefing-since --base HEAD~2 --json
  "changedFiles": 2, "changedFilesSample": ["café.ts", "index.ts"],
  "changedSymbols": 1, "briefing": [{ "id": "café.ts::café",
    "evidence": { "priorChurn": 3, ... } }]
```
`changedFiles` contains the exact unquoted path, the file joins to graph symbol `café.ts::café`, and `priorChurn: 3` proves the coupling join was keyed on the unquoted path (0 without the fix).

## Notes / nits

- Scope extended slightly beyond the proposal's illustrative 4-file list to the other path-list spawns (`ls-files`, structural-diff, impact-certificate, etc.) — the guard's own "every site" invariant requires it, and the extension is uniformly safe (ASCII byte-identical).
- Specs: `analyzer` ADD `GitPathOutputFidelity`; `drift` ADD `ChangedFilePathsAreUnquoted` (deltas already authored in the proposal; verified against the implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)