### PR TITLE
fix: normalize Windows backslash paths before splitting on '/'

### DIFF
--- a/src/core/analyzer/repository-mapper.ts
+++ b/src/core/analyzer/repository-mapper.ts
@@ -476,7 +476,7 @@ function inferDomains(files: ScoredFile[]): Record<string, ScoredFile[]> {
     // (src/main/java/com/example/inventory/Foo.java) at the business package
     // ("inventory") instead of collapsing every source file into the org root
     // ("com"/"springframework"). See issue #138.
-    const dirParts = file.path.split('/').slice(0, -1);
+    const dirParts = file.path.replace(/\\/g, '/').split('/').slice(0, -1);
     const domain = deriveDomainFromPath(dirParts);
     if (domain) {
       if (!domains[domain]) {

--- a/src/core/drift/spec-mapper.ts
+++ b/src/core/drift/spec-mapper.ts
@@ -124,7 +124,7 @@ export function parseSpecReferences(content: string): {
  * should match "auth-service.ts" but not "authorize.ts").
  */
 export function inferDomainFromPath(filePath: string, knownDomains: string[]): string | null {
-  const normalizedPath = filePath.toLowerCase();
+  const normalizedPath = filePath.toLowerCase().replace(/\\/g, '/');
   const parts = normalizedPath.split('/');
 
   // Sort domains by length (longest first) so more specific names match first

--- a/src/core/verifier/verification-engine.ts
+++ b/src/core/verifier/verification-engine.ts
@@ -416,7 +416,7 @@ export class SpecVerificationEngine {
     // 2. Path-based matching against known spec domains
     const knownDomains = this.specs.map(s => s.domain);
     const structural = new Set(['src', 'lib', 'app', 'core', 'utils', 'helpers', 'common', 'shared']);
-    const rawParts = filePath.split('/');
+    const rawParts = filePath.replace(/\\/g, '/').split('/');
     const segments = rawParts.map((p, i) =>
       i === rawParts.length - 1 ? p.replace(/\.[^.]+$/, '').toLowerCase() : p.toLowerCase()
     );
@@ -744,6 +744,7 @@ Respond in JSON:
    */
   private normalizeImport(importPath: string): string {
     const normalized = importPath
+      .replace(/\\/g, '/')
       .replace(/\.(js|ts|jsx|tsx|mjs|cjs)$/, '')
       .replace(/^\.\//, '')
       .replace(/^\.\.\//, '');


### PR DESCRIPTION
## Problem

On Windows, file paths use backslash (`\`) as the separator, but several path-matching functions split on `/` without normalizing first. This causes all path-based domain inference to produce a single segment (e.g. `"src\auth\service.ts"` stays as one token), so no domain matches and every file returns `'misc'`.

This makes `openlore verify` fail with `"No suitable verification candidates found"` on Windows because:

1. `inferDomain()` in the verification engine splits on `/` -> gets one segment -> returns `'misc'` -> all files filtered out
2. `inferDomainFromPath()` in the spec mapper has the same issue
3. `inferDomains()` in the repository mapper can't cluster files by domain on Windows

## Fix

Add `.replace(/\\/g, '/')` before every `.split('/')` that operates on file paths from the filesystem (which use OS-native separators):

| File | Method | Change |
|------|--------|--------|
| `src/core/verifier/verification-engine.ts` | `inferDomain()` | `filePath.split('/')` -> `filePath.replace(/\\/g, '/').split('/')` |
| `src/core/verifier/verification-engine.ts` | `normalizeImport()` | Same pattern (handles C# import paths on Windows) |
| `src/core/drift/spec-mapper.ts` | `inferDomainFromPath()` | Same pattern |
| `src/core/analyzer/repository-mapper.ts` | `inferDomains()` | Same pattern |

Other files in the codebase (`github-actions.ts`, `docker.ts`, `classify-yaml.ts`, `refresh-stories.ts`) already use this pattern (`path.replace(/\\/g, '/').split('/')`). This fix extends the same pattern to the remaining locations.

## Testing

- `npx vitest run src/core/verifier/` -- **41/41 passed**
- `npx vitest run src/core/drift/spec-mapper.test.ts` -- 89/90 passed (1 pre-existing failure on Windows: `relative()` returns backslashes in `adrPath` test assertion)
- `npm run build` -- compiles cleanly (TS5101 deprecation is pre-existing)

## Verification on a real Windows repo

After this fix, `openlore verify` on a 3,300+ file C# WinForms project correctly:
- Loads 1448 file-to-domain mappings
- Selects 30 verification candidates across 14 domains
- Runs LLM-based verification (28/30 files verified)
