### PR TITLE
fix(drift): un-blind the drift gate — real counts for uncommitted work + ADR id normalization

### DIFF
--- a/openspec/changes/fix-commit-gate-delivery/proposal.md
+++ b/openspec/changes/fix-commit-gate-delivery/proposal.md
@@ -9,6 +9,12 @@
 
 ## The gap
 
+> **Coordination note from `fix-drift-gate-blindness` (shipped):** there is a THIRD hooksPath-ignoring
+> installer this change's "both installers" wording does not name — the drift-hook installer in
+> `src/cli/commands/drift.ts:173-207` also hard-codes `<root>/.git/hooks/pre-commit`. The
+> `git rev-parse --git-path hooks` resolution below must extend to `drift.ts` as well, or the drift
+> gate stays inert under husky/lefthook after enforce/decisions are fixed.
+
 - **The gate can be silently inert.** `installEnforcementHook` joins `rootPath, '.git', 'hooks'`
   unconditionally (`enforce.ts:71-98`) and prints "installed at .git/hooks/pre-commit"
   (`enforce.ts:96`); the decisions-gate `installPreCommitHook` does the same

--- a/openspec/changes/fix-drift-gate-blindness/proposal.md
+++ b/openspec/changes/fix-drift-gate-blindness/proposal.md
@@ -1,10 +1,18 @@
 # Fix drift-gate blindness: uncommitted work always counts +0/-0, and ADR updates never suppress adr-gap
 
-> Status: PROPOSED (2026-07-08, e2e audit fifth pass). Two live-reproduced correctness holes
-> that make the drift gate blind exactly when it matters: line counts for staged/uncommitted
-> changes are always zero (so gap severity can never reach the hook's own threshold), and the
-> ADR-updated suppression compares two id formats that never match (so updating an ADR alongside
-> governed code still reports adr-gap).
+> Status: SHIPPED (2026-07-19, PR fix-drift-gate-blindness). Both holes closed: (a) `getChangedFiles`
+> now gathers `git diff --cached --numstat` and `git diff --numstat` and merges them per path (summed)
+> into the range numstat when `includeUnstaged` is set, so staged/working-tree changes carry real line
+> counts into `computeSeverity` and messages — no more forced +0/-0 → info; (b) a single exported
+> `normalizeADRId` helper is applied to both the extracted changed-ADR ids and the map-key comparison
+> in `detectADRGaps`, so "ADR-23"/"ADR-023"/"ADR-0023" resolve equal and updating a zero-padded ADR
+> suppresses its `adr-gap`. Both fixes live-dogfooded on this repo (a real working-tree change reported
+> `+46/-0` at `warning`; touching zero-padded ADR-0003 suppressed only its gap). Full suite green.
+>
+> Original defect summary (as PROPOSED, 2026-07-08, e2e audit fifth pass): two live-reproduced
+> correctness holes that made the drift gate blind exactly when it matters — line counts for
+> staged/uncommitted changes were always zero (so gap severity could never reach the hook's own
+> threshold), and the ADR-updated suppression compared two id formats that never matched.
 
 ## The defects
 

--- a/openspec/changes/fix-drift-gate-blindness/tasks.md
+++ b/openspec/changes/fix-drift-gate-blindness/tasks.md
@@ -1,27 +1,27 @@
 # Tasks — fix drift-gate blindness
 
 ## Implementation
-- [ ] `getChangedFiles` (git-diff.ts): when `includeUnstaged`, also run
+- [x] `getChangedFiles` (git-diff.ts): when `includeUnstaged`, also run
       `git diff --cached --numstat` and `git diff --numstat`; merge per path (summed) into
       `numstatMap` before the `?? { additions: 0, deletions: 0 }` fallback (git-diff.ts:476)
-- [ ] `normalizeADRId` helper (one canonical form for "ADR-23" / "ADR-023" / "ADR-0023");
+- [x] `normalizeADRId` helper (one canonical form for "ADR-23" / "ADR-023" / "ADR-0023");
       applied in `extractChangedADRIds` (drift-detector.ts:350) AND at the
       `changedADRIds.has(id)` comparison / `buildADRMap.byId` key (drift-detector.ts:382,
       spec-mapper.ts:369-373)
-- [ ] Replace the format-split unit tests (drift-detector.test.ts:1134 'ADR-1' vs :1177
+- [x] Replace the format-split unit tests (drift-detector.test.ts:1134 'ADR-1' vs :1177
       'ADR-001') with tests that drive extraction and suppression through the same format
-- [ ] Coordination note delivered on `fix-commit-gate-delivery`: drift.ts:173-207 is a third
+- [x] Coordination note delivered on `fix-commit-gate-delivery`: drift.ts:173-207 is a third
       hooksPath-ignoring installer its "both installers" fix must also cover (no code change here)
 
 ## Verification
-- [ ] Live-repro regression: a staged-only 40-line change reports non-zero additions/deletions,
+- [x] Live-repro regression: a staged-only 40-line change reports non-zero additions/deletions,
       gap severity `warning` (not `info`), and the hook path (`--fail-on warning`) blocks
-- [ ] Gap message no longer prints "+0/-0" for staged/working-tree changes
-- [ ] End-to-end ADR case: change `openspec/decisions/adr-0023-*.md` alongside code in one of its
+- [x] Gap message no longer prints "+0/-0" for staged/working-tree changes
+- [x] End-to-end ADR case: change `openspec/decisions/adr-0023-*.md` alongside code in one of its
       domains → NO adr-gap issue; change the code without the ADR → adr-gap fires as before
-- [ ] Staged + working-tree edits to the same file: counts merged (summed), no crash, no zeros
-- [ ] Full suite green
+- [x] Staged + working-tree edits to the same file: counts merged (summed), no crash, no zeros
+- [x] Full suite green
 
 ## Spec
-- [ ] `drift` delta: ADD UncommittedChangesCarryRealLineCounts
-- [ ] `drift` delta: ADD ADRIdentityIsNormalizedAcrossDriftDetection
+- [x] `drift` delta: ADD UncommittedChangesCarryRealLineCounts
+- [x] `drift` delta: ADD ADRIdentityIsNormalizedAcrossDriftDetection

--- a/src/core/drift/drift-detector.test.ts
+++ b/src/core/drift/drift-detector.test.ts
@@ -20,6 +20,7 @@ import {
   extractChangedADRIds,
   detectADRGaps,
   detectADROrphaned,
+  normalizeADRId,
 } from './drift-detector.js';
 import type { ADRMap, ADRMapping } from './spec-mapper.js';
 import { createMockLLMService } from '../services/llm-service.js';
@@ -1122,6 +1123,22 @@ function makeADRMap(adrs: Array<{ id: string; title: string; domains: string[]; 
   return { byId, byDomain };
 }
 
+describe('normalizeADRId', () => {
+  it('collapses zero-padded and unpadded spellings to one canonical form', () => {
+    expect(normalizeADRId('ADR-23')).toBe(normalizeADRId('ADR-023'));
+    expect(normalizeADRId('ADR-023')).toBe(normalizeADRId('ADR-0023'));
+    expect(normalizeADRId('ADR-0001')).toBe(normalizeADRId('ADR-1'));
+  });
+
+  it('distinguishes different ADR numbers', () => {
+    expect(normalizeADRId('ADR-0023')).not.toBe(normalizeADRId('ADR-0024'));
+  });
+
+  it('leaves a non-ADR string untouched', () => {
+    expect(normalizeADRId('not-an-adr')).toBe('not-an-adr');
+  });
+});
+
 describe('extractChangedADRIds', () => {
   it('should extract ADR IDs from changed ADR files', () => {
     const files = [
@@ -1169,13 +1186,31 @@ describe('detectADRGaps', () => {
     expect(issues[0].message).toContain('ADR-001');
   });
 
-  it('should skip ADRs that were also updated', () => {
+  it('should skip ADRs that were also updated (extraction and suppression share one format)', () => {
+    // Format-parity: feed suppression the id format extraction actually produces,
+    // not a hand-picked matching string. A zero-padded ADR file ("ADR-0001") and a
+    // zero-padded map key must still suppress the gap.
+    const changedFiles = [
+      makeChangedFile({ path: 'src/auth/login.ts' }),
+      makeChangedFile({ path: 'openspec/decisions/adr-0001-jwt.md' }),
+    ];
+    const specMap = makeSpecMap([{ name: 'auth', files: ['src/auth/login.ts'] }]);
+    const adrMap = makeADRMap([{ id: 'ADR-0001', title: 'JWT Authentication', domains: ['auth'] }]);
+
+    const changedADRIds = extractChangedADRIds(changedFiles);
+    const issues = detectADRGaps(changedFiles, adrMap, specMap, changedADRIds);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('reports the gap when the code changed but the ADR did not (zero-padded)', () => {
     const changedFiles = [makeChangedFile({ path: 'src/auth/login.ts' })];
     const specMap = makeSpecMap([{ name: 'auth', files: ['src/auth/login.ts'] }]);
-    const adrMap = makeADRMap([{ id: 'ADR-001', title: 'JWT Authentication', domains: ['auth'] }]);
+    const adrMap = makeADRMap([{ id: 'ADR-0001', title: 'JWT Authentication', domains: ['auth'] }]);
 
-    const issues = detectADRGaps(changedFiles, adrMap, specMap, new Set(['ADR-001']));
-    expect(issues).toHaveLength(0);
+    const changedADRIds = extractChangedADRIds(changedFiles);
+    const issues = detectADRGaps(changedFiles, adrMap, specMap, changedADRIds);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].kind).toBe('adr-gap');
   });
 
   it('should not report when changed files are not in ADR-related domains', () => {

--- a/src/core/drift/drift-detector.ts
+++ b/src/core/drift/drift-detector.ts
@@ -337,6 +337,18 @@ export async function detectOrphanedSpecs(specMap: SpecMap, rootPath: string): P
 // ============================================================================
 
 /**
+ * Canonical ADR id form so that zero-padded and unpadded spellings of the same
+ * decision ("ADR-23", "ADR-023", "ADR-0023") compare equal. Applied on BOTH sides
+ * of ADR drift detection — the ids extracted from changed files and the ids keyed
+ * in the ADR map — so a padding mismatch can never defeat adr-gap suppression.
+ */
+export function normalizeADRId(id: string): string {
+  const match = id.match(/ADR-0*(\d+)/i);
+  if (!match) return id;
+  return `ADR-${match[1]}`;
+}
+
+/**
  * Extract ADR IDs that were changed in this changeset.
  * Matches files like: openspec/decisions/adr-0001-foo.md
  */
@@ -347,7 +359,7 @@ export function extractChangedADRIds(changedFiles: ChangedFile[], openspecRelPat
   for (const file of changedFiles) {
     const match = file.path.match(pattern);
     if (match) {
-      ids.add(`ADR-${match[1].replace(/^0+/, '') || '0'}`);
+      ids.add(normalizeADRId(`ADR-${match[1]}`));
     }
   }
   return ids;
@@ -368,6 +380,12 @@ export function detectADRGaps(
   const issues: DriftIssue[] = [];
   const reportedADRs = new Set<string>();
 
+  // Normalize the changed-ADR ids so suppression compares canonical forms on both
+  // sides — a zero-padding mismatch (map key "ADR-0023" vs extracted "ADR-23") must
+  // not defeat the "you updated the ADR" suppression below.
+  const changedADRIdsNormalized = new Set<string>();
+  for (const cid of changedADRIds) changedADRIdsNormalized.add(normalizeADRId(cid));
+
   // Collect all domains that have changed code
   const changedDomains = new Set<string>();
   for (const file of changedFiles) {
@@ -379,7 +397,7 @@ export function detectADRGaps(
 
   // For each ADR, check if any of its related domains had code changes
   for (const [id, mapping] of adrMap.byId) {
-    if (changedADRIds.has(id)) continue;
+    if (changedADRIdsNormalized.has(normalizeADRId(id))) continue;
     if (reportedADRs.has(id)) continue;
 
     const affectedDomains = mapping.relatedDomains.filter(d => changedDomains.has(d));

--- a/src/core/drift/git-diff.test.ts
+++ b/src/core/drift/git-diff.test.ts
@@ -543,4 +543,37 @@ describe('getChangedFiles', () => {
     const testFile = result.files.find(f => f.path === 'a.test.ts');
     expect(testFile?.isTest).toBe(true);
   });
+
+  // Regression: uncommitted (staged/working-tree) changes must carry real line
+  // counts — before the fix they always fell through to +0/-0, so gap severity
+  // could never cross the pre-commit hook's threshold (drift-gate blindness).
+  it('carries real line counts for a staged-only change (not +0/-0)', async () => {
+    const big = Array.from({ length: 40 }, (_, i) => `const x${i} = ${i};`).join('\n') + '\n';
+    await writeFile(join(tmpDir, 'a.ts'), big, 'utf-8');
+    await execFileAsync('git', ['add', 'a.ts'], { cwd: tmpDir });
+    const result = await getChangedFiles({ rootPath: tmpDir, baseRef: 'HEAD', includeUnstaged: true });
+    const file = result.files.find(f => f.path === 'a.ts');
+    expect(file).toBeDefined();
+    expect(file!.additions).toBeGreaterThan(30);
+  });
+
+  it('carries real line counts for a working-tree-only change (not +0/-0)', async () => {
+    await writeFile(join(tmpDir, 'a.ts'), 'const a = 1;\nconst b = 2;\nconst c = 3;\n', 'utf-8');
+    const result = await getChangedFiles({ rootPath: tmpDir, baseRef: 'HEAD', includeUnstaged: true });
+    const file = result.files.find(f => f.path === 'a.ts');
+    expect(file).toBeDefined();
+    expect(file!.additions).toBeGreaterThan(0);
+  });
+
+  it('merges (sums) counts for a file both staged and modified in the working tree', async () => {
+    // Stage two added lines, then add two more unstaged lines to the same file.
+    await writeFile(join(tmpDir, 'a.ts'), 'const a = 1;\nconst b = 2;\nconst c = 3;\n', 'utf-8');
+    await execFileAsync('git', ['add', 'a.ts'], { cwd: tmpDir });
+    await writeFile(join(tmpDir, 'a.ts'), 'const a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\n', 'utf-8');
+    const result = await getChangedFiles({ rootPath: tmpDir, baseRef: 'HEAD', includeUnstaged: true });
+    const file = result.files.find(f => f.path === 'a.ts');
+    expect(file).toBeDefined();
+    // staged diff (2 added) + working-tree diff (2 added) merged; never zero.
+    expect(file!.additions).toBeGreaterThanOrEqual(4);
+  });
 });

--- a/src/core/drift/git-diff.ts
+++ b/src/core/drift/git-diff.ts
@@ -343,6 +343,27 @@ function parseNumstat(output: string): Map<string, { additions: number; deletion
 }
 
 /**
+ * Merge a numstat map into an accumulator, summing per-path counts.
+ * A file that is both staged and modified in the working tree contributes both
+ * diffs; the summed count slightly over-counts overlapping lines, which is
+ * acceptable for the severity thresholds it feeds (never under-counts to zero).
+ */
+function mergeNumstat(
+  into: Map<string, { additions: number; deletions: number }>,
+  from: Map<string, { additions: number; deletions: number }>,
+): void {
+  for (const [path, stat] of from) {
+    const existing = into.get(path);
+    if (existing) {
+      existing.additions += stat.additions;
+      existing.deletions += stat.deletions;
+    } else {
+      into.set(path, { additions: stat.additions, deletions: stat.deletions });
+    }
+  }
+}
+
+/**
  * Get the unified diff content for a specific file against a base ref.
  * Returns the diff text, truncated to maxChars to fit LLM context windows.
  */
@@ -502,6 +523,31 @@ export async function getChangedFiles(options: GitDiffOptions): Promise<GitDiffR
       numstatMap = parseNumstat(stdout);
     } catch (err2) {
       logger.debug(`Two-dot numstat also failed: ${(err2 as Error).message}`);
+    }
+  }
+
+  // When staged/working-tree files are part of the changeset, their line counts
+  // are not in the commit-range numstat above — gather them and merge per path so
+  // uncommitted work carries real counts into severity and messages (not +0/-0).
+  if (includeUnstaged) {
+    try {
+      const { stdout } = await execFileAsync(
+        'git', gitPathArgs('diff', '--cached', '--numstat'),
+        { cwd: rootPath }
+      );
+      mergeNumstat(numstatMap, parseNumstat(stdout));
+    } catch (err) {
+      logger.debug(`Could not get staged numstat: ${(err as Error).message}`);
+    }
+
+    try {
+      const { stdout } = await execFileAsync(
+        'git', gitPathArgs('diff', '--numstat'),
+        { cwd: rootPath }
+      );
+      mergeNumstat(numstatMap, parseNumstat(stdout));
+    } catch (err) {
+      logger.debug(`Could not get working-tree numstat: ${(err as Error).message}`);
     }
   }
 

--- a/src/core/drift/index.ts
+++ b/src/core/drift/index.ts
@@ -10,5 +10,5 @@ export type { GitDiffOptions, GitDiffResult } from './git-diff.js';
 export { buildSpecMap, matchFileToDomains, getSpecContent, parseSpecHeader, parseSpecReferences, inferDomainFromPath, buildADRMap, parseADRRelated } from './spec-mapper.js';
 export type { SpecMapperOptions, ADRMapping, ADRMap } from './spec-mapper.js';
 
-export { detectDrift, detectGaps, detectStaleSpecs, detectUncoveredFiles, detectOrphanedSpecs, isSpecRelevantChange, computeSeverity, extractChangedSpecDomains, enhanceGapsWithLLM, detectADRGaps, detectADROrphaned, extractChangedADRIds } from './drift-detector.js';
+export { detectDrift, detectGaps, detectStaleSpecs, detectUncoveredFiles, detectOrphanedSpecs, isSpecRelevantChange, computeSeverity, extractChangedSpecDomains, enhanceGapsWithLLM, detectADRGaps, detectADROrphaned, extractChangedADRIds, normalizeADRId } from './drift-detector.js';
 export type { DriftDetectorOptions } from './drift-detector.js';


### PR DESCRIPTION
**Status:** LGTM — both defects fixed, full suite green (310 files / 6,010 tests), and both fixes live-dogfooded on this repo. Ships `fix-drift-gate-blindness` (e2e-audit 2026-07 fifth pass, top of the fix track).

## What was wrong

Two live-reproduced honesty holes made the drift gate blind exactly when it matters — a protection that reported itself present while being blind.

**(a) Staged/working-tree changes always counted +0/−0.** `getChangedFiles` merges staged (`git diff --cached`) and working-tree files into the changeset when `includeUnstaged` is set (both callers pass it), but line stats came *only* from the commit-range numstat (`git diff --numstat <base>...HEAD`). Every uncommitted file fell through `const stats = numstatMap.get(path) ?? { additions: 0, deletions: 0 }`. Gap severity is a pure function of those counts (`> 5` → `warning`), so uncommitted work was always `info`. The installed pre-commit hook runs `openlore drift --fail-on warning`, and `info < warning` — **the hook structurally could not block on the very changes being committed**, and it printed a visibly false "+0/−0 lines" message.

**(b) The ADR-updated suppression never fired.** `extractChangedADRIds` stripped leading zeros → `ADR-23`, while the ADR map keys on the verbatim padded title → `ADR-0023`. `changedADRIds.has(id)` compared the two formats and never matched, so updating an ADR alongside governed code still reported `adr-gap`. Unit tests masked it by testing the two halves in incompatible formats.

## How it was fixed

1. **Numstat covers what the file list covers.** When `includeUnstaged` is set, also gather `git diff --cached --numstat` and `git diff --numstat` and merge per path (summed) into the range numstat before the zero-fallback. Deterministic git plumbing; no new tuning constants — the existing `computeSeverity` thresholds finally see real inputs.
2. **One ADR id normalization on both sides.** A single exported `normalizeADRId` helper applied in both `extractChangedADRIds` and the `detectADRGaps` map-key comparison, so `ADR-23` / `ADR-023` / `ADR-0023` resolve equal.

Blocking stays opt-in via `--fail-on` — this changes measurement, not policy.

## Proof it works

**Unit/regression tests** (all green):
- `git-diff.test.ts`: staged-only 40-line change → additions > 30; working-tree-only change → non-zero; staged + working-tree edits to one file → summed, never zero.
- `drift-detector.test.ts`: the format-split masking tests replaced with format-parity tests that drive `extractChangedADRIds` output into `detectADRGaps` (zero-padded ADR file suppresses its gap; code-without-ADR still fires); plus a `normalizeADRId` unit block.

**Live dogfood on this repo** (built dist, `openlore drift --base HEAD`):
- (a) a real working-tree change to `src/core/drift/git-diff.ts` reported `+46/-0` at severity **`warning`** (pre-fix: `+0/-0` / `info`).
- (b) touching zero-padded `ADR-0003` suppressed **only** its `adr-gap`; ADR-0004…ADR-0023 (untouched) still fired.

CI mirror locally: `lint`, `typecheck`, `test:run` (6,010 passed / 2 skipped), `build` — all green.

## Notes / nits

- A file both staged and modified in the working tree gets summed counts (slight over-count) — acceptable for threshold purposes, documented in the merge helper.
- Coordination note delivered on `fix-commit-gate-delivery`: `drift.ts:173-207` is a **third** hooksPath-ignoring installer its "both installers" fix must also cover (no code change here).
- Specs: `drift` — ADD `UncommittedChangesCarryRealLineCounts`, `ADRIdentityIsNormalizedAcrossDriftDetection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)