### PR TITLE
fix(runtime): an async watcher/stream 'error' must not kill a long-lived process

### DIFF
--- a/openspec/changes/harden-runtime-event-resilience/proposal.md
+++ b/openspec/changes/harden-runtime-event-resilience/proposal.md
@@ -1,6 +1,20 @@
 # Harden runtime event resilience: an async 'error' event must not kill a long-lived process
 
-> Status: PROPOSED (2026-07-03, e2e audit follow-up). Two long-lived paths register Node
+> Status: IMPLEMENTED (2026-07-19). The `.git` ref watcher now registers an `'error'` listener
+> (`mcp-watcher.ts`) that discloses once, releases the failed watcher, and degrades to the
+> batch-size VCS-flood fallback the surrounding catch already promised — an async chokidar error
+> can no longer surface as an unhandled `'error'` event and kill the warm daemon. The source
+> watcher's post-`ready` errors, which could only hit a no-op `reject` on a settled promise, are
+> now disclosed instead of silently swallowed. The `telemetry --live` tail was extracted into a
+> testable `tailTelemetryFile` that (a) attaches a stream `'error'` handler clearing the in-flight
+> guard so the file retries on the next event, and (b) detects rotation structurally — a current
+> file size below the stored offset means the file was rotated and restarted small, so the offset
+> resets to 0 instead of reading silently past EOF forever. Three test files pin it: watcher-error
+> survival + post-ready disclosure (real-EventEmitter chokidar mock so `emit('error')` reproduces
+> Node's throw-on-no-listener), tail stream-error + rotation-reset, and a grep-shaped coverage
+> guard that fails naming any long-lived `chokidar.watch` / read-stream site missing its `'error'`
+> listener. No new tuning constant (rotation detection is `size < offset`, a structural fact).
+> Originally proposed (2026-07-03, e2e audit follow-up). Two long-lived paths register Node
 > event emitters without an `'error'` listener. The MCP watcher's `.git` ref watcher can
 > crash the warm serve daemon / MCP server outright — an unhandled `'error'` event on an
 > EventEmitter throws, and these processes install no `uncaughtException` handler, so Node's

--- a/openspec/changes/harden-runtime-event-resilience/tasks.md
+++ b/openspec/changes/harden-runtime-event-resilience/tasks.md
@@ -1,33 +1,33 @@
 # Tasks — harden-runtime-event-resilience
 
 ## Implementation
-- [ ] `mcp-watcher.ts:302`: register `.on('error', ...)` on the `.git` ref watcher — one
+- [x] `mcp-watcher.ts:302`: register `.on('error', ...)` on the `.git` ref watcher — one
       debug/stderr disclosure, close the failed watcher, degrade to the batch-size VCS
       fallback (the behavior the catch block at :303-306 already promises); the host
       process never dies
-- [ ] `mcp-watcher.ts:288`: route post-`ready` `fsWatcher` errors to the same disclosure
+- [x] `mcp-watcher.ts:288`: route post-`ready` `fsWatcher` errors to the same disclosure
       instead of a no-op `reject` on a settled promise (no behavior change during setup)
-- [ ] `telemetry.ts` `tail` (:419-431): add a stream `'error'` handler that clears
+- [x] `telemetry.ts` `tail` (:419-431): add a stream `'error'` handler that clears
       `inFlight`, keeps the offset, and prints one diagnostic line; next watch event retries
-- [ ] `telemetry.ts` `tail`: before opening the stream, stat the file; if size < stored
+- [x] `telemetry.ts` `tail`: before opening the stream, stat the file; if size < stored
       offset, the file was rotated (core/services/telemetry.ts:22-30) — reset the offset to
       0 so the tail follows the new file instead of silently reading past EOF forever
 
 ## Verification
-- [ ] Watcher-survival test: inject an `'error'` event on the git watcher instance; assert
+- [x] Watcher-survival test: inject an `'error'` event on the git watcher instance; assert
       the process (and the McpWatcher) stays alive, the disclosure is emitted once, and
       subsequent file changes still flow through `handleBatch`
-- [ ] Tail-error test: force a stream error (open a path removed after the watch event);
+- [x] Tail-error test: force a stream error (open a path removed after the watch event);
       assert `--live` keeps running, `inFlight` is cleared, and a later event on the same
       file renders
-- [ ] Rotation test: write past-offset content, simulate rotation (rename + new small file),
+- [x] Rotation test: write past-offset content, simulate rotation (rename + new small file),
       fire the watch event; assert the offset resets to 0 and the new file's lines render
       (no silent empty tail)
-- [ ] Coverage check: a lint-style test that every `chokidar.watch` / `createReadStream`
+- [x] Coverage check: a lint-style test that every `chokidar.watch` / `createReadStream`
       call site in long-lived paths registers an `'error'` handler (grep-shaped over known
       sites; fails naming the uncovered site)
-- [ ] Full suite green
+- [x] Full suite green
 
 ## Spec
-- [ ] `mcp-handlers` delta: ADD WatcherErrorEventsNeverKillTheHost
-- [ ] `cli` delta: ADD LiveTelemetryTailSurvivesErrorsAndRotation
+- [x] `mcp-handlers` delta: ADD WatcherErrorEventsNeverKillTheHost
+- [x] `cli` delta: ADD LiveTelemetryTailSurvivesErrorsAndRotation

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -1192,3 +1192,32 @@ uncaught import crash, and doctor SHALL report it as a failing check naming the 
 - **GIVEN** the floor is declared in package.json `engines`, the version guard, and constants
 - **WHEN** any one declaration is changed without the others
 - **THEN** an automated test fails, keeping one floor across all declarations and doctor/README copy
+
+### Requirement: LiveTelemetryTailSurvivesErrorsAndRotation
+
+The `telemetry --live` tail SHALL attach an `'error'` handler to every read stream it opens: a
+stream error MUST NOT crash the live session and MUST clear the per-file in-flight guard so the
+file's tail can retry on the next watch event, with a one-line diagnostic disclosure. Before
+opening a stream at a stored offset, the tail SHALL detect log rotation structurally — a current
+file size smaller than the stored offset means the writer rotated the file and restarted it small —
+and reset the offset to the start of the new file, so rotation never produces a silently empty
+tail that reads past end-of-file forever.
+
+#### Scenario: A stream error does not end the live session
+
+- **GIVEN** `openlore telemetry --live` tailing a telemetry file
+- **WHEN** the read stream emits `'error'` (for example, the file was renamed away by rotation
+  between the watch event and the open)
+- **THEN** the session keeps running, one diagnostic line is printed, the in-flight guard is
+  cleared, and a later event on the same file is rendered
+
+#### Scenario: Rotation resets the offset instead of wedging the tail
+
+- **GIVEN** a telemetry file that was rotated (renamed at the size threshold and restarted small)
+  while a stale byte offset is stored for it
+- **WHEN** the next watch event triggers a tail of that file
+- **THEN** the size-below-offset condition is detected, the offset resets to 0, and the new file's
+  lines are rendered — the tail never reads silently past end-of-file forever
+
+> Change: harden-runtime-event-resilience
+> Date: 2026-07-19

--- a/openspec/specs/mcp-handlers/spec.md
+++ b/openspec/specs/mcp-handlers/spec.md
@@ -1182,3 +1182,33 @@ The tool SHALL be honest about what it does not know:
 
 > Change: add-clone-query-tool
 > Date: 2026-06-26
+
+### Requirement: WatcherErrorEventsNeverKillTheHost
+
+Every filesystem watcher the MCP watcher registers — the source-tree watcher and the `.git` ref
+watcher alike — SHALL have an `'error'` listener attached at registration, so an asynchronous
+watcher error can never surface as an unhandled `'error'` event and terminate the long-lived host
+process (the serve daemon or the stdio MCP server, neither of which installs an
+`uncaughtException` handler). On a watcher error the system SHALL disclose the failure once at
+debug/stderr level, release the failed watcher, and degrade to the documented fallback (batch-size
+VCS-flood detection for the `.git` watcher) — continuing to serve tool calls throughout. A
+post-`ready` source-watcher error, which can no longer reject the already-settled start promise,
+SHALL be disclosed rather than silently swallowed.
+
+#### Scenario: A .git watch error degrades instead of crashing
+
+- **GIVEN** a running serve daemon whose `.git` ref watcher emits an asynchronous `'error'`
+  (FD pressure, a locked `.git/index`, ref churn during a rebase)
+- **WHEN** the error event fires
+- **THEN** the process stays alive, a single debug-level disclosure is emitted, the failed watcher
+  is released, VCS-flood detection falls back to the batch-size threshold, and subsequent file
+  changes are still indexed
+
+#### Scenario: A new watcher cannot ship without an error listener
+
+- **GIVEN** a watcher registration in a long-lived path that attaches no `'error'` listener
+- **WHEN** the error-listener coverage test runs
+- **THEN** the test fails naming the uncovered registration site
+
+> Change: harden-runtime-event-resilience
+> Date: 2026-07-19

--- a/src/cli/commands/telemetry-tail-resilience.test.ts
+++ b/src/cli/commands/telemetry-tail-resilience.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the `telemetry --live` tail resilience (harden-runtime-event-resilience).
+ *
+ * `tailTelemetryFile` runs for the lifetime of a `--live` session. Two defects it
+ * must not have: (1) an unhandled read-stream 'error' crashes the session and
+ * wedges the file's tail forever (in-flight guard never cleared); (2) after log
+ * rotation (the writer renames the file at the size threshold and restarts it
+ * small) a stale byte offset points past the new small file, so the tail reads
+ * zero bytes and goes silently empty until the file regrows. These tests pin the
+ * stream-error handler and the structural rotation reset (current size < stored
+ * offset ⇒ start over).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { tailTelemetryFile, type TelemetryTailState } from './telemetry.js';
+
+function mcpLine(tool: string, ms: number): string {
+  return JSON.stringify({ ts: '2026-07-19T12:00:00.000Z', event: 'tool_call', tool, ms }) + '\n';
+}
+
+async function setup(): Promise<{ dir: string; mcpFile: string; leaseFile: string; state: TelemetryTailState }> {
+  const dir = await mkdtemp(join(tmpdir(), 'tel-tail-'));
+  const leaseFile = join(dir, 'epistemic-lease.jsonl');
+  const mcpFile = join(dir, 'mcp.jsonl');
+  const state: TelemetryTailState = { offsets: new Map(), inFlight: new Set(), leaseFile };
+  return { dir, mcpFile, leaseFile, state };
+}
+
+describe('tailTelemetryFile — live tail resilience', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('renders appended lines and advances the offset', async () => {
+    const { mcpFile, state } = await setup();
+    const line = mcpLine('orient', 12);
+    await writeFile(mcpFile, line, 'utf-8');
+
+    await tailTelemetryFile(mcpFile, state);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(String(logSpy.mock.calls[0][0])).toContain('orient');
+    expect(state.offsets.get(mcpFile)).toBe(Buffer.byteLength(line, 'utf-8'));
+    expect(state.inFlight.has(mcpFile)).toBe(false);
+  });
+
+  it('resets a stale offset after rotation (size < stored offset) and renders the new file', async () => {
+    const { mcpFile, state } = await setup();
+    // A stale offset left over from before rotation, far past the new small file.
+    state.offsets.set(mcpFile, 10_000);
+    const line = mcpLine('recall', 5);
+    await writeFile(mcpFile, line, 'utf-8');  // small, post-rotation file
+
+    await tailTelemetryFile(mcpFile, state);
+
+    // Without the reset the stream would start past EOF and render nothing.
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(String(logSpy.mock.calls[0][0])).toContain('recall');
+    expect(state.offsets.get(mcpFile)).toBe(Buffer.byteLength(line, 'utf-8'));
+  });
+
+  it('survives a read-stream error, clears the in-flight guard, and discloses once', async () => {
+    const { dir, state } = await setup();
+    // createReadStream on a directory emits EISDIR 'error' deterministically —
+    // stands in for "the file was renamed away by rotation between watch and open".
+    const badPath = join(dir, 'rotated-away');
+    await mkdir(badPath);
+
+    await expect(tailTelemetryFile(badPath, state)).resolves.toBeUndefined();
+
+    expect(state.inFlight.has(badPath)).toBe(false);
+    const disclosed = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(disclosed).toMatch(/tail of .* failed/);
+
+    // The session is still usable: a later good file on the same state renders.
+    const good = join(dir, 'mcp.jsonl');
+    await writeFile(good, mcpLine('search_code', 3), 'utf-8');
+    await tailTelemetryFile(good, state);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(String(logSpy.mock.calls[0][0])).toContain('search_code');
+  });
+
+  it('skips a file already in flight (no overlapping read)', async () => {
+    const { mcpFile, state } = await setup();
+    await writeFile(mcpFile, mcpLine('orient', 1), 'utf-8');
+    state.inFlight.add(mcpFile);
+
+    await tailTelemetryFile(mcpFile, state);
+
+    expect(logSpy).not.toHaveBeenCalled();
+    // The guard stays set — the in-flight owner clears it, not this skipped call.
+    expect(state.inFlight.has(mcpFile)).toBe(true);
+  });
+
+  it('reads only the newly appended bytes on a second tail', async () => {
+    const { mcpFile, state } = await setup();
+    await writeFile(mcpFile, mcpLine('orient', 1), 'utf-8');
+    await tailTelemetryFile(mcpFile, state);
+    logSpy.mockClear();
+
+    await writeFile(mcpFile, mcpLine('orient', 1) + mcpLine('recall', 2), 'utf-8');
+    await tailTelemetryFile(mcpFile, state);
+
+    // Only the second line is new; the first was already consumed.
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(String(logSpy.mock.calls[0][0])).toContain('recall');
+  });
+});

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -8,9 +8,9 @@
  */
 
 import { Command } from 'commander';
-import { createReadStream, existsSync, watch } from 'node:fs';
+import { createReadStream, existsSync, statSync, watch } from 'node:fs';
 import { createInterface } from 'node:readline';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { OPENLORE_DIR } from '../../constants.js';
 
 const TELEMETRY_SUBDIR = 'telemetry';
@@ -406,25 +406,82 @@ function renderSummary(
   hr();
 }
 
-function renderLive(dir: string) {
-  const leaseFile = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR, 'epistemic-lease.jsonl');
-  const mcpFile = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR, 'mcp.jsonl');
+/** Shared state a live tail carries across `watch()` events. */
+export interface TelemetryTailState {
+  /** Per-file byte offset already consumed. */
+  offsets: Map<string, number>;
+  /** Per-file guard against overlapping reads when watch() fires twice. */
+  inFlight: Set<string>;
+  /** The lease file path — selects the lease vs. mcp render branch. */
+  leaseFile: string;
+}
 
-  // Track file positions to only read new lines; in-flight guard prevents
-  // overlapping reads when watch() fires twice before the first stream ends.
-  const offsets = new Map<string, number>([
-    [leaseFile, 0], [mcpFile, 0],
-  ]);
-  const inFlight = new Set<string>();
+/** Render one telemetry JSONL line to stdout (lease branch vs. mcp branch). */
+function renderTelemetryLine(filePath: string, trimmed: string, leaseFile: string): void {
+  try {
+    const ev = JSON.parse(trimmed) as Record<string, unknown>;
+    const ts = String(ev['ts'] ?? '').slice(11, 23);
+    if (filePath === leaseFile) {
+      const evt = ev['event'];
+      if (evt === 'stale' || evt === 'degraded') {
+        const density = Number(ev['density'] ?? 0);
+        const oscillation = Number(ev['oscillation'] ?? 0);
+        const isSpike = density >= 0.60;
+        const isOscillating = oscillation >= 0.50;
+        const structuredType = isSpike ? 'TRAJECTORY_SPIKE' : 'STATE_TRANSITION';
+        const depthStr = evt === 'stale' ? ` depth=${ev['depth']}` : '';
+        let line = `${ts}  [${structuredType}] ${String(evt).toUpperCase()}${depthStr} trigger=${ev['trigger']} load=${ev['cognitive_load']} density=${density.toFixed(3)}`;
+        if (isOscillating) line += `  [OSCILLATION_DETECTED osc=${oscillation.toFixed(2)}]`;
+        console.log(line);
+      } else if (evt === 'orient_reset') {
+        console.log(`${ts}  [ORIENT_RECOVERY] from=${ev['from_state']} prior_load=${ev['prior_load']} prior_depth=${ev['prior_depth']}`);
+      } else if (evt === 'depth_escalate') {
+        const burstStr = ev['trigger'] === 'burst' ? ' (burst)' : '';
+        console.log(`${ts}  [STATE_TRANSITION] DEPTH ${ev['from_depth']} → ${ev['to_depth']}${burstStr} density=${Number(ev['density'] ?? 0).toFixed(3)}`);
+      }
+    } else {
+      const tool = ev['tool'];
+      const agent = ev['agent'] ? ` [${ev['agent']}]` : '';
+      if (ev['event'] === 'tool_call') console.log(`${ts}  ${String(tool).padEnd(30)} ${ev['ms']}ms${agent}`);
+      else if (ev['event'] === 'tool_error') console.log(`${ts}  ERROR ${tool}${agent}`);
+    }
+  } catch { /* skip */ }
+}
 
-  async function tail(filePath: string) {
-    if (!existsSync(filePath)) return;
-    if (inFlight.has(filePath)) return;
+/**
+ * Tail the lines appended to a telemetry file since its stored offset, rendering
+ * each. Resolves when the read stream ends OR errors — never rejects — so
+ * overlapping tails serialize on the `inFlight` guard and a stream error can
+ * never crash the `--live` session. Exported for the resilience tests.
+ */
+export function tailTelemetryFile(filePath: string, state: TelemetryTailState): Promise<void> {
+  const { offsets, inFlight, leaseFile } = state;
+  return new Promise<void>((resolve) => {
+    if (!existsSync(filePath)) { resolve(); return; }
+    if (inFlight.has(filePath)) { resolve(); return; }
     inFlight.add(filePath);
-    const { createReadStream } = await import('node:fs');
-    const offset = offsets.get(filePath) ?? 0;
+    let offset = offsets.get(filePath) ?? 0;
+    // Rotation detection (structural, not a threshold): the writer renames the
+    // file at the size threshold and restarts it small
+    // (core/services/telemetry.ts). If the file is now smaller than our stored
+    // offset it was rotated — reset to the start of the new file so the tail
+    // follows it instead of reading silently past end-of-file forever.
+    try {
+      if (statSync(filePath).size < offset) { offset = 0; offsets.set(filePath, 0); }
+    } catch { /* stat raced with rotation — the stream 'error' handler covers it */ }
     const stream = createReadStream(filePath, { start: offset, encoding: 'utf-8' });
     let buf = '';
+    stream.on('error', (err: unknown) => {
+      // A stream error (e.g. the file renamed away by rotation between the watch
+      // event and the open) must not crash --live. Clear the in-flight guard so
+      // the next watch event retries; keep the offset so we resume in place.
+      inFlight.delete(filePath);
+      process.stderr.write(
+        `telemetry --live: tail of ${basename(filePath)} failed ` +
+        `(${(err as Error)?.message ?? String(err)}); retrying on next event\n`
+      );
+      resolve();
+    });
     stream.on('data', chunk => { buf += chunk; });
     stream.on('end', () => {
       offsets.set(filePath, offset + Buffer.byteLength(buf, 'utf-8'));
@@ -432,50 +489,37 @@ function renderLive(dir: string) {
       for (const line of buf.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed) continue;
-        try {
-          const ev = JSON.parse(trimmed) as Record<string, unknown>;
-          const ts = String(ev['ts'] ?? '').slice(11, 23);
-          if (filePath === leaseFile) {
-            const evt = ev['event'];
-            if (evt === 'stale' || evt === 'degraded') {
-              const density = Number(ev['density'] ?? 0);
-              const oscillation = Number(ev['oscillation'] ?? 0);
-              const isSpike = density >= 0.60;
-              const isOscillating = oscillation >= 0.50;
-              const structuredType = isSpike ? 'TRAJECTORY_SPIKE' : 'STATE_TRANSITION';
-              const depthStr = evt === 'stale' ? ` depth=${ev['depth']}` : '';
-              let line = `${ts}  [${structuredType}] ${String(evt).toUpperCase()}${depthStr} trigger=${ev['trigger']} load=${ev['cognitive_load']} density=${density.toFixed(3)}`;
-              if (isOscillating) line += `  [OSCILLATION_DETECTED osc=${oscillation.toFixed(2)}]`;
-              console.log(line);
-            } else if (evt === 'orient_reset') {
-              console.log(`${ts}  [ORIENT_RECOVERY] from=${ev['from_state']} prior_load=${ev['prior_load']} prior_depth=${ev['prior_depth']}`);
-            } else if (evt === 'depth_escalate') {
-              const burstStr = ev['trigger'] === 'burst' ? ' (burst)' : '';
-              console.log(`${ts}  [STATE_TRANSITION] DEPTH ${ev['from_depth']} → ${ev['to_depth']}${burstStr} density=${Number(ev['density'] ?? 0).toFixed(3)}`);
-            }
-          } else {
-            const tool = ev['tool'];
-            const agent = ev['agent'] ? ` [${ev['agent']}]` : '';
-            if (ev['event'] === 'tool_call') console.log(`${ts}  ${String(tool).padEnd(30)} ${ev['ms']}ms${agent}`);
-            else if (ev['event'] === 'tool_error') console.log(`${ts}  ERROR ${tool}${agent}`);
-          }
-        } catch { /* skip */ }
+        renderTelemetryLine(filePath, trimmed, leaseFile);
       }
+      resolve();
     });
-  }
+  });
+}
+
+function renderLive(dir: string) {
+  const leaseFile = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR, 'epistemic-lease.jsonl');
+  const mcpFile = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR, 'mcp.jsonl');
+
+  // Track file positions to only read new lines; in-flight guard prevents
+  // overlapping reads when watch() fires twice before the first stream ends.
+  const state: TelemetryTailState = {
+    offsets: new Map<string, number>([[leaseFile, 0], [mcpFile, 0]]),
+    inFlight: new Set<string>(),
+    leaseFile,
+  };
 
   console.log(`Watching ${join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR)} — Ctrl+C to stop\n`);
 
   const files = [leaseFile, mcpFile];
   // Initial tail
-  Promise.all(files.map(tail));
+  Promise.all(files.map(f => tailTelemetryFile(f, state)));
 
   const watchDir = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR);
   if (existsSync(watchDir)) {
     watch(watchDir, { persistent: true }, async (_event, filename) => {
       if (!filename) return;
       const full = join(watchDir, filename);
-      if (files.includes(full)) await tail(full);
+      if (files.includes(full)) await tailTelemetryFile(full, state);
     });
   }
 }

--- a/src/core/services/mcp-watcher-event-resilience.test.ts
+++ b/src/core/services/mcp-watcher-event-resilience.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for McpWatcher runtime-event resilience (harden-runtime-event-resilience).
+ *
+ * The MCP watcher runs inside the long-lived serve daemon / stdio MCP server —
+ * the warm process every connected agent shares. An asynchronous chokidar
+ * 'error' on a watcher with no 'error' listener is emitted on an EventEmitter,
+ * which THROWS; with no uncaughtException handler in production `src/`, that
+ * throw is fatal. These tests pin that every watcher registers an 'error'
+ * listener, that a .git watch error degrades (disclose + release, fall back to
+ * the batch-size VCS threshold) instead of crashing, and that a post-ready
+ * source-watcher error is disclosed rather than silently swallowed.
+ *
+ * The chokidar mock returns REAL EventEmitters (not a handler map), so
+ * emit('error') reproduces Node's throw-on-no-listener semantics exactly — the
+ * failure this change prevents.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, writeFile, mkdir, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { LLMContext } from '../analyzer/artifact-generator.js';
+
+// ── chokidar mock: real EventEmitters so 'error' throws with no listener ──────
+
+type FakeWatcher = EventEmitter & { close: ReturnType<typeof vi.fn> };
+const createdWatchers: FakeWatcher[] = [];
+
+vi.mock('chokidar', () => ({
+  default: {
+    watch: vi.fn(() => {
+      const em = new EventEmitter() as FakeWatcher;
+      em.setMaxListeners(50);
+      em.close = vi.fn().mockResolvedValue(undefined);
+      createdWatchers.push(em);
+      // Real chokidar fires 'ready' asynchronously; emit on the next microtask so
+      // start()'s 'ready' listener is attached first and the start promise resolves.
+      queueMicrotask(() => em.emit('ready'));
+      return em;
+    }),
+  },
+}));
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+function makeContext(): LLMContext {
+  return {
+    phase1_survey: { purpose: '', files: [], totalTokens: 0 },
+    phase2_deep:   { purpose: '', files: [], totalTokens: 0 },
+    phase3_validation: { purpose: '', files: [], totalTokens: 0 },
+    signatures: [],
+  };
+}
+
+async function setupProject(): Promise<{ rootPath: string; outputPath: string }> {
+  const rootPath = await mkdtemp(join(tmpdir(), 'watcher-resilience-'));
+  const outputPath = join(rootPath, '.openlore', 'analysis');
+  await mkdir(outputPath, { recursive: true });
+  await writeFile(join(outputPath, 'llm-context.json'), JSON.stringify(makeContext(), null, 2), 'utf-8');
+  return { rootPath, outputPath };
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('McpWatcher — runtime event resilience', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    createdWatchers.length = 0;
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('registers an error listener on both the source and .git watchers', async () => {
+    const { rootPath, outputPath } = await setupProject();
+    const { McpWatcher } = await import('./mcp-watcher.js');
+    const watcher = new McpWatcher({ rootPath, outputPath, embed: false });
+    await watcher.start();
+
+    // start() creates exactly two watchers: [0] the source tree, [1] the .git refs.
+    expect(createdWatchers.length).toBe(2);
+    const [fsWatcher, gitWatcher] = createdWatchers;
+    expect(fsWatcher.listenerCount('error')).toBe(1);
+    expect(gitWatcher.listenerCount('error')).toBe(1);
+
+    await watcher.stop();
+  });
+
+  it('control: an EventEmitter error with no listener throws (the pre-fix fate)', () => {
+    // Documents WHY the listeners above matter — this is what a bare watcher does.
+    expect(() => new EventEmitter().emit('error', new Error('boom'))).toThrow('boom');
+  });
+
+  it('degrades on a .git watch error — discloses, releases, and does not crash', async () => {
+    const { rootPath, outputPath } = await setupProject();
+    const { McpWatcher } = await import('./mcp-watcher.js');
+    const watcher = new McpWatcher({ rootPath, outputPath, embed: false });
+    await watcher.start();
+    const gitWatcher = createdWatchers[1];
+    stderrSpy.mockClear();
+
+    // An async chokidar error (FD pressure, a locked .git/index, ref churn) must
+    // NOT propagate as an unhandled 'error' event and kill the host.
+    expect(() => gitWatcher.emit('error', new Error('EMFILE: too many open files'))).not.toThrow();
+
+    const disclosed = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(disclosed).toMatch(/\.git ref watcher error/);
+    expect(disclosed).toMatch(/batch-size threshold/);
+    expect(gitWatcher.close).toHaveBeenCalledTimes(1);
+
+    await watcher.stop();
+  });
+
+  it('keeps serving after a .git watch error — file changes still index', async () => {
+    const { rootPath, outputPath } = await setupProject();
+    await mkdir(join(rootPath, 'src'), { recursive: true });
+    const srcFile = join(rootPath, 'src', 'auth.ts');
+    await writeFile(srcFile, 'export function login(user: string): boolean { return true; }', 'utf-8');
+
+    const { McpWatcher } = await import('./mcp-watcher.js');
+    const watcher = new McpWatcher({ rootPath, outputPath, embed: false });
+    await watcher.start();
+    createdWatchers[1].emit('error', new Error('EPERM: locked .git/index'));
+
+    // The watcher is still fully functional: a change flows through to signatures.
+    await watcher.handleChange(srcFile);
+    const ctx = JSON.parse(await readFile(join(outputPath, 'llm-context.json'), 'utf-8')) as LLMContext;
+    expect(ctx.signatures?.some(s => s.path === 'src/auth.ts')).toBe(true);
+
+    await watcher.stop();
+  });
+
+  it('discloses a post-ready source-watcher error instead of silently swallowing it', async () => {
+    const { rootPath, outputPath } = await setupProject();
+    const { McpWatcher } = await import('./mcp-watcher.js');
+    const watcher = new McpWatcher({ rootPath, outputPath, embed: false });
+    await watcher.start();
+    const fsWatcher = createdWatchers[0];
+    stderrSpy.mockClear();
+
+    // Before hardening this hit reject() on an already-settled promise — safe but
+    // silent. Now it discloses and the process survives.
+    expect(() => fsWatcher.emit('error', new Error('ENOSPC'))).not.toThrow();
+    const disclosed = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(disclosed).toMatch(/source watcher error/);
+
+    await watcher.stop();
+  });
+});

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -325,8 +325,20 @@ export class McpWatcher {
         if (watched(absPath)) this.enqueueDeletion(absPath);
       });
 
-      this.fsWatcher.on('ready', () => resolve());
-      this.fsWatcher.on('error', (err: unknown) => reject(err));
+      let watcherReady = false;
+      this.fsWatcher.on('ready', () => { watcherReady = true; resolve(); });
+      this.fsWatcher.on('error', (err: unknown) => {
+        // Before 'ready', an error is a setup failure — reject the start promise.
+        // After 'ready', the promise is already settled, so reject() is a silent
+        // no-op (the pre-hardening behavior). An async watcher error must never
+        // pass silently on the long-lived host: disclose once and keep serving —
+        // pending file changes are still caught at the next full analyze.
+        if (!watcherReady) { reject(err); return; }
+        process.stderr.write(
+          `[mcp-watcher] source watcher error (${(err as Error)?.message ?? String(err)}); ` +
+          `continuing — changes may lag until the next analyze\n`
+        );
+      });
     });
 
     // Best-effort VCS-flood detection (Step 5): a branch switch / rebase / merge
@@ -350,6 +362,22 @@ export class McpWatcher {
         if (base === 'HEAD' || base === 'MERGE_HEAD' || base === 'ORIG_HEAD') {
           this.scheduleGraphRebuild('head-change');
         }
+      });
+      // A .git ref watch is a best-effort optimization; an ASYNC chokidar 'error'
+      // (FD pressure, a locked .git/index, ref churn during a rebase) is emitted
+      // AFTER this synchronous try/catch returns. Without a listener it surfaces
+      // as an unhandled 'error' event and throws — fatal for the warm daemon every
+      // connected agent shares. Disclose once, release the failed watcher, and
+      // degrade to the batch-size VCS-flood threshold in handleBatch (the same
+      // fallback the catch block below promises when setup fails).
+      this.gitWatcher.on('error', (err: unknown) => {
+        process.stderr.write(
+          `[mcp-watcher] .git ref watcher error (${(err as Error)?.message ?? String(err)}); ` +
+          `VCS-flood detection falling back to the batch-size threshold\n`
+        );
+        const failed = this.gitWatcher;
+        this.gitWatcher = undefined;
+        void failed?.close().catch(() => { /* already gone */ });
       });
     } catch {
       // no .git, or watch failed — VCS detection falls back to the batch-size

--- a/src/core/services/runtime-event-listener-coverage.test.ts
+++ b/src/core/services/runtime-event-listener-coverage.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Coverage guard for harden-runtime-event-resilience.
+ *
+ * A grep-shaped, no-machinery lint: every long-lived event-emitter site — a
+ * filesystem watcher in a process that outlives one request, or a read stream
+ * that a live tail opens — MUST register an 'error' listener. An unhandled
+ * 'error' event on an EventEmitter throws, and these production paths install no
+ * uncaughtException handler, so an unlistened error is fatal (the daemon) or
+ * crashes/wedges the session (the tail). This test fails, NAMING the site, if a
+ * new registration ships without its 'error' listener.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function fileText(rel: string): string {
+  return readFileSync(join(process.cwd(), rel), 'utf-8');
+}
+
+describe('runtime event-emitter error-listener coverage', () => {
+  const WATCHER_FILE = 'src/core/services/mcp-watcher.ts';
+
+  it('every named chokidar watcher in the MCP watcher registers an error listener', () => {
+    const src = fileText(WATCHER_FILE);
+    // Known long-lived watcher sites, by the field they assign. Each must have a
+    // paired `this.<field>.on('error', …)` registration.
+    const watcherFields = Array.from(src.matchAll(/this\.(\w+)\s*=\s*chokidar\.watch\(/g)).map(m => m[1]);
+    expect(watcherFields.length).toBeGreaterThan(0);
+    for (const field of watcherFields) {
+      const hasErrorListener = new RegExp(`this\\.${field}\\.on\\('error'`).test(src);
+      expect(
+        hasErrorListener,
+        `${WATCHER_FILE}: this.${field} is a chokidar watcher on a long-lived host with no ` +
+        `.on('error', …) listener — an async watcher error would throw and kill the process`,
+      ).toBe(true);
+    }
+  });
+
+  it('the number of error listeners is at least the number of chokidar watchers', () => {
+    // Backstop for a new watcher that does not use the `this.<field> =` shape.
+    const src = fileText(WATCHER_FILE);
+    const watches = (src.match(/chokidar\.watch\(/g) ?? []).length;
+    const errorListeners = (src.match(/\.on\('error'/g) ?? []).length;
+    expect(
+      errorListeners,
+      `${WATCHER_FILE}: ${watches} chokidar.watch site(s) but only ${errorListeners} 'error' listener(s)`,
+    ).toBeGreaterThanOrEqual(watches);
+  });
+
+  it("the telemetry --live tail attaches an 'error' handler to its read stream", () => {
+    const TAIL_FILE = 'src/cli/commands/telemetry.ts';
+    const src = fileText(TAIL_FILE);
+    // Isolate the tail function that runs for the lifetime of --live.
+    const start = src.indexOf('export function tailTelemetryFile');
+    expect(start, 'tailTelemetryFile not found — did the live tail get renamed?').toBeGreaterThanOrEqual(0);
+    const end = src.indexOf('\nfunction renderLive', start);
+    const body = src.slice(start, end > start ? end : undefined);
+    expect(body).toContain('createReadStream(');
+    expect(
+      body.includes("stream.on('error'"),
+      `${TAIL_FILE}: tailTelemetryFile opens a read stream with no stream.on('error') handler — ` +
+      `a stream error would crash the --live session`,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Status
LGTM — implements `harden-runtime-event-resilience` (e2e-audit follow-up fix track). Full suite green (6084 passed / 2 skipped), lint + typecheck clean, driven end-to-end.

## What was wrong
Two long-lived paths registered Node event emitters **without an `'error'` listener**. An unhandled `'error'` on an `EventEmitter` throws, and neither the serve daemon nor the stdio MCP server installs an `uncaughtException` handler — so the throw is fatal.

- **[high] A `.git` watch hiccup kills the daemon.** `mcp-watcher.ts` registered the `.git` ref watcher with only `.on('all', …)`. An **async** chokidar `'error'` (FD pressure, a locked `.git/index`, ref churn during a rebase) is emitted after the synchronous try/catch returns — with no listener it throws, killing the warm daemon every connected agent shares, for a best-effort optimization watcher.
- **[low] `telemetry --live` crashes on stream errors and wedges after rotation.** The tail opened a read stream with only `'data'`/`'end'` listeners; a stream `'error'` (e.g. the file renamed away by rotation) crashed `--live` and, because the in-flight guard is cleared only in `'end'`, wedged that file's tail forever. Separately, a stale byte offset after rotation made the stream read past EOF and the tail went **silently empty**.

## How it was fixed
- **`gitWatcher` gets an `'error'` listener**: disclose once, release the failed watcher, degrade to the batch-size VCS-flood fallback the surrounding catch already promised. Post-`ready` source-watcher errors (which could only hit a no-op `reject()` on a settled promise) are now disclosed instead of silently swallowed.
- **The `--live` tail** is extracted into a testable `tailTelemetryFile` that (a) attaches a stream `'error'` handler clearing the in-flight guard so the file retries on the next event, and (b) detects rotation **structurally** — current file size below the stored offset ⇒ reset to 0. No new tuning constant (`size < offset` is a structural fact).

## Proof it works
- `mcp-watcher-event-resilience.test.ts` — a **real-`EventEmitter`** chokidar mock so `emit('error')` reproduces Node's throw-on-no-listener semantics exactly. Asserts both watchers carry an `'error'` listener, a `.git` error degrades (disclose + release, no crash), the watcher keeps indexing after it, and post-ready source errors disclose.
- `telemetry-tail-resilience.test.ts` — stream-error survival + guard clearing, rotation offset-reset renders the new file, incremental offset advance.
- `runtime-event-listener-coverage.test.ts` — grep-shaped guard that fails, **naming the site**, if any long-lived `chokidar.watch` / read-stream registration ships without its `'error'` listener.
- **E2E:** `telemetry --live` against a temp dir rendered an appended line **and** a post-rotation line with no crash (without the fix the rotated line is silently lost); `openlore serve` boots the watcher and stops cleanly.
- Specs: `cli` ADD `LiveTelemetryTailSurvivesErrorsAndRotation`; `mcp-handlers` ADD `WatcherErrorEventsNeverKillTheHost`.

## Notes
- Risk is low: error paths that previously crashed or wedged now log and degrade; no happy-path behavior change. The tail extraction is behavior-preserving and additionally makes `await tail(full)` resolve on stream completion (tighter overlap serialization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)