### PR TITLE
fix(analyzer): recognize modifier-prefixed exports and fix comment-shifted line numbers

### DIFF
--- a/openspec/changes/fix-export-parser-fidelity/proposal.md
+++ b/openspec/changes/fix-export-parser-fidelity/proposal.md
@@ -1,5 +1,15 @@
 # Fix export-parser fidelity: modifier-prefixed exports and comment-shifted line numbers
 
+> Status: IMPLEMENTED (2026-07-19). `parseJSExports` gained modifier-tolerant regexes (async/
+> generator functions, abstract classes, default-async name capture, and real const-enum names);
+> the local recovery block in `public-surface.ts` was deleted (RESERVED_NAMES glitch filter kept).
+> The JS/TS and Java cleaners now blank comments with same-length whitespace (newlines kept), and
+> the Python multi-line-import collapse is scoped to `from … import ( … )`, line-count-preserving,
+> and attributed to the `from` line (line numbers read from the line-aligned cleaned text). A stray
+> `^\s*` in the Java import regex that swallowed a preceding blank line was tightened to `^[ \t]*`.
+> Tests: export-recall + line-fidelity + Python-scoping in `import-parser.test.ts`, consumer parity
+> in `dependency-graph.test.ts`; public-surface breaking-change tests stay green.
+>
 > Status: PROPOSED (2026-07-08, e2e audit fifth pass). Two fidelity defects in the shared
 > import/export parser (`src/core/analyzer/import-parser.ts`): `export async function` /
 > `export function*` / `export abstract class` are invisible to `parseJSExports` — a gap a

--- a/openspec/changes/fix-export-parser-fidelity/tasks.md
+++ b/openspec/changes/fix-export-parser-fidelity/tasks.md
@@ -1,36 +1,36 @@
 # Tasks — fix export-parser fidelity
 
 ## Implementation
-- [ ] `parseJSExports` (import-parser.ts:379,:392,:333): modifier-tolerant regexes —
+- [x] `parseJSExports` (import-parser.ts:379,:392,:333): modifier-tolerant regexes —
       `export (async )?function(*)? name`, `export (abstract )?class name`, default-export
       pattern that skips `async` before capturing the name (kind stays `function`/`class`)
-- [ ] Delete the local recovery block in `exportedNames`
+- [x] Delete the local recovery block in `exportedNames`
       (public-surface.ts:163-172) — the shared parser now returns those names; keep the
       RESERVED_NAMES glitch filter and the enum recovery unless the parser also fixes enum
       naming (then delete both together)
-- [ ] Same-length comment blanking (newlines kept, the parseHtmlAssetImports:1065 pattern)
+- [x] Same-length comment blanking (newlines kept, the parseHtmlAssetImports:1065 pattern)
       in the JS import cleaner (:163-165), JS export cleaner (:326-328), Java cleaners
       (:712-713, :776-777), and the Python cleaner — with the Python parenthesized-import
       collapse (:520) reworked to preserve total line count and scoped to import statements,
       attributing multi-line imports to their first line
-- [ ] Doc-comment the line-attribution rule for collapsed multi-line Python imports
-- [ ] Note (no code here): resolveImport's readFile existence probe (:919-921) recorded as
+- [x] Doc-comment the line-attribution rule for collapsed multi-line Python imports
+- [x] Note (no code here): resolveImport's readFile existence probe (:919-921) recorded as
       an `optimize-analyze-pipeline-passes` follow-up (access/stat instead of full read)
 
 ## Verification
-- [ ] Export-recall fixtures: `export async function`, `export function* gen`,
+- [x] Export-recall fixtures: `export async function`, `export function* gen`,
       `export async function* agen`, `export abstract class`, `export default async
       function foo` (name `foo`, never `async`) all appear in parseJSExports output
-- [ ] Consumer parity: dep-graph exports, verifier `compareExports` input, and
+- [x] Consumer parity: dep-graph exports, verifier `compareExports` input, and
       mapping-generator `exportIndex` include async exports for a fixture file; the
       public-surface breaking-change tests stay green after the local patch is deleted
-- [ ] Line-fidelity fixtures: a file with a 12-line block-comment header records the import
+- [x] Line-fidelity fixtures: a file with a 12-line block-comment header records the import
       on its TRUE line for JS, TS, Java, and Python; a multi-line Python `from x import (…)`
       is attributed to the `from` line; parseHtmlAssetImports behavior unchanged
-- [ ] Python collapse scoping: parenthesized non-import code (a multi-line call) no longer
+- [x] Python collapse scoping: parenthesized non-import code (a multi-line call) no longer
       perturbs line numbers of imports below it
-- [ ] Full suite green
+- [x] Full suite green
 
 ## Spec
-- [ ] `analyzer` delta: ADD ExportParserRecognizesModifierPrefixedExports,
+- [x] `analyzer` delta: ADD ExportParserRecognizesModifierPrefixedExports,
       ImportExportLineNumbersMatchOriginalSource

--- a/openspec/specs/analyzer/spec.md
+++ b/openspec/specs/analyzer/spec.md
@@ -5912,6 +5912,79 @@ The system SHALL expose the substrate preset (navigation core plus recall, verif
 > Decision recorded: c79ec7ca
 > Date: 2026-06-28
 
+### Requirement: ExportParserRecognizesModifierPrefixedExports
+
+The shared JavaScript/TypeScript export parser (`parseJSExports`) SHALL recognize modifier-prefixed
+exports so that no exported symbol is silently dropped or mis-named: `export async function`,
+generator `export function* gen` / `export async function* agen`, and `export abstract class` MUST
+be emitted with their real name and correct kind (`function`/`class`); `export default async
+function foo` MUST capture the name `foo`, never the `async` modifier; and `export const enum X`
+(and `export declare enum X`) MUST be emitted as an `enum` named `X`, never the bare `enum` token or
+a spurious `variable`. Because the parser is the single shared reader, every consumer — the
+dependency graph, the spec verifier's `compareExports`, and the mapping generator's export index —
+SHALL inherit this recognition without per-consumer recovery.
+
+#### Scenario: Async and generator function exports are recovered
+
+- **GIVEN** a source file with `export async function fetchData`, `export function* gen`, and
+  `export async function* agen`
+- **WHEN** its exports are parsed
+- **THEN** `fetchData`, `gen`, and `agen` each appear as a `function` export
+
+#### Scenario: A default async function keeps its real name
+
+- **GIVEN** `export default async function foo() {}`
+- **WHEN** its exports are parsed
+- **THEN** the default export is named `foo`, not `async`
+
+#### Scenario: A const-enum keeps its real name
+
+- **GIVEN** `export const enum Color { Red, Green }`
+- **WHEN** its exports are parsed
+- **THEN** an `enum` named `Color` is emitted, with no `enum`-named or `variable` export
+
+#### Scenario: The dependency-graph node inherits the recovery
+
+- **GIVEN** a file exporting `export async function loadData` and `export abstract class Store`
+- **WHEN** the dependency graph is built
+- **THEN** the file's node lists both `loadData` and `Store` among its exports
+
+> Change: fix-export-parser-fidelity
+> Date: 2026-07-19
+
+### Requirement: ImportExportLineNumbersMatchOriginalSource
+
+The import/export parser SHALL compute every recorded import and export line number against text
+that is line-aligned with the original file. Comment removal in the JavaScript/TypeScript and Java
+cleaners MUST blank comments with same-length whitespace (newlines kept), never strip them
+line-removing, so a block-comment header does not shift every recorded line upward. Python's
+multi-line-import collapse MUST be scoped to `from … import ( … )` statements, preserve the total
+line count (relocating consumed newlines to trailing blank lines), and attribute a multi-line import
+to its first (`from`) line; a parenthesized span that is not an import list MUST NOT perturb the line
+numbers of imports below it.
+
+#### Scenario: An import below a block-comment header records its true line
+
+- **GIVEN** a JS/TS or Java file with a 12-line block-comment header and an import/export below it
+- **WHEN** the file is parsed
+- **THEN** each import/export records its actual line in the original file, not a shifted one
+
+#### Scenario: A multi-line Python import is attributed to its from line
+
+- **GIVEN** a Python file with `from baz import (\n a,\n b\n)` and an `import os` below it
+- **WHEN** the file is parsed
+- **THEN** the `baz` import is recorded on its `from` line with names `a` and `b`
+- **AND** the `import os` below keeps its true line
+
+#### Scenario: A multi-line non-import call does not shift imports below it
+
+- **GIVEN** a Python file with a multi-line function call between two imports
+- **WHEN** the file is parsed
+- **THEN** the import below the call records its true line
+
+> Change: fix-export-parser-fidelity
+> Date: 2026-07-19
+
 ## Technical Notes
 
 - **Implementation**: `src/core/analyzer/repository-mapper.ts, src/api/types.ts, src/core/analyzer/embedding-service.ts, src/core/analyzer/subgraph-extractor.ts, src/core/analyzer/architecture-writer.ts, src/core/analyzer/dependency-graph.ts, src/core/analyzer/spec-vector-index.ts, src/core/analyzer/file-walker.ts, src/core/analyzer/import-resolver-bridge.ts, src/core/analyzer/refactor-analyzer.ts, src/core/analyzer/vector-index.ts, src/core/analyzer/import-parser.ts, src/core/analyzer/signature-extractor.ts, src/core/analyzer/artifact-generator.ts, src/core/analyzer/cpp-header-resolver.ts, src/core/analyzer/call-graph.ts, src/core/analyzer/duplicate-detector.ts, src/core/analyzer/type-inference-engine.ts, src/core/analyzer/significance-scorer.ts, src/core/analyzer/http-route-parser.ts, src/core/analyzer/ast-chunker.ts, src/core/analyzer/codebase-digest.ts, src/utils/progress.ts, src/utils/prompts.ts, src/utils/logger.ts, src/utils/shutdown.ts`

--- a/src/core/analyzer/dependency-graph.test.ts
+++ b/src/core/analyzer/dependency-graph.test.ts
@@ -137,6 +137,26 @@ describe('DependencyGraphBuilder', () => {
       expect(result.edges).toHaveLength(0);
     });
 
+    it('surfaces modifier-prefixed exports on the node (parity with the shared parser)', async () => {
+      // Regression for fix-export-parser-fidelity: the dep-graph node's `exports`
+      // come straight from the shared parseJSExports, so `export async function`
+      // must appear here — not only in the public-surface consumer that used to
+      // recover it locally.
+      const fileA = await createFile(
+        tempDir,
+        'a.ts',
+        'export async function loadData() {}\nexport abstract class Store {}',
+      );
+      const files: ScoredFile[] = [createScoredFile({ absolutePath: fileA, name: 'a.ts' })];
+
+      const result = await buildDependencyGraph(files, { rootDir: tempDir });
+      const node = result.nodes.find((n) => n.file.name === 'a.ts');
+      const exportNames = node?.exports.map((e) => e.name) ?? [];
+
+      expect(exportNames).toContain('loadData');
+      expect(exportNames).toContain('Store');
+    });
+
     it('should handle type-only imports with lower weight', async () => {
       const fileA = await createFile(tempDir, 'a.ts', `
         import type { User } from './types';

--- a/src/core/analyzer/import-parser.test.ts
+++ b/src/core/analyzer/import-parser.test.ts
@@ -10,6 +10,7 @@ import {
   ImportExportParser,
   parseFile,
   parseFiles,
+  parseJSExports,
   resolveImport,
 } from './import-parser.js';
 
@@ -1335,9 +1336,9 @@ export function test() {}
       const filePath = await createFile(tempDir, 'test.ts', content);
       const analysis = await parser.parseFile(filePath);
 
-      // Note: our simple regex may or may not catch 'async function'
-      // This test documents the current behavior
-      expect(analysis.exports.length).toBeGreaterThanOrEqual(0);
+      expect(analysis.exports).toContainEqual(
+        expect.objectContaining({ name: 'fetchData', kind: 'function', isDefault: false }),
+      );
     });
 
     it('should handle arrow function exports', async () => {
@@ -1597,5 +1598,191 @@ export function test() {}
 
       expect(result).toBe(fooPath);
     });
+  });
+});
+
+// ============================================================================
+// EXPORT-PARSER FIDELITY (change: fix-export-parser-fidelity)
+// ============================================================================
+
+describe('parseJSExports — modifier-prefixed exports', () => {
+  const namesOf = (src: string) => parseJSExports(src).map((e) => e.name);
+
+  it('recognizes export async function', () => {
+    expect(parseJSExports(`export async function fetchData() {}`)).toContainEqual(
+      expect.objectContaining({ name: 'fetchData', kind: 'function', isDefault: false }),
+    );
+  });
+
+  it('recognizes a generator export function* gen', () => {
+    expect(parseJSExports(`export function* gen() {}`)).toContainEqual(
+      expect.objectContaining({ name: 'gen', kind: 'function' }),
+    );
+  });
+
+  it('recognizes an async generator export async function* agen', () => {
+    expect(parseJSExports(`export async function* agen() {}`)).toContainEqual(
+      expect.objectContaining({ name: 'agen', kind: 'function' }),
+    );
+  });
+
+  it('recognizes export abstract class', () => {
+    expect(parseJSExports(`export abstract class Base {}`)).toContainEqual(
+      expect.objectContaining({ name: 'Base', kind: 'class' }),
+    );
+  });
+
+  it('captures the real name (not "async") for export default async function foo', () => {
+    const exps = parseJSExports(`export default async function foo() {}`);
+    const def = exps.find((e) => e.isDefault);
+    expect(def).toMatchObject({ name: 'foo', kind: 'function', isDefault: true });
+    expect(namesOf(`export default async function foo() {}`)).not.toContain('async');
+  });
+
+  it('captures the real name of a const-enum (export const enum X)', () => {
+    const exps = parseJSExports(`export const enum Color { Red, Green }`);
+    expect(exps).toContainEqual(expect.objectContaining({ name: 'Color', kind: 'enum' }));
+    // The bare `enum` glitch and a spurious `variable` export must not appear.
+    expect(exps.some((e) => e.name === 'enum')).toBe(false);
+    expect(exps.some((e) => e.kind === 'variable')).toBe(false);
+  });
+
+  it('still recognizes a plain export enum X', () => {
+    expect(parseJSExports(`export enum Size { S, M, L }`)).toContainEqual(
+      expect.objectContaining({ name: 'Size', kind: 'enum' }),
+    );
+  });
+
+  it('does not regress plain function/class/variable exports', () => {
+    const src = `export function plain() {}\nexport class C {}\nexport const x = 1;`;
+    const exps = parseJSExports(src);
+    expect(exps).toContainEqual(expect.objectContaining({ name: 'plain', kind: 'function' }));
+    expect(exps).toContainEqual(expect.objectContaining({ name: 'C', kind: 'class' }));
+    expect(exps).toContainEqual(expect.objectContaining({ name: 'x', kind: 'variable' }));
+  });
+
+  it('still treats a variable merely prefixed with "enum" as a variable', () => {
+    expect(parseJSExports(`export const enumValue = 3;`)).toContainEqual(
+      expect.objectContaining({ name: 'enumValue', kind: 'variable' }),
+    );
+  });
+});
+
+describe('import/export line numbers match the original source', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('records the TRUE line for a JS import/export below a 12-line block-comment header', async () => {
+    const src = [
+      '/**', // 1
+      ' * line 2', // 2
+      ' * line 3', // 3
+      ' * line 4', // 4
+      ' * line 5', // 5
+      ' * line 6', // 6
+      ' * line 7', // 7
+      ' * line 8', // 8
+      ' * line 9', // 9
+      ' * line 10', // 10
+      ' * line 11', // 11
+      ' */', // 12
+      '', // 13
+      "import { thing } from './thing';", // 14
+      'export async function run() {}', // 15
+    ].join('\n');
+    const filePath = await createFile(tempDir, 'header.ts', src);
+    const analysis = await parseFile(filePath);
+
+    expect(analysis.imports.find((i) => i.source === './thing')?.line).toBe(14);
+    expect(analysis.exports.find((e) => e.name === 'run')?.line).toBe(15);
+  });
+
+  it('records the TRUE line for a TS export below a block-comment header', async () => {
+    const src = [
+      '/* a', // 1
+      '   b */', // 2
+      '', // 3
+      'export interface Widget { id: string }', // 4
+    ].join('\n');
+    const filePath = await createFile(tempDir, 'iface.ts', src);
+    const analysis = await parseFile(filePath);
+    expect(analysis.exports.find((e) => e.name === 'Widget')?.line).toBe(4);
+  });
+
+  it('records the TRUE line for a Java import/export below a block-comment header', async () => {
+    const src = [
+      '/*', // 1
+      ' * header a', // 2
+      ' * header b', // 3
+      ' */', // 4
+      'package com.foo;', // 5
+      '', // 6
+      'import com.bar.Baz;', // 7
+      '', // 8
+      'public class Foo {}', // 9
+    ].join('\n');
+    const filePath = await createFile(tempDir, 'Foo.java', src);
+    const analysis = await parseFile(filePath);
+    expect(analysis.imports.find((i) => i.source === 'com.bar.Baz')?.line).toBe(7);
+    expect(analysis.exports.find((e) => e.name === 'Foo')?.line).toBe(9);
+  });
+
+  it('records the TRUE line for a Python import below a comment header', async () => {
+    const src = [
+      '# header line 1', // 1
+      '# header line 2', // 2
+      '', // 3
+      'from foo import bar', // 4
+    ].join('\n');
+    const filePath = await createFile(tempDir, 'a.py', src);
+    const analysis = await parseFile(filePath);
+    expect(analysis.imports.find((i) => i.source === 'foo')?.line).toBe(4);
+  });
+
+  it('attributes a multi-line Python import to its first (from) line and preserves lines below', async () => {
+    const src = [
+      'from foo import bar', // 1
+      '', // 2
+      'from baz import (', // 3
+      '    a,', // 4
+      '    b,', // 5
+      ')', // 6
+      '', // 7
+      'import os', // 8
+    ].join('\n');
+    const filePath = await createFile(tempDir, 'multi.py', src);
+    const analysis = await parseFile(filePath);
+
+    expect(analysis.imports.find((i) => i.source === 'foo')?.line).toBe(1);
+    const baz = analysis.imports.find((i) => i.source === 'baz');
+    expect(baz?.line).toBe(3);
+    expect(baz?.importedNames).toEqual(expect.arrayContaining(['a', 'b']));
+    // The collapse must not shift the line of the import below the multi-line block.
+    expect(analysis.imports.find((i) => i.source === 'os')?.line).toBe(8);
+  });
+
+  it('does not let a multi-line NON-import call perturb import line numbers below it', async () => {
+    const src = [
+      'from foo import bar', // 1
+      '', // 2
+      'result = some_call(', // 3
+      '    1,', // 4
+      '    2,', // 5
+      ')', // 6
+      '', // 7
+      'import os', // 8
+    ].join('\n');
+    const filePath = await createFile(tempDir, 'scope.py', src);
+    const analysis = await parseFile(filePath);
+
+    expect(analysis.imports.find((i) => i.source === 'foo')?.line).toBe(1);
+    expect(analysis.imports.find((i) => i.source === 'os')?.line).toBe(8);
   });
 });

--- a/src/core/analyzer/import-parser.ts
+++ b/src/core/analyzer/import-parser.ts
@@ -159,10 +159,13 @@ function parseNamedImports(namesStr: string): string[] {
 export function parseJSImports(content: string): ImportInfo[] {
   const imports: ImportInfo[] = [];
 
-  // Remove comments to avoid false matches
+  // Blank comments with same-length whitespace (newlines kept) so `match.index`
+  // offsets and `getLineNumber(content, …)` agree with the original file — the
+  // `parseHtmlAssetImports` discipline. Stripping them outright would shift every
+  // recorded import line upward past a block-comment header.
   const cleanContent = content
-    .replace(/\/\*[\s\S]*?\*\//g, '') // Block comments
-    .replace(/\/\/.*$/gm, '');        // Line comments
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' ')) // Block comments
+    .replace(/\/\/.*$/gm, (m) => ' '.repeat(m.length));            // Line comments
 
   // ES Module: import X from 'module'
   let match: RegExpExecArray | null;
@@ -322,15 +325,21 @@ export function parseJSImports(content: string): ImportInfo[] {
 export function parseJSExports(content: string): ExportInfo[] {
   const exports: ExportInfo[] = [];
 
-  // Remove comments
+  // Blank comments with same-length whitespace (newlines kept) so `match.index`
+  // offsets and `getLineNumber(content, …)` agree with the original file — the
+  // `parseHtmlAssetImports` discipline. Stripping comments outright would shift
+  // every recorded export line upward past a block-comment header.
   const cleanContent = content
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/\/\/.*$/gm, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/\/\/.*$/gm, (m) => ' '.repeat(m.length));
 
   let match: RegExpExecArray | null;
 
-  // export default
-  const defaultExportRegex = /export\s+default\s+(?:(class|function)\s+(\w+)|(\w+))/g;
+  // export default — tolerate the `async` modifier and a generator `*` so
+  // `export default async function foo` captures `foo` (not `async`), and skip
+  // `abstract` before a default class.
+  const defaultExportRegex =
+    /export\s+default\s+(?:(?:async\s+)?(?:abstract\s+)?(class|function)\s*\*?\s*(\w+)|(\w+))/g;
   while ((match = defaultExportRegex.exec(cleanContent)) !== null) {
     const kind = match[1] as 'class' | 'function' | undefined;
     const name = match[2] || match[3] || 'default';
@@ -362,8 +371,9 @@ export function parseJSExports(content: string): ExportInfo[] {
     }
   }
 
-  // export const/let/var
-  const varExportRegex = /export\s+(?:const|let|var)\s+(\w+)/g;
+  // export const/let/var — but NOT `export const enum X` (a TS const-enum,
+  // recovered with its real name by the enum regex below).
+  const varExportRegex = /export\s+(?:const|let|var)\s+(?!enum\b)(\w+)/g;
   while ((match = varExportRegex.exec(cleanContent)) !== null) {
     exports.push({
       name: match[1],
@@ -375,8 +385,10 @@ export function parseJSExports(content: string): ExportInfo[] {
     });
   }
 
-  // export function
-  const funcExportRegex = /export\s+function\s+(\w+)/g;
+  // export function — tolerate `async` and a generator `*` so
+  // `export async function`, `export function* gen`, and
+  // `export async function* agen` are not silently dropped.
+  const funcExportRegex = /export\s+(?:async\s+)?function\s*\*?\s*(\w+)/g;
   while ((match = funcExportRegex.exec(cleanContent)) !== null) {
     exports.push({
       name: match[1],
@@ -388,8 +400,8 @@ export function parseJSExports(content: string): ExportInfo[] {
     });
   }
 
-  // export class
-  const classExportRegex = /export\s+class\s+(\w+)/g;
+  // export class — tolerate the `abstract` modifier.
+  const classExportRegex = /export\s+(?:abstract\s+)?class\s+(\w+)/g;
   while ((match = classExportRegex.exec(cleanContent)) !== null) {
     exports.push({
       name: match[1],
@@ -427,8 +439,9 @@ export function parseJSExports(content: string): ExportInfo[] {
     });
   }
 
-  // export enum
-  const enumExportRegex = /export\s+enum\s+(\w+)/g;
+  // export enum — tolerate `declare` and `const` (a TS const-enum) so the real
+  // enum name is captured instead of the bare `enum` glitch.
+  const enumExportRegex = /export\s+(?:declare\s+)?(?:const\s+)?enum\s+(\w+)/g;
   while ((match = enumExportRegex.exec(cleanContent)) !== null) {
     exports.push({
       name: match[1],
@@ -513,11 +526,25 @@ const PYTHON_BUILTINS = new Set([
 export function parsePythonImports(content: string): ImportInfo[] {
   const imports: ImportInfo[] = [];
 
-  // Remove comments and collapse multi-line parenthesized imports onto one line
-  // e.g. "from x import (\n  A,\n  B\n)" → "from x import A, B"
+  // Blank line comments (same length, newlines kept) and collapse ONLY multi-line
+  // `from X import ( … )` blocks onto the `from` line, relocating the newlines the
+  // collapse consumes to trailing blank lines so total line count — and every
+  // recorded import line — matches the original source. A multi-line import is
+  // attributed to its first (the `from`) line. Parenthesized spans that are NOT
+  // import lists (e.g. a multi-line call) are left untouched, so they cannot shift
+  // the line numbers of imports below them. Because the collapse is not
+  // length-preserving, line numbers below are read from `cleanContent`, whose
+  // newline positions stay line-aligned with the original.
   const cleanContent = content
-    .replace(/#.*$/gm, '')
-    .replace(/\(\s*([\s\S]*?)\s*\)/g, (_, inner) => inner.replace(/\s*\n\s*/g, ', '));
+    .replace(/#.*$/gm, (m) => ' '.repeat(m.length))
+    .replace(
+      /^([ \t]*from\s+[\w.]+\s+import\s*)\(([\s\S]*?)\)/gm,
+      (whole, prefix, inner) => {
+        const joined = prefix + inner.replace(/\s*\n\s*/g, ', ');
+        const consumedNewlines = (whole.match(/\n/g) ?? []).length;
+        return joined + '\n'.repeat(consumedNewlines);
+      },
+    );
 
   let match: RegExpExecArray | null;
 
@@ -539,7 +566,7 @@ export function parsePythonImports(content: string): ImportInfo[] {
         hasNamespace: true,
         isTypeOnly: false,
         isDynamic: false,
-        line: getLineNumber(content, match.index),
+        line: getLineNumber(cleanContent, match.index),
       });
     }
   }
@@ -563,7 +590,7 @@ export function parsePythonImports(content: string): ImportInfo[] {
         hasNamespace: true,
         isTypeOnly: false,
         isDynamic: false,
-        line: getLineNumber(content, match.index),
+        line: getLineNumber(cleanContent, match.index),
       });
     } else {
       const names = importsPart.split(',').map(n => {
@@ -581,7 +608,7 @@ export function parsePythonImports(content: string): ImportInfo[] {
         hasNamespace: false,
         isTypeOnly: false,
         isDynamic: false,
-        line: getLineNumber(content, match.index),
+        line: getLineNumber(cleanContent, match.index),
       });
     }
   }
@@ -707,12 +734,15 @@ export function parseJavaPackage(content: string): string | undefined {
 function parseJavaImports(content: string): ImportInfo[] {
   const imports: ImportInfo[] = [];
 
-  // Strip comments to avoid false matches
+  // Blank comments with same-length whitespace (newlines kept) so recorded
+  // import lines match the original file (the `parseHtmlAssetImports` discipline).
   const clean = content
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/\/\/.*$/gm, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/\/\/.*$/gm, (m) => ' '.repeat(m.length));
 
-  const importRegex = /^\s*import\s+(static\s+)?([\w.]+(?:\.\*)?)\s*;/gm;
+  // `^[ \t]*` (not `^\s*`) so a preceding blank line's newline is not consumed
+  // into the match — that would report the import one line early.
+  const importRegex = /^[ \t]*import\s+(static\s+)?([\w.]+(?:\.\*)?)\s*;/gm;
   let match: RegExpExecArray | null;
   while ((match = importRegex.exec(clean)) !== null) {
     const isStatic = !!match[1];
@@ -772,9 +802,11 @@ function parseJavaImports(content: string): ImportInfo[] {
 function parseJavaExports(content: string): ExportInfo[] {
   const exports: ExportInfo[] = [];
 
+  // Blank comments with same-length whitespace (newlines kept) so recorded
+  // export lines match the original file (the `parseHtmlAssetImports` discipline).
   const clean = content
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/\/\/.*$/gm, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/\/\/.*$/gm, (m) => ' '.repeat(m.length));
 
   let match: RegExpExecArray | null;
 

--- a/src/core/services/mcp-handlers/public-surface.ts
+++ b/src/core/services/mcp-handlers/public-surface.ts
@@ -162,21 +162,17 @@ function exportedNames(rawContent: string, language: string): Set<string> {
     // the definition site (tracked there), and counting them here double-reports a barrel'd symbol
     // (and turns a definition-site rename into a phantom remove+add at the barrel). Matches the
     // surface-listing path, which also filters re-exports.
+    // The shared `parseJSExports` now recognizes modifier-prefixed exports directly —
+    // `export async function` / `export function* gen` / `export abstract class`,
+    // `export default async function foo` (name `foo`, not `async`), and the real name
+    // of a `export const enum X` — so no per-consumer recovery is needed here. The
+    // RESERVED_NAMES filter stays as a defense-in-depth glitch guard (e.g. an anonymous
+    // `export default function () {}` still yields the bare `function` token).
     const names = new Set(
       parseJSExports(content)
         .filter((e) => !e.isReExport && e.name && e.name !== 'default' && !RESERVED_NAMES.has(e.name))
         .map((e) => e.name),
     );
-    // `parseJSExports`' `export function` regex matches neither `export async function` nor a
-    // GENERATOR (`export function* gen` / `export async function* agen`) — recover all of those
-    // here so async/generator exports are not silently dropped. Local fix; shared parser unchanged.
-    const fn = /\bexport\s+(?:default\s+)?(?:async\s+)?function\s*\*?\s*([A-Za-z_$][\w$]*)/g;
-    // `parseJSExports` also mis-names `export const enum X` (and `export enum X`) — recover the real
-    // enum name (the bare `enum` token was filtered out above as a reserved-word glitch).
-    const en = /\bexport\s+(?:declare\s+)?(?:const\s+)?enum\s+([A-Za-z_$][\w$]*)/g;
-    let m: RegExpExecArray | null;
-    while ((m = fn.exec(content)) !== null) names.add(m[1]);
-    while ((m = en.exec(content)) !== null) names.add(m[1]);
     return names;
   }
   if (language === 'Python') {


### PR DESCRIPTION
**Status:** LGTM — implements the `fix-export-parser-fidelity` proposal (e2e-audit fifth pass). CI-equivalent gates all green locally: lint, typecheck, full suite (6062 passed / 2 skipped), build; plus an e2e self-analyze of this repo (8135 functions, 953 files) that completes clean.

## What was wrong

Two fidelity defects in the shared import/export parser (`src/core/analyzer/import-parser.ts`), each an instance of the audit's recurring theme — *the discipline exists, just not applied here*:

**(a) Modifier-prefixed exports were invisible.** `parseJSExports` matched neither `export async function` nor a generator `export function* gen`, missed `export abstract class`, and captured the name `"async"` for `export default async function foo`; `export const enum X` mis-parsed to the bare `enum` token. The gap was already patched **locally at one consumer** ([public-surface.ts](src/core/services/mcp-handlers/public-surface.ts)) while three others still read the unpatched parser — the dependency graph, the spec verifier's `compareExports`, and the mapping generator's export index. In a codebase like OpenLore itself (dozens of `export async function`), every async export was silently absent from those export sets, so `mapping.json` links fell to a weaker tier and spec verification checked a wrong export set.

**(b) Line numbers were counted in the comment-stripped string.** The JS/TS and Java cleaners removed block comments *with* their newlines, then computed `getLineNumber(content, match.index)` — but `match.index` is an offset into the shorter cleaned text. A block-comment header (nearly every source file has one) shifted essentially every recorded import/export line upward. Python was worse: it collapsed **all** parenthesized spans file-wide, so a multi-line call anywhere shifted the line numbers of every import below it.

## How it was fixed

- **Hoisted the recovery into the shared parser.** Modifier-tolerant regexes for `export (async )?function(\*)?`, `export (abstract )?class`, a default-export pattern that skips `async` before capturing the name, and `export (declare )?(const )?enum` (with a `(?!enum\b)` guard on the var regex). The local recovery block in `public-surface.ts` is deleted — one shared parser, no per-consumer recovery. The `RESERVED_NAMES` glitch filter stays as defense-in-depth. Consumers inherit the fix through `parseFile` with no call-site change.
- **Same-length comment blanking** (newlines kept — the `parseHtmlAssetImports` discipline already in the same file) in the JS/TS and Java cleaners, so offsets and line numbers agree with the original file.
- **Rescoped the Python collapse** to `from … import ( … )` only, made it line-count-preserving (consumed newlines relocated to trailing blank lines), attributed to the import's first line, with line numbers read from the line-aligned cleaned text. A multi-line non-import call no longer perturbs imports below it.
- Tightened the Java import anchor `^\s*` → `^[ \t]*` so a preceding blank line's newline isn't swallowed into the match (surfaced by fix (b)).

## Proof it works

New regression tests, all green:
- **Export recall** (`import-parser.test.ts`): `export async function`, `export function* gen`, `export async function* agen`, `export abstract class`, `export default async function foo` (name `foo`, never `async`), and `export const enum` all appear with correct name+kind; plain function/class/variable exports and an `enumValue` variable don't regress.
- **Consumer parity** (`dependency-graph.test.ts`): a dep-graph node lists `export async function` / `export abstract class` among its exports — proving the shared-parser fix reaches consumers.
- **Line fidelity**: an import/export below a 12-line block-comment header records its TRUE line for JS, TS, Java, and Python; a multi-line Python `from x import (…)` is attributed to its `from` line and the import below keeps its true line; a multi-line non-import call doesn't shift imports below it.
- The existing public-surface breaking-change tests stay green after the local patch was deleted.

E2E on the compiled `dist/` artifact over a synthetic repo confirmed: default-async exported as `boot` (not `async`), async/generator/abstract recovered, TS import at true line 14, Python `import os` at line 9 (unshifted by the multi-line block above it).

## Notes / nits

- Spec: `analyzer` gains `ExportParserRecognizesModifierPrefixedExports` and `ImportExportLineNumbersMatchOriginalSource` (both in the change delta and the main spec).
- Out of scope (noted in the proposal): `resolveImport`'s `readFile` existence probe — belongs to `optimize-analyze-pipeline-passes`.
- Risk: low. Regex widening is additive; line-number correction moves recorded lines to the TRUE lines. No existing test pinned the buggy values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
