### PR TITLE
fix(mcp-quality): guard MCP↔Pi surface parity in both directions

### DIFF
--- a/openspec/changes/fix-pi-parity-drift/tasks.md
+++ b/openspec/changes/fix-pi-parity-drift/tasks.md
@@ -1,36 +1,36 @@
 # Tasks — fix-pi-parity-drift
 
 ## Implementation
-- [ ] Add `decision-current` to Pi's `verify_claim` kind enum (extension.ts:606); extend the
+- [x] Add `decision-current` to Pi's `verify_claim` kind enum (extension.ts:606); extend the
       guideline with the decision-citation trigger (subject = 8-char decision id), matching the
       MCP contract (claim-verification.ts:60-63)
-- [ ] Add NAV_TOOLS entries for the six drifted conclusion tools — `find_clones`,
+- [x] Add NAV_TOOLS entries for the six drifted conclusion tools — `find_clones`,
       `analyze_error_propagation`, `analyze_env_impact`, `certify_public_surface`,
       `get_style_fingerprint`, `briefing_since` — trigger-first descriptions/guidelines in the
       existing house style; params a subset of each daemon inputSchema
-- [ ] Add a named, commented Pi exclusion list beside NAV_TOOLS (one stated reason per excluded
+- [x] Add a named, commented Pi exclusion list beside NAV_TOOLS (one stated reason per excluded
       conclusion tool: opt-in federation/coordination preset surface, inventories covered by
       injection, etc.)
-- [ ] Two-direction parity guard in extension.test.ts: every dispatchable conclusion tool (per
+- [x] Two-direction parity guard in extension.test.ts: every dispatchable conclusion tool (per
       TOOL_OUTPUT_CLASS) is in NAV_TOOLS or on the exclusion list — fails-until-you-decide, the
       tool-contract.test.ts precedent; keep the existing NAV_TOOLS ⊆ dispatchable direction
       (extension.test.ts:297-301)
-- [ ] Cleanup: replace the literal NUL byte in interference-map.ts:391
+- [x] Cleanup: replace the literal NUL byte in interference-map.ts:391
       (`${repo}\x00${w.filePath}` template literal, ~offset 19335) with the `'\x00'` escape
       sequence so grep/rg stop treating the file as binary; no behavior change
 
 ## Verification
-- [ ] Test: parity guard fails when a new conclusion tool is added to TOOL_OUTPUT_CLASS without a
+- [x] Test: parity guard fails when a new conclusion tool is added to TOOL_OUTPUT_CLASS without a
       NAV_TOOLS entry or exclusion-list entry (simulated in-test), and passes on the reconciled
       surface
-- [ ] Test: Pi `verify_claim` accepts kind `decision-current` and round-trips to the daemon
+- [x] Test: Pi `verify_claim` accepts kind `decision-current` and round-trips to the daemon
       handler (superseded decision → refuted with live superseder)
-- [ ] Existing param-subset test (extension.test.ts:303-314) passes for all six new NAV_TOOLS
+- [x] Existing param-subset test (extension.test.ts:303-314) passes for all six new NAV_TOOLS
       entries against their daemon inputSchemas
-- [ ] `command grep -c x src/core/services/mcp-handlers/interference-map.ts` runs in text mode
+- [x] `command grep -c x src/core/services/mcp-handlers/interference-map.ts` runs in text mode
       (no "binary file matches") and the interference-map suite is green (NUL escape is
       byte-equivalent at runtime)
-- [ ] Full suite green (`npm run test:run`)
+- [x] Full suite green (`npm run test:run`)
 
 ## Spec
-- [ ] `mcp-quality` delta: ADD PiSurfaceParityIsGuarded
+- [x] `mcp-quality` delta: ADD PiSurfaceParityIsGuarded

--- a/openspec/specs/mcp-quality/spec.md
+++ b/openspec/specs/mcp-quality/spec.md
@@ -535,6 +535,40 @@ candidate surface, a flip only on no-regression evidence, and a superseding reco
   face
 - **THEN** CI fails, naming the surface carrying the over-claim
 
+### Requirement: PiSurfaceParityIsGuarded
+
+The Pi extension's native tool surface SHALL be held in verified parity with the MCP tool surface
+in both directions: every Pi-surfaced tool SHALL be dispatchable by the daemon (the existing
+direction), AND every dispatchable conclusion tool SHALL either be present in the Pi surface or
+appear on a named, source-commented exclusion list stating why its omission is deliberate. A CI
+test SHALL fail when a conclusion tool is neither surfaced nor excluded, so a new MCP tool cannot
+silently drift out of Pi — the same fails-until-you-decide discipline the tool-contract
+classification test already enforces. Where a tool's input contract differs between surfaces
+(e.g. an enum of claim kinds), the Pi declaration SHALL NOT silently omit capabilities the MCP
+handler supports; a deliberate narrowing SHALL be stated in source.
+
+#### Scenario: A new conclusion tool cannot skip the Pi decision
+
+- **GIVEN** a new MCP tool classified `conclusion` in `TOOL_OUTPUT_CLASS`
+- **WHEN** it is added without a Pi surface entry and without an exclusion-list entry
+- **THEN** the parity guard test fails, naming the tool
+- **AND** the failure is resolved only by surfacing it in Pi or adding it to the exclusion list
+  with a stated reason
+
+#### Scenario: A deliberate omission is recorded, not silent
+
+- **GIVEN** a conclusion tool that belongs only to an opt-in preset surface (e.g. federation)
+- **WHEN** it is placed on the Pi exclusion list with its reason
+- **THEN** the parity guard passes and the omission is auditable in source
+
+#### Scenario: Pi's verify_claim expresses every claim kind the handler supports
+
+- **GIVEN** the MCP `verify_claim` handler supporting the `decision-current` claim kind
+- **WHEN** a Pi agent is about to cite a decision id to a human
+- **THEN** the Pi `verify_claim` tool accepts kind `decision-current` and returns the daemon's
+  verdict (including `refuted` with the live superseder for a superseded decision), instead of the
+  kind being inexpressible on the Pi surface
+
 ## Technical Notes
 
 - **Tension to manage:** description conciseness (token budget) vs. agent guidance ("USE THIS

--- a/src/core/services/mcp-handlers/interference-map.ts
+++ b/src/core/services/mcp-handlers/interference-map.ts
@@ -388,7 +388,7 @@ function projectToStableIds(fp: Footprint, repo: string, stableByNodeId: Map<str
   const writeSet = fp.writeSet
     .map(w => {
       const sid = stableByNodeId.get(w.id);
-      return sid ? { ...w, id: sid, filePath: `${repo} ${w.filePath}` } : null;
+      return sid ? { ...w, id: sid, filePath: `${repo}\x00${w.filePath}` } : null;
     })
     .filter((w): w is WriteMember => w !== null)
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));

--- a/src/pi/extension.test.ts
+++ b/src/pi/extension.test.ts
@@ -3,8 +3,9 @@ import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { modelsUrl, stripMarker, isUsableConfig, readConfig, formatToolResult, formatCallArgs, NAV_TOOLS } from './extension.js';
+import { modelsUrl, stripMarker, isUsableConfig, readConfig, formatToolResult, formatCallArgs, NAV_TOOLS, PI_EXCLUDED_CONCLUSION_TOOLS } from './extension.js';
 import { TOOL_DEFINITIONS } from '../cli/commands/mcp.js';
+import { TOOL_OUTPUT_CLASS } from '../core/services/mcp-handlers/tool-contract.js';
 
 describe('modelsUrl', () => {
   it('appends /v1/models to a bare host', () => {
@@ -312,5 +313,65 @@ describe('NAV_TOOLS surface', () => {
       const unknown = declared.filter(p => p !== 'directory' && !allowed.has(p));
       expect(unknown, `${tool.name} declares params absent from inputSchema: ${unknown.join(', ')}`).toEqual([]);
     }
+  });
+
+  // The load-bearing guard in the OTHER direction (spec: PiSurfaceParityIsGuarded).
+  // Every dispatchable conclusion tool must be a deliberate Pi decision — either
+  // surfaced in NAV_TOOLS or listed in PI_EXCLUDED_CONCLUSION_TOOLS with a reason.
+  // A new MCP conclusion tool now fails CI until its author makes that call, the
+  // same fails-until-you-decide discipline tool-contract.test.ts enforces for
+  // output class and capability family.
+  it('every dispatchable conclusion tool is either surfaced in Pi or excluded with a reason', () => {
+    const dispatchable = new Set(TOOL_DEFINITIONS.map(t => t.name));
+    const surfaced = new Set(NAV_TOOLS.map(t => t.name));
+    const excluded = new Set(Object.keys(PI_EXCLUDED_CONCLUSION_TOOLS));
+    const undecided = Object.entries(TOOL_OUTPUT_CLASS)
+      .filter(([name, cls]) => cls === 'conclusion' && dispatchable.has(name))
+      .map(([name]) => name)
+      .filter(name => !surfaced.has(name) && !excluded.has(name));
+    expect(
+      undecided,
+      `conclusion tools neither surfaced in NAV_TOOLS nor in PI_EXCLUDED_CONCLUSION_TOOLS: ${undecided.join(', ')} — surface each in Pi or add it to the exclusion list with a stated reason`,
+    ).toEqual([]);
+  });
+
+  // The exclusion list stays honest: no stale entries (a tool that was surfaced
+  // or removed), and every reason is a non-empty, auditable string.
+  it('the Pi exclusion list has no stale entries and every reason is stated', () => {
+    const dispatchable = new Set(TOOL_DEFINITIONS.map(t => t.name));
+    const surfaced = new Set(NAV_TOOLS.map(t => t.name));
+    for (const [name, reason] of Object.entries(PI_EXCLUDED_CONCLUSION_TOOLS)) {
+      expect(TOOL_OUTPUT_CLASS[name], `excluded tool ${name} is not classified conclusion`).toBe('conclusion');
+      expect(dispatchable.has(name), `excluded tool ${name} is not dispatchable (stale entry)`).toBe(true);
+      expect(surfaced.has(name), `excluded tool ${name} is also surfaced in NAV_TOOLS (contradiction)`).toBe(false);
+      expect(reason.trim().length, `excluded tool ${name} has an empty reason`).toBeGreaterThan(0);
+    }
+  });
+
+  // Proof the guard actually fails on drift: simulate a newly-added conclusion
+  // tool that is neither surfaced nor excluded — the guard predicate flags it.
+  it('the parity guard flags a new conclusion tool that skips the Pi decision', () => {
+    const surfaced = new Set(NAV_TOOLS.map(t => t.name));
+    const excluded = new Set(Object.keys(PI_EXCLUDED_CONCLUSION_TOOLS));
+    const simulatedNew = '__new_conclusion_tool__';
+    const undecided = [simulatedNew].filter(name => !surfaced.has(name) && !excluded.has(name));
+    expect(undecided).toEqual([simulatedNew]);
+  });
+
+  // decision-current — the claim kind the audit found inexpressible on Pi — is
+  // now in the Pi verify_claim enum, matching the daemon's inputSchema.
+  it('Pi verify_claim expresses every claim kind the daemon supports', () => {
+    const piVerify = NAV_TOOLS.find(t => t.name === 'verify_claim');
+    expect(piVerify, 'verify_claim missing from NAV_TOOLS').toBeDefined();
+    const piKinds = new Set(
+      ((piVerify!.parameters as { properties?: { kind?: { enum?: string[] } } }).properties?.kind?.enum) ?? [],
+    );
+    const daemonVerify = TOOL_DEFINITIONS.find(t => t.name === 'verify_claim');
+    const daemonKinds =
+      (daemonVerify?.inputSchema as { properties?: { kind?: { enum?: string[] } } }).properties?.kind?.enum ?? [];
+    expect(daemonKinds.length, 'daemon verify_claim has no kind enum').toBeGreaterThan(0);
+    const missing = daemonKinds.filter(k => !piKinds.has(k));
+    expect(missing, `Pi verify_claim omits daemon kinds: ${missing.join(', ')}`).toEqual([]);
+    expect(piKinds.has('decision-current'), 'Pi verify_claim must express decision-current').toBe(true);
   });
 });

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -606,11 +606,11 @@ export const NAV_TOOLS: NavToolSpec[] = [
   {
     name: 'verify_claim',
     label: 'openlore verify_claim',
-    description: 'Verify a structural claim against the graph before asserting it — "X is dead", "Y calls Z", "Z is safe to change" — and get a deterministic verdict (confirmed / refuted / unverifiable) with a citation receipt.',
-    guideline: 'Before you tell the user a structural fact ("X is dead", "Y calls Z", "this is safe to change"), call openlore_verify_claim with `kind` and `subject` (and `object` for relational kinds: calls, reaches, impacts). An "unverifiable" verdict means hedge or read the source rather than assert.',
+    description: 'Verify a structural claim against the graph before asserting it — "X is dead", "Y calls Z", "Z is safe to change" — or a decision-authority claim ("ADR abc12345 governs this") before citing it, and get a deterministic verdict (confirmed / refuted / unverifiable) with a citation receipt.',
+    guideline: 'Before you tell the user a structural fact ("X is dead", "Y calls Z", "this is safe to change"), or cite a decision id to a human, call openlore_verify_claim with `kind` and `subject` (and `object` for relational kinds: calls, reaches, impacts). For `decision-current`, `subject` is the 8-character decision id — a "refuted" verdict names the live superseder to cite instead. An "unverifiable" verdict means hedge or read the source rather than assert.',
     parameters: Type.Object({
-      kind: StringEnum(['calls', 'reaches', 'dead', 'impacts', 'safe-to-change'] as const, { description: 'REQUIRED. The kind of structural claim to verify.' }),
-      subject: Type.String({ description: 'REQUIRED. The symbol the claim is about (a function/method name).' }),
+      kind: StringEnum(['calls', 'reaches', 'dead', 'impacts', 'safe-to-change', 'decision-current'] as const, { description: 'REQUIRED. The kind of claim to verify (structural, or decision-current for decision authority).' }),
+      subject: Type.String({ description: 'REQUIRED. What the claim is about: a function/method name for structural kinds, or an 8-character decision id for decision-current.' }),
       object: Type.Optional(Type.String({ description: 'The second symbol — required for relational kinds (calls, reaches, impacts).' })),
     }),
   },
@@ -698,6 +698,70 @@ export const NAV_TOOLS: NavToolSpec[] = [
     parameters: Type.Object({
       filePath: Type.Optional(Type.String({ description: 'Restrict search to this file (relative path)' })),
       fanOutThreshold: Type.Optional(Type.Number({ description: 'Minimum fan-out to be considered a god function (default: 8)' })),
+    }),
+  },
+  {
+    name: 'find_clones',
+    label: 'openlore find_clones',
+    description: 'Before writing (or just after writing) a function, find whether a near-duplicate already exists that you should reuse instead of reinventing.',
+    guideline: 'When you are about to add a function, call openlore_find_clones with `snippet` (the code you are about to write) — or `symbol` (an existing function name, or name::path) to find clones of one already in the index. Matches are ranked exact > structural > near; reuse the canonical one it names.',
+    parameters: Type.Object({
+      symbol: Type.Optional(Type.String({ description: 'An existing function to find clones of: its name, or name::path to disambiguate. Provide exactly one of symbol or snippet.' })),
+      snippet: Type.Optional(Type.String({ description: 'Raw code to find clones of (need not be in the index) — answers the pre-write "does this already exist?".' })),
+      minSimilarity: Type.Optional(Type.Number({ description: 'Near-clone Jaccard floor (default 0.7, clamped to [0.1, 1]).' })),
+      maxResults: Type.Optional(Type.Number({ description: 'Cap on returned matches (default 25, max 200).' })),
+    }),
+  },
+  {
+    name: 'analyze_error_propagation',
+    label: 'openlore analyze_error_propagation',
+    description: 'See what exceptions can propagate OUT of a function to its callers, and which are already caught inside it — the error-handling analogue of analyze_impact.',
+    guideline: 'Before calling a function, or after changing one to throw, call openlore_analyze_error_propagation with `symbol` to learn what escapes to callers and what is handled internally. TypeScript/JavaScript/Python; other languages return an explicit unsupported result.',
+    parameters: Type.Object({
+      symbol: Type.String({ description: 'REQUIRED. The function to analyze: its name, or name::path to disambiguate.' }),
+      maxDepth: Type.Optional(Type.Number({ description: 'Callee-traversal depth bound (default 10, clamped to [1, 30]).' })),
+    }),
+  },
+  {
+    name: 'analyze_env_impact',
+    label: 'openlore analyze_env_impact',
+    description: 'See what breaks if you remove or rename an environment variable — its read sites, the callers that reach them, and the tests to run.',
+    guideline: 'Before removing or renaming an env var, call openlore_analyze_env_impact with its `name` (e.g. DATABASE_URL) to get the read sites, the blast radius, and per-site whether the read is a hard break. TypeScript/JavaScript/Python/Go/Ruby.',
+    parameters: Type.Object({
+      name: Type.String({ description: 'REQUIRED. The environment variable to analyze, e.g. DATABASE_URL.' }),
+      maxDepth: Type.Optional(Type.Number({ description: 'Backward-reachability depth bound (default 12, clamped to [1, 30]).' })),
+    }),
+  },
+  {
+    name: 'certify_public_surface',
+    label: 'openlore certify_public_surface',
+    description: 'Before shipping a library/module change, check whether you broke your consumers\' contract — a removed/renamed export, an added required param, a narrowed type.',
+    guideline: 'Before shipping a change to exported code, call openlore_certify_public_surface with `baseRef` (e.g. "main") for a breaking-change verdict; omit it to just list the public surface. A change it cannot prove compatible is reported potentially-breaking, never silently safe.',
+    parameters: Type.Object({
+      baseRef: Type.Optional(Type.String({ description: 'Git ref to diff the working tree\'s public surface against (e.g. "HEAD", "main"). Omit to return the surface itself.' })),
+      maxResults: Type.Optional(Type.Number({ description: 'Limit the surface listing in surface mode (default 200, capped 500).' })),
+    }),
+  },
+  {
+    name: 'get_style_fingerprint',
+    label: 'openlore get_style_fingerprint',
+    description: 'Before writing or editing code, learn the codebase\'s house style — arrow vs. declared functions, const vs. let, ternary vs. if, and more — so your edit matches it.',
+    guideline: 'Before writing code, call openlore_get_style_fingerprint to match the house style instead of your default. Pass `filePath` for one file or `communityId` (from get_map) for a region; omit both for the whole repo. It reports what the code IS, not a lint judgment.',
+    parameters: Type.Object({
+      communityId: Type.Optional(Type.String({ description: 'Profile one community/region by id (list ids with get_map).' })),
+      filePath: Type.Optional(Type.String({ description: 'Profile a single file (exact path or a unique path suffix); wins over communityId if both are given.' })),
+      language: Type.Optional(Type.String({ description: 'Restrict the returned languages to this one (e.g. "TypeScript").' })),
+    }),
+  },
+  {
+    name: 'briefing_since',
+    label: 'openlore briefing_since',
+    description: 'Catching up on a repo that changed a lot since you last looked — the changed functions that STRUCTURALLY MATTER (hubs, chokepoints), ranked, not a flat wall of diffs.',
+    guideline: 'To review a large change set or catch up after time away, call openlore_briefing_since with `baseRef` (e.g. "main", a PR base). It ranks changed production symbols by tier (surprising > hub > chokepoint > ordinary) with the tests to run — unlike blast_radius, which briefs YOUR pending diff.',
+    parameters: Type.Object({
+      baseRef: Type.Optional(Type.String({ description: 'Git ref to brief changes SINCE (e.g. "main", a PR base, "HEAD~20"). Default resolves main → master → HEAD~1.' })),
+      filePattern: Type.Optional(Type.String({ description: 'Region scope — only brief changes whose file path contains this substring.' })),
+      maxResults: Type.Optional(Type.Number({ description: 'Bound on briefed symbols, highest-tier-first (default 50, max 200).' })),
     }),
   },
   {
@@ -868,6 +932,58 @@ export const NAV_TOOLS: NavToolSpec[] = [
     }),
   },
 ];
+
+// Conclusion tools deliberately NOT surfaced natively in Pi, each with a stated
+// reason (project doctrine: "if parity is intentionally skipped, say why").
+// The two-direction parity guard (extension.test.ts) requires every dispatchable
+// conclusion tool to be either in NAV_TOOLS above or listed here — a new MCP
+// conclusion tool fails CI until its author makes this decision explicitly, the
+// same fails-until-you-classify discipline tool-contract.test.ts enforces.
+export const PI_EXCLUDED_CONCLUSION_TOOLS: Record<string, string> = {
+  // Opt-in preset surfaces — federation/coordination tools ship behind
+  // `--preset federation` / `--preset coordination`, not the native substrate
+  // surface Pi mirrors; surface them if a Pi host adopts those workflows.
+  change_impact_certificate: 'opt-in federation preset surface',
+  federation_status: 'opt-in federation preset surface',
+  spec_store_status: 'opt-in federation preset surface',
+  working_set_context: 'opt-in federation preset surface',
+  map_in_flight_conflicts: 'opt-in federation/coordination preset surface',
+  plan_parallel_work: 'opt-in coordination preset surface',
+  // Inventories — the before_agent_start context injection already grounds the
+  // model with the architecture digest and spec index; per-domain inventories
+  // are an on-demand CLI/full-preset concern, not the native nav surface.
+  get_route_inventory: 'inventory — context injection covers grounding',
+  get_middleware_inventory: 'inventory — context injection covers grounding',
+  get_schema_inventory: 'inventory — context injection covers grounding',
+  get_ui_component_inventory: 'inventory — context injection covers grounding',
+  get_env_vars: 'inventory — context injection covers grounding (see analyze_env_impact for blast radius)',
+  get_external_packages: 'inventory — context injection covers grounding',
+  // Generation paths — LLM-backed authoring, not the deterministic navigate
+  // surface Pi exposes; the Pi host drives generation through its own flows.
+  generate_change_proposal: 'generation path — not the deterministic navigate surface',
+  generate_tests: 'generation path — not the deterministic navigate surface',
+  annotate_story: 'generation path — not the deterministic navigate surface',
+  // Lifecycle/orchestration — the Pi host drives analysis via the warm daemon,
+  // not an agent on-demand tool call.
+  analyze_codebase: 'lifecycle — the host drives analyze via the warm daemon, not a tool call',
+  detect_changes: 'lifecycle — the host drives incremental analysis, not a tool call',
+  // Covered by a surfaced peer — the native surface already carries the
+  // edit-time conclusion; these are the whole-repo/lower-level variants.
+  get_duplicate_report: 'whole-repo audit — find_clones is the surfaced edit-time peer',
+  get_low_risk_refactor_candidates: 'covered by the surfaced get_refactor_report',
+  get_leaf_functions: 'covered by the surfaced get_landmarks structural anchors',
+  check_architecture: 'covered by the surfaced get_refactor_report; full rule reports stay full preset',
+  find_dead_code: 'covered by get_landmarks (dead label) + verify_claim kind "dead"',
+  get_signatures: 'covered by the surfaced get_function_skeleton',
+  get_mapping: 'covered by the surfaced orient / get_map',
+  get_minimal_context: 'orient is the surfaced minimal-context entry',
+  get_cluster: 'covered by the surfaced get_map / get_landmarks',
+  // Opt-in full-preset / host-owned conclusions.
+  report_coverage_gaps: 'opt-in full preset surface',
+  get_language_support: 'opt-in full preset surface',
+  locate_symbol_span: 'edit-span location is a host concern — the Pi host owns file editing',
+  get_change_coupling: 'git co-change/churn conclusion — deferred from the native surface pending demand',
+};
 
 function toolResult(text: string, details: unknown = null): AgentToolResult<unknown> {
   return { content: [{ type: 'text', text }], details };


### PR DESCRIPTION
**Status:** LGTM — full suite green (317 files / 6098 passed / 2 skipped), typecheck + lint clean, e2e round-trip verified against the live daemon.

## What was wrong
The project's parity doctrine (CLAUDE.md, "MCP tool ↔ Pi extension parity") says the same structural capabilities ship through both surfaces — the MCP tools and the Pi extension — with any deviation stated. It was being violated silently:

- **Pi couldn't verify decision authority.** Pi's `verify_claim` `kind` enum was `['calls','reaches','dead','impacts','safe-to-change']` — missing `decision-current`, which the MCP handler fully supports and the `verify` preset advertises. A Pi agent about to cite an ADR had no way to catch a superseded decision.
- **Six conclusion tools drifted out of Pi.** `NAV_TOOLS` lacked `find_clones`, `analyze_error_propagation`, `analyze_env_impact`, `certify_public_surface`, `get_style_fingerprint`, and `briefing_since` — all dispatchable, all classified `conclusion`, all with peers already surfaced in Pi.
- **Root cause: the guard was one-directional.** The only parity test asserted `NAV_TOOLS ⊆ dispatchable`; the reverse was unchecked, so every new MCP conclusion tool shipped green while silently absent from Pi.

## How it was fixed
- **`decision-current` joins Pi's enum** (+ guideline), matching the daemon's inputSchema. `subject` is the 8-char decision id; a `refuted` verdict names the live superseder.
- **The six drifted tools are surfaced in `NAV_TOOLS`** — trigger-first house-style descriptions, params a strict subset of each daemon inputSchema.
- **`PI_EXCLUDED_CONCLUSION_TOOLS`** — a named, source-commented exclusion list with one stated reason per deliberately-omitted conclusion tool (opt-in federation/coordination presets, inventories covered by context injection, generation paths, peers already surfaced, etc.).
- **Two-direction parity guard** in `extension.test.ts`: every dispatchable conclusion tool must be surfaced *or* excluded-with-reason. A new MCP conclusion tool now fails CI until its author makes the Pi decision explicitly — the same fails-until-you-decide discipline `tool-contract.test.ts` enforces. The existing `NAV_TOOLS ⊆ dispatchable` direction is kept.
- **Cleanup:** `interference-map.ts:391` embedded a literal NUL byte in a template literal (tripped grep/rg into binary mode, the same class as the known `analysis.ts` gotcha). Replaced with the `'\x00'` escape — byte-identical at runtime.
- **Spec:** `mcp-quality` gains `PiSurfaceParityIsGuarded`.

## Proof it works
- **Reproduce the original gap:** on `main`, `grep "decision-current" src/pi/extension.ts` → empty; the six tools → 0 refs in NAV_TOOLS; the parity test only checked one direction.
- **New guard test** (`extension.test.ts`): fails when a conclusion tool is neither surfaced nor excluded (simulated in-test), passes on the reconciled surface. Plus: exclusion-list has no stale entries + every reason is stated; Pi `verify_claim` expresses every daemon kind.
- **Live e2e** against `openlore serve`:
  - `verify_claim {kind: decision-current, subject: 5a27d292}` → `confirmed` with a citation receipt (previously inexpressible on Pi).
  - `get_style_fingerprint` and `briefing_since` (newly surfaced) round-trip with real data.
- Full suite: **317 files / 6098 passed / 2 skipped**; `typecheck` + `lint` clean; `build` clean.

## Notes / nits
- MCP tool surface is unchanged (no new dispatchable tool, no payload-budget or doc-count impact). Pi gains six native tools + one enum member.
- Honest scope: 30 conclusion tools remain deliberately absent from Pi and are now recorded on the exclusion list with reasons, rather than silently missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)