### PR TITLE
fix(cli): raise the Node floor to where node:sqlite exists — and probe the capability, not the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://www.npmjs.com/package/openlore"><img src="https://img.shields.io/npm/v/openlore?color=2563eb&label=npm&logo=npm&logoColor=white" alt="npm version"></a>
   <a href="https://github.com/clay-good/OpenLore/actions/workflows/ci.yml"><img src="https://github.com/clay-good/OpenLore/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
   <a href="LICENSE"><img src="https://img.shields.io/npm/l/openlore?color=22c55e" alt="MIT License"></a>
-  <img src="https://img.shields.io/node/v/openlore?color=339933&logo=node.js&logoColor=white" alt="Node >=22.5">
+  <img src="https://img.shields.io/node/v/openlore?color=339933&logo=node.js&logoColor=white" alt="Node >=22.13">
   <br>
   <img src="https://img.shields.io/badge/MCP-ready-7c3aed?logo=anthropic&logoColor=white" alt="MCP ready">
   <img src="https://img.shields.io/badge/languages-18%20%2B%2012%20IaC-f97316" alt="18 languages + 12 IaC ecosystems">
@@ -478,7 +478,7 @@ We'd rather you know these up front than discover them mid-task.
 
 ## Requirements
 
-- **Node.js 22.5+** (launching under an older Node fails fast with a one-line message and exit code 78, never a stack trace).
+- **Node.js 22.13+** (the first line where the built-in `node:sqlite` is available without runtime flags; launching under an older or incapable Node fails fast with a one-line message and exit code 78, never a stack trace).
 - **No API key** for `analyze`, `drift`, `mcp`, `init`, and every governance/navigation tool.
 - **API key** only for `generate`, `verify`, and `drift --use-llm`:
   ```bash

--- a/docs/OPENSPEC-INTEGRATION.md
+++ b/docs/OPENSPEC-INTEGRATION.md
@@ -483,7 +483,8 @@ and project-root resolution from the spawn directory.
 
 ### Node-version guard
 
-OpenLore requires **Node ≥22.5**; OpenSpec requires only ≥20.19. A user on Node 20/21 can run
+OpenLore requires **Node ≥22.13** (the first line where the built-in `node:sqlite` is available
+without runtime flags); OpenSpec requires only ≥20.19. A user on Node 20/21 can run
 `openspec lore generate`, which spawns `openlore` under an unsupported Node. `engines` is advisory at
 install time and does not protect the spawn, so OpenLore **fails fast at runtime**: one legible
 stderr line naming the required and actual versions, and a stable exit code **78** — never a stack

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -345,7 +345,7 @@ Checks performed:
 
 | Check | What it looks for |
 |-------|------------------|
-| Node.js version | ≥ 22.5 required (`node:sqlite`) |
+| Node.js version | ≥ 22.13 required, and `node:sqlite` probed as loadable |
 | Git repository | `.git` directory and `git` binary on PATH |
 | openlore config | `.openlore/config.json` exists and is parseable |
 | Analysis artifacts | `repo-structure.json` freshness (warns if >24h old) |
@@ -591,7 +591,8 @@ coherent with the `@fission-ai/openspec` peer-dep range), the help-only surfaced
 commands, the contributed skill, and `ownsConfigKeys: ["openlore"]`. See
 [OPENSPEC-INTEGRATION.md](OPENSPEC-INTEGRATION.md) for the full marketplace contract.
 
-> **Node-version guard.** OpenLore requires Node ≥22.5. The CLI checks this before
+> **Node-version guard.** OpenLore requires Node ≥22.13 (the first line where the
+> built-in `node:sqlite` is available without runtime flags). The CLI checks this before
 > any command runs; under an older Node it prints one stderr line naming the
 > required and actual versions and exits with the stable code **78** — never a
 > stack trace — so a host delegating to OpenLore (e.g. `openspec lore generate` on

--- a/openspec/changes/fix-node-sqlite-engine-floor/proposal.md
+++ b/openspec/changes/fix-node-sqlite-engine-floor/proposal.md
@@ -1,12 +1,22 @@
 # Raise the Node floor to where `node:sqlite` actually exists — and probe the capability, not the version
 
-> Status: PROPOSED (2026-07-03, e2e audit follow-up). `package.json` declares `engines.node:
+> Status: IMPLEMENTED (2026-07-19). The floor moved from `>=22.5.0` to `>=22.13.0` (the verified
+> unflagged `node:sqlite` line, nodejs/node#55854) across all three declarations — `engines.node`
+> (package.json), `MIN_NODE` (node-version-guard.ts), and `MIN_NODE_MAJOR/MINOR_VERSION`
+> (constants.ts) — plus the README badge/requirement line and the live docs (cli-reference,
+> OPENSPEC-INTEGRATION). `checkNodeVersion` and doctor's Node check now probe `node:sqlite` via
+> `process.getBuiltinModule` (injectable `isSqliteAvailable`) so the capability, not the version
+> number, has the final word: a version at/above the floor with the builtin unavailable fails
+> honestly (stderr line + exit code 78 / doctor `fail` naming the missing capability), never an
+> uncaught first-import crash. The guard test extends the floor-coherence check to constants.ts and
+> adds probe cases. Not touched: the historical `docs/specs/openlore-spec-26-*` audit record, whose
+> since-reversed "keep 22.5" recommendation is left as dated history.
+>
+> Original problem (2026-07-03, e2e audit follow-up): `package.json` declared `engines.node:
 > ">=22.5.0"`, but `node:sqlite` required `--experimental-sqlite` until Node 22.13.0 / 23.4.0 and
 > nothing in the tree passes that flag — so a fresh install on the low end of the DECLARED range
-> crashes at first import, while the version guard and doctor both bless the very version that
-> crashes. Raise the floor to the verified unflagged line, align all three floor declarations, and
-> make the guard probe `node:sqlite` availability directly so a future flag change can't reopen
-> the gap.
+> crashed at first import, while the version guard and doctor both blessed the very version that
+> crashes.
 
 ## The gap
 

--- a/openspec/changes/fix-node-sqlite-engine-floor/tasks.md
+++ b/openspec/changes/fix-node-sqlite-engine-floor/tasks.md
@@ -1,27 +1,27 @@
 # Tasks — fix-node-sqlite-engine-floor
 
 ## Implementation
-- [ ] Re-confirm the verified floor from the Node release notes (nodejs/node#55854 unflagged
+- [x] Re-confirm the verified floor from the Node release notes (nodejs/node#55854 unflagged
       `node:sqlite` in 22.13.0 / 23.4.0) and raise `engines.node` in package.json to it
-- [ ] Align every floor declaration: `MIN_NODE` (node-version-guard.ts:19),
+- [x] Align every floor declaration: `MIN_NODE` (node-version-guard.ts:19),
       `MIN_NODE_MAJOR_VERSION`/`MIN_NODE_MINOR_VERSION` (constants.ts:273-274), doctor copy
       (doctor.ts:62,461,68 nvm hint), README requirement line (README.md:481)
-- [ ] Capability probe in `assertSupportedNode` (node-version-guard.ts:44-50): after the version
+- [x] Capability probe in `assertSupportedNode` (node-version-guard.ts:44-50): after the version
       check, verify `process.getBuiltinModule('node:sqlite')` returns the module; on failure emit
       the same one-line stderr message + exit code 78 (EXIT_UNSUPPORTED_NODE), never a stack trace
-- [ ] Same probe in doctor's `checkNodeVersion` (doctor.ts:55-70): a passing version number with a
+- [x] Same probe in doctor's `checkNodeVersion` (doctor.ts:55-70): a passing version number with a
       failing probe is `fail` with "node:sqlite unavailable on this Node", not `ok`
 
 ## Verification
-- [ ] Extend the MIN_NODE ↔ `engines.node` sync test (node-version-guard.test.ts) to also assert
+- [x] Extend the MIN_NODE ↔ `engines.node` sync test (node-version-guard.test.ts) to also assert
       constants.ts's pair matches — one floor, three declarations, test-pinned
-- [ ] Unit test: probe failure (mock `getBuiltinModule` returning undefined) → `ok: false` with
+- [x] Unit test: probe failure (mock `getBuiltinModule` returning undefined) → `ok: false` with
       the capability message, exit code 78 through `assertSupportedNode`
-- [ ] Unit test: version arithmetic passes but probe fails → guard still fails (capability wins
+- [x] Unit test: version arithmetic passes but probe fails → guard still fails (capability wins
       over arithmetic); version below floor still fails with the version message
-- [ ] Manual/CI smoke: `node -e "require('node:sqlite')"`-equivalent probe green on the CI Node;
+- [x] Manual/CI smoke: `node -e "require('node:sqlite')"`-equivalent probe green on the CI Node;
       full suite green
-- [ ] Grep-check: no remaining `22.5` floor claim in src/, README, or docs after the bump
+- [x] Grep-check: no remaining `22.5` floor claim in src/, README, or docs after the bump
 
 ## Spec
-- [ ] `cli` delta: ADD NodeFloorMatchesSqliteCapability
+- [x] `cli` delta: ADD NodeFloorMatchesSqliteCapability

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -1160,3 +1160,35 @@ enumerate cached-graph commands and fail when one lacks the boundary path.
 - **GIVEN** `openlore style-fingerprint --language <unrecognized>`
 - **WHEN** the language matches no known language
 - **THEN** the command exits non-zero with a not-found shape listing the known languages, matching the honesty of its file-path counterpart
+
+### Requirement: NodeFloorMatchesSqliteCapability
+
+The declared Node.js floor (`engines.node`, the runtime guard's `MIN_NODE`, doctor's constants,
+and user-facing documentation) SHALL be a version on which every statically imported builtin —
+in particular `node:sqlite` — is available without runtime flags, and all floor declarations SHALL
+be kept equal by an automated test. The runtime guard and `openlore doctor` SHALL verify
+`node:sqlite` availability by probing the module itself (e.g.
+`process.getBuiltinModule('node:sqlite')`), not by version arithmetic alone; a probe failure SHALL
+produce the established one-line legible failure (stderr message + stable exit code 78), never an
+uncaught import crash, and doctor SHALL report it as a failing check naming the missing capability.
+
+#### Scenario: A Node inside the old declared range but below the working floor is rejected legibly
+
+- **GIVEN** openlore launched under Node 22.10 (where `node:sqlite` requires a flag nobody passes)
+- **WHEN** the CLI entry guard runs
+- **THEN** the process exits with code 78 and one stderr line naming the required Node floor,
+  before any `node:sqlite` import can throw a stack trace
+
+#### Scenario: Capability probe overrides version arithmetic
+
+- **GIVEN** a Node build whose version number satisfies the floor but on which the `node:sqlite`
+  probe fails (re-flagged or stripped builtin)
+- **WHEN** the guard or `openlore doctor` evaluates the environment
+- **THEN** the verdict is failure with a message naming `node:sqlite` unavailability — the passing
+  version number is never presented as evidence the product can run
+
+#### Scenario: Floor declarations cannot drift apart
+
+- **GIVEN** the floor is declared in package.json `engines`, the version guard, and constants
+- **WHEN** any one declaration is changed without the others
+- **THEN** an automated test fails, keeping one floor across all declarations and doctor/README copy

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "openlore": "dist/cli/index.js"
   },
   "engines": {
-    "node": ">=22.5.0"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "dev": "tsx watch src/cli/index.ts",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -16,6 +16,7 @@ import { readOpenLoreConfig, resolveOpenLoreConfigPath } from '../../core/servic
 import { validateOpenLoreConfig } from '../../core/services/config-schema.js';
 import { EdgeStore } from '../../core/services/edge-store.js';
 import { createLLMService, ProviderName } from '../../core/services/llm-service.js';
+import { isSqliteAvailable } from '../node-version-guard.js';
 import {
   MIN_NODE_MAJOR_VERSION,
   MIN_NODE_MINOR_VERSION,
@@ -70,11 +71,23 @@ interface CheckResult {
 async function checkNodeVersion(): Promise<CheckResult> {
   const [major, minor] = process.versions.node.split('.').map(Number);
   const min = `${MIN_NODE_MAJOR_VERSION}.${MIN_NODE_MINOR_VERSION}`;
-  const ok =
+  const versionOk =
     major > MIN_NODE_MAJOR_VERSION ||
     (major === MIN_NODE_MAJOR_VERSION && minor >= MIN_NODE_MINOR_VERSION);
-  if (ok) {
+  // Probe the capability itself, not just the version number: a Node whose version
+  // satisfies the floor but on which `node:sqlite` is not loadable (e.g. 23.0–23.3,
+  // or a stripped distro build) must not be blessed as `ok`.
+  const sqliteOk = isSqliteAvailable();
+  if (versionOk && sqliteOk) {
     return { name: 'Node.js version', status: 'ok', detail: `v${process.versions.node}` };
+  }
+  if (!sqliteOk) {
+    return {
+      name: 'Node.js version',
+      status: 'fail',
+      detail: `v${process.versions.node} — node:sqlite unavailable on this Node`,
+      fix: `Switch to Node ${min}+ (\`nvm use ${MIN_NODE_MAJOR_VERSION}\`) or install from https://nodejs.org/ — node:sqlite must be available without runtime flags or the MCP server will crash at first import`,
+    };
   }
   return {
     name: 'Node.js version',

--- a/src/cli/node-version-guard.test.ts
+++ b/src/cli/node-version-guard.test.ts
@@ -8,7 +8,14 @@ import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { checkNodeVersion, assertSupportedNode, MIN_NODE, EXIT_UNSUPPORTED_NODE } from './node-version-guard.js';
+import {
+  checkNodeVersion,
+  assertSupportedNode,
+  isSqliteAvailable,
+  MIN_NODE,
+  EXIT_UNSUPPORTED_NODE,
+} from './node-version-guard.js';
+import { MIN_NODE_MAJOR_VERSION, MIN_NODE_MINOR_VERSION } from '../constants.js';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -50,6 +57,55 @@ describe('Node floor coherence', () => {
     expect(Number(match![1])).toBe(MIN_NODE.major);
     expect(Number(match![2])).toBe(MIN_NODE.minor);
   });
+
+  it('MIN_NODE matches constants.ts MIN_NODE_MAJOR/MINOR_VERSION', () => {
+    // One floor, three declarations (guard, constants, package.json). If any drifts,
+    // the guard's message or doctor's copy would promise a different minimum than the
+    // package declares.
+    expect(MIN_NODE_MAJOR_VERSION).toBe(MIN_NODE.major);
+    expect(MIN_NODE_MINOR_VERSION).toBe(MIN_NODE.minor);
+  });
+});
+
+describe('node:sqlite capability probe', () => {
+  it('reports available when getBuiltinModule returns the module', () => {
+    expect(isSqliteAvailable(() => ({ DatabaseSync: class {} }))).toBe(true);
+  });
+
+  it('reports unavailable when getBuiltinModule returns undefined (flagged/stripped build)', () => {
+    expect(isSqliteAvailable(() => undefined)).toBe(false);
+  });
+
+  it('reports unavailable (never throws) when getBuiltinModule throws', () => {
+    expect(
+      isSqliteAvailable(() => {
+        throw new Error('ERR_UNKNOWN_BUILTIN_MODULE');
+      }),
+    ).toBe(false);
+  });
+
+  it('is loadable in this test runtime (the CI floor has unflagged node:sqlite)', () => {
+    expect(isSqliteAvailable()).toBe(true);
+  });
+});
+
+describe('checkNodeVersion — capability beats arithmetic', () => {
+  it('a version at/above the floor but with node:sqlite unavailable still fails, naming the builtin', () => {
+    const result = checkNodeVersion(`${MIN_NODE.major}.${MIN_NODE.minor}.0`, () => false);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('node:sqlite');
+  });
+
+  it('a version below the floor fails with the version message even if the probe would pass', () => {
+    const result = checkNodeVersion(`${MIN_NODE.major}.${MIN_NODE.minor - 1}.0`, () => true);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain(`>=${MIN_NODE.major}.${MIN_NODE.minor}`);
+    expect(result.message).not.toContain('node:sqlite');
+  });
+
+  it('a version at/above the floor with node:sqlite available passes', () => {
+    expect(checkNodeVersion(`${MIN_NODE.major}.${MIN_NODE.minor}.0`, () => true).ok).toBe(true);
+  });
 });
 
 describe('assertSupportedNode side effect', () => {
@@ -77,6 +133,26 @@ describe('assertSupportedNode side effect', () => {
     assertSupportedNode();
     expect(exitSpy).not.toHaveBeenCalled();
     exitSpy.mockRestore();
+  });
+
+  it('on a version-OK Node where node:sqlite is unavailable, still writes the capability line and exits 78', () => {
+    // Version arithmetic passes (the runner is at/above the floor), but the builtin
+    // probe fails — the guard must fail honestly, not crash at first EdgeStore.open().
+    const proc = process as unknown as { getBuiltinModule?: (id: string) => unknown };
+    const origGetBuiltin = proc.getBuiltinModule;
+    proc.getBuiltinModule = () => undefined;
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      assertSupportedNode();
+      expect(exitSpy).toHaveBeenCalledWith(EXIT_UNSUPPORTED_NODE);
+      const msg = errSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(msg).toContain('node:sqlite');
+    } finally {
+      proc.getBuiltinModule = origGetBuiltin;
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+    }
   });
 });
 

--- a/src/cli/node-version-guard.ts
+++ b/src/cli/node-version-guard.ts
@@ -1,7 +1,7 @@
 /**
  * Fail-fast Node-version guard for the OpenLore CLI.
  *
- * Why this exists: OpenLore requires Node >=22.5, but OpenSpec requires only
+ * Why this exists: OpenLore requires Node >=22.13, but OpenSpec requires only
  * >=20.19. When OpenLore runs as an OpenSpec plugin, a user on Node 20/21 can run
  * `openspec lore generate`, which spawns `openlore` under a Node OpenLore does not
  * support. `engines` in package.json is advisory at install time and does NOT
@@ -14,30 +14,75 @@
  * commander and the heavy command modules. Keep it dependency-free.
  */
 
-/** Minimum supported Node. MUST stay in sync with package.json `engines.node`
- * (a test asserts this). */
-export const MIN_NODE = { major: 22, minor: 5 } as const;
+/** Minimum supported Node. This is the first line where `node:sqlite` — imported
+ * at module load by EdgeStore, the epistemic lease, and preflight scoring — is
+ * available WITHOUT `--experimental-sqlite` (unflagged in Node 22.13.0 / 23.4.0,
+ * nodejs/node#55854). MUST stay in sync with package.json `engines.node` and
+ * constants.ts's `MIN_NODE_*` (a test asserts all three). */
+export const MIN_NODE = { major: 22, minor: 13 } as const;
 
 /** Stable, dedicated exit code for "unsupported Node" (documented contract). */
 export const EXIT_UNSUPPORTED_NODE = 78;
+
+/** The builtin whose availability the runtime actually depends on. Version
+ * arithmetic is a proxy for this; the probe below asserts the real thing. */
+const REQUIRED_BUILTIN = 'node:sqlite';
 
 export interface NodeVersionCheck {
   ok: boolean;
   message?: string;
 }
 
-/** Pure version check — no side effects, so it is unit-testable. */
-export function checkNodeVersion(versionString: string = process.versions.node): NodeVersionCheck {
+/**
+ * Probe whether `node:sqlite` is actually loadable in THIS runtime, rather than
+ * inferring it from the version number. `process.getBuiltinModule` exists since
+ * Node 22.3 (below our floor), returns the builtin when available and `undefined`
+ * when it is not (e.g. still behind a flag on 23.0–23.3, or stripped from a distro
+ * build). Injectable so the capability path is unit-testable without a second Node. */
+export function isSqliteAvailable(
+  getBuiltinModule: (id: string) => unknown =
+    (process as { getBuiltinModule?: (id: string) => unknown }).getBuiltinModule?.bind(process) ??
+    (() => undefined),
+): boolean {
+  try {
+    return getBuiltinModule(REQUIRED_BUILTIN) != null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Version + capability check — no exit side effect, so it is unit-testable.
+ * Version arithmetic gates first (a clear "upgrade Node" message), then the
+ * capability probe has the final word: a version number that satisfies the floor
+ * but on which `node:sqlite` is not loadable still fails, naming the missing
+ * builtin. `probe` is injectable so both branches are testable on a capable host. */
+export function checkNodeVersion(
+  versionString: string = process.versions.node,
+  probe: () => boolean = () => isSqliteAvailable(),
+): NodeVersionCheck {
   const [major = 0, minor = 0] = versionString.split('.').map((p) => parseInt(p, 10));
-  const ok = major > MIN_NODE.major || (major === MIN_NODE.major && minor >= MIN_NODE.minor);
-  if (ok) return { ok: true };
-  return {
-    ok: false,
-    message:
-      `openlore requires Node >=${MIN_NODE.major}.${MIN_NODE.minor} but is running on Node ${versionString}. ` +
-      `Upgrade Node (e.g. via nvm or your package manager) and retry. ` +
-      `See https://github.com/clay-good/openlore#requirements`,
-  };
+  const versionOk = major > MIN_NODE.major || (major === MIN_NODE.major && minor >= MIN_NODE.minor);
+  if (!versionOk) {
+    return {
+      ok: false,
+      message:
+        `openlore requires Node >=${MIN_NODE.major}.${MIN_NODE.minor} but is running on Node ${versionString}. ` +
+        `Upgrade Node (e.g. via nvm or your package manager) and retry. ` +
+        `See https://github.com/clay-good/openlore#requirements`,
+    };
+  }
+  if (!probe()) {
+    return {
+      ok: false,
+      message:
+        `openlore requires the built-in ${REQUIRED_BUILTIN} module, which is unavailable on this Node ` +
+        `(${versionString}). Upgrade to Node >=${MIN_NODE.major}.${MIN_NODE.minor} where ${REQUIRED_BUILTIN} ` +
+        `is available without runtime flags, and retry. ` +
+        `See https://github.com/clay-good/openlore#requirements`,
+    };
+  }
+  return { ok: true };
 }
 
 /** Side-effecting guard: writes one stderr line and exits when Node is too old. */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -278,14 +278,17 @@ export const DEFAULT_CHAT_OPENAI_MODEL = 'gpt-4o-mini';
 // ============================================================================
 
 /**
- * Minimum Node.js version required. The floor is 22.5, not 20: the EdgeStore
- * refactor moved onto `node:sqlite` / `DatabaseSync`, which is unavailable
- * before Node 22.5 (and matches `engines.node` in package.json). doctor checks
- * the minor version so a `.nvmrc`-pinned Node 20 shell fails fast with a clear
- * `nvm use` remediation instead of a cryptic module-load crash (Spec 26 B7).
+ * Minimum Node.js version required. The floor is 22.13, not 20: the EdgeStore
+ * refactor moved onto `node:sqlite` / `DatabaseSync`, which was available only
+ * behind `--experimental-sqlite` until Node 22.13.0 / 23.4.0 (unflagged in
+ * nodejs/node#55854) — and nothing in the tree passes that flag. Must equal
+ * `engines.node` in package.json and `MIN_NODE` in node-version-guard.ts (a test
+ * asserts all three). doctor checks the minor version AND probes `node:sqlite`
+ * so an unsupported Node fails fast with a clear `nvm use` remediation instead of
+ * a cryptic module-load crash (Spec 26 B7).
  */
 export const MIN_NODE_MAJOR_VERSION = 22;
-export const MIN_NODE_MINOR_VERSION = 5;
+export const MIN_NODE_MINOR_VERSION = 13;
 
 /** Analysis age (hours) beyond which doctor warns it may be stale */
 export const ANALYSIS_AGE_WARNING_HOURS = 24;


### PR DESCRIPTION
**Status:** LGTM — implements `openspec/changes/fix-node-sqlite-engine-floor`. Full suite green (309 files / 6041 tests), lint + typecheck + build clean, e2e-verified against the built CLI.

## What was wrong

`package.json` declared `engines.node: ">=22.5.0"`, but the built-in `node:sqlite` — imported at *module load* by `EdgeStore` (`edge-store.ts:3`), the epistemic lease (`epistemic-lease.ts:35`), and preflight scoring (`score.ts:22`) — required `--experimental-sqlite` until Node **22.13.0 / 23.4.0** (unflagged in [nodejs/node#55854](https://github.com/nodejs/node/pull/55854)), and nothing in the tree passes that flag. So a fresh install on **22.5–22.12** crashed with an `ERR_UNKNOWN_BUILTIN_MODULE`-shaped failure at first import — *inside the range we promised works* — while both the runtime guard and `openlore doctor` blessed the very version that crashes. That's the inverse of the honesty contract: the diagnostic certifies an environment the product can't run in.

## How it was fixed

**The floor becomes the first version where `node:sqlite` is available unflagged, and the guard stops trusting version arithmetic — it probes the module itself.**

- Raised the floor to **22.13.0** across all three declarations — `engines.node`, `MIN_NODE` (`node-version-guard.ts`), and `MIN_NODE_MAJOR/MINOR_VERSION` (`constants.ts`) — plus the README badge/requirement line and the live docs (`cli-reference.md`, `OPENSPEC-INTEGRATION.md`).
- **Capability probe > version arithmetic.** `checkNodeVersion` and doctor's Node check now call `isSqliteAvailable()` (a thin, injectable wrapper over `process.getBuiltinModule('node:sqlite')`, itself 22.3+). A version that satisfies the floor but on which the builtin isn't loadable — the **23.0–23.3** gap, or a stripped distro build — fails honestly (stderr line + exit code **78**, doctor `fail` naming `node:sqlite unavailable`), never an uncaught import crash. Arithmetic gates first (clean "upgrade Node" message); the probe has the final word.
- The floor-coherence test extends to `constants.ts` (one floor, three declarations, test-pinned).

## Proof it works

- **Unit:** new cases in `node-version-guard.test.ts` — probe true/false/throws; capability-beats-arithmetic (version-OK + probe-false → fail naming the builtin); below-floor + probe-true → version message wins; `assertSupportedNode` exits 78 on probe failure; constants↔`MIN_NODE` coherence. `node-version-guard` + `doctor` suites: **64 passed**. Full suite: **309 files / 6041 tests passed, 2 skipped**.
- **E2E (built CLI):** `doctor` → `✓ Node.js version v25.8.1`; guard passes on a capable Node; `checkNodeVersion(node, () => false)` → `ok:false` with the `node:sqlite unavailable` message; `checkNodeVersion('22.10.0', () => true)` → `ok:false` with the `>=22.13` version message.
- **Grep-check:** no live `22.5` floor claim remains in `src/`, README, or the live docs.

## Notes / nits

- **Deliberately not touched:** `docs/specs/openlore-spec-26-*` is a dated audit record whose since-reversed "keep 22.5, fix the signal" recommendation is left as history, not a live claim (the proposal's Impact list scopes it out too).
- `openspec validate fix-node-sqlite-engine-floor --strict` → valid. Spec delta `NodeFloorMatchesSqliteCapability` merged into `openspec/specs/cli/spec.md`.
- No MCP tool-surface change; guard/doctor behavior only. Users on 22.5–22.12 move from a crash to a legible "upgrade Node" line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)