### PR TITLE
perf(analyzer): run Pass-1 extraction on a worker pool, byte-identically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,14 @@ jobs:
         # diff, and this checks the real `npm pack` manifest rather than the intent.
         run: npm run audit:packlist
 
+      # The Pass-1 extraction worker is loaded by runtime path resolution, and under vitest
+      # the .ts entry is always the one resolved — so the COMPILED entry that the npm package
+      # actually ships is exercised by no other job. A compile or packaging regression there
+      # degrades every installed user to the serial lane silently, so it is checked here,
+      # where dist/ exists (change: optimize-parallel-extraction-pool).
+      - name: Verify the compiled extraction worker
+        run: npx vitest run src/core/analyzer/extraction-pool-threads.test.ts
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@
 | `OPENLORE_NO_AUTO_ANALYZE` | -- | Disable the MCP server's cold-start self-bootstrap (no background index build on first run) |
 | `OPENLORE_NO_UPDATE_NOTIFIER` | -- | Silence the passive "update available" banner (`NO_UPDATE_NOTIFIER` is also honored) |
 | `OPENLORE_SKIP_POSTINSTALL` | -- | Suppress the post-install next-step hint |
+| `OPENLORE_NO_WORKERS` | `analyze` | Run per-file extraction on a single thread instead of the worker pool. Both lanes produce byte-identical analysis output, so this only costs wall-clock — set it to isolate a worker-related problem, or in an environment where extra threads are unwelcome |
 
 > The `EMBED_*` variables configure the **remote** embedding provider only. For on-device embeddings with no endpoint or key, run `openlore embed --local` (or set `embedding.provider: "local"` in `.openlore/config.json`). Keyword (BM25) search is the first-class default and needs none of these. See [docs/semantic-search.md](semantic-search.md#retrieval-modes) for the full embedding/retrieval-mode reference.
 

--- a/openspec/changes/COMPETITIVE-SUBSTRATE-2026-07.md
+++ b/openspec/changes/COMPETITIVE-SUBSTRATE-2026-07.md
@@ -1,0 +1,68 @@
+# Change set: competitive substrate sweep 2026-07 — faster than the field, more useful than the graph
+
+This directory gained 6 change proposals on 2026-07-23, produced by a three-track research sweep
+of the code-intelligence-for-agents field (the current graph-index entrants, the fast-indexing
+engineering literature, and the published evidence on what actually improves agent success),
+diffed against the existing 141-proposal backlog so every item here is net-new whitespace. Per
+project policy, no competing product is named in any proposal; concepts are credited to the
+field or to academic sources.
+
+## What the research established
+
+**Positioning is validated.** Every breakout tool of 2025–26 in this category is local-first
+with embedded storage over MCP; the server-dependent graph-DB tools stalled on ops friction, and
+one team's own tracker records regretting a move OFF an embedded SQLite store. Conclusion-shaped
+one-call answers are the convergent adoption winner (published measurement: agents underuse
+graph tools that demand query formulation and fall back to grep — https://arxiv.org/pdf/2602.20048),
+which is OpenLore's shipped doctrine. Nobody else has symbol-anchored self-invalidating memory,
+spec drift, governance findings, or honest-boundary disclosure — the governance face is
+uncontested.
+
+**The speed bar is set by three mechanisms** the field converged on, all absent here:
+content-hash-keyed per-file memoization (re-index cost proportional to the diff), parallel
+per-file parsing, and resolve-at-index-time serving (queries as lookups, not per-call
+traversals). The evidence-backed usefulness gaps are span-level localization (agents hit the
+right file 60–70% of the time but the right lines only 14–19%; evidence-per-token correlates
+r≈0.95 with repair success — https://arxiv.org/html/2606.07297v1) and deterministic per-edit
+verification loops (+21–32 pt correctness in feedback-loop studies —
+https://arxiv.org/html/2504.06939v2).
+
+## The six proposals
+
+| # | Change | Track | One line |
+|---|--------|-------|----------|
+| 1 | `optimize-parallel-extraction-pool` | speed | Pass 1 parses serially on one core (`call-graph.ts:3979-4034`, zero workers repo-wide); a worker pool with input-order merge ≈ core-count× on the dominant phase, byte-identical output |
+| 2 | `optimize-hash-keyed-analyze` | speed | Batch analyze is skip-all or re-parse-all (`analyze.ts:411-412`); `file_hashes` exists but only the watcher reads it — per-file fact memoization makes analyze O(diff) |
+| 3 | `optimize-reachability-precompute` | speed | Every flagship conclusion re-runs BFS over per-call-built adjacency (no condensation/topo/closure exists); precompute at analyze, serve as lookups |
+| 4 | `add-span-precise-conclusions` | usefulness | The line-precise substrate (call-site lines, def-use lines) is persisted and then dropped at the conclusion boundary; surface it + a `focus` slice on `get_function_body` |
+| 5 | `add-edit-loop-breakage-verdict` | usefulness | The watcher knows about breakage at patch time and says nothing; derive a provable-only per-edit verdict (broken refs, arity, imports, reaching tests), hook-deliverable, advisory |
+| 6 | `refine-first-run-partial-serving` | onboarding | First build serves "no index found" for minutes despite significance-ordered (hubs-first) processing; flush partials + completeness receipt, extend the stale-serving contract to absent |
+
+## How they compose
+
+1+2 multiply (parallelize only the diff); 3 is the serving-side floor that keeps 5 sub-second at
+scale; 4 and 5 are the two evidence-ranked usefulness levers (localization depth, verification
+loop); 6 converts 1+2's speed into the first-contact experience. Cross-references to the
+existing backlog are named inside each proposal (`optimize-analyze-pipeline-passes`,
+`optimize-serving-hot-path-caches`, `optimize-incremental-and-coldstart-scale`,
+`add-incremental-early-cutoff`, `add-symbol-content-hashes`, `add-agent-loop-enforcement-hook`,
+`refine-orient-context-budgeting`) — none is re-proposed.
+
+## What was considered and deliberately not proposed
+
+- **Trigram/sparse-ngram literal index** — the literal-text line index shipped
+  (`text-line-index.ts`) covers the need at current scale; a posting-list sidecar is the
+  monorepo-era follow-up, not now.
+- **Reachability interval labeling (GRAIL/FERRARI class)** — condensation walks suffice below
+  hundreds of thousands of nodes; labeling adds an invalidation liability (noted as an explicit
+  non-goal in proposal 3).
+- **LLM-summarized "purpose" embeddings** — the one LLM-at-index-time idea with field evidence,
+  but it breaks no-LLM-in-the-hot-path determinism; the lexical equivalent (identifier-aware
+  BM25 + symbol boosts) already shipped.
+- **Auto-generated context-digest expansion** — published factorial evidence says LLM-generated
+  always-injected digests REDUCE agent success at higher cost (https://arxiv.org/pdf/2605.10039);
+  the existing `adopt-agent-context-interop` proposal already owns the corrective.
+- **Compiler/typecheck in the edit loop** — owned by the opt-in `add-lsp-evidence-tier`;
+  proposal 5 stays deterministic-provable-only by design.
+
+Baseline: main @ b1b9023 (v2.1.6), 141 pre-existing changes in this directory.

--- a/openspec/changes/optimize-parallel-extraction-pool/proposal.md
+++ b/openspec/changes/optimize-parallel-extraction-pool/proposal.md
@@ -1,0 +1,86 @@
+# Pass 1 parses the whole corpus on one core while the other N−1 sit idle
+
+> Status: PROPOSED (2026-07-23, competitive substrate sweep). The dominant cost of `openlore
+> analyze` — per-file tree-sitter parsing and fact extraction — runs as a strictly serial,
+> synchronous loop on the main thread. Parsing is embarrassingly parallel per file (no file's
+> extraction reads another file's state), so an M-core machine leaves roughly (M−1)/M of the
+> available parse throughput unused. Prior art: every fast indexer in the current
+> code-intelligence field parallelizes the parse phase across cores; tree-sitter-based analyzers
+> report ~1M LOC in under 10s when parallelized. Deterministic output is non-negotiable and is
+> guarded by the existing analyze-twice byte-diff oracle (change
+> `fix-artifact-output-determinism`).
+
+## The gap
+
+- **Pass 1 is a serial `for…of` with `await` per file.** `CallGraphBuilder.build` iterates
+  `for (const file of files)` and awaits `dispatchFileExtract(file)` one file at a time
+  (`src/core/analyzer/call-graph.ts:3979-4034`); `dispatchFileExtract` (`:4827-4843`) routes to
+  per-language extractors whose parse is synchronous CPU work —
+  `const tree = (parser as Parser).parse(content)` (`:616`, `:801`, `:955`, `:1047`, `:1158`,
+  `:1364`, `:1495`, `:1630`, `:1790`, `:1854`). The `async` wrapper yields only at grammar
+  `import()`, never during parsing.
+- **No worker exists anywhere in the pipeline.** A repo-wide search for `new Worker` /
+  `workerData` / `parentPort` in non-test source finds nothing; the only `worker_threads`
+  mention is a string in the Node-builtin import classifier
+  (`src/core/analyzer/import-parser.ts:89`, `:99`).
+- **Parsers are process-global singletons** (`call-graph.ts:139-151`, grammar cache `:1761`),
+  consistent with — and currently requiring — the single-threaded loop.
+- **The per-file output is already plain data.** Extraction returns serializable facts —
+  `FunctionNode`/`RawEdge` (`src/core/analyzer/call-graph-types.ts:47-55`, `:81-83`) and the
+  CFG overlay is explicitly "pure data, no AST nodes retained"
+  (`src/core/analyzer/cfg.ts:66-76`) — so results cross a worker boundary without any tree
+  marshalling.
+
+## What changes
+
+1. **A worker-pool lane for Pass 1.** A fixed-size pool of `worker_threads` (size
+   `min(availableParallelism − 1, EXTRACTION_POOL_MAX)`) receives the build's own **file records**
+   — path, language, and the content the build was handed. Each worker holds its own per-language
+   parser singletons (the module-level cache is per-thread for free), parses, extracts, and
+   returns the plain fact objects. The Lua/Dart WASM grammars (`call-graph.ts:2095`, `:2167`) load
+   per-worker with the same isolated-module discipline already required on the main thread
+   (`:1828-1835`).
+
+   > Revised during implementation: this originally said workers would receive paths and read
+   > their own files. That is wrong for correctness, not just for I/O — `build`'s input content is
+   > authoritative and is not always what is on disk (HTML pages arrive inline-script-blanked at
+   > `artifact-generator.ts:1288`, the incremental path passes in-memory content, and test builds
+   > pass synthetic files with no on-disk twin). Sending content keeps the two lanes provably
+   > identical.
+2. **Deterministic merge.** Results are assembled strictly in input order (the
+   significance-sorted order `RepositoryMapper` already produces,
+   `src/core/analyzer/repository-mapper.ts:780`, `:828`) regardless of completion order, so
+   Pass 2+ sees byte-identical input to the serial path. The acceptance oracle is
+   pool-vs-serial artifact byte-equality, reusing the analyze-twice byte-diff technique.
+3. **Fail-soft, never fail-different.** A worker crash re-runs that file on the main-thread
+   serial path; an environment where workers cannot start (or `OPENLORE_NO_WORKERS=1`) falls
+   back to today's serial loop wholesale, disclosed in the analyze summary. Parse-health
+   accounting is identical in both lanes.
+4. **Pass 1 only.** Global passes (resolution, synthesis, communities — `call-graph.ts:4036`
+   onward) stay single-threaded; they are cross-file and not the dominant cost (their pass-count
+   reduction is the sibling `optimize-analyze-pipeline-passes`).
+
+**Deliberately NOT borrowed** from the parallel-indexer field: no work-stealing scheduler, no
+shared-memory arena, no native-addon rewrite. A fixed pool with input-order merge captures the
+core speedup at a fraction of the complexity, and keeps the serial lane alive as the reference
+implementation (the rust-analyzer lesson: never let the cold path rot).
+
+## Why this is in scope
+
+Parse throughput is the substrate's admission price — every claim OpenLore makes ("re-orient
+after significant refactors", zero-interaction onboarding, the self-healing rebuild) is bounded
+below by how fast analyze runs. This is the largest single wall-clock lever available (near-M×
+on the dominant phase) with zero conclusion-shape impact and a mechanical determinism proof.
+
+## Impact
+
+- Files: `src/core/analyzer/call-graph.ts` (Pass 1 dispatch → pool lane, per-worker parser
+  cache), a new small worker module (worker entry: read → parse → extract → post facts),
+  `src/core/analyzer/artifact-generator.ts:1299-1300` (unchanged call site), `src/constants.ts`
+  (pool cap).
+- Specs: `analyzer` — 1 ADDED requirement (ExtractionPoolPreservesDeterministicOutput).
+- No new tool; no output change of any kind. Risk: medium — worker-boundary serialization bugs
+  and per-worker grammar state are the hazards; both are pinned by the byte-equality oracle and
+  a worker-crash fail-soft test. Coordinate with `optimize-hash-keyed-analyze` (the pool is the
+  re-extract lane for changed files) and `optimize-analyze-pipeline-passes` (tree reuse happens
+  inside a worker's own file scope, so the two compose).

--- a/openspec/changes/optimize-parallel-extraction-pool/specs/analyzer/spec.md
+++ b/openspec/changes/optimize-parallel-extraction-pool/specs/analyzer/spec.md
@@ -13,11 +13,23 @@ merged strictly in the input file order so every downstream pass receives input 
 serial path. The pooled path SHALL produce analysis artifacts byte-identical to the serial path for
 the same input. A worker failure SHALL fall back to serial extraction for the affected file(s), and
 an environment where workers cannot start SHALL fall back to the serial path wholesale — both
-disclosed in the analyze output, neither changing any extracted fact. Because the extractors report
-an unavailable grammar as an empty result rather than an error, a worker SHALL prove it can parse
-before it accepts work, and SHALL relay its grammar-unavailable warnings to the parent: an
-extraction lane that can produce nothing SHALL never be silently mistaken for files that contain
-nothing.
+disclosed in the analyze output, neither changing any extracted fact.
+
+Because the extractors report an unavailable grammar as an EMPTY result rather than an error, a
+worker's silence SHALL NOT be trusted until that worker has demonstrably extracted that language:
+an empty result for a language the worker has not yet produced facts for SHALL be re-checked on
+the serial path, and a case where the serial path then finds facts SHALL be disclosed as a lane
+defect. A worker SHALL additionally prove it can parse — in a language the build actually contains
+— before accepting work, and SHALL relay its grammar-unavailable warnings to the parent for
+deduplicated reporting. An extraction lane that can produce nothing SHALL never be mistaken for
+files that contain nothing.
+
+The lane SHALL bound its own cost and liveness: worker startup and each per-file request SHALL have
+deadlines after which the worker is retired and its file re-extracted on the serial path; worker
+count SHALL be bounded per PROCESS, not per build, so concurrent builds cannot multiply the resident
+worker set. Neither the pool nor the builder SHALL write to stdout — the same code path runs inside
+the stdio MCP server, whose stdout is the protocol channel — so lane disclosure SHALL be returned on
+the build result for the CLI to render.
 
 #### Scenario: Pooled and serial extraction are byte-identical
 
@@ -40,6 +52,23 @@ nothing.
 - **WHEN** the pool starts that worker
 - **THEN** the worker fails its startup parse probe and is dropped from the pool, and if no worker
   comes up healthy the whole pass falls back to the serial lane, disclosed
+
+#### Scenario: A worker that goes blind mid-run loses no symbols
+
+- **GIVEN** a worker that passed its startup probe but returns an empty result for a language it
+  has not yet extracted — the shape of a grammar that loaded on the main thread but not in that
+  thread
+- **WHEN** the pass completes
+- **THEN** those files were re-extracted on the serial path, the graph is identical to a fully
+  serial run, and the disagreement is disclosed as a lane defect rather than recorded as files
+  that contain no symbols
+
+#### Scenario: A worker that stops answering does not stall the run
+
+- **GIVEN** a worker that neither replies nor exits — during startup, or while holding a file
+- **WHEN** its deadline passes
+- **THEN** the worker is retired, its file is re-extracted on the serial path, and the run
+  completes
 
 #### Scenario: Parse health is lane-independent
 

--- a/openspec/changes/optimize-parallel-extraction-pool/specs/analyzer/spec.md
+++ b/openspec/changes/optimize-parallel-extraction-pool/specs/analyzer/spec.md
@@ -1,0 +1,49 @@
+# analyzer spec delta
+
+## ADDED Requirements
+
+### Requirement: ExtractionPoolPreservesDeterministicOutput
+
+The analyzer MAY execute Pass 1 per-file extraction on a fixed-size worker-thread pool. When it
+does, workers SHALL run the same per-file extractor the serial path runs, SHALL receive the build's
+own file records (path, language, and the content the build was given — never a re-read from disk,
+because the build's content is authoritative and is not always what is on disk), SHALL parse with
+per-worker parser instances, and SHALL return plain serializable fact objects; results SHALL be
+merged strictly in the input file order so every downstream pass receives input identical to the
+serial path. The pooled path SHALL produce analysis artifacts byte-identical to the serial path for
+the same input. A worker failure SHALL fall back to serial extraction for the affected file(s), and
+an environment where workers cannot start SHALL fall back to the serial path wholesale — both
+disclosed in the analyze output, neither changing any extracted fact. Because the extractors report
+an unavailable grammar as an empty result rather than an error, a worker SHALL prove it can parse
+before it accepts work, and SHALL relay its grammar-unavailable warnings to the parent: an
+extraction lane that can produce nothing SHALL never be silently mistaken for files that contain
+nothing.
+
+#### Scenario: Pooled and serial extraction are byte-identical
+
+- **GIVEN** a repository analyzed once with the worker pool enabled and once with
+  `OPENLORE_NO_WORKERS=1`
+- **WHEN** the two runs' analysis artifacts are compared
+- **THEN** every artifact is byte-identical, regardless of worker completion order
+
+#### Scenario: A worker crash never loses or alters a file's facts
+
+- **GIVEN** a worker that crashes while extracting one file
+- **WHEN** the analyze run completes
+- **THEN** the affected file was re-extracted on the serial path, its facts are identical to a
+  fully serial run, and the fallback is disclosed
+
+#### Scenario: A worker that cannot parse is dropped, not trusted
+
+- **GIVEN** a worker whose grammar bindings fail to load, so its extractor would return empty
+  results without throwing
+- **WHEN** the pool starts that worker
+- **THEN** the worker fails its startup parse probe and is dropped from the pool, and if no worker
+  comes up healthy the whole pass falls back to the serial lane, disclosed
+
+#### Scenario: Parse health is lane-independent
+
+- **GIVEN** a file whose grammar is unavailable or whose parse degrades
+- **WHEN** it is processed by a worker
+- **THEN** the parse-health accounting matches what the serial path would record for the same
+  file, and a grammar-unavailable warning is reported once for the run rather than once per worker

--- a/openspec/changes/optimize-parallel-extraction-pool/tasks.md
+++ b/openspec/changes/optimize-parallel-extraction-pool/tasks.md
@@ -34,7 +34,7 @@
 - [x] Serial path kept as the reference implementation — it is also the fallback executor, and the
       pool module contains no extraction logic at all
 
-## Hardening from adversarial review (two independent reviewers)
+## Hardening from adversarial review (three review passes)
 - [x] **Never trust an unproven silence.** The startup probe covers ONE grammar; the other ~20 load
       lazily and independently per thread, and an unavailable grammar returns EMPTY rather than
       throwing. So a worker's empty result is re-checked on the main thread until that worker has
@@ -62,6 +62,28 @@
       "workers that came up", not "workers still alive"; a note at the merge catch that only
       `error.message` survives the worker boundary
 
+### Round 3 (re-review of the hardened code)
+- [x] **The guard covered only half the hazard.** A per-language grammar load that fails inside a
+      worker does NOT return empty — `getPyParser` and friends do not wrap their `import`, so it
+      THROWS. That error was trusted unconditionally, which would have written `parseFailed` and
+      dropped every symbol for files the serial lane extracts fully — a graph that depends on which
+      lane ran, and on scheduling. An error from an unproven worker is now re-checked exactly like
+      an empty result; an error from a PROVEN worker is still a real per-file parse failure
+- [x] **`terminate()` was an unbounded await on all three release paths.** V8 can only interrupt a
+      thread at a JS boundary, so a thread wedged in a synchronous native call may never exit —
+      re-creating the hang the deadlines exist to prevent and stranding its process-budget slot
+      forever. The wait is now bounded and the slot is returned regardless
+- [x] **The lane disclosure was dead plumbing** — computed, carried on `AnalysisArtifacts`, and read
+      by nobody, so `laneDefectFiles` never reached a human. `openlore analyze` now renders it
+- [x] Sticky "workers do not work here" is set only for a DETERMINISTIC failure (every worker
+      refused to spawn or reported unhealthy), not for a startup timeout — a load spike must not
+      drop a long-lived daemon to the serial lane for good
+- [x] Two comments claimed a watcher opt-out that does not exist. Corrected to state what is true:
+      the watcher DOES use the pool (measured 516ms → 292ms on a 33-file subset rebuild), and what
+      bounds the daemon is the per-process worker cap, not the file-count floor
+- [x] `proven` now requires a defined, non-empty result, so `undefined` (a language with no
+      extractor) no longer marks a language proven
+
 ## Verification
 - [x] Byte-equality oracle: `openlore analyze` on a clean checkout of this repo, pooled and with
       `OPENLORE_NO_WORKERS=1` — every content artifact byte-identical (llm-context, repo-structure,
@@ -86,10 +108,19 @@
       deterministic answer, not a silence
 - [x] Protocol/budget tests: an off-protocol worker is retired instead of hanging the pass; the
       worker budget is shared across concurrent builds and returned when they finish
+- [x] Worker-error tests: a worker that THROWS for an unproven language has every file re-checked
+      and the defect disclosed; a worker that fails everything still yields a graph byte-identical
+      to serial with no invented `parseFailed` records; an error from a PROVEN worker is still
+      recorded as that file's parse failure
+- [x] Scheduling-independence test: across 12 runs at pool sizes 1-4 with randomized interleavings
+      over a mixed-language corpus, the re-check set genuinely VARIES (asserted) and the serialized
+      graph never does — the exact question the unproven-silence guard raises
 - [x] Shipped-entry test: `dist/core/analyzer/extraction-worker.js` — the file the npm package
       ships, which no other test loads because vitest always resolves the `.ts` entry — starts and
       reports ready (and says so loudly if the checkout is unbuilt, rather than passing quietly)
-- [x] Full suite green (321 files / 6146 tests), lint + typecheck clean
+- [x] MCP stdio purity: drove `openlore mcp` over stdio through a cold-start pooled build plus
+      an `orient` call — every stdout line a valid JSON-RPC frame, build noise on stderr
+- [x] Full suite green (321 files / 6150 tests), lint + typecheck clean
 
 ## Spec
 - [x] `analyzer` delta: ADD ExtractionPoolPreservesDeterministicOutput

--- a/openspec/changes/optimize-parallel-extraction-pool/tasks.md
+++ b/openspec/changes/optimize-parallel-extraction-pool/tasks.md
@@ -84,6 +84,28 @@
 - [x] `proven` now requires a defined, non-empty result, so `undefined` (a language with no
       extractor) no longer marks a language proven
 
+### Round 4 (convergence review — test honesty)
+- [x] The shipped-entry guard resolved a sibling `.js` tsc never emits, so it skipped silently in
+      a fully built checkout. Repointed at repo-root `dist/`, wired into the CI Build job, and
+      verified to fail on a corrupted compiled entry
+- [x] Deleted a test that asserted nothing about its own name: it injected a throwing extractor as
+      `serialExtract`, which a healthy stub worker never calls, so it would have passed with the
+      worker error path deleted outright. The behavior is covered by the proven-worker error test
+- [x] Probe-table guard: every snippet in `PROBES` is checked against the real extractor for a node
+      AND an edge. A snippet that quietly stops yielding both would disable the pool process-wide
+      with no failing test
+- [x] Deleted the write-only `worker` payload on the unfilled-slot record (and the generic it
+      forced); the disclosure now reports lane defects AND worker fallbacks when both occurred,
+      and says "reported no symbols" since the defect covers a throw as well as a silence
+- [x] Qualified the "byte-identical" comments: a worker thread's larger default stack means a
+      pathological deep-recursion parse can fail on one lane and not the other — a different FILE
+      failing to parse, disclosed through parse health either way, not a different reading of a
+      file that parsed
+- [ ] KNOWN LIMIT (not fixed here): the lane note is rendered by `openlore analyze` only, so a
+      lane defect during the daemon's cold-start or self-heal rebuild is not surfaced to a human.
+      Matches the spec as written; a counter on `parse-health.json` or `openlore status` would
+      close it
+
 ## Verification
 - [x] Byte-equality oracle: `openlore analyze` on a clean checkout of this repo, pooled and with
       `OPENLORE_NO_WORKERS=1` — every content artifact byte-identical (llm-context, repo-structure,
@@ -117,7 +139,10 @@
       graph never does — the exact question the unproven-silence guard raises
 - [x] Shipped-entry test: `dist/core/analyzer/extraction-worker.js` — the file the npm package
       ships, which no other test loads because vitest always resolves the `.ts` entry — starts and
-      reports ready (and says so loudly if the checkout is unbuilt, rather than passing quietly)
+      reports ready. CI runs it in the Build job, the only job where `dist/` exists. Verified it
+      FAILS on a deliberately corrupted compiled entry (the first version of this guard looked for
+      a sibling `.js` that tsc never emits, so it silently skipped in a built checkout — caught by
+      review, not by the suite)
 - [x] MCP stdio purity: drove `openlore mcp` over stdio through a cold-start pooled build plus
       an `orient` call — every stdout line a valid JSON-RPC frame, build noise on stderr
 - [x] Full suite green (321 files / 6150 tests), lint + typecheck clean

--- a/openspec/changes/optimize-parallel-extraction-pool/tasks.md
+++ b/openspec/changes/optimize-parallel-extraction-pool/tasks.md
@@ -1,8 +1,8 @@
 # Tasks — optimize-parallel-extraction-pool
 
-> Status: BUILT. Measured on this repo (macOS, 10 cores, pool size 8):
-> call-graph build **19.1s → 7.3s** (2.6×); full `openlore analyze --no-embed` **24.6s → 18.1s**.
-> Pass 1 was 14.3s of the 20.2s serial build (71%) before the change.
+> Status: BUILT + adversarially reviewed. Measured on this repo (macOS, 10 cores, pool size 8):
+> call-graph build **18.9s → 7.2s** (2.6×); full `openlore analyze --no-embed` **24.7s → 12.6s**
+> (2.0×). Pass 1 was 14.3s of the 20.2s serial build (71%) before the change.
 
 ## Implementation
 - [x] Worker entry module (`src/core/analyzer/extraction-worker.ts`): receives the build's file
@@ -34,6 +34,34 @@
 - [x] Serial path kept as the reference implementation — it is also the fallback executor, and the
       pool module contains no extraction logic at all
 
+## Hardening from adversarial review (two independent reviewers)
+- [x] **Never trust an unproven silence.** The startup probe covers ONE grammar; the other ~20 load
+      lazily and independently per thread, and an unavailable grammar returns EMPTY rather than
+      throwing. So a worker's empty result is re-checked on the main thread until that worker has
+      demonstrably extracted that language, and a disagreement is disclosed as a lane defect.
+      Measured cost on this repo: **0 re-checks** on a healthy run (a real parse of a
+      function-less file still yields style counters, so ordinary empty files are never mistaken
+      for silence)
+- [x] **Probe a language the build actually contains.** Every grammar is an optional dependency, so
+      probing TypeScript in a Python repo could disable the pool over a grammar that repo never
+      needed. The parent names the build's dominant language; a language with no probe snippet
+      skips the probe and relies on the per-language guard
+- [x] **No hang paths.** A reply whose id does not match the outstanding request retires the worker
+      (previously it was ignored, leaving the request armed forever); every per-file request has a
+      deadline; startup has one too, lowered to 10s since a healthy worker reports in well under a
+      second; a process that has proven workers cannot start remembers it instead of paying that
+      stall on every later build
+- [x] **Nothing writes to stdout.** `openlore mcp` speaks JSON-RPC over stdout and runs builds
+      in-process; a worker inherits no console patching. Workers now keep their stdout off the
+      parent's (drained, stderr still inherited), and the lane note is returned on the build result
+      for the CLI to render instead of being logged from the builder
+- [x] **Worker count is bounded per PROCESS, not per build.** The daemon runs builds concurrently
+      (a background self-heal rebuild alongside a tool-call build); each would otherwise plan a full
+      pool and double the resident isolate count. A build that finds the budget spent runs serial
+- [x] Worker handle registration moved inside the try that terminates it; `poolSize` documented as
+      "workers that came up", not "workers still alive"; a note at the merge catch that only
+      `error.message` survives the worker boundary
+
 ## Verification
 - [x] Byte-equality oracle: `openlore analyze` on a clean checkout of this repo, pooled and with
       `OPENLORE_NO_WORKERS=1` — every content artifact byte-identical (llm-context, repo-structure,
@@ -52,7 +80,16 @@
 - [x] Real-thread test: `worker_threads` workers spawn, probe, extract, and match serial byte for
       byte (`extraction-pool-threads.test.ts`)
 - [x] Wall-clock measured and reported above; no unmeasured speedup claims anywhere in docs
-- [x] Full suite green (321 files / 6137 tests), lint + typecheck clean
+- [x] Unproven-silence tests: a blind worker's graph is byte-identical to serial and its defect is
+      disclosed; an ordinary function-less file costs zero re-checks; a language with no style
+      counters is re-checked only until the worker proves it; a language with no extractor is a
+      deterministic answer, not a silence
+- [x] Protocol/budget tests: an off-protocol worker is retired instead of hanging the pass; the
+      worker budget is shared across concurrent builds and returned when they finish
+- [x] Shipped-entry test: `dist/core/analyzer/extraction-worker.js` — the file the npm package
+      ships, which no other test loads because vitest always resolves the `.ts` entry — starts and
+      reports ready (and says so loudly if the checkout is unbuilt, rather than passing quietly)
+- [x] Full suite green (321 files / 6146 tests), lint + typecheck clean
 
 ## Spec
 - [x] `analyzer` delta: ADD ExtractionPoolPreservesDeterministicOutput

--- a/openspec/changes/optimize-parallel-extraction-pool/tasks.md
+++ b/openspec/changes/optimize-parallel-extraction-pool/tasks.md
@@ -1,0 +1,58 @@
+# Tasks — optimize-parallel-extraction-pool
+
+> Status: BUILT. Measured on this repo (macOS, 10 cores, pool size 8):
+> call-graph build **19.1s → 7.3s** (2.6×); full `openlore analyze --no-embed` **24.6s → 18.1s**.
+> Pass 1 was 14.3s of the 20.2s serial build (71%) before the change.
+
+## Implementation
+- [x] Worker entry module (`src/core/analyzer/extraction-worker.ts`): receives the build's file
+      record and runs the SAME `dispatchFileExtract` the serial lane runs (per-worker parser
+      singletons come free from the per-thread module registry; the Lua/Dart WASM grammars keep
+      their isolated-module discipline per worker), then posts plain fact objects (nodes, raw
+      edges, CFG, style, parse-health)
+- [x] Deviation from the proposal, deliberate: workers receive the file's CONTENT, not just its
+      path. `build`'s input content is authoritative and is not always what is on disk — HTML
+      pages arrive inline-script-blanked, the incremental path passes in-memory content, and test
+      builds pass synthetic files — so a worker-side re-read would change facts, not just I/O
+- [x] Startup parse probe in the worker: the extractors return EMPTY (they do not throw) when a
+      grammar is unavailable, so a worker proves it can parse one known snippet before it accepts
+      work; an unhealthy worker is dropped rather than silently contributing nothing
+- [x] Worker→parent log relay: grammar-unavailable warnings are posted to the parent and deduped
+      there, so an unavailable language is disclosed once per run, not once per worker
+- [x] Pool lane in `CallGraphBuilder.build`: Pass 1 split into an EXTRACT step (pooled or serial)
+      and a MERGE step that walks `files` by index — completion order can never reach the graph
+- [x] Pool sizing constants in `src/constants.ts` (`EXTRACTION_POOL_MAX`,
+      `EXTRACTION_POOL_MIN_FILES`, `EXTRACTION_POOL_STARTUP_TIMEOUT_MS`); size =
+      `min(availableParallelism() - 1, EXTRACTION_POOL_MAX, fileCount)`; pool created once per
+      build, terminated after Pass 1
+- [x] Fail-soft ladder: per-file worker death → serial re-extract of that file on the main thread;
+      an extractor that THROWS inside a worker is recorded as that file's parse failure (identical
+      to the serial lane, no retry); no healthy worker / unresolvable worker entry /
+      `OPENLORE_NO_WORKERS=1` → wholesale serial; a worker that never reports ready is dropped on
+      a startup timeout instead of hanging analyze. Every degraded outcome is disclosed on the
+      build result (`CallGraphResult.extractionLane`) and warned in the analyze output
+- [x] Serial path kept as the reference implementation — it is also the fallback executor, and the
+      pool module contains no extraction logic at all
+
+## Verification
+- [x] Byte-equality oracle: `openlore analyze` on a clean checkout of this repo, pooled and with
+      `OPENLORE_NO_WORKERS=1` — every content artifact byte-identical (llm-context, repo-structure,
+      dependency-graph, style-fingerprint, parse-health, all inventories, CODEBASE/ARCHITECTURE).
+      The four artifacts that do differ (SUMMARY.md, fingerprint.json, refactor-priorities.json,
+      vector-index-meta.json) differ ONLY in a wall-clock timestamp, and differ identically
+      between two SAME-lane runs — pre-existing, not lane-dependent
+- [x] Order-independence test: a stub pool that answers later files FIRST (asserting the
+      completion order really was inverted) still yields a byte-identical serialized graph,
+      including the colliding-symbol case where merge order decides which node survives
+- [x] Worker-crash test: one worker dies mid-file, and separately all workers die — every file is
+      accounted for, facts identical to serial, fallback disclosed
+- [x] WASM-in-worker test: Lua and Dart fixtures interleaved with TypeScript extract identically
+      on real threads and on the main thread (asserted non-empty, so the comparison cannot pass by
+      both lanes finding nothing)
+- [x] Real-thread test: `worker_threads` workers spawn, probe, extract, and match serial byte for
+      byte (`extraction-pool-threads.test.ts`)
+- [x] Wall-clock measured and reported above; no unmeasured speedup claims anywhere in docs
+- [x] Full suite green (321 files / 6137 tests), lint + typecheck clean
+
+## Spec
+- [x] `analyzer` delta: ADD ExtractionPoolPreservesDeterministicOutput

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -202,6 +202,14 @@ export async function runAnalysis(
     envVars,
   });
 
+  // Disclose a degraded Pass-1 extraction lane (change: optimize-parallel-extraction-pool).
+  // The builder deliberately does not log this itself — the same code path runs inside the
+  // stdio MCP server, whose stdout carries JSON-RPC — so the CLI is where it surfaces.
+  // Present only when something actually degraded; a clean run says nothing.
+  if (artifacts.extractionLaneNote) {
+    logger.warning(artifacts.extractionLaneNote);
+  }
+
   // Carry anchored memory/decisions across any rename/move detected between the
   // snapshot and the freshly persisted graph. Deterministic, no LLM; a cheap no-op
   // when there are no anchored symbols or no prior snapshot. Never fails analysis.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -710,3 +710,36 @@ export const PAGERANK_CONVERGENCE_TOLERANCE = 1e-6;
 
 /** Hard cap on power-iteration passes — a termination bound, not a tuning weight. */
 export const PAGERANK_MAX_ITERATIONS = 100;
+
+// ============================================================================
+// PASS-1 EXTRACTION POOL
+// ============================================================================
+// Bounds for the worker-thread lane that runs per-file tree-sitter extraction
+// (change: optimize-parallel-extraction-pool). Pass 1 is embarrassingly parallel
+// per file; these are the only tuning knobs — everything else about the lane is a
+// determinism or fail-soft rule, not a weight.
+
+/**
+ * Hard ceiling on extraction worker threads, regardless of core count. Each worker
+ * holds its own tree-sitter parsers and grammar handles (native `.node` bindings
+ * plus, for Lua/Dart, an isolated web-tree-sitter WASM heap), so pool size is
+ * bounded by memory, not just cores. Beyond this the marginal parse throughput no
+ * longer pays for the resident grammar set.
+ */
+export const EXTRACTION_POOL_MAX = 8;
+
+/**
+ * Minimum Pass-1 file count before the pool is worth starting. Below this the worker
+ * spawn + module-load cost exceeds the parse work the pool would absorb, so small
+ * builds (including the single-file builds the watcher and tests perform) stay on the
+ * serial lane.
+ */
+export const EXTRACTION_POOL_MIN_FILES = 32;
+
+/**
+ * How long a freshly spawned extraction worker has to load its modules, pass its
+ * parse-health probe, and report ready. A worker that neither reports ready nor dies
+ * within this window (a hung module load or grammar dlopen) is dropped from the pool
+ * rather than allowed to stall analyze — a liveness bound, not a performance weight.
+ */
+export const EXTRACTION_POOL_STARTUP_TIMEOUT_MS = 30_000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -731,10 +731,13 @@ export const EXTRACTION_POOL_MAX = 8;
 /**
  * Minimum Pass-1 file count before the pool is worth starting. Below this the worker
  * spawn + module-load cost exceeds the parse work the pool would absorb, so small builds
- * stay on the serial lane. This is a cost heuristic only — it is NOT what keeps the
- * watcher off the pool. The watcher's per-save subset rebuild can exceed any such floor
- * (its closure budget alone is INCREMENTAL_CLOSURE_BUDGET files), so it opts out
- * explicitly instead of relying on this number.
+ * stay on the serial lane.
+ *
+ * This is a cost heuristic, not a safety boundary. The watcher's per-save subset rebuild can
+ * exceed it (its closure budget alone is INCREMENTAL_CLOSURE_BUDGET files) and so does use
+ * the pool — measured on this repo, a 33-file subset rebuild goes 516ms serial → 292ms
+ * pooled, so it is a win on the interactive path too. What bounds the daemon's exposure is
+ * EXTRACTION_POOL_MAX applied per PROCESS, not this floor.
  */
 export const EXTRACTION_POOL_MIN_FILES = 32;
 
@@ -757,3 +760,11 @@ export const EXTRACTION_POOL_STARTUP_TIMEOUT_MS = 10_000;
  * would wait on it forever while its siblings finish and the process looks idle.
  */
 export const EXTRACTION_POOL_REQUEST_TIMEOUT_MS = 120_000;
+
+/**
+ * How long to wait for a terminated extraction worker to actually exit before reclaiming its
+ * slot in the process budget anyway. V8 can only interrupt a thread at a JS boundary, so a
+ * thread wedged inside a synchronous native call may never exit; waiting forever would turn
+ * cleanup into the hang the other deadlines exist to prevent.
+ */
+export const EXTRACTION_POOL_TERMINATE_TIMEOUT_MS = 5_000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -730,16 +730,30 @@ export const EXTRACTION_POOL_MAX = 8;
 
 /**
  * Minimum Pass-1 file count before the pool is worth starting. Below this the worker
- * spawn + module-load cost exceeds the parse work the pool would absorb, so small
- * builds (including the single-file builds the watcher and tests perform) stay on the
- * serial lane.
+ * spawn + module-load cost exceeds the parse work the pool would absorb, so small builds
+ * stay on the serial lane. This is a cost heuristic only — it is NOT what keeps the
+ * watcher off the pool. The watcher's per-save subset rebuild can exceed any such floor
+ * (its closure budget alone is INCREMENTAL_CLOSURE_BUDGET files), so it opts out
+ * explicitly instead of relying on this number.
  */
 export const EXTRACTION_POOL_MIN_FILES = 32;
 
 /**
- * How long a freshly spawned extraction worker has to load its modules, pass its
- * parse-health probe, and report ready. A worker that neither reports ready nor dies
- * within this window (a hung module load or grammar dlopen) is dropped from the pool
- * rather than allowed to stall analyze — a liveness bound, not a performance weight.
+ * How long a freshly spawned extraction worker has to load its modules, pass its parse
+ * probe, and report ready. A worker that neither reports ready nor dies within this window
+ * (a hung module load or grammar dlopen) is dropped from the pool rather than allowed to
+ * stall analyze — a liveness bound, not a performance weight. Kept modest because this is
+ * also the stall an environment where workers CANNOT start pays before falling back: a
+ * healthy worker reports ready in well under a second, so a slow one is a broken one.
  */
-export const EXTRACTION_POOL_STARTUP_TIMEOUT_MS = 30_000;
+export const EXTRACTION_POOL_STARTUP_TIMEOUT_MS = 10_000;
+
+/**
+ * How long a worker has to answer for ONE file before it is retired and that file is
+ * re-extracted on the main thread. Deliberately generous — a pathological source file can
+ * legitimately take seconds to parse, and a false timeout costs correctness nothing but
+ * does cost the pool a worker. The serial lane needs no equivalent bound because it cannot
+ * go silent; a wedged worker emits neither a reply nor an exit, so without this the pass
+ * would wait on it forever while its siblings finish and the process looks idle.
+ */
+export const EXTRACTION_POOL_REQUEST_TIMEOUT_MS = 120_000;

--- a/src/core/analyzer/artifact-generator.ts
+++ b/src/core/analyzer/artifact-generator.ts
@@ -227,8 +227,8 @@ export interface AnalysisArtifacts {
   /**
    * A one-line note about the Pass-1 extraction lane, present ONLY when something degraded
    * (change: optimize-parallel-extraction-pool) — a worker failed, or the worker pool could
-   * not be used at all. It describes HOW the facts were computed, never WHAT they are: the
-   * pooled and serial lanes are byte-identical by contract. Returned rather than logged
+   * not be used at all. It describes HOW the facts were computed, never WHAT they are.
+   * Returned rather than logged
    * because `build()` also runs inside `openlore mcp`, whose stdout is the JSON-RPC channel;
    * only the CLI renders it.
    */

--- a/src/core/analyzer/artifact-generator.ts
+++ b/src/core/analyzer/artifact-generator.ts
@@ -224,6 +224,15 @@ export interface AnalysisArtifacts {
    * artifact written), so a healthy repo pays zero. Persisted as its own `parse-health.json`.
    */
   parseHealth?: ParseHealthReport;
+  /**
+   * A one-line note about the Pass-1 extraction lane, present ONLY when something degraded
+   * (change: optimize-parallel-extraction-pool) — a worker failed, or the worker pool could
+   * not be used at all. It describes HOW the facts were computed, never WHAT they are: the
+   * pooled and serial lanes are byte-identical by contract. Returned rather than logged
+   * because `build()` also runs inside `openlore mcp`, whose stdout is the JSON-RPC channel;
+   * only the CLI renders it.
+   */
+  extractionLaneNote?: string;
 }
 
 /**
@@ -308,6 +317,8 @@ export class AnalysisArtifactGenerator {
   private _styleFingerprint?: StyleFingerprint;
   /** Parse-health report computed during the last generateLLMContext (call-graph walk). */
   private _parseHealth?: ParseHealthReport;
+  /** Pass-1 extraction-lane degradation note from the last generateLLMContext, if any. */
+  private _extractionLaneNote?: string;
 
   constructor(options: ArtifactGeneratorOptions) {
     this.options = {
@@ -340,6 +351,7 @@ export class AnalysisArtifactGenerator {
       llmContext,
       styleFingerprint: this._styleFingerprint,
       parseHealth: this._parseHealth,
+      extractionLaneNote: this._extractionLaneNote,
     };
   }
 
@@ -1200,6 +1212,7 @@ export class AnalysisArtifactGenerator {
     // All dynamic imports grouped here; CALL_GRAPH_LANGS hoisted out of the loop.
     const { extractSignatures, detectLanguage, resolveHeaderLanguage } = await import('./signature-extractor.js');
     const { CallGraphBuilder, serializeCallGraph } = await import('./call-graph.js');
+    const { describeExtractionLane } = await import('./extraction-pool.js');
     const { extractHtmlScripts } = await import('./html-script-extractor.js');
     const { detectDuplicates } = await import('./duplicate-detector.js');
     const { analyzeForRefactoring } = await import('./refactor-analyzer.js');
@@ -1298,6 +1311,11 @@ export class AnalysisArtifactGenerator {
     // Build call graph
     const builder = new CallGraphBuilder();
     const callGraphResult = await builder.build(callGraphFiles);
+    // Stash the lane note for the CLI to render. Never logged from here: this code path
+    // also runs inside the stdio MCP server (change: optimize-parallel-extraction-pool).
+    this._extractionLaneNote = callGraphResult.extractionLane
+      ? describeExtractionLane(callGraphResult.extractionLane)
+      : undefined;
     const callGraph = serializeCallGraph(callGraphResult);
 
     // Style fingerprint (change: add-codebase-style-fingerprint): roll the raw per-file idiom

--- a/src/core/analyzer/call-graph-types.ts
+++ b/src/core/analyzer/call-graph-types.ts
@@ -12,6 +12,7 @@
 import type { FunctionCfg } from './cfg.js';
 import type { FileStyleRaw } from './style-fingerprint.js';
 import type { FileParseHealth } from './parse-health.js';
+import type { ExtractionLaneDisclosure } from './extraction-pool.js';
 
 export type EdgeConfidence =
   | 'self_cls'       // intra-class call via self/cls
@@ -368,6 +369,15 @@ export interface CallGraphResult {
    * (undefined) when the graph has no ambiguous sites.
    */
   ambiguousSites?: AmbiguousCallSite[];
+  /**
+   * Which lane Pass-1 extraction actually ran on — the worker pool or the serial
+   * reference path — and whether anything degraded (change:
+   * optimize-parallel-extraction-pool). Transient build-time data: it describes HOW the
+   * facts were computed, never WHAT they are (the two lanes are byte-identical by
+   * contract), so it is deliberately not carried into {@link SerializedCallGraph} or any
+   * artifact. Read by the analyze summary to disclose a fallback.
+   */
+  extractionLane?: ExtractionLaneDisclosure;
 }
 
 /** Serializable version (Maps replaced by arrays) for JSON storage */

--- a/src/core/analyzer/call-graph-types.ts
+++ b/src/core/analyzer/call-graph-types.ts
@@ -375,7 +375,8 @@ export interface CallGraphResult {
    * optimize-parallel-extraction-pool). Transient build-time data: it describes HOW the
    * facts were computed, never WHAT they are, so it is deliberately not carried into
    * {@link SerializedCallGraph} or any artifact. Read by the analyze summary to disclose a
-   * degraded lane.   *
+   * degraded lane.
+   *
    * "Byte-identical" is the contract for every fact the extractors produce, and it is
    * verified end to end. One residual asymmetry is inherent rather than a gap: a worker
    * thread gets a larger default stack than the main thread, so a pathological

--- a/src/core/analyzer/call-graph-types.ts
+++ b/src/core/analyzer/call-graph-types.ts
@@ -373,9 +373,15 @@ export interface CallGraphResult {
    * Which lane Pass-1 extraction actually ran on — the worker pool or the serial
    * reference path — and whether anything degraded (change:
    * optimize-parallel-extraction-pool). Transient build-time data: it describes HOW the
-   * facts were computed, never WHAT they are (the two lanes are byte-identical by
-   * contract), so it is deliberately not carried into {@link SerializedCallGraph} or any
-   * artifact. Read by the analyze summary to disclose a fallback.
+   * facts were computed, never WHAT they are, so it is deliberately not carried into
+   * {@link SerializedCallGraph} or any artifact. Read by the analyze summary to disclose a
+   * degraded lane.   *
+   * "Byte-identical" is the contract for every fact the extractors produce, and it is
+   * verified end to end. One residual asymmetry is inherent rather than a gap: a worker
+   * thread gets a larger default stack than the main thread, so a pathological
+   * deep-recursion parse can succeed on one lane and fail on the other. That is a
+   * different FILE failing to parse, disclosed through parse health either way — not a
+   * different interpretation of a file that parsed.
    */
   extractionLane?: ExtractionLaneDisclosure;
 }

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -3973,10 +3973,9 @@ function isEmptyExtractResult(result: FileExtractResult | undefined): boolean {
 export interface CallGraphBuilderOptions {
   /**
    * Controls for the Pass-1 extraction lane (change: optimize-parallel-extraction-pool).
-   * Production passes at most `disabled` (the watcher's interactive subset rebuild);
-   * otherwise the lane decides for itself from core count, file count, and
-   * `OPENLORE_NO_WORKERS`. Tests use the rest to drive a stub pool whose completion order
-   * and failure modes are deterministic.
+   * Production passes nothing: the lane decides for itself from core count, file count, the
+   * process-wide worker budget, and `OPENLORE_NO_WORKERS`. Tests use these to drive a stub
+   * pool whose completion order and failure modes are deterministic.
    */
   extraction?: ExtractionLaneOptions;
 }

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -34,6 +34,14 @@ import { synthesizeTypeHierarchyEdges, type RawMethodCall } from './cha.js';
 import { logger } from '../../utils/logger.js';
 import { tallyFileStyle, type FileStyleRaw, type StyleAstNode } from './style-fingerprint.js';
 import { tallyParseHealth, type FileParseHealth, type ParseHealthNode } from './parse-health.js';
+// Pass-1 extraction lane (change: optimize-parallel-extraction-pool). The pool holds no
+// extraction logic of its own — it dispatches `dispatchFileExtract` to worker threads and
+// merges by input index, with the serial loop as both reference and fallback.
+import {
+  extractFilesForPass1,
+  describeExtractionLane,
+  type ExtractionWorkerFactory,
+} from './extraction-pool.js';
 
 // ============================================================================
 // TYPES — extracted to ./call-graph-types.ts and re-exported here so this file
@@ -3951,7 +3959,24 @@ export async function synthesizeDynamicDispatchEdges(
   return results.flat();
 }
 
+/** Construction-time options for {@link CallGraphBuilder}. */
+export interface CallGraphBuilderOptions {
+  /**
+   * Overrides for the Pass-1 extraction lane (change: optimize-parallel-extraction-pool).
+   * Production never passes this — the lane decides for itself from core count, file
+   * count, and `OPENLORE_NO_WORKERS`. Tests use it to drive a stub pool whose completion
+   * order and failure modes are deterministic.
+   */
+  extraction?: { workerFactory?: ExtractionWorkerFactory; poolSize?: number };
+}
+
 export class CallGraphBuilder {
+  private readonly extractionOptions: CallGraphBuilderOptions['extraction'];
+
+  constructor(options: CallGraphBuilderOptions = {}) {
+    this.extractionOptions = options.extraction;
+  }
+
   /**
    * Build a call graph from a list of source files.
    *
@@ -3976,10 +4001,32 @@ export class CallGraphBuilder {
     const styleByFile = new Map<string, FileStyleRaw>();
     const parseHealthByFile = new Map<string, FileParseHealth>();
 
-    // Pass 1: Extract nodes and raw edges from each file
-    for (const file of files) {
+    // Pass 1: Extract nodes and raw edges from each file.
+    //
+    // Extraction runs on a worker-thread pool when one is available and the build is large
+    // enough to pay for the spawn (change: optimize-parallel-extraction-pool); otherwise it
+    // runs on the serial lane, which stays the reference implementation and the fallback
+    // executor — `dispatchFileExtract` is the single extractor for both lanes.
+    //
+    // The EXTRACT step and the MERGE step below are separated on purpose. Extraction may
+    // complete in any order; the merge walks `files` by index and applies each result in
+    // input order, so worker scheduling can never reach the graph. Every determinism
+    // property downstream (node overwrite order, raw-edge sequence) is a property of this
+    // loop, not of the extraction lane.
+    const { outcomes: extractOutcomes, disclosure: extractionLane } = await extractFilesForPass1(
+      files,
+      dispatchFileExtract,
+      this.extractionOptions ?? {},
+    );
+    const laneNote = describeExtractionLane(extractionLane);
+    if (laneNote) logger.warning(laneNote);
+
+    for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+      const file = files[fileIndex];
+      const outcome = extractOutcomes[fileIndex];
       try {
-        const result = await dispatchFileExtract(file);
+        if (outcome.status === 'error') throw outcome.error;
+        const result = outcome.value;
         if (!result) continue;
 
         // Compute startLine (1-based) from byte offset — cheap, done once at build time
@@ -4746,6 +4793,7 @@ export class CallGraphBuilder {
       styleByFile: styleByFile.size > 0 ? styleByFile : undefined,
       parseHealthByFile: parseHealthByFile.size > 0 ? parseHealthByFile : undefined,
       ambiguousSites: ambiguousSites.length > 0 ? ambiguousSites : undefined,
+      extractionLane,
     };
   }
 
@@ -4810,7 +4858,7 @@ function assignClassStableIds(classes: ClassNode[]): void {
 }
 
 /** The per-file result of Pass-1 extraction (before cross-file resolution). */
-type FileExtractResult = {
+export type FileExtractResult = {
   nodes: FunctionNode[];
   rawEdges: RawEdge[];
   cfg?: Map<string, FunctionCfg>;
@@ -4821,10 +4869,11 @@ type FileExtractResult = {
 /**
  * Dispatch ONE file to its per-language extractor (Pass-1 only — nodes/edges/cfg/style/parseHealth,
  * no cross-file resolution). The single source of truth for the language→extractor mapping, shared
- * by the full build and the watcher's per-file refreshers so the dispatch is never duplicated.
- * Returns `undefined` for a language with no extractor.
+ * by the full build, the watcher's per-file refreshers, AND the extraction-pool worker
+ * (change: optimize-parallel-extraction-pool) so the dispatch is never duplicated and the pooled
+ * lane cannot drift from the serial one. Returns `undefined` for a language with no extractor.
  */
-async function dispatchFileExtract(
+export async function dispatchFileExtract(
   file: { path: string; content: string; language: string },
 ): Promise<FileExtractResult | undefined> {
   if (file.language === 'Python') return extractPyGraph(file.path, file.content);

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -37,11 +37,7 @@ import { tallyParseHealth, type FileParseHealth, type ParseHealthNode } from './
 // Pass-1 extraction lane (change: optimize-parallel-extraction-pool). The pool holds no
 // extraction logic of its own — it dispatches `dispatchFileExtract` to worker threads and
 // merges by input index, with the serial loop as both reference and fallback.
-import {
-  extractFilesForPass1,
-  describeExtractionLane,
-  type ExtractionWorkerFactory,
-} from './extraction-pool.js';
+import { extractFilesForPass1, type ExtractionLaneOptions } from './extraction-pool.js';
 
 // ============================================================================
 // TYPES — extracted to ./call-graph-types.ts and re-exported here so this file
@@ -3959,15 +3955,30 @@ export async function synthesizeDynamicDispatchEdges(
   return results.flat();
 }
 
+/**
+ * Does a Pass-1 extraction result carry no facts at all? Used only to decide whether a
+ * WORKER's silence has been proven trustworthy (see `extraction-pool.ts`) — never to alter
+ * a result. `undefined` (a language with no extractor) is not emptiness: it is the same
+ * deterministic answer on both lanes.
+ */
+function isEmptyExtractResult(result: FileExtractResult | undefined): boolean {
+  if (!result) return false;
+  return result.nodes.length === 0
+    && result.rawEdges.length === 0
+    && !result.parseHealth
+    && !result.style;
+}
+
 /** Construction-time options for {@link CallGraphBuilder}. */
 export interface CallGraphBuilderOptions {
   /**
-   * Overrides for the Pass-1 extraction lane (change: optimize-parallel-extraction-pool).
-   * Production never passes this — the lane decides for itself from core count, file
-   * count, and `OPENLORE_NO_WORKERS`. Tests use it to drive a stub pool whose completion
-   * order and failure modes are deterministic.
+   * Controls for the Pass-1 extraction lane (change: optimize-parallel-extraction-pool).
+   * Production passes at most `disabled` (the watcher's interactive subset rebuild);
+   * otherwise the lane decides for itself from core count, file count, and
+   * `OPENLORE_NO_WORKERS`. Tests use the rest to drive a stub pool whose completion order
+   * and failure modes are deterministic.
    */
-  extraction?: { workerFactory?: ExtractionWorkerFactory; poolSize?: number };
+  extraction?: ExtractionLaneOptions;
 }
 
 export class CallGraphBuilder {
@@ -4016,10 +4027,9 @@ export class CallGraphBuilder {
     const { outcomes: extractOutcomes, disclosure: extractionLane } = await extractFilesForPass1(
       files,
       dispatchFileExtract,
+      isEmptyExtractResult,
       this.extractionOptions ?? {},
     );
-    const laneNote = describeExtractionLane(extractionLane);
-    if (laneNote) logger.warning(laneNote);
 
     for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
       const file = files[fileIndex];
@@ -4066,6 +4076,11 @@ export class CallGraphBuilder {
         // Record it as a structured parse-health failure so downstream conclusions disclose it
         // instead of treating the missing symbols as genuinely absent (change:
         // add-parse-health-boundary-disclosure). Still fail-soft — the build proceeds.
+        //
+        // Only `error.message` may be relied on here. A throw that happened inside an
+        // extraction worker crossed a structured-clone boundary, so its class, `code`, and
+        // stack did not survive — an `instanceof`/`.code` check added below would behave
+        // differently on the two lanes (change: optimize-parallel-extraction-pool).
         parseHealthByFile.set(file.path, {
           filePath: file.path,
           language: file.language,

--- a/src/core/analyzer/extraction-pool-threads.test.ts
+++ b/src/core/analyzer/extraction-pool-threads.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Real worker-thread coverage for the Pass-1 extraction pool
+ * (change: optimize-parallel-extraction-pool).
+ *
+ * `extraction-pool.test.ts` pins the ordering and fail-soft SEMANTICS with an in-process
+ * stub lane. This file pins the thing a stub cannot: that actual `worker_threads` workers
+ * load the extractor, load their own grammars — including the two WASM grammars whose
+ * emscripten heaps must be isolated per thread (Lua, Dart) — and return facts identical to
+ * the serial lane.
+ *
+ * The rest of the suite runs with `OPENLORE_NO_WORKERS=1` (see vitest.config.ts) so it
+ * never pays for thread spawn; this file clears the flag for its own scope only.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { CallGraphBuilder, serializeCallGraph } from './call-graph.js';
+import { resolveWorkerEntry, type ExtractionFile } from './extraction-pool.js';
+
+const fixtures = join(__dirname, 'fixtures');
+/** Two workers is enough to prove the lane; more only buys spawn cost in CI. */
+const POOL_SIZE = 2;
+
+let savedFlag: string | undefined;
+beforeAll(() => {
+  savedFlag = process.env.OPENLORE_NO_WORKERS;
+  delete process.env.OPENLORE_NO_WORKERS;
+});
+afterAll(() => {
+  if (savedFlag === undefined) delete process.env.OPENLORE_NO_WORKERS;
+  else process.env.OPENLORE_NO_WORKERS = savedFlag;
+});
+
+/** TypeScript filler with real cross-file calls, so the merge order is observable. */
+function tsFiles(count: number): ExtractionFile[] {
+  return Array.from({ length: count }, (_, i) => ({
+    path: `src/thread${i}.ts`,
+    language: 'TypeScript',
+    content:
+      `export function seed${i}(n: number): number { return n * ${i + 1}; }\n` +
+      `export class Runner${i} {\n` +
+      `  go(): number { return seed${i}(2) + seed${(i + 1) % count}(3); }\n` +
+      `}\n`,
+  }));
+}
+
+function fixtureFile(rel: string, language: string): ExtractionFile | undefined {
+  const abs = join(fixtures, rel);
+  if (!existsSync(abs)) return undefined;
+  return { path: rel, content: readFileSync(abs, 'utf-8'), language };
+}
+
+async function buildJson(files: ExtractionFile[], poolSize?: number): Promise<string> {
+  const builder = new CallGraphBuilder(poolSize ? { extraction: { poolSize } } : {});
+  return JSON.stringify(serializeCallGraph(await builder.build(files.map(f => ({ ...f })))));
+}
+
+describe('extraction pool — real worker threads', () => {
+  it('extracts on real threads and matches the serial lane byte for byte', async () => {
+    if (!resolveWorkerEntry()) return; // no worker entry in this runtime — serial lane covers it
+    const files = tsFiles(48);
+
+    process.env.OPENLORE_NO_WORKERS = '1';
+    const serial = await buildJson(files);
+    delete process.env.OPENLORE_NO_WORKERS;
+
+    const builder = new CallGraphBuilder({ extraction: { poolSize: POOL_SIZE } });
+    const result = await builder.build(files.map(f => ({ ...f })));
+    expect(result.extractionLane?.lane).toBe('pooled');
+    expect(result.extractionLane?.poolSize).toBe(POOL_SIZE);
+    expect(result.extractionLane?.workerFallbackFiles).toEqual([]);
+    expect(JSON.stringify(serializeCallGraph(result))).toBe(serial);
+  }, 120_000);
+
+  it('loads the per-thread WASM grammars (Lua, Dart) without cross-contaminating them', async () => {
+    if (!resolveWorkerEntry()) return;
+    const lua = fixtureFile('lua/app.lua', 'Lua');
+    const dart = fixtureFile('dart/app.dart', 'Dart');
+    if (!lua || !dart) return; // fixtures absent — nothing to prove here
+
+    // Interleaved with enough TypeScript to keep the pool busy, so Lua and Dart are very
+    // likely handled by DIFFERENT threads — the exact shape that corrupts a shared
+    // emscripten heap when grammar isolation is wrong.
+    const files: ExtractionFile[] = [...tsFiles(20), lua, dart, ...tsFiles(20).map((f, i) => ({ ...f, path: `src/tail${i}.ts` }))];
+
+    process.env.OPENLORE_NO_WORKERS = '1';
+    const serial = await buildJson(files);
+    delete process.env.OPENLORE_NO_WORKERS;
+
+    const pooled = await buildJson(files, POOL_SIZE);
+    expect(pooled).toBe(serial);
+
+    // Guard against the whole comparison passing because BOTH lanes found nothing.
+    const names = JSON.parse(pooled).nodes.filter((n: { language: string }) => n.language === 'Lua' || n.language === 'Dart');
+    if (names.length === 0) return; // WASM unavailable in this env → graceful skip, as elsewhere
+    expect(names.map((n: { name: string }) => n.name).sort()).toEqual(['boot', 'helper', 'helper', 'main', 'run', 'run']);
+  }, 120_000);
+});

--- a/src/core/analyzer/extraction-pool-threads.test.ts
+++ b/src/core/analyzer/extraction-pool-threads.test.ts
@@ -18,6 +18,8 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { CallGraphBuilder, serializeCallGraph } from './call-graph.js';
 import { resolveWorkerEntry, type ExtractionFile } from './extraction-pool.js';
+import { dispatchFileExtract } from './call-graph.js';
+import { PROBES } from './extraction-worker.js';
 
 const fixtures = join(__dirname, 'fixtures');
 /** Two workers is enough to prove the lane; more only buys spawn cost in CI. */
@@ -74,10 +76,13 @@ describe('extraction pool — the entry that actually ships', () => {
     // is the file the npm package ships and the one `openlore analyze` actually loads —
     // without this, a compile or packaging regression would degrade silently to the serial
     // lane with a green suite.
-    const compiled = join(__dirname, 'extraction-worker.js');
+    // Repo-root `dist/`, not a sibling of this file: tsc emits src/ -> dist/, so a sibling
+    // `.js` never exists and looking for one made this guard silently skip in a fully built
+    // checkout — which is exactly the failure it is supposed to catch.
+    const compiled = join(__dirname, '..', '..', '..', 'dist', 'core', 'analyzer', 'extraction-worker.js');
     if (!existsSync(compiled)) {
-      // Not built in this checkout. Say so rather than passing quietly.
-      console.warn('[extraction-pool] dist entry absent — compiled-worker check skipped (run `npm run build`)');
+      // Unbuilt checkout. CI runs this file again inside the Build job, where dist exists.
+      console.warn(`[extraction-pool] compiled-worker check skipped — ${compiled} absent (run \`npm run build\`)`);
       return;
     }
     const { Worker } = await import('node:worker_threads');
@@ -178,4 +183,20 @@ describe('extraction pool — real worker threads', () => {
     const present = new Set(nodes.filter(n => !n.isExternal).map(n => n.language));
     expect(present.size).toBeGreaterThanOrEqual(4);
   }, 180_000);
+});
+
+describe('extraction pool — the startup probe table', () => {
+  // A probe snippet that stops yielding a node and an edge does not fail loudly: every
+  // worker reports `unhealthy`, the pool is disabled for the whole process, and analyze
+  // just gets slower. So the table is checked against the real extractor.
+  for (const [language, probe] of Object.entries(PROBES)) {
+    it(`the ${language} probe snippet yields a node and an edge`, async () => {
+      const result = await dispatchFileExtract({ ...probe, language });
+      // A grammar genuinely unavailable in this environment yields nothing on the main
+      // thread too — that is the case the probe is allowed to fail on, so skip it here.
+      if (!result || (result.nodes.length === 0 && result.rawEdges.length === 0)) return;
+      expect(result.nodes.length, `${language} probe produced no function node`).toBeGreaterThan(0);
+      expect(result.rawEdges.length, `${language} probe produced no call edge`).toBeGreaterThan(0);
+    }, 30_000);
+  }
 });

--- a/src/core/analyzer/extraction-pool-threads.test.ts
+++ b/src/core/analyzer/extraction-pool-threads.test.ts
@@ -51,15 +51,25 @@ function fixtureFile(rel: string, language: string): ExtractionFile | undefined 
   return { path: rel, content: readFileSync(abs, 'utf-8'), language };
 }
 
+/**
+ * Serialize a build. When `poolSize` is given the build MUST have run pooled — asserted
+ * here, because `OPENLORE_NO_WORKERS` silently forces the serial lane and would otherwise
+ * turn every comparison in this file into a vacuous serial-vs-serial pass.
+ */
 async function buildJson(files: ExtractionFile[], poolSize?: number): Promise<string> {
   const builder = new CallGraphBuilder(poolSize ? { extraction: { poolSize } } : {});
-  return JSON.stringify(serializeCallGraph(await builder.build(files.map(f => ({ ...f })))));
+  const result = await builder.build(files.map(f => ({ ...f })));
+  if (poolSize) {
+    expect(result.extractionLane?.lane).toBe('pooled');
+    expect(result.extractionLane?.workerFallbackFiles).toEqual([]);
+  }
+  return JSON.stringify(serializeCallGraph(result));
 }
 
 describe('extraction pool — real worker threads', () => {
   it('extracts on real threads and matches the serial lane byte for byte', async () => {
     if (!resolveWorkerEntry()) return; // no worker entry in this runtime — serial lane covers it
-    const files = tsFiles(48);
+    const files = tsFiles(16);
 
     process.env.OPENLORE_NO_WORKERS = '1';
     const serial = await buildJson(files);
@@ -82,7 +92,7 @@ describe('extraction pool — real worker threads', () => {
     // Interleaved with enough TypeScript to keep the pool busy, so Lua and Dart are very
     // likely handled by DIFFERENT threads — the exact shape that corrupts a shared
     // emscripten heap when grammar isolation is wrong.
-    const files: ExtractionFile[] = [...tsFiles(20), lua, dart, ...tsFiles(20).map((f, i) => ({ ...f, path: `src/tail${i}.ts` }))];
+    const files: ExtractionFile[] = [...tsFiles(8), lua, dart, ...tsFiles(8).map((f, i) => ({ ...f, path: `src/tail${i}.ts` }))];
 
     process.env.OPENLORE_NO_WORKERS = '1';
     const serial = await buildJson(files);
@@ -96,4 +106,43 @@ describe('extraction pool — real worker threads', () => {
     if (names.length === 0) return; // WASM unavailable in this env → graceful skip, as elsewhere
     expect(names.map((n: { name: string }) => n.name).sort()).toEqual(['boot', 'helper', 'helper', 'main', 'run', 'run']);
   }, 120_000);
+
+  it('matches the serial lane for every native-grammar language, not just TypeScript', async () => {
+    if (!resolveWorkerEntry()) return;
+    // Each worker loads each grammar independently; a language that loads on the main
+    // thread but not in a worker would return EMPTY rather than throw, so this pins
+    // per-language parity instead of trusting one language to speak for the rest.
+    const samples: Record<string, [string, string]> = {
+      Python: ['py', 'def helper(x):\n    return x + 1\n\nclass Svc:\n    def run(self):\n        return helper(2)\n'],
+      Go: ['go', 'package main\n\nfunc helper(x int) int { return x + 1 }\n\nfunc Run() int { return helper(2) }\n'],
+      Rust: ['rs', 'fn helper(x: i32) -> i32 { x + 1 }\npub fn run() -> i32 { helper(2) }\n'],
+      Ruby: ['rb', 'def helper(x)\n  x + 1\nend\n\nclass Svc\n  def run\n    helper(2)\n  end\nend\n'],
+      Java: ['java', 'public class Svc {\n  static int helper(int x) { return x + 1; }\n  int run() { return helper(2); }\n}\n'],
+      'C++': ['cpp', 'int helper(int x) { return x + 1; }\nint run() { return helper(2); }\n'],
+      Swift: ['swift', 'func helper(_ x: Int) -> Int { return x + 1 }\nfunc run() -> Int { return helper(2) }\n'],
+      JavaScript: ['js', 'export function helper(x) { return x + 1; }\nexport function run() { return helper(2); }\n'],
+    };
+    const files: ExtractionFile[] = [];
+    for (const [language, [ext, src]] of Object.entries(samples)) {
+      for (let i = 0; i < 3; i++) {
+        files.push({
+          path: `poly${i}_${language.replace(/\W/g, '')}.${ext}`,
+          language,
+          content: src.replace(/helper/g, `helper${i}`).replace(/run/g, `run${i}`),
+        });
+      }
+    }
+
+    process.env.OPENLORE_NO_WORKERS = '1';
+    const serial = await buildJson(files);
+    delete process.env.OPENLORE_NO_WORKERS;
+
+    expect(await buildJson(files, POOL_SIZE)).toBe(serial);
+    // Guard against a green comparison that passed because BOTH lanes found nothing. A
+    // grammar genuinely missing from this environment yields nothing on either lane (which
+    // the byte comparison already covers), so require breadth rather than a fixed list.
+    const nodes: Array<{ language: string; isExternal?: boolean }> = JSON.parse(serial).nodes;
+    const present = new Set(nodes.filter(n => !n.isExternal).map(n => n.language));
+    expect(present.size).toBeGreaterThanOrEqual(4);
+  }, 180_000);
 });

--- a/src/core/analyzer/extraction-pool-threads.test.ts
+++ b/src/core/analyzer/extraction-pool-threads.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { CallGraphBuilder, serializeCallGraph } from './call-graph.js';
 import { resolveWorkerEntry, type ExtractionFile } from './extraction-pool.js';
 
@@ -65,6 +66,38 @@ async function buildJson(files: ExtractionFile[], poolSize?: number): Promise<st
   }
   return JSON.stringify(serializeCallGraph(result));
 }
+
+describe('extraction pool — the entry that actually ships', () => {
+  it('the compiled worker entry starts and reports ready', async () => {
+    // Under vitest `resolveWorkerEntry()` always picks the `.ts` + tsx branch, so every
+    // other test here exercises the SOURCE entry. `dist/core/analyzer/extraction-worker.js`
+    // is the file the npm package ships and the one `openlore analyze` actually loads —
+    // without this, a compile or packaging regression would degrade silently to the serial
+    // lane with a green suite.
+    const compiled = join(__dirname, 'extraction-worker.js');
+    if (!existsSync(compiled)) {
+      // Not built in this checkout. Say so rather than passing quietly.
+      console.warn('[extraction-pool] dist entry absent — compiled-worker check skipped (run `npm run build`)');
+      return;
+    }
+    const { Worker } = await import('node:worker_threads');
+    const worker = new Worker(pathToFileURL(compiled), {
+      workerData: { probeLanguage: 'TypeScript' },
+      stdout: true,
+    });
+    worker.stdout.resume();
+    try {
+      const first = await new Promise<{ type: string; reason?: string }>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('compiled worker never reported')), 30_000);
+        worker.on('message', (m) => { clearTimeout(timer); resolve(m as { type: string }); });
+        worker.on('error', (e) => { clearTimeout(timer); reject(e); });
+      });
+      expect(first.type).toBe('ready');
+    } finally {
+      await worker.terminate();
+    }
+  }, 60_000);
+});
 
 describe('extraction pool — real worker threads', () => {
   it('extracts on real threads and matches the serial lane byte for byte', async () => {

--- a/src/core/analyzer/extraction-pool-threads.test.ts
+++ b/src/core/analyzer/extraction-pool-threads.test.ts
@@ -16,9 +16,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { CallGraphBuilder, serializeCallGraph } from './call-graph.js';
+import { CallGraphBuilder, serializeCallGraph, dispatchFileExtract } from './call-graph.js';
 import { resolveWorkerEntry, type ExtractionFile } from './extraction-pool.js';
-import { dispatchFileExtract } from './call-graph.js';
 import { PROBES } from './extraction-worker.js';
 
 const fixtures = join(__dirname, 'fixtures');
@@ -87,7 +86,8 @@ describe('extraction pool — the entry that actually ships', () => {
     }
     const { Worker } = await import('node:worker_threads');
     const worker = new Worker(pathToFileURL(compiled), {
-      workerData: { probeLanguage: 'TypeScript' },
+      // The sentinel the pool sends; without it the entry stays inert by design.
+      workerData: { openloreExtractionWorker: true, probeLanguage: 'TypeScript' },
       stdout: true,
     });
     worker.stdout.resume();

--- a/src/core/analyzer/extraction-pool-threads.test.ts
+++ b/src/core/analyzer/extraction-pool-threads.test.ts
@@ -102,6 +102,32 @@ describe('extraction pool — the entry that actually ships', () => {
       await worker.terminate();
     }
   }, 60_000);
+
+  it('stays inert when spawned without the pool\'s sentinel', async () => {
+    // The closed direction of the same gate. Without it, anything that imports this module
+    // while running inside SOME OTHER worker thread (a test runner using a thread pool, say)
+    // would attach a message handler to that thread's channel and patch its logger. Asserting
+    // only the ready path would leave the gate itself free to be deleted.
+    const compiled = join(__dirname, '..', '..', '..', 'dist', 'core', 'analyzer', 'extraction-worker.js');
+    if (!existsSync(compiled)) return; // covered by the sibling test's warning
+
+    const { Worker } = await import('node:worker_threads');
+    const worker = new Worker(pathToFileURL(compiled), {
+      workerData: { probeLanguage: 'TypeScript' }, // no sentinel
+      stdout: true,
+    });
+    worker.stdout.resume();
+    try {
+      const spoke = await new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => resolve(false), 5_000);
+        worker.on('message', () => { clearTimeout(timer); resolve(true); });
+        worker.on('error', () => { clearTimeout(timer); resolve(true); });
+      });
+      expect(spoke, 'a worker without the sentinel must not speak').toBe(false);
+    } finally {
+      await worker.terminate();
+    }
+  }, 60_000);
 });
 
 describe('extraction pool — real worker threads', () => {

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -326,25 +326,6 @@ describe('extraction pool — fail-soft ladder', () => {
     expect(outcomes.every(o => o.status === 'ok')).toBe(true);
   }, 30_000);
 
-  it('reports an extractor that throws inside a worker as that file\'s failure, not a lane failure', async () => {
-    const files = corpus();
-    const boom = files[5].path;
-    const factory = stubWorkerFactory({});
-    // Wrap the serial extractor so the stub's in-process dispatch throws for one file,
-    // exactly as a real worker would report `failed`.
-    const { outcomes, disclosure } = await extractFilesForPass1(
-      files,
-      async (f) => { if (f.path === boom) throw new Error('synthetic parse failure'); return dispatchFileExtract(f); },
-      isEmpty,
-      { workerFactory: factory, poolSize: 2 },
-    );
-    // The stub calls the real dispatch, so the injected failure only affects the serial
-    // path here; what matters is that a `failed` reply becomes a per-file error outcome.
-    expect(disclosure.lane).toBe('pooled');
-    expect(outcomes).toHaveLength(files.length);
-    expect(disclosure.workerFallbackFiles).toHaveLength(0);
-  }, 30_000);
-
   it('does not let a worker that fails everything write parse failures the serial lane never would', async () => {
     // A worker that reports a failure for every file has proven nothing, so nothing it says
     // is believed: each file is re-extracted on the main thread. Believing it would have

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -18,14 +18,16 @@ import {
   plannedPoolSize,
   resolveWorkerEntry,
   describeExtractionLane,
+  __resetExtractionPoolStateForTests,
   type ExtractionFile,
+  type ExtractionLaneDisclosure,
   type ExtractionWorkerFactory,
   type ExtractionWorkerHandle,
   type ExtractionRequest,
   type ExtractionResponse,
 } from './extraction-pool.js';
-import { CallGraphBuilder, serializeCallGraph, dispatchFileExtract } from './call-graph.js';
-import { EXTRACTION_POOL_MIN_FILES } from '../../constants.js';
+import { CallGraphBuilder, serializeCallGraph, dispatchFileExtract, type FileExtractResult } from './call-graph.js';
+import { EXTRACTION_POOL_MIN_FILES, EXTRACTION_POOL_STARTUP_TIMEOUT_MS } from '../../constants.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -72,6 +74,13 @@ interface StubOptions {
   silentStartup?: boolean;
   /** Warnings each worker relays at startup — used to prove parent-side dedupe. */
   relayWarnings?: string[];
+  /**
+   * Answer with an EMPTY result for these languages instead of extracting — a worker whose
+   * grammar for that language failed to load in its own thread.
+   */
+  blindTo?: (language: string) => boolean;
+  /** Reply with an id that does not match the request — an off-protocol worker. */
+  wrongId?: boolean;
   /** Records the input index of every answer, in the order the parent received it. */
   completionLog?: number[];
 }
@@ -104,9 +113,15 @@ function stubWorkerFactory(opts: StubOptions = {}): ExtractionWorkerFactory {
             emit('exit', 1);
             return;
           }
+          const replyId = opts.wrongId ? id + 1000 : id;
+          if (opts.blindTo?.(file.language)) {
+            opts.completionLog?.push(id);
+            send({ type: 'result', id: replyId, value: { nodes: [], rawEdges: [], cfg: new Map() } });
+            return;
+          }
           void dispatchFileExtract(file).then(
-            (value) => { opts.completionLog?.push(id); send({ type: 'result', id, value }); },
-            (err: Error) => { opts.completionLog?.push(id); send({ type: 'failed', id, message: err.message }); },
+            (value) => { opts.completionLog?.push(id); send({ type: 'result', id: replyId, value }); },
+            (err: Error) => { opts.completionLog?.push(id); send({ type: 'failed', id: replyId, message: err.message }); },
           );
         }, opts.delayFor?.(id) ?? 0);
       },
@@ -136,14 +151,28 @@ async function buildJson(
   return JSON.stringify(serializeCallGraph(result));
 }
 
-afterEach(() => { vi.restoreAllMocks(); });
+/**
+ * The same emptiness predicate production uses: a result carrying no facts at all. Only
+ * ever used to decide whether a worker's SILENCE has been proven trustworthy.
+ */
+function isEmpty(result: FileExtractResult | undefined): boolean {
+  if (!result) return false;
+  return result.nodes.length === 0 && result.rawEdges.length === 0 && !result.parseHealth && !result.style;
+}
+
+/** A disclosure with the routine fields filled in, for the describe-only assertions. */
+function disclosure(partial: Partial<ExtractionLaneDisclosure>): ExtractionLaneDisclosure {
+  return { lane: 'serial', poolSize: 0, workerFallbackFiles: [], laneDefectFiles: [], emptyRechecks: 0, ...partial };
+}
+
+afterEach(() => { vi.restoreAllMocks(); __resetExtractionPoolStateForTests(); });
 
 // ---------------------------------------------------------------------------
 
 describe('extraction pool — lane selection', () => {
   it('stays serial below the file-count floor, and says why', async () => {
     const files = corpus(EXTRACTION_POOL_MIN_FILES - 1);
-    const { disclosure } = await extractFilesForPass1(files, dispatchFileExtract);
+    const { disclosure } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty);
     expect(disclosure.lane).toBe('serial');
     expect(disclosure.serialReason).toBe('too-few-files');
     expect(plannedPoolSize(files.length)).toBe(0);
@@ -152,16 +181,21 @@ describe('extraction pool — lane selection', () => {
   it('OPENLORE_NO_WORKERS forces the serial lane even for a large build', async () => {
     // The suite already sets this flag; assert the contract rather than assuming it.
     expect(process.env.OPENLORE_NO_WORKERS).toBe('1');
-    const { disclosure } = await extractFilesForPass1(corpus(EXTRACTION_POOL_MIN_FILES + 8), dispatchFileExtract);
+    const { disclosure } = await extractFilesForPass1(corpus(EXTRACTION_POOL_MIN_FILES + 8), dispatchFileExtract, isEmpty);
     expect(disclosure.lane).toBe('serial');
     expect(disclosure.serialReason).toBe('disabled-by-env');
   }, 30_000);
 
   it('a normal serial choice is not reported as a degradation', () => {
-    expect(describeExtractionLane({ lane: 'serial', poolSize: 0, serialReason: 'too-few-files', workerFallbackFiles: [] })).toBeUndefined();
-    expect(describeExtractionLane({ lane: 'pooled', poolSize: 4, workerFallbackFiles: [] })).toBeUndefined();
-    expect(describeExtractionLane({ lane: 'pooled', poolSize: 4, workerFallbackFiles: ['a.ts'] })).toMatch(/re-extracted on the main thread/);
-    expect(describeExtractionLane({ lane: 'serial', poolSize: 0, serialReason: 'pool-unavailable', workerFallbackFiles: [] })).toMatch(/serial lane/);
+    expect(describeExtractionLane(disclosure({ serialReason: 'too-few-files' }))).toBeUndefined();
+    expect(describeExtractionLane(disclosure({ serialReason: 'insufficient-cores' }))).toBeUndefined();
+    expect(describeExtractionLane(disclosure({ serialReason: 'pool-saturated' }))).toBeUndefined();
+    expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4 }))).toBeUndefined();
+    // An empty re-check is routine work, not a degradation — it must stay silent.
+    expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, emptyRechecks: 9 }))).toBeUndefined();
+    expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, workerFallbackFiles: ['a.ts'] }))).toMatch(/re-extracted on the main thread/);
+    expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, laneDefectFiles: ['a.ts'] }))).toMatch(/no symbols for 1 file/);
+    expect(describeExtractionLane(disclosure({ serialReason: 'pool-unavailable' }))).toMatch(/serial lane/);
   }, 30_000);
 
   it('resolves a worker entry for the current runtime', () => {
@@ -178,7 +212,7 @@ describe('extraction pool — determinism', () => {
     // Later files answer sooner: the completion order is deliberately inverted.
     const factory = stubWorkerFactory({ delayFor: (i) => (files.length - i), completionLog });
 
-    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
+    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
       workerFactory: factory,
       poolSize: 4,
     });
@@ -224,7 +258,7 @@ describe('extraction pool — fail-soft ladder', () => {
     const victim = files[7].path;
     const factory = stubWorkerFactory({ dieOn: (f) => f.path === victim });
 
-    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
+    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
       workerFactory: factory,
       poolSize: 3,
     });
@@ -241,7 +275,7 @@ describe('extraction pool — fail-soft ladder', () => {
   it('survives every worker dying — no file is lost', async () => {
     const files = corpus();
     const factory = stubWorkerFactory({ dieOn: () => true });
-    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
+    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
       workerFactory: factory,
       poolSize: 4,
     });
@@ -252,7 +286,7 @@ describe('extraction pool — fail-soft ladder', () => {
 
   it('falls back to the serial lane wholesale when no worker comes up healthy', async () => {
     const files = corpus();
-    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
+    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
       workerFactory: stubWorkerFactory({ unhealthy: true }),
       poolSize: 4,
     });
@@ -262,7 +296,7 @@ describe('extraction pool — fail-soft ladder', () => {
   }, 30_000);
 
   it('falls back when the worker factory itself throws', async () => {
-    const { disclosure, outcomes } = await extractFilesForPass1(corpus(), dispatchFileExtract, {
+    const { disclosure, outcomes } = await extractFilesForPass1(corpus(), dispatchFileExtract, isEmpty, {
       workerFactory: () => { throw new Error('spawn refused'); },
       poolSize: 4,
     });
@@ -280,6 +314,7 @@ describe('extraction pool — fail-soft ladder', () => {
     const { outcomes, disclosure } = await extractFilesForPass1(
       files,
       async (f) => { if (f.path === boom) throw new Error('synthetic parse failure'); return dispatchFileExtract(f); },
+      isEmpty,
       { workerFactory: factory, poolSize: 2 },
     );
     // The stub calls the real dispatch, so the injected failure only affects the serial
@@ -314,15 +349,15 @@ describe('extraction pool — fail-soft ladder', () => {
   it('drops a worker that never reports ready instead of hanging', async () => {
     const files = corpus();
     vi.useFakeTimers();
-    const promise = extractFilesForPass1(files, dispatchFileExtract, {
+    const promise = extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
       workerFactory: stubWorkerFactory({ silentStartup: true }),
       poolSize: 2,
     });
-    await vi.advanceTimersByTimeAsync(31_000);
+    await vi.advanceTimersByTimeAsync(EXTRACTION_POOL_STARTUP_TIMEOUT_MS + 1_000);
     vi.useRealTimers();
-    const { disclosure, outcomes } = await promise;
-    expect(disclosure.lane).toBe('serial');
-    expect(disclosure.serialReason).toBe('pool-unavailable');
+    const { disclosure: d, outcomes } = await promise;
+    expect(d.lane).toBe('serial');
+    expect(d.serialReason).toBe('pool-unavailable');
     expect(outcomes).toHaveLength(files.length);
   }, 30_000);
 });
@@ -331,11 +366,137 @@ describe('extraction pool — worker log relay', () => {
   it('prints a relayed grammar warning once, not once per worker', async () => {
     const { logger } = await import('../../utils/logger.js');
     const warn = vi.spyOn(logger, 'warning').mockImplementation(() => {});
-    await extractFilesForPass1(corpus(), dispatchFileExtract, {
+    await extractFilesForPass1(corpus(), dispatchFileExtract, isEmpty, {
       workerFactory: stubWorkerFactory({ relayWarnings: ['language Lua grammar unavailable'] }),
       poolSize: 4,
     });
     const relayed = warn.mock.calls.filter(c => String(c[0]).includes('Lua grammar unavailable'));
     expect(relayed).toHaveLength(1);
+  }, 30_000);
+});
+
+describe('extraction pool — never trust an unproven silence', () => {
+  it('re-checks a worker that reports nothing for a language it has not proven, and discloses the defect', async () => {
+    // The exact silent-loss shape: the grammar loaded on the main thread but not in the
+    // worker, so the worker returns EMPTY rather than throwing.
+    const files = corpus();
+    const { outcomes, disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({ blindTo: (l) => l === 'TypeScript' }),
+      poolSize: 2,
+    });
+
+    expect(d.lane).toBe('pooled');
+    // Every file was re-checked, and every re-check found facts the worker had missed.
+    expect(d.emptyRechecks).toBe(files.length);
+    expect(d.laneDefectFiles).toHaveLength(files.length);
+    expect(outcomes.every(o => o.status === 'ok' && (o.value?.nodes.length ?? 0) > 0)).toBe(true);
+    expect(describeExtractionLane(d)).toMatch(/no symbols for \d+ file/);
+  }, 30_000);
+
+  it('a blind worker still yields a graph byte-identical to the serial lane', async () => {
+    const files = corpus();
+    const pooled = await buildJson(files, {
+      workerFactory: stubWorkerFactory({ blindTo: () => true }),
+      poolSize: 2,
+    });
+    expect(pooled).toBe(await buildJson(files));
+  }, 30_000);
+
+  it('costs nothing on a healthy worker: a file that merely has no functions is not a silence', async () => {
+    // The predicate matches the no-grammar SIGNATURE (no nodes, no edges, no style, no
+    // parse health) — not "no functions". A real parse of a comment- or types-only file
+    // still yields style counters, so ordinary empty files never trigger a re-check.
+    const files: ExtractionFile[] = [
+      { path: 'src/blank0.ts', language: 'TypeScript', content: '// nothing here\n' },
+      { path: 'src/types.ts', language: 'TypeScript', content: 'export interface X { a: number }\n' },
+      ...corpus(6),
+    ];
+    const { disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({}),
+      poolSize: 1,
+    });
+    expect(d.lane).toBe('pooled');
+    expect(d.emptyRechecks).toBe(0);
+    expect(d.laneDefectFiles).toEqual([]);
+    expect(describeExtractionLane(d)).toBeUndefined();
+  }, 30_000);
+
+  it('re-checks only until the worker proves the language, for a language with no style counters', async () => {
+    // Java carries no style tally, so a genuinely empty Java file IS indistinguishable from
+    // a missing grammar — and is re-checked, until a real Java file proves the worker can
+    // parse Java. That bounded cost is the price of never trusting an unproven silence.
+    const blank = (i: number): ExtractionFile => ({ path: `Blank${i}.java`, language: 'Java', content: '// nothing\n' });
+    const real: ExtractionFile = {
+      path: 'Svc.java', language: 'Java',
+      content: 'class Svc {\n  static int helper(int x) { return x + 1; }\n  int run() { return helper(2); }\n}\n',
+    };
+    const files = [blank(0), blank(1), real, blank(2), blank(3)];
+    const { disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({}),
+      poolSize: 1,
+    });
+    expect(d.lane).toBe('pooled');
+    // The two before the proof are re-checked; the two after are trusted.
+    expect(d.emptyRechecks).toBe(2);
+    expect(d.laneDefectFiles).toEqual([]);
+    expect(describeExtractionLane(d)).toBeUndefined();
+  }, 30_000);
+
+  it('treats a language with no extractor as a deterministic answer, not a silence', async () => {
+    // `undefined` (no extractor for this language) is identical on both lanes, so it must
+    // NOT trigger a main-thread re-check on every single file.
+    const files: ExtractionFile[] = Array.from({ length: 6 }, (_, i) => ({
+      path: `notes${i}.txt`, language: 'PlainText', content: 'nothing to extract\n',
+    }));
+    const { outcomes, disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({}),
+      poolSize: 2,
+    });
+    expect(d.emptyRechecks).toBe(0);
+    expect(outcomes.every(o => o.status === 'ok' && o.value === undefined)).toBe(true);
+  }, 30_000);
+});
+
+describe('extraction pool — protocol and budget', () => {
+  it('retires an off-protocol worker instead of waiting forever for the reply it owes', async () => {
+    // A reply whose id does not match the one outstanding request. Ignoring it would leave
+    // the request armed and hang the whole pass; the worker is retired instead.
+    const files = corpus();
+    const { outcomes, disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({ wrongId: true }),
+      poolSize: 2,
+    });
+    expect(d.lane).toBe('pooled');
+    expect(d.workerFallbackFiles).toHaveLength(files.length);
+    expect(outcomes.every(o => o.status === 'ok')).toBe(true);
+  }, 30_000);
+
+  it('caps workers across the process, not per build', async () => {
+    // Two builds in flight at once must not each plan a full pool: a worker's resident cost
+    // is per process, and the MCP daemon does run builds concurrently (a background
+    // self-heal rebuild alongside a tool-call build).
+    const many = EXTRACTION_POOL_MIN_FILES + 64;
+    const first = plannedPoolSize(many);
+    expect(first).toBeGreaterThan(0);
+
+    // Workers that spawn and then say nothing, so they stay live while we look at the budget.
+    const silent: ExtractionWorkerFactory = () => ({
+      postMessage() { /* never answers */ },
+      on() { /* no events */ },
+      terminate() { /* nothing to stop */ },
+    });
+    const trivial = async (): Promise<FileExtractResult | undefined> => undefined;
+
+    vi.useFakeTimers();
+    const holding = extractFilesForPass1(corpus(4), trivial, isEmpty, { workerFactory: silent, poolSize: first });
+    await Promise.resolve();
+    // Those workers are alive, so a build starting now plans a smaller pool.
+    expect(plannedPoolSize(many)).toBeLessThan(first);
+
+    await vi.advanceTimersByTimeAsync(EXTRACTION_POOL_STARTUP_TIMEOUT_MS + 1_000);
+    vi.useRealTimers();
+    await holding;
+    // …and the budget comes back once they are gone.
+    expect(plannedPoolSize(many)).toBe(first);
   }, 30_000);
 });

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Pass-1 extraction pool (change: optimize-parallel-extraction-pool).
+ *
+ * The pool exists to make extraction faster WITHOUT making it different, so almost every
+ * test here is a parity test: run the same input through the pooled lane and the serial
+ * lane and require identical facts. The hazards being pinned are worker completion order,
+ * worker death, an extractor that throws inside a worker, and a worker that cannot parse
+ * at all.
+ *
+ * The stub-worker lane below is not a mock of extraction — it calls the real
+ * `dispatchFileExtract`. It only controls WHEN each answer arrives, which is precisely the
+ * variable a real thread pool introduces and the one determinism must survive.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  extractFilesForPass1,
+  plannedPoolSize,
+  resolveWorkerEntry,
+  describeExtractionLane,
+  type ExtractionFile,
+  type ExtractionWorkerFactory,
+  type ExtractionWorkerHandle,
+  type ExtractionRequest,
+  type ExtractionResponse,
+} from './extraction-pool.js';
+import { CallGraphBuilder, serializeCallGraph, dispatchFileExtract } from './call-graph.js';
+import { EXTRACTION_POOL_MIN_FILES } from '../../constants.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** A deterministic corpus with real cross-file calls, so ordering bugs show up as edges. */
+function corpus(count = 40): ExtractionFile[] {
+  const files: ExtractionFile[] = [];
+  for (let i = 0; i < count; i++) {
+    files.push({
+      path: `src/mod${i}.ts`,
+      language: 'TypeScript',
+      content:
+        `export function helper${i}(x: number): number {\n` +
+        `  return x + ${i};\n` +
+        `}\n\n` +
+        `export class Widget${i} {\n` +
+        `  render(): number {\n` +
+        `    return helper${i}(${i}) + helper${(i + 1) % count}(1);\n` +
+        `  }\n` +
+        `}\n`,
+    });
+  }
+  return files;
+}
+
+/** Every file resolves to the same name in every lane, so a shuffled merge is detectable. */
+function collidingCorpus(): ExtractionFile[] {
+  return Array.from({ length: 8 }, (_, i) => ({
+    path: `src/dup${i}.ts`,
+    language: 'TypeScript',
+    content: `export function shared(): number { return ${i}; }\n`,
+  }));
+}
+
+interface StubOptions {
+  /** Milliseconds to wait before answering file at `index`. Drives completion order. */
+  delayFor?: (index: number) => number;
+  /** Kill the worker instead of answering this file (simulates a crashed thread). */
+  dieOn?: (file: ExtractionFile, index: number) => boolean;
+  /** Report `unhealthy` at startup instead of `ready`. */
+  unhealthy?: boolean;
+  /** Never say anything at startup (a hung worker). */
+  silentStartup?: boolean;
+  /** Warnings each worker relays at startup — used to prove parent-side dedupe. */
+  relayWarnings?: string[];
+  /** Records the input index of every answer, in the order the parent received it. */
+  completionLog?: number[];
+}
+
+/**
+ * A worker handle that runs the REAL extractor in-process while controlling timing.
+ * Deliberately not a `worker_threads` worker: the ordering hazard is what is under test,
+ * and threads would make it nondeterministic rather than pinned.
+ */
+function stubWorkerFactory(opts: StubOptions = {}): ExtractionWorkerFactory {
+  return () => {
+    const listeners: Record<string, Array<(v: never) => void>> = { message: [], error: [], exit: [] };
+    let dead = false;
+    const emit = (event: 'message' | 'error' | 'exit', value: unknown): void => {
+      if (dead && event === 'message') return;
+      for (const l of listeners[event]) (l as (v: unknown) => void)(value);
+    };
+    const send = (msg: ExtractionResponse): void => emit('message', msg);
+
+    const handle: ExtractionWorkerHandle = {
+      postMessage(raw: unknown) {
+        const msg = raw as ExtractionRequest;
+        if (msg.type !== 'extract') return;
+        const { id, file } = msg;
+        setTimeout(() => {
+          if (dead) return;
+          if (opts.dieOn?.(file, id)) {
+            dead = true;
+            emit('error', new Error(`stub worker died on ${file.path}`));
+            emit('exit', 1);
+            return;
+          }
+          void dispatchFileExtract(file).then(
+            (value) => { opts.completionLog?.push(id); send({ type: 'result', id, value }); },
+            (err: Error) => { opts.completionLog?.push(id); send({ type: 'failed', id, message: err.message }); },
+          );
+        }, opts.delayFor?.(id) ?? 0);
+      },
+      on(event: string, listener: (v: never) => void) { listeners[event].push(listener); },
+      terminate() { dead = true; },
+    };
+
+    // Startup handshake, always asynchronous — the parent must not assume it is ready.
+    setTimeout(() => {
+      if (dead) return;
+      for (const w of opts.relayWarnings ?? []) send({ type: 'log', level: 'warning', message: w });
+      if (opts.silentStartup) return;
+      if (opts.unhealthy) send({ type: 'unhealthy', reason: 'stub grammar unavailable' });
+      else send({ type: 'ready' });
+    }, 0);
+
+    return handle;
+  };
+}
+
+/** Serialize a build so two lanes can be compared byte-for-byte. */
+async function buildJson(
+  files: ExtractionFile[],
+  extraction?: { workerFactory?: ExtractionWorkerFactory; poolSize?: number },
+): Promise<string> {
+  const result = await new CallGraphBuilder(extraction ? { extraction } : {}).build(files.map(f => ({ ...f })));
+  return JSON.stringify(serializeCallGraph(result));
+}
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+// ---------------------------------------------------------------------------
+
+describe('extraction pool — lane selection', () => {
+  it('stays serial below the file-count floor, and says why', async () => {
+    const files = corpus(EXTRACTION_POOL_MIN_FILES - 1);
+    const { disclosure } = await extractFilesForPass1(files, dispatchFileExtract);
+    expect(disclosure.lane).toBe('serial');
+    expect(disclosure.serialReason).toBe('too-few-files');
+    expect(plannedPoolSize(files.length)).toBe(0);
+  });
+
+  it('OPENLORE_NO_WORKERS forces the serial lane even for a large build', async () => {
+    // The suite already sets this flag; assert the contract rather than assuming it.
+    expect(process.env.OPENLORE_NO_WORKERS).toBe('1');
+    const { disclosure } = await extractFilesForPass1(corpus(64), dispatchFileExtract);
+    expect(disclosure.lane).toBe('serial');
+    expect(disclosure.serialReason).toBe('disabled-by-env');
+  });
+
+  it('a normal serial choice is not reported as a degradation', () => {
+    expect(describeExtractionLane({ lane: 'serial', poolSize: 0, serialReason: 'too-few-files', workerFallbackFiles: [] })).toBeUndefined();
+    expect(describeExtractionLane({ lane: 'pooled', poolSize: 4, workerFallbackFiles: [] })).toBeUndefined();
+    expect(describeExtractionLane({ lane: 'pooled', poolSize: 4, workerFallbackFiles: ['a.ts'] })).toMatch(/re-extracted on the main thread/);
+    expect(describeExtractionLane({ lane: 'serial', poolSize: 0, serialReason: 'pool-unavailable', workerFallbackFiles: [] })).toMatch(/serial lane/);
+  });
+
+  it('resolves a worker entry for the current runtime', () => {
+    // Source tree (vitest) resolves the .ts entry via tsx; dist resolves the .js sibling.
+    const entry = resolveWorkerEntry();
+    expect(entry?.specifier.href).toMatch(/extraction-worker\.(js|ts)$/);
+  });
+});
+
+describe('extraction pool — determinism', () => {
+  it('merges in input order even when workers complete in reverse', async () => {
+    const files = corpus(40);
+    const completionLog: number[] = [];
+    // Later files answer sooner: the completion order is deliberately inverted.
+    const factory = stubWorkerFactory({ delayFor: (i) => (files.length - i), completionLog });
+
+    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
+      workerFactory: factory,
+      poolSize: 4,
+    });
+
+    expect(disclosure.lane).toBe('pooled');
+    // Prove the hazard was actually exercised — otherwise this test proves nothing.
+    expect(completionLog).not.toEqual([...completionLog].sort((a, b) => a - b));
+    // …and that the merge is nevertheless in input order.
+    for (let i = 0; i < files.length; i++) {
+      expect(outcomes[i].status).toBe('ok');
+      const value = outcomes[i].status === 'ok' ? (outcomes[i] as { value?: { nodes: Array<{ filePath: string }> } }).value : undefined;
+      expect(value?.nodes[0]?.filePath).toBe(files[i].path);
+    }
+  });
+
+  it('produces a byte-identical graph to the serial lane', async () => {
+    const files = corpus(40);
+    const serial = await buildJson(files);
+    const pooled = await buildJson(files, {
+      workerFactory: stubWorkerFactory({ delayFor: (i) => (files.length - i) }),
+      poolSize: 4,
+    });
+    expect(pooled).toBe(serial);
+  });
+
+  it('keeps last-writer-wins on colliding symbol ids', async () => {
+    // Every file defines `shared()`, so the surviving node is decided purely by merge
+    // order. Out-of-order completion must not change which file wins.
+    const files = collidingCorpus();
+    const serial = await buildJson(files);
+    const pooled = await buildJson(files, {
+      workerFactory: stubWorkerFactory({ delayFor: (i) => (files.length - i) }),
+      poolSize: 4,
+    });
+    expect(pooled).toBe(serial);
+    expect(JSON.parse(serial).nodes.some((n: { filePath: string }) => n.filePath === 'src/dup7.ts')).toBe(true);
+  });
+});
+
+describe('extraction pool — fail-soft ladder', () => {
+  it('re-extracts a dead worker\'s file on the main thread, with identical facts', async () => {
+    const files = corpus(40);
+    const victim = files[17].path;
+    const factory = stubWorkerFactory({ dieOn: (f) => f.path === victim });
+
+    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
+      workerFactory: factory,
+      poolSize: 3,
+    });
+
+    expect(disclosure.lane).toBe('pooled');
+    expect(disclosure.workerFallbackFiles).toContain(victim);
+    expect(outcomes).toHaveLength(files.length);
+    expect(outcomes.every(o => o.status === 'ok')).toBe(true);
+
+    const pooled = await buildJson(files, { workerFactory: stubWorkerFactory({ dieOn: (f) => f.path === victim }), poolSize: 3 });
+    expect(pooled).toBe(await buildJson(files));
+  });
+
+  it('survives every worker dying — no file is lost', async () => {
+    const files = corpus(40);
+    const factory = stubWorkerFactory({ dieOn: () => true });
+    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
+      workerFactory: factory,
+      poolSize: 4,
+    });
+    expect(disclosure.workerFallbackFiles).toHaveLength(files.length);
+    expect(outcomes.every(o => o.status === 'ok')).toBe(true);
+    expect(await buildJson(files, { workerFactory: stubWorkerFactory({ dieOn: () => true }), poolSize: 4 })).toBe(await buildJson(files));
+  });
+
+  it('falls back to the serial lane wholesale when no worker comes up healthy', async () => {
+    const files = corpus(40);
+    const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
+      workerFactory: stubWorkerFactory({ unhealthy: true }),
+      poolSize: 4,
+    });
+    expect(disclosure.lane).toBe('serial');
+    expect(disclosure.serialReason).toBe('pool-unavailable');
+    expect(outcomes.every(o => o.status === 'ok')).toBe(true);
+  });
+
+  it('falls back when the worker factory itself throws', async () => {
+    const { disclosure, outcomes } = await extractFilesForPass1(corpus(40), dispatchFileExtract, {
+      workerFactory: () => { throw new Error('spawn refused'); },
+      poolSize: 4,
+    });
+    expect(disclosure.lane).toBe('serial');
+    expect(disclosure.serialReason).toBe('pool-unavailable');
+    expect(outcomes.every(o => o.status === 'ok')).toBe(true);
+  });
+
+  it('reports an extractor that throws inside a worker as that file\'s failure, not a lane failure', async () => {
+    const files = corpus(40);
+    const boom = files[5].path;
+    const factory = stubWorkerFactory({});
+    // Wrap the serial extractor so the stub's in-process dispatch throws for one file,
+    // exactly as a real worker would report `failed`.
+    const { outcomes, disclosure } = await extractFilesForPass1(
+      files,
+      async (f) => { if (f.path === boom) throw new Error('synthetic parse failure'); return dispatchFileExtract(f); },
+      { workerFactory: factory, poolSize: 2 },
+    );
+    // The stub calls the real dispatch, so the injected failure only affects the serial
+    // path here; what matters is that a `failed` reply becomes a per-file error outcome.
+    expect(disclosure.lane).toBe('pooled');
+    expect(outcomes).toHaveLength(files.length);
+    expect(disclosure.workerFallbackFiles).toHaveLength(0);
+  });
+
+  it('records a worker-reported failure as a parse-health failure, exactly like the serial lane', async () => {
+    const files = corpus(4);
+    const failing: ExtractionWorkerFactory = () => {
+      const listeners: Record<string, Array<(v: never) => void>> = { message: [], error: [], exit: [] };
+      const emit = (e: string, v: unknown): void => { for (const l of listeners[e]) (l as (x: unknown) => void)(v); };
+      const h: ExtractionWorkerHandle = {
+        postMessage(raw: unknown) {
+          const msg = raw as ExtractionRequest;
+          if (msg.type === 'extract') setTimeout(() => emit('message', { type: 'failed', id: msg.id, message: 'grammar exploded' }), 0);
+        },
+        on(event: string, l: (v: never) => void) { listeners[event].push(l); },
+        terminate() { /* no-op */ },
+      };
+      setTimeout(() => emit('message', { type: 'ready' }), 0);
+      return h;
+    };
+    const result = await new CallGraphBuilder({ extraction: { workerFactory: failing, poolSize: 1 } }).build(files);
+    expect(result.nodes.size).toBe(0);
+    expect([...(result.parseHealthByFile ?? new Map()).values()].every(h => h.parseFailed)).toBe(true);
+    expect(result.parseHealthByFile?.size).toBe(files.length);
+  });
+
+  it('drops a worker that never reports ready instead of hanging', async () => {
+    const files = corpus(40);
+    vi.useFakeTimers();
+    const promise = extractFilesForPass1(files, dispatchFileExtract, {
+      workerFactory: stubWorkerFactory({ silentStartup: true }),
+      poolSize: 2,
+    });
+    await vi.advanceTimersByTimeAsync(31_000);
+    vi.useRealTimers();
+    const { disclosure, outcomes } = await promise;
+    expect(disclosure.lane).toBe('serial');
+    expect(disclosure.serialReason).toBe('pool-unavailable');
+    expect(outcomes).toHaveLength(files.length);
+  });
+});
+
+describe('extraction pool — worker log relay', () => {
+  it('prints a relayed grammar warning once, not once per worker', async () => {
+    const { logger } = await import('../../utils/logger.js');
+    const warn = vi.spyOn(logger, 'warning').mockImplementation(() => {});
+    await extractFilesForPass1(corpus(40), dispatchFileExtract, {
+      workerFactory: stubWorkerFactory({ relayWarnings: ['language Lua grammar unavailable'] }),
+      poolSize: 4,
+    });
+    const relayed = warn.mock.calls.filter(c => String(c[0]).includes('Lua grammar unavailable'));
+    expect(relayed).toHaveLength(1);
+  });
+});

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -13,6 +13,8 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   extractFilesForPass1,
   plannedPoolSize,
@@ -539,7 +541,7 @@ describe('extraction pool — scheduling independence', () => {
       ['py', 'Python', (i) => `def h${i}(x):\n    return x + ${i}\n`],
     ];
     const files: ExtractionFile[] = [];
-    for (let i = 0; i < 6; i++) {
+    for (let i = 0; i < 3; i++) {
       for (const [ext, language, gen] of languages) {
         files.push({ path: `sched${i}_${files.length}.${ext}`, language, content: gen(i) });
       }
@@ -548,7 +550,7 @@ describe('extraction pool — scheduling independence', () => {
     const baseline = await buildJson(files);
     const observedRecheckCounts = new Set<number>();
 
-    for (let run = 0; run < 12; run++) {
+    for (let run = 0; run < 8; run++) {
       // A deterministic pseudo-random delay per file: the interleaving differs per run, but
       // the test itself does not depend on wall-clock timing.
       let seed = run * 7919 + 13;
@@ -616,4 +618,26 @@ describe('extraction pool — protocol and budget', () => {
     // …and the budget comes back once they are gone.
     expect(plannedPoolSize(many)).toBe(first);
   }, 30_000);
+});
+
+describe('extraction pool — the disclosure reaches a human', () => {
+  // The lane note is deliberately NOT logged from the builder: `build()` also runs inside
+  // the stdio MCP server, whose stdout carries JSON-RPC. That makes it easy for the note to
+  // become dead plumbing — computed, carried on the artifacts, and rendered by nobody, which
+  // is exactly what an earlier round of this change shipped. These guards pin both halves.
+
+  const src = (rel: string): string => readFileSync(join(__dirname, '..', '..', rel), 'utf-8');
+
+  it('the builder never logs the lane note itself', () => {
+    const builder = readFileSync(join(__dirname, 'call-graph.ts'), 'utf-8');
+    expect(builder).not.toMatch(/logger\.\w+\([^)]*describeExtractionLane/);
+    expect(builder).not.toContain('describeExtractionLane');
+  });
+
+  it('the analyze CLI renders it', () => {
+    // If this fails, a lane defect — a worker returning no symbols for a file that has them
+    // — is computed and then silently discarded.
+    expect(src('cli/commands/analyze.ts')).toContain('extractionLaneNote');
+    expect(src('core/analyzer/artifact-generator.ts')).toContain('describeExtractionLane');
+  });
 });

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -81,6 +81,14 @@ interface StubOptions {
   blindTo?: (language: string) => boolean;
   /** Reply with an id that does not match the request — an off-protocol worker. */
   wrongId?: boolean;
+  /**
+   * Report a THROW for these languages. The per-language grammar `import`s are not wrapped,
+   * so a grammar that loads on the main thread but not in this thread surfaces as an error,
+   * not as an empty result.
+   */
+  throwsFor?: (language: string) => boolean;
+  /** Answer normally for the first N files, then throw — a worker that degrades mid-run. */
+  throwsAfter?: number;
   /** Records the input index of every answer, in the order the parent received it. */
   completionLog?: number[];
 }
@@ -94,6 +102,7 @@ function stubWorkerFactory(opts: StubOptions = {}): ExtractionWorkerFactory {
   return () => {
     const listeners: Record<string, Array<(v: never) => void>> = { message: [], error: [], exit: [] };
     let dead = false;
+    let answered = 0;
     const emit = (event: 'message' | 'error' | 'exit', value: unknown): void => {
       if (dead && event === 'message') return;
       for (const l of listeners[event]) (l as (v: unknown) => void)(value);
@@ -114,6 +123,16 @@ function stubWorkerFactory(opts: StubOptions = {}): ExtractionWorkerFactory {
             return;
           }
           const replyId = opts.wrongId ? id + 1000 : id;
+          if (opts.throwsAfter !== undefined && answered++ >= opts.throwsAfter) {
+            opts.completionLog?.push(id);
+            send({ type: 'failed', id: replyId, message: 'degraded mid-run' });
+            return;
+          }
+          if (opts.throwsFor?.(file.language)) {
+            opts.completionLog?.push(id);
+            send({ type: 'failed', id: replyId, message: `Cannot find module 'tree-sitter-${file.language}'` });
+            return;
+          }
           if (opts.blindTo?.(file.language)) {
             opts.completionLog?.push(id);
             send({ type: 'result', id: replyId, value: { nodes: [], rawEdges: [], cfg: new Map() } });
@@ -162,7 +181,7 @@ function isEmpty(result: FileExtractResult | undefined): boolean {
 
 /** A disclosure with the routine fields filled in, for the describe-only assertions. */
 function disclosure(partial: Partial<ExtractionLaneDisclosure>): ExtractionLaneDisclosure {
-  return { lane: 'serial', poolSize: 0, workerFallbackFiles: [], laneDefectFiles: [], emptyRechecks: 0, ...partial };
+  return { lane: 'serial', poolSize: 0, workerFallbackFiles: [], laneDefectFiles: [], unprovenRechecks: 0, ...partial };
 }
 
 afterEach(() => { vi.restoreAllMocks(); __resetExtractionPoolStateForTests(); });
@@ -192,7 +211,7 @@ describe('extraction pool — lane selection', () => {
     expect(describeExtractionLane(disclosure({ serialReason: 'pool-saturated' }))).toBeUndefined();
     expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4 }))).toBeUndefined();
     // An empty re-check is routine work, not a degradation — it must stay silent.
-    expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, emptyRechecks: 9 }))).toBeUndefined();
+    expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, unprovenRechecks: 9 }))).toBeUndefined();
     expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, workerFallbackFiles: ['a.ts'] }))).toMatch(/re-extracted on the main thread/);
     expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, laneDefectFiles: ['a.ts'] }))).toMatch(/no symbols for 1 file/);
     expect(describeExtractionLane(disclosure({ serialReason: 'pool-unavailable' }))).toMatch(/serial lane/);
@@ -324,7 +343,11 @@ describe('extraction pool — fail-soft ladder', () => {
     expect(disclosure.workerFallbackFiles).toHaveLength(0);
   }, 30_000);
 
-  it('records a worker-reported failure as a parse-health failure, exactly like the serial lane', async () => {
+  it('does not let a worker that fails everything write parse failures the serial lane never would', async () => {
+    // A worker that reports a failure for every file has proven nothing, so nothing it says
+    // is believed: each file is re-extracted on the main thread. Believing it would have
+    // written `parseFailed` records and dropped every symbol — a graph that depends on which
+    // lane ran, which is the one thing this change may not do.
     const files = corpus(4);
     const failing: ExtractionWorkerFactory = () => {
       const listeners: Record<string, Array<(v: never) => void>> = { message: [], error: [], exit: [] };
@@ -340,10 +363,12 @@ describe('extraction pool — fail-soft ladder', () => {
       setTimeout(() => emit('message', { type: 'ready' }), 0);
       return h;
     };
-    const result = await new CallGraphBuilder({ extraction: { workerFactory: failing, poolSize: 1 } }).build(files);
-    expect(result.nodes.size).toBe(0);
-    expect([...(result.parseHealthByFile ?? new Map()).values()].every(h => h.parseFailed)).toBe(true);
-    expect(result.parseHealthByFile?.size).toBe(files.length);
+    const result = await new CallGraphBuilder({ extraction: { workerFactory: failing, poolSize: 1 } })
+      .build(files.map(f => ({ ...f })));
+    expect(result.nodes.size).toBeGreaterThan(0);
+    expect(result.parseHealthByFile).toBeUndefined();
+    expect(result.extractionLane?.laneDefectFiles).toHaveLength(files.length);
+    expect(JSON.stringify(serializeCallGraph(result))).toBe(await buildJson(files));
   }, 30_000);
 
   it('drops a worker that never reports ready instead of hanging', async () => {
@@ -387,7 +412,7 @@ describe('extraction pool — never trust an unproven silence', () => {
 
     expect(d.lane).toBe('pooled');
     // Every file was re-checked, and every re-check found facts the worker had missed.
-    expect(d.emptyRechecks).toBe(files.length);
+    expect(d.unprovenRechecks).toBe(files.length);
     expect(d.laneDefectFiles).toHaveLength(files.length);
     expect(outcomes.every(o => o.status === 'ok' && (o.value?.nodes.length ?? 0) > 0)).toBe(true);
     expect(describeExtractionLane(d)).toMatch(/no symbols for \d+ file/);
@@ -416,7 +441,7 @@ describe('extraction pool — never trust an unproven silence', () => {
       poolSize: 1,
     });
     expect(d.lane).toBe('pooled');
-    expect(d.emptyRechecks).toBe(0);
+    expect(d.unprovenRechecks).toBe(0);
     expect(d.laneDefectFiles).toEqual([]);
     expect(describeExtractionLane(d)).toBeUndefined();
   }, 30_000);
@@ -437,9 +462,52 @@ describe('extraction pool — never trust an unproven silence', () => {
     });
     expect(d.lane).toBe('pooled');
     // The two before the proof are re-checked; the two after are trusted.
-    expect(d.emptyRechecks).toBe(2);
+    expect(d.unprovenRechecks).toBe(2);
     expect(d.laneDefectFiles).toEqual([]);
     expect(describeExtractionLane(d)).toBeUndefined();
+  }, 30_000);
+
+
+  it('re-checks a worker that THROWS for a language it has not proven', async () => {
+    // The other half of the same hazard: `getPyParser` and friends do NOT wrap their
+    // per-language `import`, so a grammar that loads on the main thread but not in this
+    // worker surfaces as a throw. Trusting it would record `parseFailed` and zero symbols
+    // for files the serial lane extracts fully — a lane-dependent graph.
+    const files = corpus();
+    const { outcomes, disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({ throwsFor: (l) => l === 'TypeScript' }),
+      poolSize: 2,
+    });
+
+    expect(d.lane).toBe('pooled');
+    expect(d.unprovenRechecks).toBe(files.length);
+    expect(d.laneDefectFiles).toHaveLength(files.length);
+    expect(outcomes.every(o => o.status === 'ok' && (o.value?.nodes.length ?? 0) > 0)).toBe(true);
+  }, 30_000);
+
+  it('a throwing worker still yields a graph byte-identical to the serial lane', async () => {
+    const files = corpus();
+    const pooled = await buildJson(files, {
+      workerFactory: stubWorkerFactory({ throwsFor: () => true }),
+      poolSize: 2,
+    });
+    expect(pooled).toBe(await buildJson(files));
+  }, 30_000);
+
+  it('trusts an error from a worker that has already proven the language', async () => {
+    // The guard must not launder every error into a re-check: once a worker has shown it
+    // can extract a language, a throw from it is a real per-file parse failure and is
+    // recorded as one — exactly as the serial lane would.
+    const files = corpus(6);
+    const { outcomes, disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({ throwsAfter: 3 }),
+      poolSize: 1,
+    });
+    expect(d.lane).toBe('pooled');
+    // The first three prove TypeScript; the throws that follow are believed, not re-checked.
+    expect(d.unprovenRechecks).toBe(0);
+    expect(d.laneDefectFiles).toEqual([]);
+    expect(outcomes.slice(3).every(o => o.status === 'error')).toBe(true);
   }, 30_000);
 
   it('treats a language with no extractor as a deterministic answer, not a silence', async () => {
@@ -452,9 +520,53 @@ describe('extraction pool — never trust an unproven silence', () => {
       workerFactory: stubWorkerFactory({}),
       poolSize: 2,
     });
-    expect(d.emptyRechecks).toBe(0);
+    expect(d.unprovenRechecks).toBe(0);
     expect(outcomes.every(o => o.status === 'ok' && o.value === undefined)).toBe(true);
   }, 30_000);
+});
+
+describe('extraction pool — scheduling independence', () => {
+  it('varies which files it re-checks, and never varies the output', async () => {
+    // The subtlest hazard the unproven-silence guard introduces: WHICH files get re-checked
+    // on the main thread depends on scheduling (a language is proven at a different point in
+    // each run). This asserts both halves — that the re-check set really does vary, and that
+    // the merged graph does not — across pool sizes and randomized interleavings.
+    const languages: Array<[string, string, (i: number) => string]> = [
+      ['ts', 'TypeScript', (i) => `export function h${i}(x: number): number { return x + ${i}; }\n`],
+      ['java', 'Java', (i) => `class S${i} {\n  static int h(int x) { return x + ${i}; }\n  int r() { return h(2); }\n}\n`],
+      // Empty AND carrying no style counters — the shape that takes the re-check path.
+      ['java', 'Java', () => '// nothing at all\n'],
+      ['py', 'Python', (i) => `def h${i}(x):\n    return x + ${i}\n`],
+    ];
+    const files: ExtractionFile[] = [];
+    for (let i = 0; i < 6; i++) {
+      for (const [ext, language, gen] of languages) {
+        files.push({ path: `sched${i}_${files.length}.${ext}`, language, content: gen(i) });
+      }
+    }
+
+    const baseline = await buildJson(files);
+    const observedRecheckCounts = new Set<number>();
+
+    for (let run = 0; run < 12; run++) {
+      // A deterministic pseudo-random delay per file: the interleaving differs per run, but
+      // the test itself does not depend on wall-clock timing.
+      let seed = run * 7919 + 13;
+      const nextDelay = (): number => {
+        seed = (seed * 1664525 + 1013904223) >>> 0;
+        return (seed / 2 ** 32) * 5;
+      };
+      const result = await new CallGraphBuilder({
+        extraction: { workerFactory: stubWorkerFactory({ delayFor: nextDelay }), poolSize: 1 + (run % 4) },
+      }).build(files.map(f => ({ ...f })));
+
+      observedRecheckCounts.add(result.extractionLane?.unprovenRechecks ?? 0);
+      expect(JSON.stringify(serializeCallGraph(result))).toBe(baseline);
+    }
+
+    // If the re-check count never varied, this test would not be exercising the hazard.
+    expect(observedRecheckCounts.size).toBeGreaterThan(1);
+  }, 60_000);
 });
 
 describe('extraction pool — protocol and budget', () => {

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -32,7 +32,7 @@ import { EXTRACTION_POOL_MIN_FILES } from '../../constants.js';
 // ---------------------------------------------------------------------------
 
 /** A deterministic corpus with real cross-file calls, so ordering bugs show up as edges. */
-function corpus(count = 40): ExtractionFile[] {
+function corpus(count = 12): ExtractionFile[] {
   const files: ExtractionFile[] = [];
   for (let i = 0; i < count; i++) {
     files.push({
@@ -147,33 +147,33 @@ describe('extraction pool — lane selection', () => {
     expect(disclosure.lane).toBe('serial');
     expect(disclosure.serialReason).toBe('too-few-files');
     expect(plannedPoolSize(files.length)).toBe(0);
-  });
+  }, 30_000);
 
   it('OPENLORE_NO_WORKERS forces the serial lane even for a large build', async () => {
     // The suite already sets this flag; assert the contract rather than assuming it.
     expect(process.env.OPENLORE_NO_WORKERS).toBe('1');
-    const { disclosure } = await extractFilesForPass1(corpus(64), dispatchFileExtract);
+    const { disclosure } = await extractFilesForPass1(corpus(EXTRACTION_POOL_MIN_FILES + 8), dispatchFileExtract);
     expect(disclosure.lane).toBe('serial');
     expect(disclosure.serialReason).toBe('disabled-by-env');
-  });
+  }, 30_000);
 
   it('a normal serial choice is not reported as a degradation', () => {
     expect(describeExtractionLane({ lane: 'serial', poolSize: 0, serialReason: 'too-few-files', workerFallbackFiles: [] })).toBeUndefined();
     expect(describeExtractionLane({ lane: 'pooled', poolSize: 4, workerFallbackFiles: [] })).toBeUndefined();
     expect(describeExtractionLane({ lane: 'pooled', poolSize: 4, workerFallbackFiles: ['a.ts'] })).toMatch(/re-extracted on the main thread/);
     expect(describeExtractionLane({ lane: 'serial', poolSize: 0, serialReason: 'pool-unavailable', workerFallbackFiles: [] })).toMatch(/serial lane/);
-  });
+  }, 30_000);
 
   it('resolves a worker entry for the current runtime', () => {
     // Source tree (vitest) resolves the .ts entry via tsx; dist resolves the .js sibling.
     const entry = resolveWorkerEntry();
     expect(entry?.specifier.href).toMatch(/extraction-worker\.(js|ts)$/);
-  });
+  }, 30_000);
 });
 
 describe('extraction pool — determinism', () => {
   it('merges in input order even when workers complete in reverse', async () => {
-    const files = corpus(40);
+    const files = corpus();
     const completionLog: number[] = [];
     // Later files answer sooner: the completion order is deliberately inverted.
     const factory = stubWorkerFactory({ delayFor: (i) => (files.length - i), completionLog });
@@ -192,17 +192,17 @@ describe('extraction pool — determinism', () => {
       const value = outcomes[i].status === 'ok' ? (outcomes[i] as { value?: { nodes: Array<{ filePath: string }> } }).value : undefined;
       expect(value?.nodes[0]?.filePath).toBe(files[i].path);
     }
-  });
+  }, 30_000);
 
   it('produces a byte-identical graph to the serial lane', async () => {
-    const files = corpus(40);
+    const files = corpus();
     const serial = await buildJson(files);
     const pooled = await buildJson(files, {
       workerFactory: stubWorkerFactory({ delayFor: (i) => (files.length - i) }),
       poolSize: 4,
     });
     expect(pooled).toBe(serial);
-  });
+  }, 30_000);
 
   it('keeps last-writer-wins on colliding symbol ids', async () => {
     // Every file defines `shared()`, so the surviving node is decided purely by merge
@@ -215,13 +215,13 @@ describe('extraction pool — determinism', () => {
     });
     expect(pooled).toBe(serial);
     expect(JSON.parse(serial).nodes.some((n: { filePath: string }) => n.filePath === 'src/dup7.ts')).toBe(true);
-  });
+  }, 30_000);
 });
 
 describe('extraction pool — fail-soft ladder', () => {
   it('re-extracts a dead worker\'s file on the main thread, with identical facts', async () => {
-    const files = corpus(40);
-    const victim = files[17].path;
+    const files = corpus();
+    const victim = files[7].path;
     const factory = stubWorkerFactory({ dieOn: (f) => f.path === victim });
 
     const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
@@ -236,10 +236,10 @@ describe('extraction pool — fail-soft ladder', () => {
 
     const pooled = await buildJson(files, { workerFactory: stubWorkerFactory({ dieOn: (f) => f.path === victim }), poolSize: 3 });
     expect(pooled).toBe(await buildJson(files));
-  });
+  }, 30_000);
 
   it('survives every worker dying — no file is lost', async () => {
-    const files = corpus(40);
+    const files = corpus();
     const factory = stubWorkerFactory({ dieOn: () => true });
     const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
       workerFactory: factory,
@@ -248,10 +248,10 @@ describe('extraction pool — fail-soft ladder', () => {
     expect(disclosure.workerFallbackFiles).toHaveLength(files.length);
     expect(outcomes.every(o => o.status === 'ok')).toBe(true);
     expect(await buildJson(files, { workerFactory: stubWorkerFactory({ dieOn: () => true }), poolSize: 4 })).toBe(await buildJson(files));
-  });
+  }, 30_000);
 
   it('falls back to the serial lane wholesale when no worker comes up healthy', async () => {
-    const files = corpus(40);
+    const files = corpus();
     const { outcomes, disclosure } = await extractFilesForPass1(files, dispatchFileExtract, {
       workerFactory: stubWorkerFactory({ unhealthy: true }),
       poolSize: 4,
@@ -259,20 +259,20 @@ describe('extraction pool — fail-soft ladder', () => {
     expect(disclosure.lane).toBe('serial');
     expect(disclosure.serialReason).toBe('pool-unavailable');
     expect(outcomes.every(o => o.status === 'ok')).toBe(true);
-  });
+  }, 30_000);
 
   it('falls back when the worker factory itself throws', async () => {
-    const { disclosure, outcomes } = await extractFilesForPass1(corpus(40), dispatchFileExtract, {
+    const { disclosure, outcomes } = await extractFilesForPass1(corpus(), dispatchFileExtract, {
       workerFactory: () => { throw new Error('spawn refused'); },
       poolSize: 4,
     });
     expect(disclosure.lane).toBe('serial');
     expect(disclosure.serialReason).toBe('pool-unavailable');
     expect(outcomes.every(o => o.status === 'ok')).toBe(true);
-  });
+  }, 30_000);
 
   it('reports an extractor that throws inside a worker as that file\'s failure, not a lane failure', async () => {
-    const files = corpus(40);
+    const files = corpus();
     const boom = files[5].path;
     const factory = stubWorkerFactory({});
     // Wrap the serial extractor so the stub's in-process dispatch throws for one file,
@@ -287,7 +287,7 @@ describe('extraction pool — fail-soft ladder', () => {
     expect(disclosure.lane).toBe('pooled');
     expect(outcomes).toHaveLength(files.length);
     expect(disclosure.workerFallbackFiles).toHaveLength(0);
-  });
+  }, 30_000);
 
   it('records a worker-reported failure as a parse-health failure, exactly like the serial lane', async () => {
     const files = corpus(4);
@@ -309,10 +309,10 @@ describe('extraction pool — fail-soft ladder', () => {
     expect(result.nodes.size).toBe(0);
     expect([...(result.parseHealthByFile ?? new Map()).values()].every(h => h.parseFailed)).toBe(true);
     expect(result.parseHealthByFile?.size).toBe(files.length);
-  });
+  }, 30_000);
 
   it('drops a worker that never reports ready instead of hanging', async () => {
-    const files = corpus(40);
+    const files = corpus();
     vi.useFakeTimers();
     const promise = extractFilesForPass1(files, dispatchFileExtract, {
       workerFactory: stubWorkerFactory({ silentStartup: true }),
@@ -324,18 +324,18 @@ describe('extraction pool — fail-soft ladder', () => {
     expect(disclosure.lane).toBe('serial');
     expect(disclosure.serialReason).toBe('pool-unavailable');
     expect(outcomes).toHaveLength(files.length);
-  });
+  }, 30_000);
 });
 
 describe('extraction pool — worker log relay', () => {
   it('prints a relayed grammar warning once, not once per worker', async () => {
     const { logger } = await import('../../utils/logger.js');
     const warn = vi.spyOn(logger, 'warning').mockImplementation(() => {});
-    await extractFilesForPass1(corpus(40), dispatchFileExtract, {
+    await extractFilesForPass1(corpus(), dispatchFileExtract, {
       workerFactory: stubWorkerFactory({ relayWarnings: ['language Lua grammar unavailable'] }),
       poolSize: 4,
     });
     const relayed = warn.mock.calls.filter(c => String(c[0]).includes('Lua grammar unavailable'));
     expect(relayed).toHaveLength(1);
-  });
+  }, 30_000);
 });

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -27,7 +27,7 @@ import {
   type ExtractionResponse,
 } from './extraction-pool.js';
 import { CallGraphBuilder, serializeCallGraph, dispatchFileExtract, type FileExtractResult } from './call-graph.js';
-import { EXTRACTION_POOL_MIN_FILES, EXTRACTION_POOL_STARTUP_TIMEOUT_MS } from '../../constants.js';
+import { EXTRACTION_POOL_MAX, EXTRACTION_POOL_MIN_FILES, EXTRACTION_POOL_STARTUP_TIMEOUT_MS } from '../../constants.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -477,7 +477,8 @@ describe('extraction pool — protocol and budget', () => {
     // self-heal rebuild alongside a tool-call build).
     const many = EXTRACTION_POOL_MIN_FILES + 64;
     const first = plannedPoolSize(many);
-    expect(first).toBeGreaterThan(0);
+    // A machine too small for any pool has nothing to cap; the cores test covers that case.
+    if (first === 0) return;
 
     // Workers that spawn and then say nothing, so they stay live while we look at the budget.
     const silent: ExtractionWorkerFactory = () => ({
@@ -488,10 +489,14 @@ describe('extraction pool — protocol and budget', () => {
     const trivial = async (): Promise<FileExtractResult | undefined> => undefined;
 
     vi.useFakeTimers();
-    const holding = extractFilesForPass1(corpus(4), trivial, isEmpty, { workerFactory: silent, poolSize: first });
+    // Hold the whole process budget. Sizing is otherwise core-bound, so this — not a
+    // partial hold — is what proves the budget is the thing doing the capping.
+    const holding = extractFilesForPass1(corpus(4), trivial, isEmpty, {
+      workerFactory: silent,
+      poolSize: EXTRACTION_POOL_MAX,
+    });
     await Promise.resolve();
-    // Those workers are alive, so a build starting now plans a smaller pool.
-    expect(plannedPoolSize(many)).toBeLessThan(first);
+    expect(plannedPoolSize(many)).toBe(0);
 
     await vi.advanceTimersByTimeAsync(EXTRACTION_POOL_STARTUP_TIMEOUT_MS + 1_000);
     vi.useRealTimers();

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -214,8 +214,16 @@ describe('extraction pool — lane selection', () => {
     expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4 }))).toBeUndefined();
     // An empty re-check is routine work, not a degradation — it must stay silent.
     expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, unprovenRechecks: 9 }))).toBeUndefined();
-    expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, workerFallbackFiles: ['a.ts'] }))).toMatch(/re-extracted on the main thread/);
+    expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, workerFallbackFiles: ['a.ts'] })))
+      .toMatch(/extraction pool degraded: 1 file\(s\) re-extracted on the main thread/);
     expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4, laneDefectFiles: ['a.ts'] }))).toMatch(/no symbols for 1 file/);
+    // Both happened: neither may swallow the other — an earlier revision dropped the
+    // fallback count whenever a defect was also present.
+    const both = describeExtractionLane(disclosure({
+      lane: 'pooled', poolSize: 4, laneDefectFiles: ['a.ts'], workerFallbackFiles: ['b.ts', 'c.ts'],
+    }));
+    expect(both).toMatch(/no symbols for 1 file/);
+    expect(both).toMatch(/2 file\(s\) re-extracted on the main thread/);
     expect(describeExtractionLane(disclosure({ serialReason: 'pool-unavailable' }))).toMatch(/serial lane/);
   }, 30_000);
 

--- a/src/core/analyzer/extraction-pool.ts
+++ b/src/core/analyzer/extraction-pool.ts
@@ -139,6 +139,16 @@ export interface ExtractionLaneOptions {
 /** Handed to a worker at construction. */
 export interface ExtractionWorkerData {
   /**
+   * Marks this thread as an extraction worker spawned by THIS pool.
+   *
+   * The worker entry serves requests on `parentPort` as a top-level side effect of being
+   * imported, so anything else that imports it while running inside some other worker
+   * thread would hijack that thread's message channel. `parentPort !== null` is not enough
+   * to tell the two apart (a test runner using a thread pool looks identical), so the
+   * module stays inert unless it finds this sentinel.
+   */
+  openloreExtractionWorker: true;
+  /**
    * The language the worker should prove it can parse before accepting work. Chosen from
    * the build's own files so the probe never gates on a grammar this repo does not use —
    * every grammar is an optional dependency. Absent, or a language with no probe snippet,
@@ -353,7 +363,7 @@ async function runSerial<T>(
 function createNodeWorker(entry: ResolvedWorkerEntry, probeLanguage?: string): ExtractionWorkerHandle {
   const worker = new Worker(entry.specifier, {
     ...(entry.execArgv ? { execArgv: entry.execArgv } : {}),
-    workerData: { probeLanguage } satisfies ExtractionWorkerData,
+    workerData: { openloreExtractionWorker: true, probeLanguage } satisfies ExtractionWorkerData,
     stdout: true,
   });
   worker.stdout.resume();
@@ -654,7 +664,7 @@ export function describeExtractionLane(d: ExtractionLaneDisclosure): string | un
       );
     }
     if (d.workerFallbackFiles.length > 0) {
-      parts.push(`${d.workerFallbackFiles.length} file(s) re-extracted on the main thread after a worker failed`);
+      parts.push(`extraction pool degraded: ${d.workerFallbackFiles.length} file(s) re-extracted on the main thread after a worker failed`);
     }
     return parts.length > 0 ? parts.join('; ') : undefined;
   }

--- a/src/core/analyzer/extraction-pool.ts
+++ b/src/core/analyzer/extraction-pool.ts
@@ -23,11 +23,17 @@
  *     *throws inside* a worker is reported as an error for that file — exactly what the
  *     serial lane would record — and is NOT retried, so a deterministic parse failure
  *     costs the same in both lanes.
- *  4. **Silence is disclosed, not assumed benign.** The extractors return an empty result
- *     (rather than throwing) when a grammar is unavailable, so a worker with a broken
- *     grammar load would silently contribute nothing. Two guards close that: a startup
- *     probe that requires a real parse before the worker accepts work, and relaying the
- *     worker's grammar-unavailable warnings to the parent logger.
+ *  4. **An unproven silence is never trusted.** The extractors return an empty result
+ *     (rather than throwing) when a grammar is unavailable, so a worker whose grammar for
+ *     some language failed to load in ITS thread would report every file of that language
+ *     as containing nothing — and the merge would read that as "no symbols here". A startup
+ *     probe cannot close this (it proves one grammar; the other ~20 load lazily per thread),
+ *     so the pool re-checks an empty result on the main thread until that worker has PROVEN
+ *     it can extract that language. See {@link runPooled}.
+ *  5. **Nothing here writes to stdout.** `openlore mcp` speaks JSON-RPC over stdout, and
+ *     `build()` runs inside it. Workers keep their stdout off the parent's, relay their
+ *     logging as messages, and the lane's own disclosure is returned on the build result
+ *     for the CLI to render — never logged from the builder.
  *
  * File contents are sent to workers rather than re-read from disk. Deliberate: `build`'s
  * input content is authoritative and is not always what's on disk — HTML pages arrive as
@@ -45,6 +51,7 @@ import {
   EXTRACTION_POOL_MAX,
   EXTRACTION_POOL_MIN_FILES,
   EXTRACTION_POOL_STARTUP_TIMEOUT_MS,
+  EXTRACTION_POOL_REQUEST_TIMEOUT_MS,
 } from '../../constants.js';
 import { logger } from '../../utils/logger.js';
 
@@ -69,13 +76,18 @@ export type SerialLaneReason =
   | 'disabled-by-env'
   | 'too-few-files'
   | 'insufficient-cores'
+  | 'pool-saturated'
   | 'worker-entry-unresolved'
   | 'pool-unavailable';
 
 /** What lane Pass 1 actually ran on, and what (if anything) degraded. */
 export interface ExtractionLaneDisclosure {
   lane: 'pooled' | 'serial';
-  /** Worker count actually started (0 on the serial lane). */
+  /**
+   * Workers that passed the startup probe and accepted work (0 on the serial lane).
+   * Counts workers that ever came up, not workers still alive at the end — a worker that
+   * died mid-run is still counted here, and its files appear in `workerFallbackFiles`.
+   */
   poolSize: number;
   /** Present only on the serial lane. */
   serialReason?: SerialLaneReason;
@@ -84,6 +96,19 @@ export interface ExtractionLaneDisclosure {
    * thread. Non-empty means the pool degraded but the facts are still whole.
    */
   workerFallbackFiles: string[];
+  /**
+   * Files a worker reported as containing NOTHING where the main thread then found real
+   * facts — a worker-local extraction defect (typically a grammar that loaded on the main
+   * thread but not in that thread). The facts are whole because the main-thread result is
+   * the one that is used, but this is a genuine defect and is disclosed loudly.
+   */
+  laneDefectFiles: string[];
+  /**
+   * How many empty worker results were re-checked on the main thread because that worker
+   * had not yet proven it can extract that language. Routine, not a degradation — the
+   * cost of never trusting an unproven silence. See {@link runPooled}.
+   */
+  emptyRechecks: number;
 }
 
 /**
@@ -101,6 +126,25 @@ export interface ExtractionWorkerHandle {
 
 /** Creates one worker. Returns the handle, or throws if the worker cannot start. */
 export type ExtractionWorkerFactory = () => ExtractionWorkerHandle;
+
+/** Caller-side control over the Pass-1 lane. Production passes none of these. */
+export interface ExtractionLaneOptions {
+  /** Test-only: drive a stub lane whose completion order and failures are deterministic. */
+  workerFactory?: ExtractionWorkerFactory;
+  /** Test-only: pin the worker count, bypassing the core/file-count/process-budget sizing. */
+  poolSize?: number;
+}
+
+/** Handed to a worker at construction. */
+export interface ExtractionWorkerData {
+  /**
+   * The language the worker should prove it can parse before accepting work. Chosen from
+   * the build's own files so the probe never gates on a grammar this repo does not use —
+   * every grammar is an optional dependency. Absent, or a language with no probe snippet,
+   * means no startup probe: the per-language unproven-silence guard still covers it.
+   */
+  probeLanguage?: string;
+}
 
 /** Parent → worker. */
 export type ExtractionRequest =
@@ -153,20 +197,53 @@ function canResolveTsx(): boolean {
 }
 
 /**
+ * Extraction workers alive across THIS PROCESS, not this build.
+ *
+ * Pool size is decided per `build()`, but the resident cost is per process: each worker
+ * holds its own tree-sitter parsers and grammar handles, so a pool of 8 costs a few hundred
+ * MB. `openlore mcp` runs builds concurrently — a background self-heal rebuild alongside a
+ * tool-call build — and without a process-wide budget each would independently plan a full
+ * pool, doubling the isolate count on the same cores. This is the ceiling that makes the
+ * per-build sizing safe to compose.
+ */
+let liveWorkers = 0;
+
+/** Workers this process may still start right now. */
+function remainingWorkerBudget(): number {
+  return Math.max(0, EXTRACTION_POOL_MAX - liveWorkers);
+}
+
+/**
+ * Sticky "workers do not work here". Set once a pool comes up with zero healthy workers
+ * (restricted sandbox, thread rlimit, broken native install). Without it every subsequent
+ * build in a long-lived process would pay the full startup timeout again before falling
+ * back to the lane it already knows it needs.
+ */
+let workersProvenUnavailable = false;
+
+/**
  * How many workers Pass 1 should use for `fileCount` files, or `0` for the serial lane.
- * One core is left for the main thread (which merges results and runs Pass 2+).
+ * One core is left for the main thread (which merges results and runs Pass 2+), and the
+ * process-wide budget is honored so concurrent builds cannot multiply the isolate count.
  */
 export function plannedPoolSize(fileCount: number): number {
   if (fileCount < EXTRACTION_POOL_MIN_FILES) return 0;
   const cores = availableParallelism();
   if (cores < 3) return 0;
-  return Math.min(cores - 1, EXTRACTION_POOL_MAX, fileCount);
+  return Math.min(cores - 1, remainingWorkerBudget(), fileCount);
 }
 
 /** Why `plannedPoolSize` returned 0 — for disclosure only. */
 function serialReasonFor(fileCount: number): SerialLaneReason {
   if (fileCount < EXTRACTION_POOL_MIN_FILES) return 'too-few-files';
-  return 'insufficient-cores';
+  if (availableParallelism() < 3) return 'insufficient-cores';
+  return 'pool-saturated';
+}
+
+/** Test-only: forget the sticky unavailability and the live-worker count. */
+export function __resetExtractionPoolStateForTests(): void {
+  liveWorkers = 0;
+  workersProvenUnavailable = false;
 }
 
 function workersDisabledByEnv(): boolean {
@@ -184,7 +261,8 @@ function workersDisabledByEnv(): boolean {
 export async function extractFilesForPass1<T>(
   files: ExtractionFile[],
   serialExtract: (file: ExtractionFile) => Promise<T | undefined>,
-  opts: { workerFactory?: ExtractionWorkerFactory; poolSize?: number } = {},
+  isEmptyResult: (value: T | undefined) => boolean,
+  opts: ExtractionLaneOptions = {},
 ): Promise<{ outcomes: Array<ExtractOutcome<T>>; disclosure: ExtractionLaneDisclosure }> {
   const serial = async (reason: SerialLaneReason): Promise<{
     outcomes: Array<ExtractOutcome<T>>;
@@ -192,7 +270,13 @@ export async function extractFilesForPass1<T>(
   }> => {
     const outcomes: Array<ExtractOutcome<T>> = [];
     for (const file of files) outcomes.push(await runSerial(file, serialExtract));
-    return { outcomes, disclosure: { lane: 'serial', poolSize: 0, serialReason: reason, workerFallbackFiles: [] } };
+    return {
+      outcomes,
+      disclosure: {
+        lane: 'serial', poolSize: 0, serialReason: reason,
+        workerFallbackFiles: [], laneDefectFiles: [], emptyRechecks: 0,
+      },
+    };
   };
 
   // Reasons are checked most-intrinsic first, so the disclosed reason is the one that
@@ -208,14 +292,37 @@ export async function extractFilesForPass1<T>(
 
   let factory = explicitFactory;
   if (!factory) {
+    if (workersProvenUnavailable) return serial('pool-unavailable');
     const entry = resolveWorkerEntry();
     if (!entry) return serial('worker-entry-unresolved');
-    factory = () => createNodeWorker(entry);
+    // Probe with a language this build actually contains: every grammar is an OPTIONAL
+    // dependency, so probing a language the repo does not use could disable the pool over
+    // a grammar the build would never have asked for.
+    const probeLanguage = dominantLanguage(files);
+    factory = () => createNodeWorker(entry, probeLanguage);
   }
 
-  const pooled = await runPooled(files, factory, size, serialExtract);
-  if (!pooled) return serial('pool-unavailable');
+  const pooled = await runPooled(files, factory, size, serialExtract, isEmptyResult);
+  if (!pooled) {
+    // Zero healthy workers. Remember it: in a long-lived process (the MCP daemon) every
+    // later build would otherwise pay the same startup timeout to learn the same thing.
+    if (!explicitFactory) workersProvenUnavailable = true;
+    return serial('pool-unavailable');
+  }
   return pooled;
+}
+
+/** The language most of this build's files are written in — the one worth probing. */
+function dominantLanguage(files: ExtractionFile[]): string | undefined {
+  const counts = new Map<string, number>();
+  for (const f of files) counts.set(f.language, (counts.get(f.language) ?? 0) + 1);
+  let best: string | undefined;
+  let bestCount = 0;
+  // Ties break on language name so the probe choice is deterministic for a given input.
+  for (const [language, count] of [...counts].sort((a, b) => a[0].localeCompare(b[0]))) {
+    if (count > bestCount) { best = language; bestCount = count; }
+  }
+  return best;
 }
 
 async function runSerial<T>(
@@ -230,28 +337,61 @@ async function runSerial<T>(
 }
 
 /**
- * Spawn a real `worker_threads` worker for the resolved entry. stdout/stderr are left
- * inherited (Node's default) so an unexpected write is still visible; the worker routes
- * its own logging through the parent instead (see the `log` message), which is what keeps
- * per-worker warnings from being printed N times.
+ * Spawn a real `worker_threads` worker for the resolved entry.
+ *
+ * `stdout: true` keeps the worker's stdout OFF the parent's stdout. That is not tidiness:
+ * `openlore mcp` speaks JSON-RPC over stdout, so a stray write from a worker would corrupt
+ * the protocol frame. The captured stream is drained so it cannot apply backpressure, and
+ * the worker's own logging is relayed to the parent as messages (see the `log` response)
+ * — which is also what keeps a per-thread warning from being printed once per worker.
+ * stderr stays inherited: it is not a protocol channel, and losing a crash trace is worse
+ * than printing one.
  */
-function createNodeWorker(entry: ResolvedWorkerEntry): ExtractionWorkerHandle {
-  return new Worker(entry.specifier, {
+function createNodeWorker(entry: ResolvedWorkerEntry, probeLanguage?: string): ExtractionWorkerHandle {
+  const worker = new Worker(entry.specifier, {
     ...(entry.execArgv ? { execArgv: entry.execArgv } : {}),
-  }) as unknown as ExtractionWorkerHandle;
+    workerData: { probeLanguage } satisfies ExtractionWorkerData,
+    stdout: true,
+  });
+  worker.stdout.resume();
+  return worker as unknown as ExtractionWorkerHandle;
 }
+
+/** Why a slot was left for the main thread to fill. */
+type UnfilledReason = 'worker-died' | 'unproven-empty';
 
 /**
  * Drive the pool. Returns `undefined` when not a single worker could be brought up
  * healthy (the caller then runs the serial lane wholesale, disclosed).
+ *
+ * ## Never trust an unproven silence
+ *
+ * The extractors report an unavailable grammar by returning an EMPTY result, not by
+ * throwing (`call-graph.ts` — `if (!r) return { nodes: [], rawEdges: [], cfg: new Map() }`).
+ * A worker whose grammar for some language failed to load in ITS thread would therefore
+ * report every file of that language as containing nothing, and the merge would treat the
+ * missing symbols as genuinely absent — the exact silent loss the parse-health work exists
+ * to prevent. The startup probe cannot close this: it proves one grammar, and each of the
+ * ~20 others loads lazily and independently in each thread.
+ *
+ * So the pool tracks, per worker, which languages that worker has PROVEN it can extract —
+ * proven by having returned a non-empty result for that language at least once. An empty
+ * result for a language a worker has not yet proven is not trusted: the slot is left for
+ * the main thread, which is the reference implementation. Once a worker proves a language,
+ * its empty results for that language are trusted, so the cost is bounded by the files that
+ * arrive before each worker's first real result per language — near zero on a healthy run,
+ * and full main-thread coverage exactly when a worker is broken. If the main thread then
+ * finds facts where the worker found none, that is a real defect and is disclosed loudly.
  */
 async function runPooled<T>(
   files: ExtractionFile[],
   factory: ExtractionWorkerFactory,
   size: number,
   serialExtract: (file: ExtractionFile) => Promise<T | undefined>,
+  isEmptyResult: (value: T | undefined) => boolean,
 ): Promise<{ outcomes: Array<ExtractOutcome<T>>; disclosure: ExtractionLaneDisclosure } | undefined> {
   const slots: Array<ExtractOutcome<T> | undefined> = new Array(files.length).fill(undefined);
+  const unfilled: Array<UnfilledReason | undefined> = new Array(files.length).fill(undefined);
   /** Next unclaimed input index. Shared across workers; each claims by post-increment. */
   let cursor = 0;
   let started = 0;
@@ -265,12 +405,19 @@ async function runPooled<T>(
     } catch {
       return; // this worker never existed; siblings (or the serial fallback) cover its share
     }
+    // Counted from spawn to termination, so a concurrent build in the same process sees
+    // this worker in the budget even while it is still starting up.
+    liveWorkers++;
+    let released = false;
+    const release = (): void => { if (!released) { released = true; liveWorkers--; } };
 
     let dead = false;
     let deadReason: Error | undefined;
     let pending: { id: number; resolve: (v: ExtractOutcome<T>) => void; reject: (e: Error) => void } | undefined;
     /** Resolves on `ready`, rejects if the worker dies or reports itself unhealthy first. */
     let settleStartup: ((err?: Error) => void) | undefined;
+    /** Languages this worker has demonstrably extracted (see the doc comment above). */
+    const proven = new Set<string>();
 
     const die = (err: Error): void => {
       if (dead) return;
@@ -282,36 +429,49 @@ async function runPooled<T>(
       p?.reject(err);
     };
 
-    worker.on('message', (raw) => {
-      const msg = raw as ExtractionResponse;
-      if (!msg || typeof msg !== 'object') return;
-      if (msg.type === 'ready') {
-        settleStartup?.();
-        return;
-      }
-      if (msg.type === 'unhealthy') {
-        die(new Error(`extraction worker unhealthy: ${msg.reason}`));
-        return;
-      }
-      if (msg.type === 'log') {
-        if (msg.level === 'warning') {
-          if (!relayedWarnings.has(msg.message)) {
-            relayedWarnings.add(msg.message);
-            logger.warning(msg.message);
-          }
-        } else {
-          logger.debug(msg.message);
+    try {
+      worker.on('message', (raw) => {
+        const msg = raw as ExtractionResponse;
+        if (!msg || typeof msg !== 'object') return;
+        if (msg.type === 'ready') {
+          settleStartup?.();
+          return;
         }
-        return;
-      }
-      const p = pending;
-      if (!p || p.id !== msg.id) return; // stale/unmatched reply — ignore, the slot stays open
-      pending = undefined;
-      if (msg.type === 'result') p.resolve({ status: 'ok', value: msg.value as T | undefined });
-      else p.resolve({ status: 'error', error: new Error(msg.message) });
-    });
-    worker.on('error', (err) => die(err instanceof Error ? err : new Error(String(err))));
-    worker.on('exit', () => die(deadReason ?? new Error('extraction worker exited')));
+        if (msg.type === 'unhealthy') {
+          die(new Error(`extraction worker unhealthy: ${msg.reason}`));
+          return;
+        }
+        if (msg.type === 'log') {
+          if (msg.level === 'warning') {
+            if (!relayedWarnings.has(msg.message)) {
+              relayedWarnings.add(msg.message);
+              logger.warning(msg.message);
+            }
+          } else {
+            logger.debug(msg.message);
+          }
+          return;
+        }
+        const p = pending;
+        if (!p) return; // nothing in flight — a duplicate/late reply, safely ignored
+        if (p.id !== msg.id) {
+          // A reply that does not match the one outstanding request means this worker is
+          // off-protocol. Retiring it hands its file to the main thread; ignoring it would
+          // leave `pending` armed forever and hang the whole pass.
+          die(new Error(`extraction worker replied for #${msg.id} while #${p.id} was in flight`));
+          return;
+        }
+        pending = undefined;
+        if (msg.type === 'result') p.resolve({ status: 'ok', value: msg.value as T | undefined });
+        else p.resolve({ status: 'error', error: new Error(msg.message) });
+      });
+      worker.on('error', (err) => die(err instanceof Error ? err : new Error(String(err))));
+      worker.on('exit', () => die(deadReason ?? new Error('extraction worker exited')));
+    } catch (err) {
+      await terminateQuietly(worker);
+      release();
+      throw err;
+    }
 
     // Wait for the startup probe before handing this worker any real file. A worker that
     // neither reports ready nor dies (a hung module load / grammar dlopen) must not hang
@@ -330,6 +490,7 @@ async function runPooled<T>(
       });
     } catch {
       await terminateQuietly(worker);
+      release();
       return;
     }
     started++;
@@ -339,22 +500,33 @@ async function runPooled<T>(
         const index = cursor;
         if (index >= files.length) break;
         cursor = index + 1;
+        const file = files[index];
+        let outcome: ExtractOutcome<T>;
         try {
-          slots[index] = await new Promise<ExtractOutcome<T>>((resolve, reject) => {
-            pending = { id: index, resolve, reject };
-            worker.postMessage({ type: 'extract', id: index, file: files[index] } satisfies ExtractionRequest);
-          });
+          outcome = await requestExtract<T>(worker, index, file, (p) => { pending = p; });
         } catch {
-          // The worker died holding this file. Leave the slot empty — the main thread
-          // re-extracts it below — and stop feeding this worker.
+          // The worker died (or wedged past its deadline) holding this file. Leave the slot
+          // for the main thread and stop feeding this worker.
+          unfilled[index] = 'worker-died';
           break;
         }
+        if (outcome.status === 'ok' && isEmptyResult(outcome.value)) {
+          if (!proven.has(file.language)) {
+            // Unproven silence — the main thread decides, below.
+            unfilled[index] = 'unproven-empty';
+            continue;
+          }
+        } else if (outcome.status === 'ok') {
+          proven.add(file.language);
+        }
+        slots[index] = outcome;
       }
     } finally {
       if (!dead) {
         try { worker.postMessage({ type: 'shutdown' } satisfies ExtractionRequest); } catch { /* already gone */ }
       }
       await terminateQuietly(worker);
+      release();
     }
   };
 
@@ -364,19 +536,55 @@ async function runPooled<T>(
 
   if (started === 0) return undefined;
 
-  // Any slot the pool did not fill — a worker died holding it, or every worker died
-  // before claiming it — is re-extracted on the main thread, in input order.
+  // Fill every slot the pool left, on the main thread, in input order.
   const workerFallbackFiles: string[] = [];
+  const laneDefectFiles: string[] = [];
+  let emptyRechecks = 0;
   for (let i = 0; i < files.length; i++) {
     if (slots[i] !== undefined) continue;
-    workerFallbackFiles.push(files[i].path);
-    slots[i] = await runSerial(files[i], serialExtract);
+    // A slot with no recorded reason belongs to a file no worker ever claimed (every
+    // worker died first) — the same situation as a worker dying while holding it.
+    const reason = unfilled[i] ?? 'worker-died';
+    const outcome = await runSerial(files[i], serialExtract);
+    if (reason === 'worker-died') {
+      workerFallbackFiles.push(files[i].path);
+    } else {
+      emptyRechecks++;
+      // The worker said "nothing here" and the main thread disagrees: a worker-local
+      // extraction defect, not an empty file.
+      if (outcome.status !== 'ok' || !isEmptyResult(outcome.value)) laneDefectFiles.push(files[i].path);
+    }
+    slots[i] = outcome;
   }
 
   return {
     outcomes: slots as Array<ExtractOutcome<T>>,
-    disclosure: { lane: 'pooled', poolSize: started, workerFallbackFiles },
+    disclosure: { lane: 'pooled', poolSize: started, workerFallbackFiles, laneDefectFiles, emptyRechecks },
   };
+}
+
+/**
+ * Send one file to a worker and await its reply, bounded by a deadline. The serial lane has
+ * no such bound — but it also cannot go silent: a wedged worker emits neither a reply nor
+ * an `exit`, so without a deadline the whole pass would wait on it forever while its
+ * siblings finish and the process looks idle. On timeout the worker is retired and its file
+ * falls to the main thread.
+ */
+function requestExtract<T>(
+  worker: ExtractionWorkerHandle,
+  index: number,
+  file: ExtractionFile,
+  arm: (pending: { id: number; resolve: (v: ExtractOutcome<T>) => void; reject: (e: Error) => void }) => void,
+): Promise<ExtractOutcome<T>> {
+  return new Promise<ExtractOutcome<T>>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`extraction worker did not answer for ${file.path} within ${EXTRACTION_POOL_REQUEST_TIMEOUT_MS}ms`));
+    }, EXTRACTION_POOL_REQUEST_TIMEOUT_MS);
+    timer.unref?.();
+    const settle = <R>(fn: (v: R) => void) => (v: R): void => { clearTimeout(timer); fn(v); };
+    arm({ id: index, resolve: settle(resolve), reject: settle(reject) });
+    worker.postMessage({ type: 'extract', id: index, file } satisfies ExtractionRequest);
+  });
 }
 
 async function terminateQuietly(worker: ExtractionWorkerHandle): Promise<void> {
@@ -395,14 +603,21 @@ async function terminateQuietly(worker: ExtractionWorkerHandle): Promise<void> {
  */
 export function describeExtractionLane(d: ExtractionLaneDisclosure): string | undefined {
   if (d.lane === 'pooled') {
+    // A worker that reported nothing where the main thread found facts is the one outcome
+    // that means something was actually WRONG with a worker, so it leads.
+    if (d.laneDefectFiles.length > 0) {
+      return `extraction worker returned no symbols for ${d.laneDefectFiles.length} file(s) that do contain symbols `
+        + `(e.g. ${d.laneDefectFiles[0]}); the main-thread result was used. Set OPENLORE_NO_WORKERS=1 if this recurs`;
+    }
     if (d.workerFallbackFiles.length === 0) return undefined;
     return `extraction pool degraded: ${d.workerFallbackFiles.length} file(s) re-extracted on the main thread after a worker failed`;
   }
-  // A small build, a small machine, or an explicit opt-out are ordinary choices, not
-  // degradations — warning about them would be noise on every run.
+  // A small build, a small machine, a caller opting out, or an explicit env opt-out are
+  // ordinary choices, not degradations — warning about them would be noise on every run.
   if (
     d.serialReason === 'too-few-files' ||
     d.serialReason === 'insufficient-cores' ||
+    d.serialReason === 'pool-saturated' ||
     d.serialReason === 'disabled-by-env'
   ) return undefined;
   return `extraction ran on the serial lane (${d.serialReason}) — analysis is complete but slower`;

--- a/src/core/analyzer/extraction-pool.ts
+++ b/src/core/analyzer/extraction-pool.ts
@@ -1,0 +1,409 @@
+/**
+ * Pass-1 extraction worker pool (change: optimize-parallel-extraction-pool).
+ *
+ * Per-file tree-sitter parsing and fact extraction is the dominant cost of
+ * `openlore analyze`, and it is embarrassingly parallel: no file's extraction reads
+ * another file's state. This module runs that pass on a fixed-size pool of
+ * `worker_threads` while preserving the one property the rest of the pipeline
+ * depends on — **input order**.
+ *
+ * Determinism rules (the reason this module exists rather than a bare `Promise.all`):
+ *
+ *  1. **Index-keyed slots, never completion order.** Each file is dispatched with its
+ *     input index and its result is written to `outcomes[index]`. Completion order is
+ *     free to vary with core contention; the array the caller merges from is always in
+ *     input order, so every downstream pass sees byte-identical input to the serial lane.
+ *  2. **No extraction logic lives here.** Workers call the same `dispatchFileExtract`
+ *     the serial lane calls (via {@link ./extraction-worker.ts}), and the serial lane
+ *     stays the reference implementation — the caller passes it in as `serialExtract`,
+ *     which is also the fallback executor.
+ *  3. **Fail-soft, never fail-different.** A worker that dies mid-file leaves its slot
+ *     empty and the file is re-extracted on the main thread. A worker that cannot start,
+ *     or fails its startup health probe, disables the lane wholesale. An extractor that
+ *     *throws inside* a worker is reported as an error for that file — exactly what the
+ *     serial lane would record — and is NOT retried, so a deterministic parse failure
+ *     costs the same in both lanes.
+ *  4. **Silence is disclosed, not assumed benign.** The extractors return an empty result
+ *     (rather than throwing) when a grammar is unavailable, so a worker with a broken
+ *     grammar load would silently contribute nothing. Two guards close that: a startup
+ *     probe that requires a real parse before the worker accepts work, and relaying the
+ *     worker's grammar-unavailable warnings to the parent logger.
+ *
+ * File contents are sent to workers rather than re-read from disk. Deliberate: `build`'s
+ * input content is authoritative and is not always what's on disk — HTML pages arrive as
+ * inline-script-blanked text, and the incremental path passes in-memory content — so a
+ * worker-side re-read would change extracted facts, not just I/O.
+ */
+
+import { availableParallelism } from 'node:os';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Worker } from 'node:worker_threads';
+import {
+  EXTRACTION_POOL_MAX,
+  EXTRACTION_POOL_MIN_FILES,
+  EXTRACTION_POOL_STARTUP_TIMEOUT_MS,
+} from '../../constants.js';
+import { logger } from '../../utils/logger.js';
+
+/** One Pass-1 input record — the same shape `CallGraphBuilder.build` receives. */
+export interface ExtractionFile {
+  path: string;
+  content: string;
+  language: string;
+}
+
+/**
+ * The outcome for one file. `ok` carries the extractor's return value (`undefined` for a
+ * language with no extractor); `error` carries whatever the extractor threw, so the caller
+ * can record the identical parse-health failure it records on the serial lane.
+ */
+export type ExtractOutcome<T> =
+  | { status: 'ok'; value: T | undefined }
+  | { status: 'error'; error: unknown };
+
+/** Why the serial lane ran instead of the pool. */
+export type SerialLaneReason =
+  | 'disabled-by-env'
+  | 'too-few-files'
+  | 'insufficient-cores'
+  | 'worker-entry-unresolved'
+  | 'pool-unavailable';
+
+/** What lane Pass 1 actually ran on, and what (if anything) degraded. */
+export interface ExtractionLaneDisclosure {
+  lane: 'pooled' | 'serial';
+  /** Worker count actually started (0 on the serial lane). */
+  poolSize: number;
+  /** Present only on the serial lane. */
+  serialReason?: SerialLaneReason;
+  /**
+   * Files whose worker died mid-extraction and which were re-extracted on the main
+   * thread. Non-empty means the pool degraded but the facts are still whole.
+   */
+  workerFallbackFiles: string[];
+}
+
+/**
+ * The subset of `worker_threads.Worker` the pool uses. Narrow on purpose: tests
+ * inject a fake handle to drive completion order and worker death deterministically,
+ * without spawning threads.
+ */
+export interface ExtractionWorkerHandle {
+  postMessage(message: unknown): void;
+  on(event: 'message', listener: (value: unknown) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+  on(event: 'exit', listener: (code: number) => void): void;
+  terminate(): void | Promise<unknown>;
+}
+
+/** Creates one worker. Returns the handle, or throws if the worker cannot start. */
+export type ExtractionWorkerFactory = () => ExtractionWorkerHandle;
+
+/** Parent → worker. */
+export type ExtractionRequest =
+  | { type: 'extract'; id: number; file: ExtractionFile }
+  | { type: 'shutdown' };
+
+/** Worker → parent. */
+export type ExtractionResponse =
+  | { type: 'ready' }
+  | { type: 'unhealthy'; reason: string }
+  | { type: 'result'; id: number; value: unknown }
+  | { type: 'failed'; id: number; message: string }
+  | { type: 'log'; level: 'warning' | 'debug'; message: string };
+
+/** Set to `1`/`true` to force the serial lane (the documented escape hatch). */
+const NO_WORKERS_ENV = 'OPENLORE_NO_WORKERS';
+
+/** Resolved worker entry: the module a worker loads, plus any exec args it needs. */
+export interface ResolvedWorkerEntry {
+  specifier: URL;
+  execArgv?: string[];
+}
+
+/**
+ * Locate the worker entry module for the current runtime.
+ *
+ * Compiled (`dist/`) is the production case: the sibling `.js` exists and needs no exec
+ * args. Running from TypeScript source (dev, vitest) needs a loader, so the `.ts` sibling
+ * is used with `--import tsx` — and only when `tsx` actually resolves. When neither is
+ * available the pool is simply not offered; the serial lane covers it.
+ */
+export function resolveWorkerEntry(): ResolvedWorkerEntry | undefined {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const compiled = join(here, 'extraction-worker.js');
+  if (existsSync(compiled)) return { specifier: pathToFileURL(compiled) };
+  const source = join(here, 'extraction-worker.ts');
+  if (existsSync(source) && canResolveTsx()) {
+    return { specifier: pathToFileURL(source), execArgv: ['--import', 'tsx'] };
+  }
+  return undefined;
+}
+
+function canResolveTsx(): boolean {
+  try {
+    createRequire(import.meta.url).resolve('tsx');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * How many workers Pass 1 should use for `fileCount` files, or `0` for the serial lane.
+ * One core is left for the main thread (which merges results and runs Pass 2+).
+ */
+export function plannedPoolSize(fileCount: number): number {
+  if (fileCount < EXTRACTION_POOL_MIN_FILES) return 0;
+  const cores = availableParallelism();
+  if (cores < 3) return 0;
+  return Math.min(cores - 1, EXTRACTION_POOL_MAX, fileCount);
+}
+
+/** Why `plannedPoolSize` returned 0 — for disclosure only. */
+function serialReasonFor(fileCount: number): SerialLaneReason {
+  if (fileCount < EXTRACTION_POOL_MIN_FILES) return 'too-few-files';
+  return 'insufficient-cores';
+}
+
+function workersDisabledByEnv(): boolean {
+  const v = process.env[NO_WORKERS_ENV];
+  return v === '1' || v === 'true';
+}
+
+/**
+ * Run Pass-1 extraction over `files`, on the worker pool when it is available and worth
+ * it, otherwise serially. `serialExtract` is both the reference implementation and the
+ * fallback executor — extraction logic never forks between lanes.
+ *
+ * The returned `outcomes` array is always the same length as `files` and in input order.
+ */
+export async function extractFilesForPass1<T>(
+  files: ExtractionFile[],
+  serialExtract: (file: ExtractionFile) => Promise<T | undefined>,
+  opts: { workerFactory?: ExtractionWorkerFactory; poolSize?: number } = {},
+): Promise<{ outcomes: Array<ExtractOutcome<T>>; disclosure: ExtractionLaneDisclosure }> {
+  const serial = async (reason: SerialLaneReason): Promise<{
+    outcomes: Array<ExtractOutcome<T>>;
+    disclosure: ExtractionLaneDisclosure;
+  }> => {
+    const outcomes: Array<ExtractOutcome<T>> = [];
+    for (const file of files) outcomes.push(await runSerial(file, serialExtract));
+    return { outcomes, disclosure: { lane: 'serial', poolSize: 0, serialReason: reason, workerFallbackFiles: [] } };
+  };
+
+  // Reasons are checked most-intrinsic first, so the disclosed reason is the one that
+  // actually decided the lane: a 6-file build is "too-few-files" whether or not workers
+  // are also switched off.
+  const size = opts.poolSize ?? plannedPoolSize(files.length);
+  if (size <= 0) return serial(serialReasonFor(files.length));
+
+  // `OPENLORE_NO_WORKERS` disables worker THREADS. An explicitly injected factory is not a
+  // thread — it is a test lane — so it is honored either way; production never passes one.
+  const explicitFactory = opts.workerFactory;
+  if (!explicitFactory && workersDisabledByEnv()) return serial('disabled-by-env');
+
+  let factory = explicitFactory;
+  if (!factory) {
+    const entry = resolveWorkerEntry();
+    if (!entry) return serial('worker-entry-unresolved');
+    factory = () => createNodeWorker(entry);
+  }
+
+  const pooled = await runPooled(files, factory, size, serialExtract);
+  if (!pooled) return serial('pool-unavailable');
+  return pooled;
+}
+
+async function runSerial<T>(
+  file: ExtractionFile,
+  serialExtract: (file: ExtractionFile) => Promise<T | undefined>,
+): Promise<ExtractOutcome<T>> {
+  try {
+    return { status: 'ok', value: await serialExtract(file) };
+  } catch (error) {
+    return { status: 'error', error };
+  }
+}
+
+/**
+ * Spawn a real `worker_threads` worker for the resolved entry. stdout/stderr are left
+ * inherited (Node's default) so an unexpected write is still visible; the worker routes
+ * its own logging through the parent instead (see the `log` message), which is what keeps
+ * per-worker warnings from being printed N times.
+ */
+function createNodeWorker(entry: ResolvedWorkerEntry): ExtractionWorkerHandle {
+  return new Worker(entry.specifier, {
+    ...(entry.execArgv ? { execArgv: entry.execArgv } : {}),
+  }) as unknown as ExtractionWorkerHandle;
+}
+
+/**
+ * Drive the pool. Returns `undefined` when not a single worker could be brought up
+ * healthy (the caller then runs the serial lane wholesale, disclosed).
+ */
+async function runPooled<T>(
+  files: ExtractionFile[],
+  factory: ExtractionWorkerFactory,
+  size: number,
+  serialExtract: (file: ExtractionFile) => Promise<T | undefined>,
+): Promise<{ outcomes: Array<ExtractOutcome<T>>; disclosure: ExtractionLaneDisclosure } | undefined> {
+  const slots: Array<ExtractOutcome<T> | undefined> = new Array(files.length).fill(undefined);
+  /** Next unclaimed input index. Shared across workers; each claims by post-increment. */
+  let cursor = 0;
+  let started = 0;
+  /** Grammar-unavailable warnings relayed from workers, deduped across the pool. */
+  const relayedWarnings = new Set<string>();
+
+  const runOne = async (): Promise<void> => {
+    let worker: ExtractionWorkerHandle;
+    try {
+      worker = factory();
+    } catch {
+      return; // this worker never existed; siblings (or the serial fallback) cover its share
+    }
+
+    let dead = false;
+    let deadReason: Error | undefined;
+    let pending: { id: number; resolve: (v: ExtractOutcome<T>) => void; reject: (e: Error) => void } | undefined;
+    /** Resolves on `ready`, rejects if the worker dies or reports itself unhealthy first. */
+    let settleStartup: ((err?: Error) => void) | undefined;
+
+    const die = (err: Error): void => {
+      if (dead) return;
+      dead = true;
+      deadReason = err;
+      settleStartup?.(err);
+      const p = pending;
+      pending = undefined;
+      p?.reject(err);
+    };
+
+    worker.on('message', (raw) => {
+      const msg = raw as ExtractionResponse;
+      if (!msg || typeof msg !== 'object') return;
+      if (msg.type === 'ready') {
+        settleStartup?.();
+        return;
+      }
+      if (msg.type === 'unhealthy') {
+        die(new Error(`extraction worker unhealthy: ${msg.reason}`));
+        return;
+      }
+      if (msg.type === 'log') {
+        if (msg.level === 'warning') {
+          if (!relayedWarnings.has(msg.message)) {
+            relayedWarnings.add(msg.message);
+            logger.warning(msg.message);
+          }
+        } else {
+          logger.debug(msg.message);
+        }
+        return;
+      }
+      const p = pending;
+      if (!p || p.id !== msg.id) return; // stale/unmatched reply — ignore, the slot stays open
+      pending = undefined;
+      if (msg.type === 'result') p.resolve({ status: 'ok', value: msg.value as T | undefined });
+      else p.resolve({ status: 'error', error: new Error(msg.message) });
+    });
+    worker.on('error', (err) => die(err instanceof Error ? err : new Error(String(err))));
+    worker.on('exit', () => die(deadReason ?? new Error('extraction worker exited')));
+
+    // Wait for the startup probe before handing this worker any real file. A worker that
+    // neither reports ready nor dies (a hung module load / grammar dlopen) must not hang
+    // analyze, so startup is bounded — a timed-out worker is simply dropped from the pool.
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          settleStartup?.(new Error(`extraction worker did not start within ${EXTRACTION_POOL_STARTUP_TIMEOUT_MS}ms`));
+        }, EXTRACTION_POOL_STARTUP_TIMEOUT_MS);
+        timer.unref?.();
+        settleStartup = (err) => {
+          settleStartup = undefined;
+          clearTimeout(timer);
+          if (err) reject(err); else resolve();
+        };
+      });
+    } catch {
+      await terminateQuietly(worker);
+      return;
+    }
+    started++;
+
+    try {
+      while (!dead) {
+        const index = cursor;
+        if (index >= files.length) break;
+        cursor = index + 1;
+        try {
+          slots[index] = await new Promise<ExtractOutcome<T>>((resolve, reject) => {
+            pending = { id: index, resolve, reject };
+            worker.postMessage({ type: 'extract', id: index, file: files[index] } satisfies ExtractionRequest);
+          });
+        } catch {
+          // The worker died holding this file. Leave the slot empty — the main thread
+          // re-extracts it below — and stop feeding this worker.
+          break;
+        }
+      }
+    } finally {
+      if (!dead) {
+        try { worker.postMessage({ type: 'shutdown' } satisfies ExtractionRequest); } catch { /* already gone */ }
+      }
+      await terminateQuietly(worker);
+    }
+  };
+
+  // A worker lane must never be able to reject the whole pass: anything unexpected inside
+  // `runOne` costs that worker's share, which the main-thread fallback below picks up.
+  await Promise.all(Array.from({ length: size }, () => runOne().catch(() => undefined)));
+
+  if (started === 0) return undefined;
+
+  // Any slot the pool did not fill — a worker died holding it, or every worker died
+  // before claiming it — is re-extracted on the main thread, in input order.
+  const workerFallbackFiles: string[] = [];
+  for (let i = 0; i < files.length; i++) {
+    if (slots[i] !== undefined) continue;
+    workerFallbackFiles.push(files[i].path);
+    slots[i] = await runSerial(files[i], serialExtract);
+  }
+
+  return {
+    outcomes: slots as Array<ExtractOutcome<T>>,
+    disclosure: { lane: 'pooled', poolSize: started, workerFallbackFiles },
+  };
+}
+
+async function terminateQuietly(worker: ExtractionWorkerHandle): Promise<void> {
+  try {
+    await worker.terminate();
+  } catch {
+    /* nothing left to terminate */
+  }
+}
+
+/**
+ * One-line disclosure of the lane Pass 1 ran on, or `undefined` when there is nothing to
+ * disclose (the pool ran clean, or the serial lane was the ordinary choice). Only genuine
+ * degradations speak: a lane that ran as designed says nothing, so a message here always
+ * means analysis was slower than it should have been — never that it was less complete.
+ */
+export function describeExtractionLane(d: ExtractionLaneDisclosure): string | undefined {
+  if (d.lane === 'pooled') {
+    if (d.workerFallbackFiles.length === 0) return undefined;
+    return `extraction pool degraded: ${d.workerFallbackFiles.length} file(s) re-extracted on the main thread after a worker failed`;
+  }
+  // A small build, a small machine, or an explicit opt-out are ordinary choices, not
+  // degradations — warning about them would be noise on every run.
+  if (
+    d.serialReason === 'too-few-files' ||
+    d.serialReason === 'insufficient-cores' ||
+    d.serialReason === 'disabled-by-env'
+  ) return undefined;
+  return `extraction ran on the serial lane (${d.serialReason}) — analysis is complete but slower`;
+}

--- a/src/core/analyzer/extraction-pool.ts
+++ b/src/core/analyzer/extraction-pool.ts
@@ -52,6 +52,7 @@ import {
   EXTRACTION_POOL_MIN_FILES,
   EXTRACTION_POOL_STARTUP_TIMEOUT_MS,
   EXTRACTION_POOL_REQUEST_TIMEOUT_MS,
+  EXTRACTION_POOL_TERMINATE_TIMEOUT_MS,
 } from '../../constants.js';
 import { logger } from '../../utils/logger.js';
 
@@ -104,11 +105,11 @@ export interface ExtractionLaneDisclosure {
    */
   laneDefectFiles: string[];
   /**
-   * How many empty worker results were re-checked on the main thread because that worker
-   * had not yet proven it can extract that language. Routine, not a degradation — the
-   * cost of never trusting an unproven silence. See {@link runPooled}.
+   * How many worker answers were re-checked on the main thread because that worker had not
+   * yet proven it can extract that language — an empty result, or a throw. Routine, not a
+   * degradation: the cost of never trusting an unproven worker. See {@link runPooled}.
    */
-  emptyRechecks: number;
+  unprovenRechecks: number;
 }
 
 /**
@@ -214,10 +215,12 @@ function remainingWorkerBudget(): number {
 }
 
 /**
- * Sticky "workers do not work here". Set once a pool comes up with zero healthy workers
- * (restricted sandbox, thread rlimit, broken native install). Without it every subsequent
- * build in a long-lived process would pay the full startup timeout again before falling
- * back to the lane it already knows it needs.
+ * Sticky "workers do not work here". Set once a pool comes up with zero healthy workers for
+ * a DETERMINISTIC reason — every worker refused to spawn, or reported itself unhealthy.
+ * Without it, every later build in a long-lived process would re-pay the startup cost to
+ * learn what this one already knows. A pool that came up empty only because its workers ran
+ * out of time does NOT set it: that is a transient load spike, and permanently dropping the
+ * daemon to the serial lane over one bad moment would be worse than re-trying.
  */
 let workersProvenUnavailable = false;
 
@@ -274,7 +277,7 @@ export async function extractFilesForPass1<T>(
       outcomes,
       disclosure: {
         lane: 'serial', poolSize: 0, serialReason: reason,
-        workerFallbackFiles: [], laneDefectFiles: [], emptyRechecks: 0,
+        workerFallbackFiles: [], laneDefectFiles: [], unprovenRechecks: 0,
       },
     };
   };
@@ -303,13 +306,13 @@ export async function extractFilesForPass1<T>(
   }
 
   const pooled = await runPooled(files, factory, size, serialExtract, isEmptyResult);
-  if (!pooled) {
-    // Zero healthy workers. Remember it: in a long-lived process (the MCP daemon) every
-    // later build would otherwise pay the same startup timeout to learn the same thing.
-    if (!explicitFactory) workersProvenUnavailable = true;
+  if (!pooled.disclosure) {
+    // Zero healthy workers. Remember it only when the cause was deterministic — see
+    // `workersProvenUnavailable`.
+    if (!explicitFactory && pooled.deterministicFailure) workersProvenUnavailable = true;
     return serial('pool-unavailable');
   }
-  return pooled;
+  return { outcomes: pooled.outcomes!, disclosure: pooled.disclosure };
 }
 
 /** The language most of this build's files are written in — the one worth probing. */
@@ -357,8 +360,10 @@ function createNodeWorker(entry: ResolvedWorkerEntry, probeLanguage?: string): E
   return worker as unknown as ExtractionWorkerHandle;
 }
 
-/** Why a slot was left for the main thread to fill. */
-type UnfilledReason = 'worker-died' | 'unproven-empty';
+/** Why a slot was left for the main thread to fill, and what the worker had said. */
+type UnfilledSlot<T> =
+  | { reason: 'worker-died' }
+  | { reason: 'unproven'; worker: ExtractOutcome<T> };
 
 /**
  * Drive the pool. Returns `undefined` when not a single worker could be brought up
@@ -389,12 +394,19 @@ async function runPooled<T>(
   size: number,
   serialExtract: (file: ExtractionFile) => Promise<T | undefined>,
   isEmptyResult: (value: T | undefined) => boolean,
-): Promise<{ outcomes: Array<ExtractOutcome<T>>; disclosure: ExtractionLaneDisclosure } | undefined> {
+): Promise<{
+  outcomes?: Array<ExtractOutcome<T>>;
+  disclosure?: ExtractionLaneDisclosure;
+  /** Set when no worker came up AND the cause was deterministic rather than a timeout. */
+  deterministicFailure?: boolean;
+}> {
   const slots: Array<ExtractOutcome<T> | undefined> = new Array(files.length).fill(undefined);
-  const unfilled: Array<UnfilledReason | undefined> = new Array(files.length).fill(undefined);
+  const unfilled: Array<UnfilledSlot<T> | undefined> = new Array(files.length).fill(undefined);
   /** Next unclaimed input index. Shared across workers; each claims by post-increment. */
   let cursor = 0;
   let started = 0;
+  /** A worker was dropped because it ran out of time, not because it refused to work. */
+  let sawStartupTimeout = false;
   /** Grammar-unavailable warnings relayed from workers, deduped across the pool. */
   const relayedWarnings = new Set<string>();
 
@@ -479,6 +491,7 @@ async function runPooled<T>(
     try {
       await new Promise<void>((resolve, reject) => {
         const timer = setTimeout(() => {
+          sawStartupTimeout = true;
           settleStartup?.(new Error(`extraction worker did not start within ${EXTRACTION_POOL_STARTUP_TIMEOUT_MS}ms`));
         }, EXTRACTION_POOL_STARTUP_TIMEOUT_MS);
         timer.unref?.();
@@ -507,17 +520,24 @@ async function runPooled<T>(
         } catch {
           // The worker died (or wedged past its deadline) holding this file. Leave the slot
           // for the main thread and stop feeding this worker.
-          unfilled[index] = 'worker-died';
+          unfilled[index] = { reason: 'worker-died' };
           break;
         }
-        if (outcome.status === 'ok' && isEmptyResult(outcome.value)) {
+        // A worker that cannot handle a language reports it two ways, and BOTH are
+        // indistinguishable from a real answer: an empty result (the core binding failed to
+        // load) or a throw (the per-language grammar `import` failed — those loads are not
+        // wrapped). Neither is trusted until this worker has actually produced facts for the
+        // language; until then the main thread decides.
+        const producedFacts = outcome.status === 'ok'
+          && outcome.value !== undefined
+          && !isEmptyResult(outcome.value);
+        if (producedFacts) {
+          proven.add(file.language);
+        } else if (outcome.status !== 'ok' || isEmptyResult(outcome.value)) {
           if (!proven.has(file.language)) {
-            // Unproven silence — the main thread decides, below.
-            unfilled[index] = 'unproven-empty';
+            unfilled[index] = { reason: 'unproven', worker: outcome };
             continue;
           }
-        } else if (outcome.status === 'ok') {
-          proven.add(file.language);
         }
         slots[index] = outcome;
       }
@@ -534,32 +554,37 @@ async function runPooled<T>(
   // `runOne` costs that worker's share, which the main-thread fallback below picks up.
   await Promise.all(Array.from({ length: size }, () => runOne().catch(() => undefined)));
 
-  if (started === 0) return undefined;
+  // No worker survived startup. Distinguish "this environment cannot run workers" from
+  // "everything was slow just now" — only the former is worth remembering for the process.
+  if (started === 0) return { deterministicFailure: !sawStartupTimeout };
 
   // Fill every slot the pool left, on the main thread, in input order.
   const workerFallbackFiles: string[] = [];
   const laneDefectFiles: string[] = [];
-  let emptyRechecks = 0;
+  let unprovenRechecks = 0;
   for (let i = 0; i < files.length; i++) {
     if (slots[i] !== undefined) continue;
     // A slot with no recorded reason belongs to a file no worker ever claimed (every
     // worker died first) — the same situation as a worker dying while holding it.
-    const reason = unfilled[i] ?? 'worker-died';
+    const record = unfilled[i];
     const outcome = await runSerial(files[i], serialExtract);
-    if (reason === 'worker-died') {
+    if (!record || record.reason === 'worker-died') {
       workerFallbackFiles.push(files[i].path);
     } else {
-      emptyRechecks++;
-      // The worker said "nothing here" and the main thread disagrees: a worker-local
-      // extraction defect, not an empty file.
-      if (outcome.status !== 'ok' || !isEmptyResult(outcome.value)) laneDefectFiles.push(files[i].path);
+      unprovenRechecks++;
+      // The worker reported nothing (empty, or a throw) and the main thread found real
+      // facts: a worker-local extraction defect, not an empty or unparseable file.
+      const mainThreadFoundFacts = outcome.status === 'ok'
+        && outcome.value !== undefined
+        && !isEmptyResult(outcome.value);
+      if (mainThreadFoundFacts) laneDefectFiles.push(files[i].path);
     }
     slots[i] = outcome;
   }
 
   return {
     outcomes: slots as Array<ExtractOutcome<T>>,
-    disclosure: { lane: 'pooled', poolSize: started, workerFallbackFiles, laneDefectFiles, emptyRechecks },
+    disclosure: { lane: 'pooled', poolSize: started, workerFallbackFiles, laneDefectFiles, unprovenRechecks },
   };
 }
 
@@ -587,9 +612,26 @@ function requestExtract<T>(
   });
 }
 
+/**
+ * Ask a worker to stop, and do not wait indefinitely for it to comply.
+ *
+ * `Worker.terminate()` resolves when the thread actually exits, and V8 can only interrupt a
+ * thread at a JS boundary — so a thread blocked inside a synchronous native call (a hung
+ * grammar `dlopen`, a pathological parse) may never exit. Awaiting that unbounded would
+ * re-create the exact hang the startup and request deadlines exist to prevent, and would
+ * strand this worker's process budget forever. So the wait is bounded; past the bound the
+ * slot is returned even though the thread may still be resident. That is the honest trade:
+ * a lingering thread is a leak the OS reclaims at exit, an unresolvable await is a hang.
+ */
 async function terminateQuietly(worker: ExtractionWorkerHandle): Promise<void> {
   try {
-    await worker.terminate();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const bounded = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, EXTRACTION_POOL_TERMINATE_TIMEOUT_MS);
+      timer.unref?.();
+    });
+    await Promise.race([Promise.resolve(worker.terminate()).then(() => undefined), bounded]);
+    if (timer) clearTimeout(timer);
   } catch {
     /* nothing left to terminate */
   }

--- a/src/core/analyzer/extraction-pool.ts
+++ b/src/core/analyzer/extraction-pool.ts
@@ -360,10 +360,8 @@ function createNodeWorker(entry: ResolvedWorkerEntry, probeLanguage?: string): E
   return worker as unknown as ExtractionWorkerHandle;
 }
 
-/** Why a slot was left for the main thread to fill, and what the worker had said. */
-type UnfilledSlot<T> =
-  | { reason: 'worker-died' }
-  | { reason: 'unproven'; worker: ExtractOutcome<T> };
+/** Why a slot was left for the main thread to fill. */
+type UnfilledReason = 'worker-died' | 'unproven';
 
 /**
  * Drive the pool. Returns `undefined` when not a single worker could be brought up
@@ -401,7 +399,7 @@ async function runPooled<T>(
   deterministicFailure?: boolean;
 }> {
   const slots: Array<ExtractOutcome<T> | undefined> = new Array(files.length).fill(undefined);
-  const unfilled: Array<UnfilledSlot<T> | undefined> = new Array(files.length).fill(undefined);
+  const unfilled: Array<UnfilledReason | undefined> = new Array(files.length).fill(undefined);
   /** Next unclaimed input index. Shared across workers; each claims by post-increment. */
   let cursor = 0;
   let started = 0;
@@ -520,7 +518,7 @@ async function runPooled<T>(
         } catch {
           // The worker died (or wedged past its deadline) holding this file. Leave the slot
           // for the main thread and stop feeding this worker.
-          unfilled[index] = { reason: 'worker-died' };
+          unfilled[index] = 'worker-died';
           break;
         }
         // A worker that cannot handle a language reports it two ways, and BOTH are
@@ -535,7 +533,7 @@ async function runPooled<T>(
           proven.add(file.language);
         } else if (outcome.status !== 'ok' || isEmptyResult(outcome.value)) {
           if (!proven.has(file.language)) {
-            unfilled[index] = { reason: 'unproven', worker: outcome };
+            unfilled[index] = 'unproven';
             continue;
           }
         }
@@ -566,9 +564,9 @@ async function runPooled<T>(
     if (slots[i] !== undefined) continue;
     // A slot with no recorded reason belongs to a file no worker ever claimed (every
     // worker died first) — the same situation as a worker dying while holding it.
-    const record = unfilled[i];
+    const reason = unfilled[i] ?? 'worker-died';
     const outcome = await runSerial(files[i], serialExtract);
-    if (!record || record.reason === 'worker-died') {
+    if (reason === 'worker-died') {
       workerFallbackFiles.push(files[i].path);
     } else {
       unprovenRechecks++;
@@ -645,14 +643,20 @@ async function terminateQuietly(worker: ExtractionWorkerHandle): Promise<void> {
  */
 export function describeExtractionLane(d: ExtractionLaneDisclosure): string | undefined {
   if (d.lane === 'pooled') {
-    // A worker that reported nothing where the main thread found facts is the one outcome
-    // that means something was actually WRONG with a worker, so it leads.
+    const parts: string[] = [];
+    // A worker that reported nothing (an empty result OR a throw) where the main thread
+    // found facts is the one outcome meaning something was actually WRONG with a worker,
+    // so it leads. Both outcomes are reported when both happened.
     if (d.laneDefectFiles.length > 0) {
-      return `extraction worker returned no symbols for ${d.laneDefectFiles.length} file(s) that do contain symbols `
-        + `(e.g. ${d.laneDefectFiles[0]}); the main-thread result was used. Set OPENLORE_NO_WORKERS=1 if this recurs`;
+      parts.push(
+        `extraction worker reported no symbols for ${d.laneDefectFiles.length} file(s) that do contain symbols `
+        + `(e.g. ${d.laneDefectFiles[0]}); the main-thread result was used. Set OPENLORE_NO_WORKERS=1 if this recurs`,
+      );
     }
-    if (d.workerFallbackFiles.length === 0) return undefined;
-    return `extraction pool degraded: ${d.workerFallbackFiles.length} file(s) re-extracted on the main thread after a worker failed`;
+    if (d.workerFallbackFiles.length > 0) {
+      parts.push(`${d.workerFallbackFiles.length} file(s) re-extracted on the main thread after a worker failed`);
+    }
+    return parts.length > 0 ? parts.join('; ') : undefined;
   }
   // A small build, a small machine, a caller opting out, or an explicit env opt-out are
   // ordinary choices, not degradations — warning about them would be noise on every run.

--- a/src/core/analyzer/extraction-worker.ts
+++ b/src/core/analyzer/extraction-worker.ts
@@ -16,26 +16,43 @@
  * Two honesty rules are implemented here:
  *
  *  - **Startup probe.** The extractors return an empty result (they do not throw) when a
- *    grammar cannot be loaded, so a worker whose native bindings failed would silently
- *    contribute nothing to the graph. Before accepting any work this thread parses a
- *    known-good snippet and requires the expected node and edge; a worker that cannot do
- *    that reports itself `unhealthy` and is dropped from the pool instead of returning
- *    plausible-looking emptiness.
+ *    grammar cannot be loaded, so a worker whose bindings failed would silently contribute
+ *    nothing to the graph. Before accepting work this thread parses a known-good snippet in
+ *    the language the parent named and requires the expected node and edge; a worker that
+ *    cannot do that reports itself `unhealthy` and is dropped. This is a FAST-FAIL, not the
+ *    guarantee: it covers one language, and the pool's per-language unproven-silence guard
+ *    is what actually makes an empty result trustworthy.
  *  - **Log relay.** A grammar that is genuinely unavailable warns once per thread. Left
- *    alone that prints N times and interleaves with the parent's spinner, so the logger's
- *    output is redirected to the parent, which dedupes and prints it once.
+ *    alone that prints N times, interleaves with the parent's spinner, and — because a
+ *    worker inherits no console patching — could write to a stdout that is carrying
+ *    JSON-RPC. So the logger is redirected to the parent, which dedupes and prints once.
  */
 
-import { parentPort } from 'node:worker_threads';
+import { parentPort, workerData } from 'node:worker_threads';
 import { dispatchFileExtract } from './call-graph.js';
 import { logger } from '../../utils/logger.js';
-import type { ExtractionRequest, ExtractionResponse } from './extraction-pool.js';
+import type { ExtractionRequest, ExtractionResponse, ExtractionWorkerData } from './extraction-pool.js';
 
-/** The probe source: one function containing one call — the minimum that proves a real parse. */
-const PROBE_FILE = {
-  path: '__openlore_extraction_probe__.ts',
-  content: 'export function __openloreProbe(): void { __openloreProbeCallee(); }\n',
-  language: 'TypeScript',
+/**
+ * Probe sources, per language: one function containing one call — the minimum that proves a
+ * real parse produced both a node and an edge.
+ *
+ * The parent picks which language to probe from the build's OWN files, because every
+ * grammar is an optional dependency: probing TypeScript in a Python repo could disable the
+ * pool over a grammar that repo never needed. A language absent from this table simply
+ * skips the probe — the per-language unproven-silence guard in the pool still covers it,
+ * so the probe is a fast-fail optimization, never the sole line of defense.
+ */
+const PROBES: Record<string, { path: string; content: string }> = {
+  TypeScript: { path: '__openlore_probe__.ts', content: 'export function olProbe(): void { olProbeCallee(); }\n' },
+  JavaScript: { path: '__openlore_probe__.js', content: 'export function olProbe() { olProbeCallee(); }\n' },
+  Python: { path: '__openlore_probe__.py', content: 'def ol_probe():\n    ol_probe_callee()\n' },
+  Go: { path: '__openlore_probe__.go', content: 'package p\n\nfunc OlProbe() { olProbeCallee() }\n' },
+  Rust: { path: '__openlore_probe__.rs', content: 'fn ol_probe() { ol_probe_callee(); }\n' },
+  Ruby: { path: '__openlore_probe__.rb', content: 'def ol_probe\n  ol_probe_callee\nend\n' },
+  Java: { path: '__openlore_probe__.java', content: 'class OlProbe { void probe() { callee(); } }\n' },
+  'C++': { path: '__openlore_probe__.cpp', content: 'void olProbe() { olProbeCallee(); }\n' },
+  Swift: { path: '__openlore_probe__.swift', content: 'func olProbe() { olProbeCallee() }\n' },
 };
 
 function post(message: ExtractionResponse): void {
@@ -57,17 +74,20 @@ function relayLogging(): void {
 
 /**
  * Prove this thread can actually parse before it accepts work. Returns the reason it
- * cannot, or `undefined` when healthy.
+ * cannot, or `undefined` when healthy (including when there is nothing to probe).
  */
-async function probeFailureReason(): Promise<string | undefined> {
+async function probeFailureReason(language: string | undefined): Promise<string | undefined> {
+  if (!language) return undefined; // nothing named — the pool's per-language guard covers it
+  const probe = PROBES[language];
+  if (!probe) return undefined; // no probe for this language — same guard covers it
   try {
-    const result = await dispatchFileExtract(PROBE_FILE);
-    if (!result) return 'probe language has no extractor in this worker';
-    if (result.nodes.length === 0) return 'probe parse produced no function node (grammar unavailable in worker)';
-    if (result.rawEdges.length === 0) return 'probe parse produced no call edge (query support unavailable in worker)';
+    const result = await dispatchFileExtract({ ...probe, language });
+    if (!result) return `${language} has no extractor in this worker`;
+    if (result.nodes.length === 0) return `${language} probe produced no function node (grammar unavailable in worker)`;
+    if (result.rawEdges.length === 0) return `${language} probe produced no call edge (query support unavailable in worker)`;
     return undefined;
   } catch (err) {
-    return `probe parse threw: ${(err as Error).message}`;
+    return `${language} probe threw: ${(err as Error).message}`;
   }
 }
 
@@ -75,7 +95,7 @@ async function main(): Promise<void> {
   if (!parentPort) return; // not running as a worker — nothing to serve
   relayLogging();
 
-  const failure = await probeFailureReason();
+  const failure = await probeFailureReason((workerData as ExtractionWorkerData | null)?.probeLanguage);
   if (failure) {
     post({ type: 'unhealthy', reason: failure });
     return;

--- a/src/core/analyzer/extraction-worker.ts
+++ b/src/core/analyzer/extraction-worker.ts
@@ -92,10 +92,16 @@ async function probeFailureReason(language: string | undefined): Promise<string 
 }
 
 async function main(): Promise<void> {
-  if (!parentPort) return; // not running as a worker — nothing to serve
+  // Serve only when this thread is an extraction worker THIS pool spawned. Importing this
+  // module for its `PROBES` table (the probe-snippet guard test does) must never attach a
+  // message handler — and `parentPort !== null` cannot tell "I am an extraction worker"
+  // from "I am running inside someone else's worker thread", e.g. a test runner using a
+  // thread pool rather than forked processes.
+  const data = workerData as ExtractionWorkerData | null;
+  if (!parentPort || data?.openloreExtractionWorker !== true) return;
   relayLogging();
 
-  const failure = await probeFailureReason((workerData as ExtractionWorkerData | null)?.probeLanguage);
+  const failure = await probeFailureReason(data.probeLanguage);
   if (failure) {
     post({ type: 'unhealthy', reason: failure });
     return;

--- a/src/core/analyzer/extraction-worker.ts
+++ b/src/core/analyzer/extraction-worker.ts
@@ -43,7 +43,7 @@ import type { ExtractionRequest, ExtractionResponse, ExtractionWorkerData } from
  * skips the probe — the per-language unproven-silence guard in the pool still covers it,
  * so the probe is a fast-fail optimization, never the sole line of defense.
  */
-const PROBES: Record<string, { path: string; content: string }> = {
+export const PROBES: Record<string, { path: string; content: string }> = {
   TypeScript: { path: '__openlore_probe__.ts', content: 'export function olProbe(): void { olProbeCallee(); }\n' },
   JavaScript: { path: '__openlore_probe__.js', content: 'export function olProbe() { olProbeCallee(); }\n' },
   Python: { path: '__openlore_probe__.py', content: 'def ol_probe():\n    ol_probe_callee()\n' },

--- a/src/core/analyzer/extraction-worker.ts
+++ b/src/core/analyzer/extraction-worker.ts
@@ -1,0 +1,109 @@
+/**
+ * Pass-1 extraction worker entry (change: optimize-parallel-extraction-pool).
+ *
+ * One instance of this module runs per pool worker. It holds this thread's own
+ * tree-sitter parser and grammar singletons (the module-level caches in
+ * `call-graph.ts` are per-module-registry, so a worker thread gets its own set for
+ * free) and answers one request at a time:
+ *
+ *   parent → { type: 'extract', id, file }   worker → { type: 'result', id, value }
+ *                                                   | { type: 'failed', id, message }
+ *
+ * It contains NO extraction logic of its own — it calls the same
+ * `dispatchFileExtract` the serial lane calls, which is what makes the two lanes
+ * provably identical rather than merely similar.
+ *
+ * Two honesty rules are implemented here:
+ *
+ *  - **Startup probe.** The extractors return an empty result (they do not throw) when a
+ *    grammar cannot be loaded, so a worker whose native bindings failed would silently
+ *    contribute nothing to the graph. Before accepting any work this thread parses a
+ *    known-good snippet and requires the expected node and edge; a worker that cannot do
+ *    that reports itself `unhealthy` and is dropped from the pool instead of returning
+ *    plausible-looking emptiness.
+ *  - **Log relay.** A grammar that is genuinely unavailable warns once per thread. Left
+ *    alone that prints N times and interleaves with the parent's spinner, so the logger's
+ *    output is redirected to the parent, which dedupes and prints it once.
+ */
+
+import { parentPort } from 'node:worker_threads';
+import { dispatchFileExtract } from './call-graph.js';
+import { logger } from '../../utils/logger.js';
+import type { ExtractionRequest, ExtractionResponse } from './extraction-pool.js';
+
+/** The probe source: one function containing one call — the minimum that proves a real parse. */
+const PROBE_FILE = {
+  path: '__openlore_extraction_probe__.ts',
+  content: 'export function __openloreProbe(): void { __openloreProbeCallee(); }\n',
+  language: 'TypeScript',
+};
+
+function post(message: ExtractionResponse): void {
+  parentPort?.postMessage(message);
+}
+
+/**
+ * Route this thread's logger through the parent. `logger.warning` is the channel the
+ * grammar loaders use to disclose an unavailable language, and it must survive — deduped
+ * — rather than be swallowed or printed once per worker.
+ */
+function relayLogging(): void {
+  const relay = (level: 'warning' | 'debug') => (message: string): void => post({ type: 'log', level, message });
+  // Instance-level override, scoped to this worker thread only.
+  const sink = logger as unknown as Record<string, (message: string) => void>;
+  sink.warning = relay('warning');
+  sink.debug = relay('debug');
+}
+
+/**
+ * Prove this thread can actually parse before it accepts work. Returns the reason it
+ * cannot, or `undefined` when healthy.
+ */
+async function probeFailureReason(): Promise<string | undefined> {
+  try {
+    const result = await dispatchFileExtract(PROBE_FILE);
+    if (!result) return 'probe language has no extractor in this worker';
+    if (result.nodes.length === 0) return 'probe parse produced no function node (grammar unavailable in worker)';
+    if (result.rawEdges.length === 0) return 'probe parse produced no call edge (query support unavailable in worker)';
+    return undefined;
+  } catch (err) {
+    return `probe parse threw: ${(err as Error).message}`;
+  }
+}
+
+async function main(): Promise<void> {
+  if (!parentPort) return; // not running as a worker — nothing to serve
+  relayLogging();
+
+  const failure = await probeFailureReason();
+  if (failure) {
+    post({ type: 'unhealthy', reason: failure });
+    return;
+  }
+
+  // Requests are served strictly one at a time: the parent never has more than one
+  // in-flight file per worker, so no queueing or interleaving is needed here.
+  parentPort.on('message', (raw: unknown) => {
+    const msg = raw as ExtractionRequest;
+    if (!msg || typeof msg !== 'object') return;
+    if (msg.type === 'shutdown') {
+      parentPort?.close();
+      return;
+    }
+    if (msg.type !== 'extract') return;
+    void (async () => {
+      try {
+        const value = await dispatchFileExtract(msg.file);
+        post({ type: 'result', id: msg.id, value });
+      } catch (err) {
+        // Mirrors the serial lane: a throwing extractor is a parse failure for THIS file,
+        // recorded as such by the parent — not a reason to fall back or retry.
+        post({ type: 'failed', id: msg.id, message: (err as Error).message });
+      }
+    })();
+  });
+
+  post({ type: 'ready' });
+}
+
+await main();

--- a/src/core/services/mcp-watcher-incremental.test.ts
+++ b/src/core/services/mcp-watcher-incremental.test.ts
@@ -43,6 +43,23 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true });
 });
 
+/**
+ * Wait until `done()` reports the debounced flush has landed, or give up after `budget` ms.
+ *
+ * These tests used to sleep a fixed 150-200ms and assert immediately. That encodes a guess
+ * about how fast the machine is: on a loaded CI runner the flush had not run yet and the
+ * assertion failed for a reason that has nothing to do with the behavior under test. Polling
+ * for the observable outcome keeps the same assertions while removing the guess — a fast
+ * machine still finishes in one tick, and a slow one is simply given room.
+ */
+async function until(done: () => boolean | Promise<boolean>, budget = 5_000): Promise<void> {
+  const deadline = Date.now() + budget;
+  while (Date.now() < deadline) {
+    if (await done()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
 describe('McpWatcher — Spec 13.1 freshness', () => {
   it('G6: a save patches the just-changed signature into llm-context.json on disk', async () => {
     await writeContext([]);
@@ -117,7 +134,7 @@ describe('McpWatcher — Spec 13.1 freshness', () => {
     const watcher = new McpWatcher({ rootPath: root, embed: false, debounceMs: 30, maxBatchMs: 1000 });
     for (const f of files) (watcher as unknown as { enqueue(p: string): void }).enqueue(join(root, f));
 
-    await new Promise((r) => setTimeout(r, 200));
+    await until(() => summaries.length > 0);
 
     expect(summaries.length).toBe(1);
     expect(summaries[0]).toContain('updated 4 files');
@@ -145,7 +162,7 @@ describe('McpWatcher — Spec 13.1 freshness', () => {
 
     const watcher = new McpWatcher({ rootPath: root, embed: false, debounceMs: 20, maxBatchMs: 1000 });
     (watcher as unknown as { enqueue(p: string): void }).enqueue(fooAbs);
-    await new Promise((r) => setTimeout(r, 150));
+    await until(() => primeSpy.mock.calls.length > 0);
 
     // The flush handed the patched context to the read cache exactly once.
     expect(primeSpy).toHaveBeenCalledTimes(1);
@@ -172,7 +189,7 @@ describe('McpWatcher — Spec 13.1 freshness', () => {
 
     const watcher = new McpWatcher({ rootPath: root, embed: false, debounceMs: 30, bulkThreshold: 3 });
     for (const f of files) (watcher as unknown as { enqueue(p: string): void }).enqueue(join(root, f));
-    await new Promise((r) => setTimeout(r, 200));
+    await until(() => summaries.length > 0);
 
     expect(summaries.length).toBe(1);
     expect(summaries[0]).toContain('coalesced 3 changes');
@@ -185,7 +202,9 @@ describe('McpWatcher — Spec 13.1 freshness', () => {
 
     const watcher = new McpWatcher({ rootPath: root, embed: false, debounceMs: 20, maxBatchMs: 1000 });
     (watcher as unknown as { enqueue(p: string): void }).enqueue(fooAbs);
-    await new Promise((r) => setTimeout(r, 150));
+    await until(async () => {
+      try { return (await readFile(contextPath, 'utf-8')).includes('delta'); } catch { return false; }
+    });
 
     const onDisk = JSON.parse(await readFile(contextPath, 'utf-8')) as { signatures: Array<{ path: string; entries: Array<{ name: string }> }> };
     const foo = onDisk.signatures.find((s) => s.path === 'foo.ts');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,14 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts', 'test/**/*.test.ts', 'examples/**/*.test.ts'],
     exclude: ['**/*.integration.test.ts', 'node_modules/**'],
+    env: {
+      // Keep the suite on the serial Pass-1 extraction lane by default
+      // (change: optimize-parallel-extraction-pool): spawning real worker threads under
+      // vitest would add seconds per multi-file build for zero coverage value. The pool
+      // itself is covered deliberately — by a stub-worker lane for ordering/failure
+      // semantics, and by one test that clears this flag to exercise real threads.
+      OPENLORE_NO_WORKERS: '1',
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.integration.test.ts'],
     testTimeout: 60000,   // embedding + LanceDB build can take a few seconds
+    env: {
+      // Serial Pass-1 extraction by default — see the note in vitest.config.ts
+      // (change: optimize-parallel-extraction-pool).
+      OPENLORE_NO_WORKERS: '1',
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
**Status:** Ready for review. Full suite green (321 files / 6146 tests), lint + typecheck clean, byte-equality oracle passes end to end, and two rounds of adversarial review are folded in.

Implements change `optimize-parallel-extraction-pool` (proposal 1 of the competitive-substrate sweep).

## What was missing

`openlore analyze`'s dominant cost is Pass 1 — per-file tree-sitter parsing and fact extraction — and it ran as a strictly serial `for…of` on the main thread. On this repo that is **14.3s of a 20.2s call-graph build (71%)**, with every other core idle. Parsing is embarrassingly parallel per file (no file's extraction reads another file's state), and there was no worker anywhere in the pipeline.

Parse throughput is the substrate's admission price: "re-analyze after significant refactors", zero-interaction onboarding, and the self-healing rebuild are all bounded below by how fast analyze runs.

## What it does

A fixed-size `worker_threads` lane for Pass 1, sized `min(availableParallelism() - 1, remaining process budget, fileCount)` and started only above `EXTRACTION_POOL_MIN_FILES`.

The design is built around one property — **the pool must make extraction faster without making it different**:

- **No extraction logic in the pool.** Workers call the same `dispatchFileExtract` the serial lane calls. The pool module is scheduling and failure handling only, so the two lanes cannot drift.
- **Index-keyed slots, never completion order.** Pass 1 is now an EXTRACT step (pooled or serial) followed by a MERGE step that walks `files` by index. Every determinism property downstream — which node wins an id collision, the raw-edge sequence — is a property of the merge loop, not of the lane.
- **The serial lane stays the reference implementation** and is also the fallback executor.

**Deviation from the proposal, deliberate:** workers receive the file's *content*, not just its path. `build`'s input content is authoritative and is not always what is on disk — HTML pages arrive inline-script-blanked, the incremental path passes in-memory content, and test builds pass synthetic files with no on-disk twin. A worker-side re-read would change facts, not just I/O. The proposal and spec delta carry that rationale.

## The interesting failure mode: a worker that goes blind

The extractors report an unavailable grammar by returning an **empty result**, not by throwing. A worker whose grammar for some language failed to load *in its thread* would therefore report every file of that language as containing nothing, and the merge would record that as "no symbols here" — precisely the silent loss the parse-health work exists to prevent. A startup probe cannot close this: it proves one grammar, and the other ~20 load lazily and independently per thread.

So **a worker's silence is not trusted until that worker has demonstrably extracted that language**. An empty result for an unproven language is re-checked on the main thread; if the main thread then finds facts, that is disclosed as a lane defect rather than recorded as an empty file. Measured cost on a healthy run of this repo: **zero re-checks** — a real parse of a function-less file still yields style counters, so ordinary empty files are never mistaken for silence. The bounded cost lands only on languages with no style tally, and only until that worker's first real result.

The startup probe still runs as a fast-fail, now in a language the build actually contains (every grammar is an optional dependency, so probing TypeScript in a Python repo could disable the pool over a grammar that repo never needed).

## Fail-soft ladder

Every rung is disclosed on `CallGraphResult.extractionLane` and surfaced by the CLI; none of it changes a fact.

| Failure | Response |
|---|---|
| A worker dies mid-file | that file is re-extracted on the main thread |
| An extractor *throws* inside a worker | recorded as that file's parse failure — identical to serial, no retry |
| A worker returns nothing for an unproven language | re-checked on the main thread; a disagreement is disclosed as a lane defect |
| A worker replies off-protocol, or stops answering | retired on a deadline; its file falls to the main thread |
| No worker comes up healthy / no worker entry / `OPENLORE_NO_WORKERS=1` | wholesale serial lane (and the process remembers, so later builds don't re-pay the stall) |

**Nothing on this path writes to stdout.** `openlore mcp` speaks JSON-RPC over stdout and runs builds in-process, and a worker thread inherits none of the parent's console patching. Workers keep their stdout off the parent's (drained; stderr stays inherited, since it is not a protocol channel and losing a crash trace is worse), and the lane note is returned on the build result for the CLI to render instead of being logged from the builder.

**Worker count is bounded per process, not per build** — the daemon runs a background self-heal rebuild alongside tool-call builds, and each would otherwise plan a full pool and double the resident isolate count.

## Proof it works

**Measured** (this repo, macOS, 10 cores, pool size 8):

| | serial | pooled |
|---|---|---|
| call-graph build | 18.9s | **7.2s** (2.6×) |
| `openlore analyze --no-embed` | 24.7s | **12.6s** (2.0×) |

**Byte-equality oracle** — `openlore analyze` on a clean checkout, pooled and with `OPENLORE_NO_WORKERS=1`. Every content artifact is byte-identical: `llm-context.json`, `repo-structure.json`, `dependency-graph.json`, `style-fingerprint.json`, `parse-health.json`, every inventory, `CODEBASE.md`, `ARCHITECTURE.md`. Four artifacts differ — `SUMMARY.md`, `fingerprint.json`, `refactor-priorities.json`, `vector-index-meta.json` — in a wall-clock timestamp only, and they differ identically between two *same-lane* runs, so that is pre-existing and not lane-dependent.

**MCP stdio purity** — drove `openlore mcp` over stdio through a cold-start index build (which runs the pool in-process) plus an `orient` tool call: 3 stdout lines, all valid JSON-RPC frames, all requests answered, build noise on stderr.

**Tests** (26 across two files):
- *Order independence*: a stub pool that answers later files **first** — asserting the completion order really was inverted — still yields a byte-identical serialized graph, including a colliding-symbol corpus where merge order alone decides which node survives.
- *Blind worker*: a worker that reports nothing for a language still yields a graph byte-identical to serial, and its defect is disclosed. A function-less file costs zero re-checks; a language with no style counters is re-checked only until the worker proves it; a language with no extractor is a deterministic answer, not a silence.
- *Worker crash*: one worker dies mid-file, and separately **all** workers die. Every file accounted for, facts identical to serial, fallback disclosed.
- *Protocol and liveness*: an off-protocol reply retires the worker instead of hanging the pass; a worker that never reports ready is dropped on its deadline (driven with fake timers, so it cannot quietly become a slow test).
- *Process budget*: concurrent builds share one worker budget, and it is returned when they finish.
- *Real threads*: actual `worker_threads` spawn, probe, extract, and match serial byte for byte — including the Lua and Dart **WASM** grammars, whose emscripten heaps must be isolated per thread, and a per-language sweep over Python/Go/Rust/Ruby/Java/C++/Swift/JavaScript (a grammar that loads on the main thread but not in a worker returns *empty* rather than throwing, so one language cannot speak for the rest).
- *Shipped entry*: `dist/core/analyzer/extraction-worker.js` — the file the npm package ships, which no other test loads because vitest always resolves the `.ts` entry — starts and reports ready, and says so loudly if the checkout is unbuilt rather than passing quietly.

## Notes / nits

- **CI's Lint & Type Check job fails on `npm audit --audit-level=high`, which runs before lint and is red on `main` itself** (the `sharp`/libvips advisory chain, handled separately on `fix/security-dependency-alerts`). Nothing here touches dependencies; `npm run lint` and `npm run typecheck` are clean.
- The suite runs with `OPENLORE_NO_WORKERS=1` (both vitest configs) so the ~320 other test files never pay for thread spawn. The pool is covered deliberately instead: a stub lane for ordering/failure semantics, and one file that clears the flag to exercise real threads.
- Scope is Pass 1 only. Global passes (resolution, synthesis, communities) stay single-threaded — they are cross-file and not the dominant cost; their pass-count reduction is the sibling `optimize-analyze-pipeline-passes`.
- No tool, no output shape, and no conclusion changed — so there is no MCP↔Pi parity work here.
- `extraction-worker.ts` is reached only through a runtime path resolution, so OpenLore's own `find_dead_code` / `report_coverage_gaps` will report its functions as unreachable. That is a true statement about the static graph, not a bug in either.
- `OPENLORE_NO_WORKERS=1` is the documented escape hatch (now in `docs/configuration.md`), and the serial lane is exercised on every run of the suite, so the cold path cannot rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
