### PR TITLE
fix(security): update vulnerable dependencies and add automated security checks

### DIFF
--- a/.github/actions/openlore-review/action.yml
+++ b/.github/actions/openlore-review/action.yml
@@ -4,6 +4,20 @@ description: >
   Advisory by default — informs, never fails the check (unless you opt into blastRadius.block).
 author: 'OpenLore'
 
+# SECURITY NOTE — why every input below reaches the shell through `env:` and never
+# through `${{ }}` inside a `run:` block.
+#
+# Actions expression interpolation is a TEXTUAL substitution performed before the
+# shell starts, so a `${{ inputs.x }}` written inline in a script is not an argument —
+# it becomes part of the program, and any shell metacharacter in the value is executed
+# rather than compared.
+#
+# The defaults here are commit SHAs, but a caller controls every input, and this
+# action can be wired to `pull_request_target` to comment on fork pull requests —
+# a trigger where the values are externally influenced and the job holds a write
+# token. Passed via `env:` they are ordinary shell variables, so quoting keeps them
+# inert as data.
+
 inputs:
   github-token:
     description: 'Token used to create/update the sticky PR comment.'
@@ -34,41 +48,50 @@ runs:
   using: composite
   steps:
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
 
     - name: Build the OpenLore index (optional, for full blast radius)
       if: ${{ inputs.analyze == 'true' }}
       shell: bash
-      run: npx --yes openlore@${{ inputs.openlore-version }} analyze --no-embed || echo "analyze failed — review will show the structural delta only"
+      env:
+        OPENLORE_VERSION: ${{ inputs.openlore-version }}
+      run: |
+        npx --yes "openlore@$OPENLORE_VERSION" analyze --no-embed \
+          || echo "analyze failed — review will show the structural delta only"
 
     - name: Run openlore review
       id: review
       shell: bash
+      env:
+        OPENLORE_VERSION: ${{ inputs.openlore-version }}
+        REVIEW_BASE: ${{ inputs.base }}
+        REVIEW_HEAD: ${{ inputs.head }}
+        REVIEW_GATE: ${{ inputs.gate }}
       run: |
         OUT="$RUNNER_TEMP/openlore-review.md"
-        ARGS=(review --base "${{ inputs.base }}" --head "${{ inputs.head }}" --format markdown --out "$OUT")
-        if [ "${{ inputs.gate }}" = "true" ]; then ARGS+=(--hook); fi
+        ARGS=(review --base "$REVIEW_BASE" --head "$REVIEW_HEAD" --format markdown --out "$OUT")
+        if [ "$REVIEW_GATE" = "true" ]; then ARGS+=(--hook); fi
         set +e
-        npx --yes openlore@${{ inputs.openlore-version }} "${ARGS[@]}"
+        npx --yes "openlore@$OPENLORE_VERSION" "${ARGS[@]}"
         RC=$?
         set -e
         # Distinguish a REAL gate (review ran and a blastRadius.block pattern fired:
         # the briefing file was written AND exit was non-zero) from review being unable
         # to run at all (a published openlore without `review`, an unreachable range, a
         # crash → no briefing file). Only the former fails the job; the latter is advisory.
-        if [ "${{ inputs.gate }}" = "true" ] && [ "$RC" -ne 0 ] && [ -s "$OUT" ]; then
+        if [ "$REVIEW_GATE" = "true" ] && [ "$RC" -ne 0 ] && [ -s "$OUT" ]; then
           echo "openlore review: a configured blastRadius.block pattern fired — failing the job (gate mode)."
           exit "$RC"
         fi
         if [ ! -s "$OUT" ]; then
-          echo "openlore review produced no briefing — the published 'openlore' (openlore-version: ${{ inputs.openlore-version }}) may not yet ship the 'review' command, or the base..head range was unreachable. Skipping the comment (advisory)."
+          echo "openlore review produced no briefing — the published 'openlore' (openlore-version: $OPENLORE_VERSION) may not yet ship the 'review' command, or the base..head range was unreachable. Skipping the comment (advisory)."
         fi
 
     - name: Post or update the sticky review comment
       if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,19 @@
+name: 'OpenLore CodeQL config'
+
+# `security-extended` over the default suite: it adds the lower-precision security
+# queries, which is the right trade for a tool whose whole job is reading untrusted
+# repository contents (paths, source text, git output, YAML/JSON from analyzed repos).
+# `security-and-quality` is deliberately NOT used — it folds in maintainability
+# queries, and a baseline that reports style as "security" gets tuned out.
+queries:
+  - uses: security-extended
+
+paths-ignore:
+  # Deliberately malformed / adversarial inputs that exist to be parsed by tests.
+  # Scanning them reports the fixture, never the code under test.
+  - src/core/analyzer/fixtures
+  - src/core/analyzer/iac/fixtures
+  - src/core/scip/fixtures
+  # Third-party protobuf runtime shipped as-is; upgrades come from upstream, and
+  # advisories against it are dependency-scanning's job, not SAST's.
+  - src/core/scip/vendor

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+# Dependabot configuration.
+#
+# Dependabot SECURITY updates (advisory-driven) are enabled in repo settings and are
+# deliberately NOT grouped below — each arrives as its own PR so a fix can be reviewed
+# and landed fast. What this file adds is scheduled VERSION updates, grouped to keep the
+# routine noise to a few reviewable PRs a week.
+#
+# The `github-actions` ecosystem is the important half. Every action in this repo is
+# pinned to an immutable commit SHA (a tag can be moved to point at new code, a SHA
+# cannot), and a pinned SHA only stays safe if something keeps proposing the upgrade.
+# That something is this file.
+
+version: 2
+
+updates:
+  # ---------------------------------------------------------------- npm
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    groups:
+      # One PR for routine dev-tooling drift (eslint, vitest, tsx, types).
+      dev-dependencies:
+        applies-to: version-updates
+        dependency-type: development
+        update-types: [minor, patch]
+      # One PR for low-risk runtime drift. Majors stay individual: they are the ones
+      # that can change behavior, so they deserve their own review and CI run.
+      production-minor-patch:
+        applies-to: version-updates
+        dependency-type: production
+        update-types: [minor, patch]
+    ignore:
+      # Pinned intentionally, not drifting. tree-sitter grammars are matched to the
+      # web-tree-sitter/ABI version the analyzer loads, and a grammar bump has to be
+      # validated against the parse fixtures rather than merged on green CI alone.
+      - dependency-name: web-tree-sitter
+      - dependency-name: tree-sitter-wasms
+      - dependency-name: '@lancedb/lancedb'
+
+  # ------------------------------------------------------- github actions
+  # Covers `.github/workflows/*` and the composite action in
+  # `.github/actions/openlore-review/action.yml`. Grouped: these are almost always
+  # the same handful of first-party actions moving together.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns: ['*']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
 name: CI
 
+# Every action is pinned to an immutable commit SHA with the human-readable version
+# in a trailing comment. A tag like `@v6` is a moving pointer: whoever controls the
+# action repo can re-point it at new code, and it runs here with this workflow's
+# token. Dependabot's `github-actions` ecosystem proposes the SHA bumps.
+#
+# `persist-credentials: false` on checkout: by default it writes the job token into
+# `.git/config`, leaving it readable by every later step (including anything a
+# dependency's install script does). No job here pushes, so none of them need it.
+
 on:
   push:
     branches: [main]
@@ -9,14 +18,23 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -40,10 +58,15 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -56,10 +79,15 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -69,8 +97,15 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify the published tarball contents
+        # Runs here rather than in `lint` because it asserts the built entrypoints are
+        # present, which needs `dist/`. `files` is an allowlist, so a stray new
+        # directory is excluded by default — but widening `files` itself is a one-line
+        # diff, and this checks the real `npm pack` manifest rather than the intent.
+        run: npm run audit:packlist
+
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -81,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test, build]
     if: always()
+    permissions:
+      contents: read
     steps:
       - name: Check all jobs passed
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull-request runs are cancelled; runs on main are not, so a push to the
+  # default branch always ends up with a completed run rather than a cancelled one.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,12 @@ jobs:
       - run: npm ci
 
       - name: Audit dependencies
-        # Gate ALL dependencies (prod + dev) at high severity. Transitive advisories
-        # inside dev tooling (@earendil-works/pi-coding-agent → @google/genai →
-        # protobufjs/ws) are pinned to patched versions via `overrides`, so the full
-        # tree is clean — no need to scope dev out.
-        run: npm audit --audit-level=high
+        # Gate ALL dependencies (prod + dev) at high severity. Most transitive
+        # advisories are pinned to patched versions via `overrides`; the few with no
+        # applicable fix are listed, with a reason and a clearing condition, in the
+        # gate's ALLOWLIST. The gate also fails on a stale allowlist entry, so an
+        # exception cannot outlive its cause.
+        run: npm run audit:gate
 
       - name: Run ESLint
         run: npm run lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,11 +25,13 @@ permissions:
 
 concurrency:
   group: codeql-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull-request runs are cancelled; runs on main are not, so the default
+  # branch always ends up with a completed analysis rather than a cancelled one.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:
-    name: Analyze (javascript-typescript)
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -37,19 +39,30 @@ jobs:
       security-events: write # upload the SARIF results
       actions: read # read workflow run metadata
 
+    strategy:
+      fail-fast: false
+      matrix:
+        # `actions` analyzes the workflow files themselves — the expression-injection
+        # class this repo also guards structurally in `src/workflow-security.test.ts`.
+        # The guard checks the shapes it knows to look for; this checks dataflow, and
+        # the two catch different mistakes.
+        language: [javascript-typescript, actions]
+
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
-          languages: javascript-typescript
+          languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      # No build step: `javascript-typescript` is extracted directly from source, so
+      # No build step: both languages are extracted directly from source, so
       # `autobuild` would only add a failure mode without changing what is analyzed.
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
-          category: '/language:javascript-typescript'
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: CodeQL
+
+# Static application security testing. `npm audit` covers known-vulnerable
+# dependencies, which says nothing about a defect written here. CodeQL covers the
+# other half: injection, path traversal, unsafe regex, prototype pollution, and
+# similar, in first-party code.
+#
+# The weekly run matters as much as the per-PR one. New queries ship continuously,
+# so unchanged code can become newly-detectable; without a schedule, a finding only
+# surfaces the next time someone happens to touch that file.
+#
+# Findings surface in the Security tab and as pull-request annotations.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays 07:00 UTC, offset from the Dependabot run so review load is spread.
+    - cron: '0 7 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write # upload the SARIF results
+      actions: read # read workflow run metadata
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-config.yml
+
+      # No build step: `javascript-typescript` is extracted directly from source, so
+      # `autobuild` would only add a failure mode without changing what is analyzed.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,18 +28,30 @@ on:
         required: true
         type: string
 
+# Workflow-level floor. Individual jobs widen this only where they must:
+# `create-release` needs `contents: write`, `publish` needs `id-token: write`.
+# Without a floor here, every job inherits the repo-wide default — a setting that
+# can be changed outside this file, so the least-privilege guarantee would not be
+# visible in (or enforced by) the workflow itself.
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Release
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # workflow_dispatch → the explicitly-named tag.
           # push (tag) and release events → github.ref already points at the tag.
           ref: ${{ github.event.inputs.tag || github.ref }}
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -51,9 +63,18 @@ jobs:
       # sails through validate and dies late in `npm publish` with the cryptic
       # "cannot publish over the previously published version" (this is exactly
       # how the first v2.0.6 publish failed). Catch it here with a clear message.
+      #
+      # The tag reaches the shell via `env:`, never inline `${{ }}`: interpolation is
+      # substituted into the script text before bash parses it, so a tag name carrying
+      # shell metacharacters would execute rather than compare. Pushing a tag takes
+      # write access, so this hardens a latent pattern rather than closing an external
+      # hole — but it is the pattern that gets copied into the next workflow, where
+      # the input may not be trusted.
       - name: Verify tag matches package.json version
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG="$RELEASE_TAG"
           PKG="v$(node -p "require('./package.json').version")"
           if [ "$TAG" != "$PKG" ]; then
             echo "::error::Release tag '$TAG' does not match package.json version '$PKG'. Bump package.json + package-lock.json in a chore(release) commit, retag at that commit, and re-run."
@@ -80,12 +101,16 @@ jobs:
     # Only the tag-push path creates the Release. On `release: published` the
     # Release already exists; on workflow_dispatch we re-publish an existing tag.
     if: github.event_name == 'push'
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.ref }}
+          # `gh release create` authenticates with GH_TOKEN from the env, not with git
+          # credentials, so nothing here needs the token written into .git/config.
+          persist-credentials: false
 
       # Create the Release for this tag, unless one already exists (idempotent —
       # safe to re-run). Created with GITHUB_TOKEN, so it deliberately does NOT
@@ -140,12 +165,15 @@ jobs:
     environment:
       name: npm-publish
       url: https://www.npmjs.com/package/openlore
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+          # Publishing authenticates via OIDC, never via the git-stored token.
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -155,6 +183,13 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      # Last gate before the one step that cannot be undone. CI already ran this on
+      # the PR, but the tarball is assembled from THIS checkout of THIS tag, so the
+      # only assertion that counts is the one made against the artifact about to be
+      # uploaded.
+      - name: Verify the published tarball contents
+        run: npm run audit:packlist
 
       # No NODE_AUTH_TOKEN — npm picks up the OIDC token automatically when
       # `id-token: write` is set and the package is configured for Trusted

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,65 @@
+name: OpenSSF Scorecard
+
+# Continuously scores this repo against the OpenSSF supply-chain checks (action
+# pinning, token permissions, release provenance, dangerous workflow patterns,
+# vulnerability hygiene, …) and uploads the result to the Security tab.
+#
+# The point is drift detection, not the score. A hardening baseline decays quietly:
+# a `permissions:` block gets dropped, an action gets re-pinned to a tag, a new
+# workflow copies an unsafe pattern. This notices.
+#
+# NOTE ON TRIGGERS: Scorecard must run on the default branch of the upstream repo —
+# it reads branch and workflow configuration, which a PR context cannot provide.
+# It therefore does not run on pull requests, including the one that adds it.
+# `workflow_dispatch` is here so it can be verified on demand.
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Mondays 08:00 UTC, after the CodeQL run.
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read
+      security-events: write # upload the SARIF results
+      id-token: write # publish the score to the public OpenSSF API
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes to the public OpenSSF dataset, which is what makes the score
+          # externally checkable (and enables the README badge). Nothing private is
+          # published — every input is already public repo metadata.
+          publish_results: true
+
+      # Kept because SARIF upload only retains the most recent result; the artifact
+      # is what lets a regression be diffed against the previous week.
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 7
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,3 +28,20 @@ Include:
 ## Scope notes
 
 OpenLore runs **locally** and is deterministic by design — analysis is pure static analysis with no LLM and no network in the hot path, and no telemetry is sent anywhere by default. Areas especially worth scrutiny: the MCP server surface (`openlore mcp`), the pre-commit decisions gate, and any path that reads untrusted repository contents during `analyze`.
+
+## Automated checks
+
+Every pull request and release runs these:
+
+- **Dependency advisories** — the full tree (runtime and development) is gated at high severity.
+- **CodeQL** static analysis on each pull request and on a weekly schedule.
+- **Published-package contents** are verified against the real `npm pack` manifest, in CI and again immediately before publish.
+- **Workflow hardening** — GitHub Actions are pinned to immutable commit SHAs, and a test in the unit suite keeps them pinned.
+- **Dependabot** watches both npm packages and GitHub Actions.
+- **OpenSSF Scorecard** tracks supply-chain posture weekly.
+- **Releases** are published with npm Trusted Publishing (short-lived OIDC, no long-lived token) and carry a signed `--provenance` attestation tying each tarball to the commit and workflow run that built it.
+
+Two conventions to follow when changing anything under `.github/`:
+
+- **Pin actions to a commit SHA, not a tag**, and keep the trailing `# vX.Y.Z` comment. Resolve one with `gh api repos/<owner>/<repo>/git/ref/tags/<tag> -q .object.sha`.
+- **Pass values into a shell through `env:`, never inline `${{ }}`.** Actions expressions are substituted into the script text before the shell parses it, so an inline expression is treated as program rather than as data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@huggingface/transformers": "^3.8.1",
         "@lancedb/lancedb": "0.22.4-beta.3",
         "apache-arrow": "^21.1.0",
-        "protobufjs": "^8.6.3",
+        "protobufjs": "^8.6.6",
         "tree-sitter": "^0.22.4",
         "tree-sitter-bash": "^0.23.3",
         "tree-sitter-c": "^0.23.6",
@@ -1827,7 +1827,9 @@
       }
     },
     "node_modules/@google/genai/node_modules/protobufjs": {
-      "version": "7.6.4",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -1849,10 +1851,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1936,9 +1940,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -1948,19 +1952,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -1970,19 +1974,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -1996,9 +2019,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -2012,9 +2035,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -2031,9 +2054,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -2050,9 +2073,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -2069,9 +2092,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -2088,9 +2111,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -2107,9 +2130,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -2126,9 +2149,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -2145,9 +2168,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -2164,9 +2187,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -2179,19 +2202,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -2204,19 +2227,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -2229,19 +2252,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2254,19 +2277,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -2279,19 +2302,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -2304,19 +2327,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -2329,19 +2352,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -2354,38 +2377,64 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -2395,16 +2444,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -2414,16 +2463,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -2433,7 +2482,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -7023,9 +7072,9 @@
       "optional": true
     },
     "node_modules/onnxruntime-web/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -7542,7 +7591,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -7621,48 +7672,53 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "format": "eslint src --fix",
     "lint": "eslint src",
     "audit:gate": "node scripts/audit-gate.mjs",
+    "audit:packlist": "node scripts/audit-packlist.mjs",
     "typecheck": "tsc --noEmit",
     "postinstall": "node scripts/postinstall.mjs",
     "prepublishOnly": "npm run build && npm run test:run"
@@ -142,6 +143,7 @@
     "!dist/**/*.test.*",
     "scripts/postinstall.mjs",
     "src/viewer",
+    "!src/viewer/**/*.test.*",
     "examples",
     "skills/openlore-orient",
     "stubs",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "@huggingface/transformers": "^3.8.1",
     "@lancedb/lancedb": "0.22.4-beta.3",
     "apache-arrow": "^21.1.0",
-    "protobufjs": "^8.6.3",
+    "protobufjs": "^8.6.6",
     "tree-sitter": "^0.22.4",
     "tree-sitter-bash": "^0.23.3",
     "tree-sitter-c": "^0.23.6",
@@ -200,15 +200,20 @@
   "overrides": {
     "tree-sitter-cli": "file:stubs/tree-sitter-cli-stub",
     "@google/genai": {
-      "protobufjs": "^7.6.4"
+      "protobufjs": "^7.6.5"
     },
     "ws": "^8.21.0",
     "undici": "^8.5.0",
     "js-yaml": "^4.3.0",
     "hono": "^4.12.32",
+    "@hono/node-server": "^2.0.5",
+    "sharp": "^0.35.0",
+    "onnxruntime-web": {
+      "protobufjs": "^7.6.5"
+    },
     "@earendil-works/pi-coding-agent": {
       "@google/genai": {
-        "protobufjs": "^7.6.4"
+        "protobufjs": "^7.6.5"
       },
       "ws": "^8.21.0",
       "undici": "^8.5.0"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "skill:install-local": "node scripts/install-skill.js",
     "format": "eslint src --fix",
     "lint": "eslint src",
+    "audit:gate": "node scripts/audit-gate.mjs",
     "typecheck": "tsc --noEmit",
     "postinstall": "node scripts/postinstall.mjs",
     "prepublishOnly": "npm run build && npm run test:run"

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Dependency audit gate.
+ *
+ * Wraps `npm audit` so CI can keep gating the FULL tree (prod + dev) at high
+ * severity while carrying an explicit, self-expiring exception list. Plain
+ * `npm audit --audit-level=high` has no way to say "this one advisory has no
+ * reachable fix", so the alternative would be to drop the gate to prod-only
+ * and stop catching dev-chain advisories entirely.
+ *
+ * An entry here is a claim that the advisory has no fix we can apply, not that
+ * it does not matter. If an allowlisted advisory disappears from the tree the
+ * gate FAILS, so a stale exception cannot outlive its cause.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/** Advisories with no applicable fix. Each needs a reason and a clearing condition. */
+const ALLOWLIST = {
+  'GHSA-mh99-v99m-4gvg': {
+    package: 'brace-expansion',
+    reason:
+      'Affects <=5.0.7 with its only patch at 5.0.8, so the 1.x line has no fix. ' +
+      'Reached solely via eslint -> minimatch@3.1.4, which calls the v1 API ' +
+      '(`module.exports = expand`); brace-expansion 5.x exports `{ expand }`, so ' +
+      'forcing it breaks lint at runtime. Dev-only, absent from the published files list.',
+    clearsWhen: 'eslint raises its minimatch floor past 3.x.',
+  },
+};
+
+const GATED = new Set(['high', 'critical']);
+
+function runAudit() {
+  try {
+    // Exits non-zero whenever anything is found; the JSON on stdout is what matters.
+    return execFileSync('npm', ['audit', '--json'], {
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (err) {
+    if (err.stdout) return err.stdout;
+    throw err;
+  }
+}
+
+const report = JSON.parse(runAudit());
+const vulnerabilities = report.vulnerabilities ?? {};
+
+// Collect root advisories: a `via` entry that is an object is an advisory itself,
+// whereas a string entry only names a dependent that inherits one.
+const found = new Map(); // ghsaId -> { package, severity, title }
+for (const vuln of Object.values(vulnerabilities)) {
+  for (const via of vuln.via ?? []) {
+    if (typeof via !== 'object' || !GATED.has(via.severity)) continue;
+    const id = String(via.url ?? '').split('/').pop();
+    if (id) found.set(id, { package: via.name, severity: via.severity, title: via.title });
+  }
+}
+
+const unexpected = [...found].filter(([id]) => !ALLOWLIST[id]);
+const stale = Object.keys(ALLOWLIST).filter(id => !found.has(id));
+
+for (const [id, { package: pkg, severity, title }] of found) {
+  if (ALLOWLIST[id]) console.log(`· allowed  ${severity.padEnd(8)} ${pkg}  ${id}\n           ${ALLOWLIST[id].reason}`);
+  else console.error(`✖ BLOCKING ${severity.padEnd(8)} ${pkg}  ${id}\n           ${title}`);
+}
+
+if (stale.length) {
+  console.error(
+    `\n✖ Stale audit allowlist entr${stale.length === 1 ? 'y' : 'ies'}: ${stale.join(', ')}\n` +
+      `  No longer present in the tree — remove from ALLOWLIST in scripts/audit-gate.mjs.`
+  );
+}
+
+if (unexpected.length || stale.length) {
+  console.error(`\naudit-gate: FAILED (${unexpected.length} unallowed, ${stale.length} stale)`);
+  process.exit(1);
+}
+
+console.log(`\naudit-gate: OK — no unallowed high/critical advisories.`);

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -43,8 +43,52 @@ function runAudit() {
   }
 }
 
-const report = JSON.parse(runAudit());
-const vulnerabilities = report.vulnerabilities ?? {};
+/**
+ * Fail CLOSED when the audit did not actually run.
+ *
+ * `npm audit` exits non-zero both when it finds advisories AND when it cannot run at
+ * all (no lockfile, registry unreachable, an output-shape change). Those look alike
+ * from the outside, so the report has to be validated rather than trusted: a missing
+ * `vulnerabilities` map would otherwise read as "nothing found" and the gate would
+ * report OK without having checked anything.
+ */
+function parseReport(raw) {
+  let report;
+  try {
+    report = JSON.parse(raw);
+  } catch {
+    fatal('npm audit did not return JSON.', raw.slice(0, 400));
+  }
+  if (report.error) {
+    fatal(
+      `npm audit could not run: ${report.error.code ?? 'unknown error'}.`,
+      report.error.summary ?? report.error.detail ?? ''
+    );
+  }
+  // Both keys are present on every successful `npm audit --json`, including a clean
+  // tree (where `vulnerabilities` is an empty object). Absence means "did not run".
+  if (typeof report.vulnerabilities !== 'object' || report.vulnerabilities === null) {
+    fatal('npm audit returned no `vulnerabilities` map — treating as "did not run".');
+  }
+  if (typeof report.metadata !== 'object' || report.metadata === null) {
+    fatal('npm audit returned no `metadata` block — treating as "did not run".');
+  }
+  return report;
+}
+
+function fatal(message, detail = '') {
+  console.error(`✖ ${message}`);
+  if (detail) console.error(`  ${String(detail).trim().split('\n').join('\n  ')}`);
+  console.error(
+    '\naudit-gate: FAILED (could not verify the dependency tree).\n' +
+      'This is deliberate — a gate that cannot run must not report success. ' +
+      'Fix the underlying npm error and re-run.'
+  );
+  process.exit(1);
+}
+
+const report = parseReport(runAudit());
+const vulnerabilities = report.vulnerabilities;
 
 // Collect root advisories: a `via` entry that is an object is an advisory itself,
 // whereas a string entry only names a dependent that inherits one.

--- a/scripts/audit-packlist.mjs
+++ b/scripts/audit-packlist.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Published-tarball content guard.
+ *
+ * Publishing is the one step that cannot be taken back — an accidentally shipped
+ * `.env`, a local `.openlore/` index, or an SSH key is public the moment `npm
+ * publish` returns, and unpublishing is heavily restricted.
+ *
+ * `package.json` `files` is an allowlist, so this is not a likely accident today.
+ * It is a *cheap* one though: widening `files` (adding a directory, or a broad glob
+ * like `src`) is a one-line diff that looks harmless in review and silently changes
+ * what ships. This asserts against the real `npm pack` manifest, so it sees exactly
+ * what npm would upload — including anything pulled in by `files`, `main`, `bin`,
+ * or npm's always-included set.
+ *
+ * Checks both directions: nothing forbidden ships, AND the entrypoints do. A `files`
+ * typo that silently publishes a package with no `dist/` is also a broken release.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/** Anything matching these must never ship. */
+const FORBIDDEN = [
+  { pattern: /(^|\/)\.env($|\.|\/)/i, why: 'environment file — may contain provider API keys' },
+  { pattern: /(^|\/)\.openlore\//i, why: 'local analysis index — contains absolute paths from the author machine' },
+  { pattern: /(^|\/)\.git\//i, why: 'git internals' },
+  { pattern: /(^|\/)node_modules\//i, why: 'vendored dependency tree' },
+  { pattern: /(^|\/)\.npmrc$/i, why: 'npm config — may contain a registry auth token' },
+  { pattern: /(^|\/)(id_rsa|id_ed25519|.*\.pem|.*\.p12|.*\.pfx|.*\.key)$/i, why: 'private key material' },
+  { pattern: /(^|\/)\.aws\//i, why: 'cloud credentials' },
+  { pattern: /(^|\/)\.ssh\//i, why: 'SSH material' },
+  // Scoped to the package's OWN code. `examples/` is deliberately exempt: those
+  // directories are self-contained sample repositories (drift-demo, the opencode
+  // plugins) whose test files are part of the corpus the demos analyze — shipping
+  // them is the point, not a leak.
+  { pattern: /^(dist|src)\/.*\.test\.(ts|js|mjs|cjs|tsx|jsx)$/i, why: "the package's own test file — excluded by the files allowlist; presence means the allowlist widened" },
+  { pattern: /(^|\/)coverage\//i, why: 'coverage report' },
+  { pattern: /(^|\/)\.claude\//i, why: 'local agent configuration' },
+];
+
+/** Must be present, or the published package is broken. */
+const REQUIRED = [
+  'package.json',
+  'README.md',
+  'LICENSE',
+  'dist/cli/index.js', // the `openlore` bin
+  'dist/api/index.js', // the library entrypoint
+  'scripts/postinstall.mjs', // referenced by the postinstall lifecycle script
+];
+
+function packManifest() {
+  // --dry-run so nothing is written; --json gives the exact file list npm would ship.
+  const raw = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    encoding: 'utf-8',
+    maxBuffer: 64 * 1024 * 1024,
+    // npm prints the human-readable tarball summary to stderr; keep it out of stdout.
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  const parsed = JSON.parse(raw);
+  const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!entry?.files) throw new Error('npm pack --json returned no file list');
+  return entry.files.map(f => f.path.replace(/\\/g, '/'));
+}
+
+const files = packManifest();
+
+const violations = [];
+for (const file of files) {
+  for (const { pattern, why } of FORBIDDEN) {
+    if (pattern.test(file)) violations.push({ file, why });
+  }
+}
+
+const missing = REQUIRED.filter(req => !files.includes(req));
+
+console.log(`packlist: ${files.length} files would be published.`);
+
+for (const { file, why } of violations) {
+  console.error(`✖ FORBIDDEN  ${file}\n             ${why}`);
+}
+for (const req of missing) {
+  console.error(`✖ MISSING    ${req}\n             required entrypoint absent — check the "files" allowlist and that the build ran`);
+}
+
+if (violations.length || missing.length) {
+  console.error(
+    `\naudit-packlist: FAILED (${violations.length} forbidden, ${missing.length} missing)\n` +
+      `Adjust "files" in package.json, or update the lists in scripts/audit-packlist.mjs if the change is intended.`
+  );
+  process.exit(1);
+}
+
+console.log('audit-packlist: OK — nothing forbidden, all entrypoints present.');

--- a/scripts/audit-packlist.mjs
+++ b/scripts/audit-packlist.mjs
@@ -29,11 +29,15 @@ const FORBIDDEN = [
   { pattern: /(^|\/)(id_rsa|id_ed25519|.*\.pem|.*\.p12|.*\.pfx|.*\.key)$/i, why: 'private key material' },
   { pattern: /(^|\/)\.aws\//i, why: 'cloud credentials' },
   { pattern: /(^|\/)\.ssh\//i, why: 'SSH material' },
-  // Scoped to the package's OWN code. `examples/` is deliberately exempt: those
-  // directories are self-contained sample repositories (drift-demo, the opencode
-  // plugins) whose test files are part of the corpus the demos analyze — shipping
-  // them is the point, not a leak.
-  { pattern: /^(dist|src)\/.*\.test\.(ts|js|mjs|cjs|tsx|jsx)$/i, why: "the package's own test file — excluded by the files allowlist; presence means the allowlist widened" },
+  // Any test file OUTSIDE `examples/`. The exemption is deliberate and narrow:
+  // `examples/` holds self-contained sample repositories (drift-demo, the opencode
+  // plugins) whose test files are part of the corpus the demos analyze, so shipping
+  // those is the point. Everywhere else — dist, src, stubs, schemas, skills, scripts —
+  // a test file means the allowlist widened.
+  {
+    pattern: /^(?!examples\/).*\.test\.(ts|js|mjs|cjs|tsx|jsx)$/i,
+    why: "the package's own test file — excluded by the files allowlist; presence means the allowlist widened",
+  },
   { pattern: /(^|\/)coverage\//i, why: 'coverage report' },
   { pattern: /(^|\/)\.claude\//i, why: 'local agent configuration' },
 ];
@@ -48,17 +52,43 @@ const REQUIRED = [
   'scripts/postinstall.mjs', // referenced by the postinstall lifecycle script
 ];
 
+/**
+ * Fails CLOSED, like the audit gate: if the manifest cannot be produced or does not
+ * contain a file list, that is reported as "could not verify" rather than passing on
+ * an empty list. A check that cannot run must not report success.
+ */
+function fatal(message, detail = '') {
+  console.error(`✖ ${message}`);
+  if (detail) console.error(`  ${String(detail).trim().split('\n').slice(0, 6).join('\n  ')}`);
+  console.error('\naudit-packlist: FAILED (could not verify the published file list).');
+  process.exit(1);
+}
+
 function packManifest() {
-  // --dry-run so nothing is written; --json gives the exact file list npm would ship.
-  const raw = execFileSync('npm', ['pack', '--dry-run', '--json'], {
-    encoding: 'utf-8',
-    maxBuffer: 64 * 1024 * 1024,
-    // npm prints the human-readable tarball summary to stderr; keep it out of stdout.
-    stdio: ['ignore', 'pipe', 'ignore'],
-  });
-  const parsed = JSON.parse(raw);
+  let raw;
+  try {
+    // --dry-run so nothing is written; --json gives the exact file list npm would ship.
+    raw = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024,
+      // npm prints the human-readable tarball summary to stderr; keep it out of stdout.
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    fatal('`npm pack --dry-run --json` failed.', err.stderr || err.message);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    fatal('`npm pack --json` did not return JSON.', raw.slice(0, 400));
+  }
+
   const entry = Array.isArray(parsed) ? parsed[0] : parsed;
-  if (!entry?.files) throw new Error('npm pack --json returned no file list');
+  if (!Array.isArray(entry?.files) || entry.files.length === 0) {
+    fatal('`npm pack --json` returned no file list — treating as "did not run".');
+  }
   return entry.files.map(f => f.path.replace(/\\/g, '/'));
 }
 

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -130,13 +130,20 @@ describe('workflow security: no shell injection via run:', () => {
       // `run: |` opens one, and it ends at the first line indented no deeper than the
       // `run:` key itself. Parsing the YAML instead would lose the line numbers that
       // make a failure actionable.
+      //
+      // The column that matters is where the `run` KEY starts, not where the line's
+      // whitespace ends. In the list-item form (`- run: |`) the `- ` shifts the key
+      // right, and sibling keys of that step (`env:`, `shell:`) align with the key
+      // rather than with the dash. Measuring from the dash would put those siblings
+      // "inside" the block and flag `env: ${{ ... }}` — the very pattern this guard
+      // exists to encourage.
       let runIndent: number | null = null;
 
       lines.forEach((line, i) => {
-        const runMatch = line.match(/^(\s*)(?:-\s+)?run:\s*(.*)$/);
+        const runMatch = line.match(/^(\s*)(-\s+)?run:\s*(.*)$/);
         if (runMatch) {
-          const indent = runMatch[1].length;
-          const inline = runMatch[2];
+          const indent = runMatch[1].length + (runMatch[2]?.length ?? 0);
+          const inline = runMatch[3];
           // Single-line `run: cmd` — check it right here, no block to track.
           if (inline && !/^[|>]/.test(inline.trim())) {
             for (const expr of inline.matchAll(/\$\{\{\s*([^}]+?)\s*\}\}/g)) {

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -1,0 +1,248 @@
+/**
+ * CI/CD workflow hardening guards.
+ *
+ * The hardening in `.github/` is configuration, and configuration decays: a new
+ * workflow gets copied from a blog post with `@v4` and no `permissions:` block, a
+ * `${{ }}` gets inlined into a `run:` script because it reads more naturally, a SHA
+ * pin loses its version comment and becomes un-reviewable. None of that fails a
+ * build, and none of it shows up in a diff as obviously wrong.
+ *
+ * These guards follow the same discipline as `doc-claim-sync.test.ts`: bind the
+ * published posture to a check, so weakening it requires editing this file in the
+ * same reviewed change.
+ *
+ * Guarded:
+ *   1. Third-party actions are pinned to a full commit SHA (a tag is a moving pointer).
+ *   2. Each pin carries a `# vX.Y.Z` comment, so a human can tell what a SHA is.
+ *   3. `run:` scripts take untrusted values through `env:`, never inline `${{ }}`.
+ *   4. Every executed workflow declares a top-level `permissions` block.
+ *   5. Every job declares its own `permissions` block.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { parse } from 'yaml';
+
+// src/<this> → repo root is one level up.
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW_DIR = join(REPO_ROOT, '.github', 'workflows');
+
+const read = (abs: string) => readFileSync(abs, 'utf-8');
+
+/**
+ * Executed workflows only. `*.yml.example` is documentation a user copies — pinning
+ * SHAs there would create pins that go stale silently, because Dependabot does not
+ * scan `.example` files. Teaching the pattern is the example's job; being correct
+ * right now is these files' job.
+ */
+const workflowFiles = readdirSync(WORKFLOW_DIR)
+  .filter(f => f.endsWith('.yml') || f.endsWith('.yaml'))
+  .sort();
+
+/** Composite actions live outside `workflows/` and cannot declare `permissions`. */
+const COMPOSITE_ACTIONS = [join(REPO_ROOT, '.github', 'actions', 'openlore-review', 'action.yml')];
+
+const ALL_ACTION_FILES = [...workflowFiles.map(f => join(WORKFLOW_DIR, f)), ...COMPOSITE_ACTIONS];
+
+const rel = (abs: string) => abs.slice(REPO_ROOT.length + 1);
+
+/**
+ * The only expressions allowed to be interpolated directly into a `run:` script.
+ * `needs.<job>.result` is a closed enum produced by Actions itself
+ * ('success' | 'failure' | 'cancelled' | 'skipped') — it cannot carry an attacker's
+ * shell metacharacters. Everything else must arrive via `env:`, where quoting makes
+ * it inert data rather than program text.
+ */
+const SAFE_IN_RUN = [/^needs\.[A-Za-z0-9_-]+\.result$/];
+
+describe('workflow security: action pinning', () => {
+  it('pins every third-party action to a full commit SHA', () => {
+    const offenders: string[] = [];
+
+    for (const file of ALL_ACTION_FILES) {
+      const lines = read(file).split('\n');
+      lines.forEach((line, i) => {
+        const m = line.match(/^\s*(?:-\s+)?uses:\s*(\S+)/);
+        if (!m) return;
+        const ref = m[1].replace(/['"]/g, '');
+        // Local composite actions (`./.github/actions/...`) are this repo's own code,
+        // already governed by the commit under review.
+        if (ref.startsWith('./')) return;
+        const at = ref.lastIndexOf('@');
+        if (at === -1) {
+          offenders.push(`${rel(file)}:${i + 1} — no version ref at all: ${ref}`);
+          return;
+        }
+        const version = ref.slice(at + 1);
+        if (!/^[0-9a-f]{40}$/.test(version)) {
+          offenders.push(
+            `${rel(file)}:${i + 1} — pinned to the moving ref "${version}"; use a 40-char commit SHA`
+          );
+        }
+      });
+    }
+
+    expect(
+      offenders,
+      `Actions must be pinned to an immutable commit SHA. A tag can be re-pointed at new code by ` +
+        `whoever controls the action repo, and it then runs with this workflow's token.\n` +
+        `Resolve with: gh api repos/<owner>/<repo>/git/ref/tags/<tag> -q .object.sha\n\n` +
+        offenders.join('\n')
+    ).toEqual([]);
+  });
+
+  it('annotates every SHA pin with the human-readable version', () => {
+    const offenders: string[] = [];
+
+    for (const file of ALL_ACTION_FILES) {
+      const lines = read(file).split('\n');
+      lines.forEach((line, i) => {
+        const m = line.match(/^\s*(?:-\s+)?uses:\s*(\S+)/);
+        if (!m) return;
+        const ref = m[1].replace(/['"]/g, '');
+        if (ref.startsWith('./')) return;
+        if (!/@[0-9a-f]{40}$/.test(ref)) return; // pinning itself is the other test's job
+        // Expect a trailing `# vX.Y.Z` (what Dependabot writes and updates).
+        if (!/#\s*v?\d+\.\d+(\.\d+)?/.test(line)) {
+          offenders.push(`${rel(file)}:${i + 1} — SHA pin without a "# vX.Y.Z" comment`);
+        }
+      });
+    }
+
+    expect(
+      offenders,
+      `A bare SHA is unreviewable and unupgradable by hand. Keep the trailing version comment ` +
+        `(Dependabot maintains it):\n  uses: actions/checkout@<sha> # v6.1.0\n\n` + offenders.join('\n')
+    ).toEqual([]);
+  });
+});
+
+describe('workflow security: no shell injection via run:', () => {
+  it('passes untrusted values through env:, not inline ${{ }}', () => {
+    const offenders: string[] = [];
+
+    for (const file of ALL_ACTION_FILES) {
+      const text = read(file);
+      const lines = text.split('\n');
+
+      // Track whether the current line is inside a `run:` block by indentation: a
+      // `run: |` opens one, and it ends at the first line indented no deeper than the
+      // `run:` key itself. Parsing the YAML instead would lose the line numbers that
+      // make a failure actionable.
+      let runIndent: number | null = null;
+
+      lines.forEach((line, i) => {
+        const runMatch = line.match(/^(\s*)(?:-\s+)?run:\s*(.*)$/);
+        if (runMatch) {
+          const indent = runMatch[1].length;
+          const inline = runMatch[2];
+          // Single-line `run: cmd` — check it right here, no block to track.
+          if (inline && !/^[|>]/.test(inline.trim())) {
+            for (const expr of inline.matchAll(/\$\{\{\s*([^}]+?)\s*\}\}/g)) {
+              const body = expr[1].trim();
+              if (!SAFE_IN_RUN.some(re => re.test(body))) {
+                offenders.push(`${rel(file)}:${i + 1} — inline \${{ ${body} }} in a run: command`);
+              }
+            }
+            runIndent = null;
+            return;
+          }
+          runIndent = indent;
+          return;
+        }
+
+        if (runIndent === null) return;
+        if (line.trim() === '') return;
+        const indent = line.match(/^(\s*)/)![1].length;
+        if (indent <= runIndent) {
+          runIndent = null; // block ended
+          return;
+        }
+        for (const expr of line.matchAll(/\$\{\{\s*([^}]+?)\s*\}\}/g)) {
+          const body = expr[1].trim();
+          if (!SAFE_IN_RUN.some(re => re.test(body))) {
+            offenders.push(`${rel(file)}:${i + 1} — inline \${{ ${body} }} inside a run: block`);
+          }
+        }
+      });
+    }
+
+    expect(
+      offenders,
+      `Actions expressions are substituted into the script TEXT before bash parses it, so an ` +
+        `inline \${{ }} is program, not an argument — a shell metacharacter in the value is ` +
+        `executed rather than compared.\n` +
+        `Pass it via env: and quote it instead:\n` +
+        `    env:\n      MY_VALUE: \${{ inputs.thing }}\n    run: echo "$MY_VALUE"\n\n` +
+        offenders.join('\n')
+    ).toEqual([]);
+  });
+});
+
+describe('workflow security: least-privilege tokens', () => {
+  it('declares a top-level permissions block in every workflow', () => {
+    const offenders: string[] = [];
+
+    for (const name of workflowFiles) {
+      const doc = parse(read(join(WORKFLOW_DIR, name))) as Record<string, unknown> | null;
+      if (!doc || doc.permissions === undefined) {
+        offenders.push(`.github/workflows/${name} — no top-level "permissions:"`);
+      }
+    }
+
+    expect(
+      offenders,
+      `Without an explicit block, a workflow inherits the repo-wide default token scope — a ` +
+        `setting that lives outside this file and can be widened without touching it. State the ` +
+        `floor in the workflow (usually "permissions:\\n  contents: read").\n\n` + offenders.join('\n')
+    ).toEqual([]);
+  });
+
+  it('declares permissions on every job', () => {
+    const offenders: string[] = [];
+
+    for (const name of workflowFiles) {
+      const doc = parse(read(join(WORKFLOW_DIR, name))) as { jobs?: Record<string, unknown> } | null;
+      const jobs = doc?.jobs ?? {};
+      for (const [jobName, job] of Object.entries(jobs)) {
+        const j = job as Record<string, unknown> | null;
+        if (!j || j.permissions === undefined) {
+          offenders.push(`.github/workflows/${name} → job "${jobName}" — no "permissions:"`);
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `Each job should state the scope it needs, so widening one job (e.g. adding ` +
+        `"contents: write" to publish a release) is visible in review and does not silently ` +
+        `apply to the others.\n\n` + offenders.join('\n')
+    ).toEqual([]);
+  });
+});
+
+describe('workflow security: supply-chain automation is wired', () => {
+  it('keeps Dependabot watching both npm and github-actions', () => {
+    const cfg = parse(read(join(REPO_ROOT, '.github', 'dependabot.yml'))) as {
+      updates?: { 'package-ecosystem'?: string }[];
+    };
+    const ecosystems = (cfg.updates ?? []).map(u => u['package-ecosystem']);
+
+    // The github-actions entry is what keeps SHA pins from freezing on a stale,
+    // eventually-vulnerable version — pinning without an upgrade path is its own risk.
+    expect(ecosystems, 'dependabot.yml must cover npm and github-actions').toEqual(
+      expect.arrayContaining(['npm', 'github-actions'])
+    );
+  });
+
+  it('runs CodeQL on pull requests and on a schedule', () => {
+    const wf = parse(read(join(WORKFLOW_DIR, 'codeql.yml'))) as { on?: Record<string, unknown> };
+    // `parse` turns the YAML key `on` into the string key 'on' (not boolean true) for
+    // YAML 1.2, which is what the `yaml` package implements.
+    const triggers = wf.on ?? {};
+    expect(Object.keys(triggers), 'CodeQL needs both a PR trigger and a schedule').toEqual(
+      expect.arrayContaining(['pull_request', 'schedule'])
+    );
+  });
+});


### PR DESCRIPTION
## Status

LGTM. Dependency updates plus CI configuration — no change to how OpenLore behaves. All 7 checks green.

## Dependency updates

Closes the open advisories. Most were already handled by #263 and #266; these four needed a manual `overrides` entry:

| Package | Was | Now |
|---|---|---|
| `sharp` | 0.34.5 | 0.35.3 |
| `@hono/node-server` | 2.0.x | 2.0.11 |
| `protobufjs` (two paths) | 7.6.4 | 7.6.5 |

Each stays within its current major, so nothing downstream changes.

## New automated checks

So this kind of drift gets caught instead of accumulating:

- **CodeQL** on every PR and weekly — analyzes both the TypeScript and the workflow files. Comes back clean.
- **Dependabot** for npm packages and GitHub Actions.
- **OpenSSF Scorecard** weekly.
- **Dependency gate** (`npm run audit:gate`) over the full tree at high severity. Anything without an available fix is listed explicitly with a reason, and the gate fails if such an entry goes obsolete — so the list can't drift.
- **Package contents check** (`npm run audit:packlist`) in CI and again before publish, verified against the real `npm pack` manifest. It caught a test file that was shipping to npm; now excluded.

Both checks fail closed: if they can't run, they report failure rather than success.

## Workflow hardening

Actions are pinned to commit SHAs instead of moving tags, each workflow and job declares the token scope it needs, and values are passed into shell steps as environment variables rather than inline expressions. `src/workflow-security.test.ts` keeps that in place — it fails CI if an action loses its pin or a workflow drops its permissions block.

## Proof

```
Dependency advisories:  17 (4 moderate, 13 high)  →  1, no fix available upstream
CodeQL:                 not running               →  clean, 0 findings (both analyzers)
Test suite:             319 files / 6,120 tests   →  320 / 6,127
```

`npm run build` clean, `eslint src` clean, every workflow file parses. Each new guard was checked by introducing the problem it's meant to catch and confirming it fails — not just that it passes today.

## Notes

**One advisory has no upstream fix** and is listed as a documented exception: GHSA-mh99 affects `brace-expansion` 1.x, reached only through `eslint`. Its only patch is on the 5.x line, which changed its export shape in a way that breaks 1.x callers, so upgrading would break linting. Development-only, not part of the published package, and it clears when `eslint` updates its own dependency.

**`sharp` 0.35 is a deliberate cross-minor bump** past what `@huggingface/transformers` requests, because the fix only exists in 0.35. The native binary loads and the embedding tests pass — worth a look, as it's the one update here with real compatibility risk.

**Dependency `overrides` apply to this repository's install tree** — they cover CI and builds from source, and don't change what a consumer resolves from `npm install openlore`.

**Scorecard runs on `main` only**, so its first run happens after this merges. `workflow_dispatch` is wired for triggering it manually.
