### PR TITLE
fix(mcp-security): validate serve.json at every reader — one shared lock, three doors

### DIFF
--- a/openspec/changes/harden-serve-descriptor-trust/proposal.md
+++ b/openspec/changes/harden-serve-descriptor-trust/proposal.md
@@ -1,6 +1,14 @@
 # Harden serve-descriptor trust: one untrusted artifact, one validator, three readers
 
-> Status: PROPOSED (2026-07-03, e2e audit follow-up). `.openlore/serve.json` is a
+> Status: SHIPPED (2026-07-19). Extracted `serve.ts`'s validation into the shared
+> `src/cli/commands/serve-descriptor.ts` (`validateServeDescriptor` + `readServeDescriptor`,
+> dependency-light: node builtins + `isLoopbackHost`). All three readers — `serve.ts`,
+> `serve-client.ts`, and the Pi extension — now resolve `.openlore/serve.json` through it, so a
+> poisoned descriptor is treated exactly as absent (no fetch, no header, no signal target). A
+> source-level coverage guard (`serve-descriptor.test.ts`) fails CI if a future reader reads the
+> file raw. Spec `mcp-security` gained `ServeDescriptorValidatedAtEveryReader`.
+>
+> Original (PROPOSED 2026-07-03, e2e audit follow-up): `.openlore/serve.json` is a
 > repo-local, attacker-writable artifact, and OpenLore reads it at three sites with two
 > security postures. `serve.ts` validates it — port range, integer pid, loopback-only host —
 > with a comment citing the mcp-security "Untrusted Artifact Deserialization" requirement.

--- a/openspec/changes/harden-serve-descriptor-trust/tasks.md
+++ b/openspec/changes/harden-serve-descriptor-trust/tasks.md
@@ -1,34 +1,34 @@
 # Tasks — harden-serve-descriptor-trust
 
 ## Implementation
-- [ ] Extract the descriptor validator from `serve.ts:247-271` into a dependency-light
+- [x] Extract the descriptor validator from `serve.ts:247-271` into a dependency-light
       shared module (loopback-only host via `isLoopbackHost`, integer port 1-65535,
       integer pid > 0, token absent-or-string); `serve.ts` `readDescriptor` delegates to
       it with behavior unchanged (keeps its startedAt/version normalization)
-- [ ] `serve-client.ts` `readDescriptor` (:56-62): replace the raw
+- [x] `serve-client.ts` `readDescriptor` (:56-62): replace the raw
       `JSON.parse(...) as ServeDescriptor` cast with the shared validator; an invalid
       descriptor returns null (treated as absent → existing spawn / in-process fallback)
       with a debug-level disclosure, never a followed endpoint
-- [ ] `pi/extension.ts` `readDescriptor` (:400-404): same replacement; confirm the module
+- [x] `pi/extension.ts` `readDescriptor` (:400-404): same replacement; confirm the module
       stays dependency-light per the parity doctrine (Pi host must not import the analyzer)
-- [ ] Grep-audit for any other serve.json reader (none known beyond the three); add a test
+- [x] Grep-audit for any other serve.json reader (none known beyond the three); add a test
       pinning that every reader resolves descriptors through the shared validator
 
 ## Verification
-- [ ] Poisoned-descriptor test per reader: serve.json with a non-loopback `host` (e.g.
+- [x] Poisoned-descriptor test per reader: serve.json with a non-loopback `host` (e.g.
       `169.254.169.254`, an intranet name), out-of-range/non-integer `port`, non-integer
       `pid`, or non-string `token` → reader returns null; no fetch is issued (assert via a
       mocked/instrumented fetch)
-- [ ] Fallback test: with an invalid descriptor on disk, `ensureServeDaemon` behaves as if
+- [x] Fallback test: with an invalid descriptor on disk, `ensureServeDaemon` behaves as if
       no descriptor existed (spawns when allowed, returns null when `spawn:false`), and the
       MCP dispatch path (`mcp.ts:2566`) falls back to in-process — no tool call reaches the
       poisoned endpoint
-- [ ] Round-trip test: the descriptor `serve` actually writes passes the shared validator
+- [x] Round-trip test: the descriptor `serve` actually writes passes the shared validator
       (no false rejection of a healthy daemon); existing serve.json validation tests
       (`serve.ts:245` notes they exist) still pass against the delegating reader
-- [ ] `serve stop` / status paths unchanged: guarded reader behavior identical before and
+- [x] `serve stop` / status paths unchanged: guarded reader behavior identical before and
       after the extraction
-- [ ] Full suite green
+- [x] Full suite green
 
 ## Spec
-- [ ] `mcp-security` delta: ADD ServeDescriptorValidatedAtEveryReader
+- [x] `mcp-security` delta: ADD ServeDescriptorValidatedAtEveryReader

--- a/openspec/specs/mcp-security/spec.md
+++ b/openspec/specs/mcp-security/spec.md
@@ -237,6 +237,42 @@ graceful-shutdown handlers and a descriptor for stale-instance detection.
 - **WHEN** the guard-coverage test runs
 - **THEN** the test fails naming the unguarded route
 
+### Requirement: ServeDescriptorValidatedAtEveryReader
+
+Every code path that reads the daemon discovery descriptor (`.openlore/serve.json`) SHALL
+validate it through one shared, dependency-light validator before using any field: the host
+MUST be a loopback form, the port an integer in 1-65535, the pid a positive integer, and the
+token absent or a string. A descriptor failing validation SHALL be treated exactly as an
+absent descriptor — the reader returns null and the caller takes its existing no-daemon path
+(spawn a fresh daemon or fall back to in-process dispatch) — with at most a debug-level
+disclosure. No field of an unvalidated or invalid descriptor may ever become a fetch target,
+a request header, or a signal target. This is the outbound counterpart of the inbound
+local-HTTP guard (`AllLocalHttpSurfacesShareTheGuard`): the same untrusted-artifact threat
+model, applied to what a local client trusts rather than what a local server accepts.
+
+#### Scenario: A poisoned host is never fetched
+
+- **GIVEN** a repository whose `.openlore/serve.json` names a non-loopback host (an internal
+  address or attacker-controlled name)
+- **WHEN** any reader — the serve CLI, the serve client used by the MCP server, or the Pi
+  extension — resolves the descriptor
+- **THEN** validation fails, no request is issued to the named host, and the caller proceeds
+  as if no descriptor existed
+
+#### Scenario: An invalid descriptor degrades, never redirects
+
+- **GIVEN** a descriptor with an out-of-range port, a non-integer pid, or a non-string token
+- **WHEN** the MCP server's tool dispatch attempts daemon delegation
+- **THEN** the descriptor is treated as absent and the tool call is served by a freshly
+  spawned daemon or in-process dispatch — attacker-authored tool results can never enter the
+  agent's context through the descriptor
+
+#### Scenario: A new reader cannot opt out silently
+
+- **GIVEN** a future code path that reads `.openlore/serve.json` without the shared validator
+- **WHEN** the descriptor-reader coverage test runs
+- **THEN** the test fails naming the unguarded reader
+
 ### Requirement: Write Confinement for Mutating Tools
 
 Tools that write to disk or mutate persistent state (`record_decision`, `sync_decisions`,

--- a/src/cli/commands/serve-descriptor.test.ts
+++ b/src/cli/commands/serve-descriptor.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for serve-descriptor — the one validator for the untrusted
+ * `.openlore/serve.json` daemon-discovery artifact (mcp-security:
+ * ServeDescriptorValidatedAtEveryReader).
+ *
+ * Two jobs:
+ *   1. The validator fails closed on every poisoned field and round-trips a
+ *      healthy loopback descriptor unchanged.
+ *   2. A source-level coverage guard pins that every production reader of
+ *      serve.json resolves it through this module — a future reader that reads
+ *      the file raw fails the guard, naming itself.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  validateServeDescriptor,
+  readServeDescriptor,
+} from './serve-descriptor.js';
+
+const HEALTHY = { port: 8080, pid: 4242, host: '127.0.0.1', token: 't', startedAt: 's', version: 'v' };
+
+describe('validateServeDescriptor', () => {
+  it('accepts a well-formed loopback descriptor and round-trips its fields', () => {
+    expect(validateServeDescriptor(HEALTHY)).toEqual(HEALTHY);
+  });
+
+  it('accepts every loopback host form', () => {
+    for (const host of ['127.0.0.1', 'localhost', '::1', '127.9.9.9']) {
+      const d = validateServeDescriptor({ ...HEALTHY, host });
+      expect(d, host).not.toBeNull();
+      expect(d!.host).toBe(host);
+    }
+  });
+
+  it('normalizes missing/ill-typed startedAt and version to empty strings', () => {
+    const d = validateServeDescriptor({ port: 8080, pid: 1, host: '127.0.0.1' });
+    expect(d).toEqual({ port: 8080, pid: 1, host: '127.0.0.1', token: undefined, startedAt: '', version: '' });
+  });
+
+  it('accepts an absent token but rejects a non-string one', () => {
+    expect(validateServeDescriptor({ port: 8080, pid: 1, host: '127.0.0.1' })).not.toBeNull();
+    expect(validateServeDescriptor({ port: 8080, pid: 1, host: '127.0.0.1', token: 5 })).toBeNull();
+  });
+
+  it('rejects a non-loopback host (SSRF/egress guard)', () => {
+    for (const host of ['169.254.169.254', 'evil.example.com', '0.0.0.0', '10.0.0.1', '', '128.0.0.1']) {
+      expect(validateServeDescriptor({ ...HEALTHY, host }), host).toBeNull();
+    }
+  });
+
+  it('rejects a bad port', () => {
+    for (const port of ['8080', 70000, 0, -1, 8080.5, NaN]) {
+      expect(validateServeDescriptor({ ...HEALTHY, port }), String(port)).toBeNull();
+    }
+  });
+
+  it('rejects a bad pid', () => {
+    for (const pid of [0, -1, 1.5, '1', NaN]) {
+      expect(validateServeDescriptor({ ...HEALTHY, pid }), String(pid)).toBeNull();
+    }
+  });
+
+  it('rejects a non-object, null, or array', () => {
+    for (const v of [null, undefined, 42, 'str', [HEALTHY], []]) {
+      expect(validateServeDescriptor(v), JSON.stringify(v)).toBeNull();
+    }
+  });
+});
+
+describe('readServeDescriptor', () => {
+  let dir = '';
+  const path = (): string => join(dir, '.openlore', 'serve.json');
+  const write = async (raw: string): Promise<void> => {
+    dir = await mkdtemp(join(tmpdir(), 'openlore-desc-'));
+    await mkdir(join(dir, '.openlore'), { recursive: true });
+    await writeFile(path(), raw, 'utf-8');
+  };
+
+  it('returns null for a missing file', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'openlore-desc-'));
+    try {
+      expect(await readServeDescriptor(join(empty, '.openlore', 'serve.json'))).toBeNull();
+    } finally {
+      await rm(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for malformed JSON', async () => {
+    await write('{ not json');
+    try {
+      expect(await readServeDescriptor(path())).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for a poisoned (non-loopback) descriptor', async () => {
+    await write(JSON.stringify({ port: 8080, pid: 1, host: '169.254.169.254' }));
+    try {
+      expect(await readServeDescriptor(path())).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the validated descriptor for a healthy file', async () => {
+    await write(JSON.stringify(HEALTHY));
+    try {
+      expect(await readServeDescriptor(path())).toEqual(HEALTHY);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── No fourth door: every serve.json reader routes through the validator ───────
+
+/** Recursively collect production .ts files (excluding tests) under `root`. */
+function productionTsFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...productionTsFiles(full));
+    } else if (
+      entry.endsWith('.ts') &&
+      !entry.endsWith('.test.ts') &&
+      !entry.endsWith('.integration.test.ts')
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('serve.json reader coverage (mcp-security: ServeDescriptorValidatedAtEveryReader)', () => {
+  const srcRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+  const validatorModule = fileURLToPath(new URL('./serve-descriptor.ts', import.meta.url));
+
+  it('every production file referencing serve.json resolves it through readServeDescriptor', () => {
+    const offenders: string[] = [];
+    for (const file of productionTsFiles(srcRoot)) {
+      if (file === validatorModule) continue; // the validator itself
+      const src = readFileSync(file, 'utf-8');
+      if (!src.includes('serve.json')) continue;
+      // A reader is guarded iff it imports the shared validator. A file that
+      // only writes/unlinks serve.json need not import it — but then it must
+      // never read the file raw (the antipattern below).
+      const guarded = src.includes('readServeDescriptor');
+      const rawRead =
+        /readFile\s*\([^;]*serve\.json/s.test(src) ||
+        /\bas\s+ServeDescriptor\b/.test(src);
+      if (!guarded && rawRead) offenders.push(file);
+    }
+    expect(offenders, `unguarded serve.json reader(s): ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('the three known readers each import the shared validator', () => {
+    const readers = [
+      join(srcRoot, 'cli', 'commands', 'serve.ts'),
+      join(srcRoot, 'core', 'services', 'serve-client.ts'),
+      join(srcRoot, 'pi', 'extension.ts'),
+    ];
+    for (const reader of readers) {
+      const src = readFileSync(reader, 'utf-8');
+      expect(src.includes('readServeDescriptor'), `${reader} must route through readServeDescriptor`).toBe(true);
+    }
+  });
+});

--- a/src/cli/commands/serve-descriptor.ts
+++ b/src/cli/commands/serve-descriptor.ts
@@ -1,0 +1,86 @@
+/**
+ * serve-descriptor — the ONE validator for the untrusted daemon-discovery
+ * artifact `.openlore/serve.json`.
+ *
+ * The descriptor is a repo-local, attacker-writable file that OpenLore reads at
+ * three sites — the `serve` CLI, the serve-client the stdio MCP server delegates
+ * through, and the Pi extension. Each reader then FETCHES the host/port the file
+ * names for a liveness probe and, on a healthy answer, POSTs the project
+ * directory and full tool arguments to it. A poisoned descriptor is therefore an
+ * SSRF / egress vector, a leak of the directory + tool args, and a result-
+ * poisoning channel into the agent's context (mcp-security: Untrusted Artifact
+ * Deserialization). One threat model must not have three postures.
+ *
+ * This module is the one lock, extracted verbatim from `serve.ts`'s existing
+ * reader: loopback-only host, integer port 1–65535, integer pid > 0, token
+ * absent-or-string. No check is invented here beyond the ones `serve` already
+ * applied. A descriptor that fails any check is treated exactly as ABSENT — the
+ * reader returns null and the caller takes its existing no-daemon path (spawn a
+ * fresh daemon or fall back to in-process dispatch). No field of an invalid
+ * descriptor ever becomes a fetch target, a request header, or a signal target.
+ *
+ * Dependency-light by contract (mcp-security ServeDescriptorValidatedAtEveryReader
+ * + the MCP↔Pi parity doctrine): it imports only node builtins and the loopback
+ * predicate it shares with the HTTP guard, so the Pi host can import it without
+ * pulling in the analyzer.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { isLoopbackHost } from './local-http-guard.js';
+
+/**
+ * The validated daemon-discovery descriptor. `startedAt` / `version` are
+ * advisory metadata (normalized to '' when absent or ill-typed); the other four
+ * fields are security-critical and are only present on a descriptor that passed
+ * {@link validateServeDescriptor}.
+ */
+export interface ServeDescriptor {
+  port: number;
+  pid: number;
+  host: string;
+  token?: string;
+  startedAt: string;
+  version: string;
+}
+
+/**
+ * Validate an already-parsed value as a {@link ServeDescriptor}. Returns the
+ * normalized descriptor, or null if ANY security-critical field is
+ * missing / ill-typed / out of range, or the host is not a loopback form.
+ */
+export function validateServeDescriptor(parsed: unknown): ServeDescriptor | null {
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const d = parsed as Record<string, unknown>;
+  const portOk =
+    typeof d.port === 'number' && Number.isInteger(d.port) && d.port >= 1 && d.port <= 65535;
+  const pidOk = typeof d.pid === 'number' && Number.isInteger(d.pid) && d.pid > 0;
+  // Confine host to loopback: a recorded non-loopback host must never become an
+  // outbound fetch target during liveness probing (egress / SSRF).
+  const hostOk = typeof d.host === 'string' && isLoopbackHost(d.host);
+  const tokenOk = d.token === undefined || typeof d.token === 'string';
+  if (!portOk || !pidOk || !hostOk || !tokenOk) return null;
+  return {
+    port: d.port as number,
+    pid: d.pid as number,
+    host: d.host as string,
+    token: d.token as string | undefined,
+    startedAt: typeof d.startedAt === 'string' ? d.startedAt : '',
+    version: typeof d.version === 'string' ? d.version : '',
+  };
+}
+
+/**
+ * Read + validate a serve.json at `descriptorPath`. Any failure — missing file,
+ * malformed JSON, or a descriptor that fails {@link validateServeDescriptor} —
+ * resolves to null, so a poisoned descriptor is indistinguishable from an absent
+ * one and no field of it ever reaches a fetch, a header, or a signal target.
+ */
+export async function readServeDescriptor(descriptorPath: string): Promise<ServeDescriptor | null> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(descriptorPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+  return validateServeDescriptor(parsed);
+}

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -32,7 +32,7 @@
 import { Command } from 'commander';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createRequire } from 'node:module';
-import { writeFile, readFile, unlink, mkdir } from 'node:fs/promises';
+import { writeFile, unlink, mkdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { logger } from '../../utils/logger.js';
 import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, FULL_PRESET, FULL_PRESET_ALIAS, LEAN_DEFAULT_PRESET } from '../../constants.js';
@@ -50,6 +50,7 @@ import {
   originDefenseError,
   OPENLORE_TOKEN_HEADER,
 } from './local-http-guard.js';
+import { readServeDescriptor, type ServeDescriptor } from './serve-descriptor.js';
 
 /**
  * Debounce before a full call-graph re-analyze after edits settle. Longer than
@@ -94,15 +95,6 @@ const HEALTH_PROBE_TIMEOUT_MS = 2500;
 const _require = createRequire(import.meta.url);
 const _pkgVersion = (_require('../../../package.json') as { version: string }).version;
 
-/** Daemon discovery descriptor written to <root>/.openlore/serve.json. */
-interface ServeDescriptor {
-  port: number;
-  pid: number;
-  host: string;
-  token?: string;
-  startedAt: string;
-  version: string;
-}
 
 interface ServeCliOptions {
   directory?: string;
@@ -173,36 +165,15 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
 /**
  * Read + validate <root>/.openlore/serve.json. The discovery file is an untrusted
  * on-disk artifact (mcp-security: Untrusted Artifact Deserialization): a hostile repo
- * could ship a poisoned serve.json. We fail closed unless every field has the expected
- * type AND the host is a loopback name — otherwise `daemonAlive` would fetch an
- * arbitrary host (egress / SSRF) and `stopDaemon` could SIGTERM an arbitrary pid.
+ * could ship a poisoned serve.json, and `daemonAlive` would then fetch an arbitrary
+ * host (egress / SSRF) and `stopDaemon` could SIGTERM an arbitrary pid. Validation
+ * lives in the shared {@link readServeDescriptor} so every reader fails closed the
+ * same way (mcp-security: ServeDescriptorValidatedAtEveryReader).
  *
  * Exported for the serve.json validation tests.
  */
 export async function readDescriptor(root: string): Promise<ServeDescriptor | null> {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(await readFile(serveFilePath(root), 'utf-8'));
-  } catch {
-    return null;
-  }
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
-  const d = parsed as Record<string, unknown>;
-  const portOk = typeof d.port === 'number' && Number.isInteger(d.port) && d.port >= 1 && d.port <= 65535;
-  const pidOk = typeof d.pid === 'number' && Number.isInteger(d.pid) && d.pid > 0;
-  // Confine host to loopback: a recorded non-loopback host must never become an
-  // outbound fetch target during liveness probing.
-  const hostOk = typeof d.host === 'string' && isLoopbackHost(d.host);
-  const tokenOk = d.token === undefined || typeof d.token === 'string';
-  if (!portOk || !pidOk || !hostOk || !tokenOk) return null;
-  return {
-    port: d.port as number,
-    pid: d.pid as number,
-    host: d.host as string,
-    token: d.token as string | undefined,
-    startedAt: typeof d.startedAt === 'string' ? d.startedAt : '',
-    version: typeof d.version === 'string' ? d.version : '',
-  };
+  return readServeDescriptor(serveFilePath(root));
 }
 
 /**

--- a/src/core/services/serve-client.test.ts
+++ b/src/core/services/serve-client.test.ts
@@ -9,7 +9,7 @@
  * discover-only paths against a daemon we start in-process.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -81,6 +81,53 @@ describe('serve-client', () => {
   it('throws when the daemon is unreachable (stale endpoint)', async () => {
     const ep = { baseUrl: 'http://127.0.0.1:1' }; // nothing listening
     await expect(callServeTool(ep, 'orient', { task: 'x' }, '/tmp')).rejects.toThrow();
+  });
+
+  it('treats a poisoned serve.json as absent and issues no fetch (SSRF guard)', async () => {
+    // A hostile repo ships a serve.json naming an attacker-controlled host. The
+    // shared validator rejects the non-loopback host, so the descriptor is
+    // treated as absent — no liveness probe is ever fetched at the poisoned
+    // endpoint (mcp-security: ServeDescriptorValidatedAtEveryReader).
+    const dir = await mkdtemp(join(tmpdir(), 'openlore-poison-'));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    try {
+      const { writeFile, mkdir } = await import('node:fs/promises');
+      await mkdir(join(dir, '.openlore'), { recursive: true });
+      await writeFile(
+        join(dir, '.openlore', 'serve.json'),
+        JSON.stringify({ port: 8080, pid: 99999, host: '169.254.169.254', token: 'x' }),
+        'utf-8',
+      );
+      // spawn:false → with the descriptor rejected as absent, ensureServeDaemon
+      // returns null without probing or spawning.
+      const ep = await ensureServeDaemon(dir, { spawn: false });
+      expect(ep).toBeNull();
+      expect(fetchSpy, 'no fetch may be issued for a poisoned descriptor').not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('treats a malformed-field serve.json (bad port/pid/token) as absent', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openlore-malformed-'));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    try {
+      const { writeFile, mkdir } = await import('node:fs/promises');
+      await mkdir(join(dir, '.openlore'), { recursive: true });
+      // Loopback host, but an out-of-range port and a non-string token.
+      await writeFile(
+        join(dir, '.openlore', 'serve.json'),
+        JSON.stringify({ port: 70000, pid: -1, host: '127.0.0.1', token: 5 }),
+        'utf-8',
+      );
+      const ep = await ensureServeDaemon(dir, { spawn: false });
+      expect(ep).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it('returns null for a stale serve.json pointing at a dead port (kill -9 simulation)', async () => {

--- a/src/core/services/serve-client.ts
+++ b/src/core/services/serve-client.ts
@@ -12,17 +12,9 @@
  */
 
 import { spawn } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { OPENLORE_DIR } from '../../constants.js';
-
-/** Subset of the daemon's serve.json we need to reach it. */
-interface ServeDescriptor {
-  port: number;
-  pid: number;
-  host: string;
-  token?: string;
-}
+import { readServeDescriptor, type ServeDescriptor } from '../../cli/commands/serve-descriptor.js';
 
 /** A resolved, reachable daemon. */
 export interface ServeEndpoint {
@@ -53,12 +45,16 @@ export function serveSpawnArgs(directory: string): string[] {
   return ['serve', '--directory', directory];
 }
 
+/**
+ * Discover the daemon descriptor. `.openlore/serve.json` is an untrusted,
+ * repo-writable artifact, so it is resolved through the shared validator
+ * ({@link readServeDescriptor}) — a poisoned descriptor (non-loopback host,
+ * bad port/pid, non-string token) is treated exactly as absent, so no field of
+ * it ever becomes a fetch target or request header (mcp-security:
+ * ServeDescriptorValidatedAtEveryReader).
+ */
 async function readDescriptor(directory: string): Promise<ServeDescriptor | null> {
-  try {
-    return JSON.parse(await readFile(descriptorPath(directory), 'utf-8')) as ServeDescriptor;
-  } catch {
-    return null;
-  }
+  return readServeDescriptor(descriptorPath(directory));
 }
 
 /** True when a descriptor points at a LIVE daemon (ok:true /health), not a stale

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -53,6 +53,11 @@ import {
   POINTER_LINE,
   type LeanOrientResult,
 } from '../cli/commands/orient-inject-render.js';
+// The shared serve.json validator. Dependency-light (node builtins + the loopback
+// predicate) so it does not drag the analyzer into the Pi host, and it guarantees
+// Pi trusts the untrusted descriptor exactly as the CLI and MCP server do
+// (mcp-security: ServeDescriptorValidatedAtEveryReader).
+import { readServeDescriptor, type ServeDescriptor } from '../cli/commands/serve-descriptor.js';
 import type { ContextInjectionConfig } from '../types/index.js';
 
 // ── Config types & helpers ────────────────────────────────────────────────────
@@ -379,7 +384,6 @@ async function runConfigWizard(ctx: ExtensionContext, existing?: OpenLoreConfig 
 
 // ── Daemon discovery + lifecycle ──────────────────────────────────────────────
 
-interface ServeDescriptor { port: number; pid: number; host: string; token?: string }
 interface Daemon { baseUrl: string; token?: string }
 
 const HEALTH_TIMEOUT_MS = 8000;
@@ -397,10 +401,12 @@ const KEEPALIVE_MS = 5 * 60_000;
 const RESULT_MAX = 50_000;
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+// `.openlore/serve.json` is an untrusted, repo-writable artifact; resolve it
+// through the shared validator so a poisoned descriptor (non-loopback host, bad
+// port/pid, non-string token) is treated exactly as absent and no field of it
+// ever becomes a fetch target or request header.
 async function readDescriptor(cwd: string): Promise<ServeDescriptor | null> {
-  try {
-    return JSON.parse(await readFile(join(cwd, OPENLORE_DIR, 'serve.json'), 'utf-8')) as ServeDescriptor;
-  } catch { return null; }
+  return readServeDescriptor(join(cwd, OPENLORE_DIR, 'serve.json'));
 }
 
 async function healthy(desc: ServeDescriptor): Promise<boolean> {


### PR DESCRIPTION
**Status:** LGTM — implements the `harden-serve-descriptor-trust` proposal (e2e-audit follow-up fix track).

## What was wrong
`.openlore/serve.json` is a repo-local, **attacker-writable** artifact. OpenLore reads it at three sites to discover the warm `serve` daemon, then fetches the host/port it names for a liveness probe and, on a healthy answer, POSTs the project directory + full tool arguments to it (which can carry source snippets, e.g. `find_clones --snippet`). Only `serve.ts` validated the descriptor (loopback host, integer port 1–65535, integer pid > 0, string token). Its two siblings did a raw cast:

- `serve-client.ts:58` (the path the stdio MCP server delegates every tool call through) — `JSON.parse(...) as ServeDescriptor`
- `pi/extension.ts:402` — same raw cast

So a hostile repo's serve.json could (a) point OpenLore's tool traffic at an arbitrary/internal host (SSRF/egress), (b) exfiltrate the directory + tool args, and (c) return attacker-authored "tool results" injected verbatim into the agent's context. One threat model, three doors; one had the lock.

## How it was fixed
Extracted `serve.ts`'s existing checks **verbatim** into a shared, dependency-light module `src/cli/commands/serve-descriptor.ts`:
- `validateServeDescriptor(parsed)` — the lock (loopback host via `isLoopbackHost`, integer port 1–65535, integer pid > 0, token absent-or-string), normalizing `startedAt`/`version`.
- `readServeDescriptor(path)` — read + parse + validate; any failure → `null`.

It imports only node builtins + `isLoopbackHost`, so the Pi host doesn't pull in the analyzer (parity doctrine). All three readers now delegate to it. An invalid descriptor is treated **exactly as absent** — the reader returns `null` and the caller takes its existing no-daemon path (spawn a fresh daemon or fall back to in-process dispatch). No new check invented; no field of an invalid descriptor ever becomes a fetch target, header, or signal target. This is the **outbound** counterpart of the inbound `AllLocalHttpSurfacesShareTheGuard`.

## Replication / proof
- **`serve-descriptor.test.ts`** — validator unit tests (every poisoned field rejected: non-loopback host incl. `169.254.169.254`/`0.0.0.0`/`10.0.0.1`, bad port/pid, non-string token; healthy loopback round-trips) + a source-level **coverage guard** that fails CI if a future production file reads `serve.json` raw ("no fourth door").
- **`serve-client.test.ts`** — poisoned (`169.254.169.254`) and malformed (bad port/pid/token) descriptors → `ensureServeDaemon(dir,{spawn:false})` returns `null` and **no fetch is issued** (asserted via a spied `global.fetch`).
- **E2E against a real daemon**: a real `startServe` writes `127.0.0.1:<port>` → validates and is discovered; a poisoned `169.254.169.254` descriptor → null endpoint, **zero fetch**.
- lint + typecheck clean; full suite **6042 passed / 2 skipped** (313 files).

## Spec
`mcp-security` — 1 ADDED requirement: `ServeDescriptorValidatedAtEveryReader` (+ 3 scenarios).

## Notes
- Tool surface unchanged (no new tool, no payload-budget impact).
- Risk low: a legitimate non-loopback descriptor cannot exist today (`serve` only binds non-loopback with an explicit flag and refuses to start without a token), so treating one as absent changes no working setup.
- Sibling `harden-local-http-surfaces` (shipped) guards the inbound face of the same threat model; together they close both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)