### PR TITLE
fix(analyzer): length-preserving comment mask for TS/JS route lines — no more drifted route-handler edges

### DIFF
--- a/openspec/changes/delegate-lifecycle-scope-decision-sync/proposal.md
+++ b/openspec/changes/delegate-lifecycle-scope-decision-sync/proposal.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: shipped
 date: 2026-07-18
 ---
 

--- a/openspec/changes/fix-route-anchor-fidelity/proposal.md
+++ b/openspec/changes/fix-route-anchor-fidelity/proposal.md
@@ -1,6 +1,15 @@
 # Fix TS/JS route line fidelity: skeleton-relative lines anchored against original file bytes
 
-> Status: PROPOSED (2026-07-08, e2e audit fifth pass). TS/JS route lines are computed against a
+> Status: SHIPPED (2026-07-19). `extractTsRouteDefinitions` now masks comments length-preservingly
+> (blank-to-spaces, newlines kept) instead of skeletonizing, so every `route.line` is byte-aligned
+> with the original file and exact by construction — the dropped/mis-attributed route-handler edge
+> and false dead-code candidate are both fixed. Orphaned `getSkeletonContent`/`detectLanguage`
+> imports removed. Spec `analyzer` gained `RouteLineFidelityIsLengthPreserving`. Regression proof:
+> unit line-fidelity + false-positive-suppression (ts-route-extractor.test.ts), route-handler edge
+> wired through the real builder despite the drift (edge-synthesis.test.ts), and a full
+> build → find_dead_code e2e (reachability-synthesis.test.ts) — all four fail without the fix.
+>
+> Original (PROPOSED 2026-07-08, e2e audit fifth pass): TS/JS route lines are computed against a
 > SHRUNKEN skeleton but consumed against ORIGINAL file bytes — dropped or mis-attributed
 > route-handler edges, and live Express/Fastify handlers surfacing as false dead-code candidates
 > (empirically reproduced). The length-preserving discipline already exists in the same file.

--- a/openspec/changes/fix-route-anchor-fidelity/tasks.md
+++ b/openspec/changes/fix-route-anchor-fidelity/tasks.md
@@ -1,28 +1,28 @@
 # Tasks — fix route anchor fidelity
 
 ## Implementation
-- [ ] `extractTsRouteDefinitions` (http-route-parser.ts:1055-1062): replace `getSkeletonContent`
+- [x] `extractTsRouteDefinitions` (http-route-parser.ts:1055-1062): replace `getSkeletonContent`
       with a length-preserving comment mask — `blankKeepNewlines` (:891) for block comments +
       the prefix-preserving line-comment replacement already used in `extractHttpCalls`
       (:192-194); no new masking logic
-- [ ] Remove the "Line numbers in the result are approximate" caveat (:1059-1061) — lines are
+- [x] Remove the "Line numbers in the result are approximate" caveat (:1059-1061) — lines are
       exact by construction after the change
-- [ ] Confirm the NestJS decorator and Next.js App Router branches (same `source`) inherit
+- [x] Confirm the NestJS decorator and Next.js App Router branches (same `source`) inherit
       exact lines; confirm `recOffset` (:1178) still composes correctly with the mask
-- [ ] Verify the handler-name lookup (`lines[routeLine - 1]`, :1182) now reads the true
+- [x] Verify the handler-name lookup (`lines[routeLine - 1]`, :1182) now reads the true
       registration line
 
 ## Verification
-- [ ] Repro fixture pinned: copyright block + comment + `console.log` above
+- [x] Repro fixture pinned: copyright block + comment + `console.log` above
       `setupRoutes` containing `app.get('/users', listUsers)` → route reported at the true line;
       `synthesizeRouteHandlerEdges` wires `setupRoutes` → `listUsers` (edge neither dropped nor
       attributed to the previous function)
-- [ ] Dead-code regression: the routed handler in the repro fixture is NOT a `find_dead_code`
+- [x] Dead-code regression: the routed handler in the repro fixture is NOT a `find_dead_code`
       candidate (liveness root present via `externallyInvokedHandlerIds`)
-- [ ] False-positive protection retained: a route pattern string inside a comment
+- [x] False-positive protection retained: a route pattern string inside a comment
       (`// app.get('/example', h)`) still produces no route
-- [ ] Existing route-parser + cross-service-edge suites green
-- [ ] Full suite green
+- [x] Existing route-parser + cross-service-edge suites green
+- [x] Full suite green
 
 ## Spec
-- [ ] `analyzer` delta: ADD RouteLineFidelityIsLengthPreserving
+- [x] `analyzer` delta: ADD RouteLineFidelityIsLengthPreserving

--- a/openspec/specs/analyzer/spec.md
+++ b/openspec/specs/analyzer/spec.md
@@ -5596,6 +5596,36 @@ The system SHALL mask Python triple-quoted strings and line comments length-pres
 
 > Decision recorded: 65d4ac12
 > Date: 2026-06-17
+
+### Requirement: RouteLineFidelityIsLengthPreserving
+
+TS/JS route extraction SHALL compute every route's line number against text that is byte-aligned with the original file: comment masking MUST be length-preserving (blanked to spaces, newlines kept), never line-removing, so that `route.line` consumed by original-byte consumers — enclosing-function anchoring for route-handler edge synthesis, dead-code liveness roots, the route inventory, and the registration-line handler lookup — is exact, not approximate. Masking SHALL still prevent route patterns inside comments from matching as real routes.
+
+#### Scenario: Comments above a route do not drift its line
+
+- **GIVEN** a TS file with a multi-line copyright block, a line comment, and a log line above a function containing `app.get('/users', listUsers)`
+- **WHEN** route definitions are extracted
+- **THEN** the route's reported line equals its actual line in the original file
+
+#### Scenario: The route-handler edge anchors to the true enclosing function
+
+- **GIVEN** the same fixture, with `listUsers` defined in the repo
+- **WHEN** route-handler edges are synthesized
+- **THEN** an edge from the function enclosing the registration to `listUsers` exists
+- **AND** the edge is neither silently dropped nor attributed to a preceding function
+
+#### Scenario: A framework-invoked handler is never a false dead-code candidate
+
+- **GIVEN** a handler referenced only by a route registration preceded by long comments
+- **WHEN** dead-code reachability runs with synthesized routes included
+- **THEN** the handler is a liveness root and is not reported as a dead-code candidate
+
+#### Scenario: Commented-out routes still do not match
+
+- **GIVEN** a comment line containing `app.get('/example', handler)`
+- **WHEN** route definitions are extracted
+- **THEN** no route is produced for the commented pattern
+
 ### Requirement: HardenChaPrecisionFromRealooDogfoodingSamefileBaseResolutionVarnewtTypeRecoveryCHierarchyExtraction
 
 The system SHALL resolve base-class references to same-file declarations before falling back to global name matching, and SHALL recover types from `var x = new T()` patterns in Java and C#.

--- a/src/core/analyzer/edge-synthesis.test.ts
+++ b/src/core/analyzer/edge-synthesis.test.ts
@@ -871,4 +871,35 @@ describe('route-handler synthesis (on-disk fixtures)', () => {
     expect(edge!.synthesizedBy).toBe('route-handler');
     expect(edge!.kind).toBe('calls');
   });
+
+  // Regression (fix-route-anchor-fidelity): a comment/log preamble above the
+  // route registration used to shrink the skeleton the route line was computed
+  // against, so the line anchored into the ORIGINAL file landed ABOVE `setup`
+  // (no enclosing function → edge silently dropped) or inside the PREVIOUS
+  // function (mis-attributed). With the length-preserving mask the edge wires to
+  // `setup`, not to `listUsers`'s neighbor.
+  it('wires the route despite a comment/log preamble that used to drift the line', async () => {
+    const file = join(root, 'src', 'server.ts');
+    const content = [
+      '/*',
+      ' * Copyright 2026 Example Corp.',
+      ' * All rights reserved.',
+      ' */',
+      '// Route wiring module.',
+      "console.log('booting route module');",
+      '',
+      'function listUsers(req, res) { res.send([]); }',
+      '',
+      'function setup(app) {',
+      "  app.get('/users', listUsers);",
+      '}',
+    ].join('\n');
+    await writeFile(file, content, 'utf-8');
+    const b = await new CallGraphBuilder().build([{ path: file, content, language: 'TypeScript' }]);
+    const setup = idByName(b, 'setup'), handler = idByName(b, 'listUsers');
+    const edge = b.edges.find(e => e.calleeId === handler && e.confidence === 'synthesized' && e.synthesizedBy === 'route-handler');
+    expect(edge).toBeDefined();
+    // Attributed to the real enclosing function, neither dropped nor mis-attributed.
+    expect(edge!.callerId).toBe(setup);
+  });
 });

--- a/src/core/analyzer/http-route-parser.ts
+++ b/src/core/analyzer/http-route-parser.ts
@@ -29,8 +29,6 @@
 import { readFile } from 'node:fs/promises';
 import { extname } from 'node:path';
 import { isTestFile } from './test-file.js';
-import { getSkeletonContent } from './code-shaper.js';
-import { detectLanguage } from './language-detection.js';
 
 // ============================================================================
 // TYPES
@@ -1056,11 +1054,19 @@ function detectTsFramework(source: string, filePath: string): string {
 export async function extractTsRouteDefinitions(filePath: string): Promise<RouteDefinition[]> {
   let source: string;
   try {
-    const { readFile } = await import('node:fs/promises');
-    // Use skeleton to strip comments — prevents false positives from comment
-    // examples inside parser/extractor files that contain route pattern strings.
-    // Line numbers in the result are approximate (skeleton line positions).
-    source = getSkeletonContent(await readFile(filePath, 'utf-8'), detectLanguage(filePath));
+    const raw = await readFile(filePath, 'utf-8');
+    // Mask comments LENGTH-PRESERVINGLY (blank to spaces, keep newlines) rather than
+    // skeletonizing. The skeleton REMOVES pure-comment/log/blank lines and shrinks the
+    // text, so every `route.line` was computed in a coordinate system offset from the
+    // ORIGINAL file that synthesizeRouteHandlerEdges (call-graph.ts) and find_dead_code
+    // consume it against — silently dropping or mis-attributing route-handler edges and
+    // surfacing live handlers as false dead-code. Blanking keeps the string byte-aligned
+    // with the original, so `route.line` is exact by construction while route pattern
+    // strings inside comments still never match. Same length-preserving discipline as
+    // extractHttpCalls (:193-195) and maskPythonNonCode (:906-908).
+    source = raw
+      .replace(/\/\*[\s\S]*?\*\//g, blankKeepNewlines)
+      .replace(/(^|[\s,;()[\]{}])(\/\/.*)$/gm, (_m, prefix, comment) => prefix + ' '.repeat(comment.length));
   } catch {
     return [];
   }

--- a/src/core/analyzer/ts-route-extractor.test.ts
+++ b/src/core/analyzer/ts-route-extractor.test.ts
@@ -358,6 +358,60 @@ router.get('/ping', (req, res) => {
   });
 });
 
+// Regression (fix-route-anchor-fidelity): route lines were computed against a
+// SHRUNKEN skeleton (comment/log/blank lines removed) but consumed against the
+// ORIGINAL file bytes, so any comment/log preamble above a route drifted its
+// reported line — silently dropping or mis-attributing the synthesized
+// route-handler edge and surfacing live handlers as false dead-code. The mask is
+// now length-preserving, so `route.line` is exact by construction.
+describe('extractTsRouteDefinitions — line fidelity under a comment/log preamble', () => {
+  let tmpDir: string;
+  beforeEach(async () => { tmpDir = await createTempDir(); });
+  afterEach(async () => { await rm(tmpDir, { recursive: true, force: true }); });
+
+  it('reports the TRUE line for a route beneath a copyright block, a comment, and a log line', async () => {
+    const content = [
+      '/*',                                            // 1
+      ' * Copyright 2026 Example Corp.',               // 2
+      ' * All rights reserved.',                       // 3
+      ' */',                                           // 4
+      '// Route wiring module.',                       // 5
+      "console.log('booting route module');",          // 6
+      '',                                              // 7
+      'function listUsers(req, res) { res.send([]); }', // 8
+      '',                                              // 9
+      'function setup(app) {',                         // 10
+      "  app.get('/users', listUsers);",               // 11  <- the true line
+      '}',                                             // 12
+    ].join('\n');
+    const fp = await createFile(tmpDir, 'server.ts', content);
+    const routes = await extractTsRouteDefinitions(fp);
+    const route = routes.find(r => r.path === '/users');
+    expect(route).toBeDefined();
+    // Exact: not the drifted skeleton line (which lands above `setup`, dropping the edge).
+    expect(route!.line).toBe(11);
+    // The registration line the handler-name lookup reads is the real one.
+    expect(route!.handlerName).toBe('listUsers');
+  });
+
+  it('still suppresses a route pattern that appears only inside a comment (no false route)', async () => {
+    const content = [
+      "import express from 'express';",
+      'const app = express();',
+      "// app.get('/example', exampleHandler);  a doc example, not a real route",
+      "app.get('/real', realHandler); /* app.post('/inline', h) is only a comment */",
+    ].join('\n');
+    const fp = await createFile(tmpDir, 'app.ts', content);
+    const routes = await extractTsRouteDefinitions(fp);
+    const paths = routes.map(r => r.path);
+    expect(paths).toContain('/real');
+    expect(paths).not.toContain('/example');
+    expect(paths).not.toContain('/inline');
+    // And the surviving real route keeps its exact line (4).
+    expect(routes.find(r => r.path === '/real')!.line).toBe(4);
+  });
+});
+
 describe('buildRouteInventory', () => {
   let tmpDir: string;
 

--- a/src/core/services/mcp-handlers/reachability-synthesis.test.ts
+++ b/src/core/services/mcp-handlers/reachability-synthesis.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_LLM_CONTEXT } from '../../../constants.js';
 import { handleFindDeadCode } from './reachability.js';
+import { CallGraphBuilder, serializeCallGraph } from '../../analyzer/call-graph.js';
 import type { FunctionNode, CallEdge } from '../../analyzer/call-graph.js';
 
 let root: string;
@@ -122,5 +123,37 @@ describe('provenance-aware reachability', () => {
     await writeContext(nodes, edges);
     const r = (await handleFindDeadCode({ directory: root, directResolvedOnly: true })) as { candidateDead: Array<{ name: string }> };
     expect(r.candidateDead.find(c => c.name === 'listUsers')).toBeDefined();
+  });
+
+  // End-to-end regression (fix-route-anchor-fidelity): build a real graph from
+  // source whose route sits beneath a comment/log preamble (the exact drift that
+  // used to drop the synthesized route-handler edge), then run find_dead_code over
+  // the serialized graph. The framework-invoked handler must NOT be a dead-code
+  // candidate — the whole point of route-handler liveness roots, which a dropped
+  // edge silently defeated.
+  it('a route handler beneath a comment/log preamble is not false dead-code (full build → find_dead_code)', async () => {
+    const dir = join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+    await mkdir(dir, { recursive: true });
+    const file = join(root, 'server.ts');
+    const content = [
+      '/*',
+      ' * Copyright 2026 Example Corp.',
+      ' * All rights reserved.',
+      ' */',
+      '// Route wiring module.',
+      "console.log('booting route module');",
+      '',
+      'function listUsers(req, res) { res.send([]); }',
+      '',
+      'function setup(app) {',
+      "  app.get('/users', listUsers);",
+      '}',
+    ].join('\n');
+    await writeFile(file, content, 'utf-8');
+    const built = await new CallGraphBuilder().build([{ path: file, content, language: 'TypeScript' }]);
+    await writeFile(join(dir, ARTIFACT_LLM_CONTEXT), JSON.stringify({ callGraph: serializeCallGraph(built) }), 'utf-8');
+
+    const r = (await handleFindDeadCode({ directory: root })) as { candidateDead: Array<{ name: string }> };
+    expect(r.candidateDead.find(c => c.name === 'listUsers')).toBeUndefined();
   });
 });


### PR DESCRIPTION
**Status:** LGTM — deterministic bug fix, 4 failing-then-passing regressions + real-CLI e2e, full suite green (6046 passed / 2 skipped).

## What was wrong
`extractTsRouteDefinitions` (`http-route-parser.ts`) parsed the **skeleton** of a file — comment lines, log lines, and blank runs removed, so the text is strictly *shorter* — and computed every `route.line` against that shrunken text. But the consumers anchor that line into the **original file bytes**. So any comment/log preamble above a route registration drifted its reported line:

- `synthesizeRouteHandlerEdges` (`call-graph.ts`) fed the drifted line to `offsetOfLine(originalContent, …)` → `findEnclosingFunction`. The offset landed **above** the enclosing function (edge silently dropped) or **inside the previous function** (edge mis-attributed).
- `find_dead_code` seeds dead-code liveness roots from the *targets* of those `route-handler` edges (`reachability.ts`). A dropped edge turned a live, framework-invoked Express/Fastify handler into a **false dead-code candidate**, and cost `blast_radius` its registration-site caller.

The code even admitted it: *"Line numbers in the result are approximate (skeleton line positions)."*

## How it was fixed
Mask comments **length-preservingly** (blank to spaces, keep newlines) instead of skeletonizing — the exact discipline `extractHttpCalls` (`:193-195`) and the Python `maskPythonNonCode` (`:906-908`) already use in this same file. The masked text stays byte-aligned with the original, so `route.line` is **exact by construction** while route patterns inside comments still never match. No new masking logic, no new constants.

Orphaned `getSkeletonContent` / `detectLanguage` imports removed (only use was this call site); the redundant dynamic `readFile` import dropped for the module-level one.

## Replication / proof
Each new test **fails without the fix and passes with it** (verified by stashing the source change):

| Layer | Test | Asserts |
|---|---|---|
| unit | `ts-route-extractor.test.ts` | route beneath a copyright block + comment + log line reports its **true** line; a route pattern inside a comment yields **no** route (false-positive protection retained) |
| integration | `edge-synthesis.test.ts` | the `route-handler` edge wires to the real enclosing `setup` through the live `CallGraphBuilder` despite the drift — neither dropped nor mis-attributed |
| e2e | `reachability-synthesis.test.ts` | full **build → `find_dead_code`** — the routed handler is **not** a dead-code candidate |

Real-CLI e2e: built the dist and ran `openlore analyze` on an Express fixture whose route sits under a copyright block + `console.log`; the graph wires `setup → listUsers` at the **true line 14** (under the old skeleton it drifted to ~line 6 and was dropped).

- Spec `analyzer`: ADD `RouteLineFidelityIsLengthPreserving` (synced into the main spec beside its Python sibling).
- typecheck + lint clean; full suite **6046 passed / 2 skipped**.

## Notes / backlog reconciliation
- Consumers (`call-graph.ts`, `reachability.ts`) are untouched — they were correct; their input was wrong.
- **Status straggler fixed:** `delegate-lifecycle-scope-decision-sync` frontmatter `proposed → shipped` (merged as #236; prose was already reconciled by #248).
- **Physical archiving of the shipped backlog is deferred — and this PR documents why.** `openspec archive` currently fails against the backlog for two *pre-existing, systemic* reasons: (1) several main specs are structurally invalid — requirements live under `## Sub-components` instead of `## Requirements` (analyzer, mcp-handlers, drift, …), so `archive_spec_update_failed`; and (2) some shipped deltas were already synced at ship time, so their `ADDED` requirement "already exists." Both need a dedicated corpus/archive-repair change; brute-force `git mv` would silently drop unsynced spec deltas and produce an unreviewable diff. Statuses themselves are accurate (per #248), which is the safe, non-destructive part of the reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)