### PR TITLE
chore(deps): close two gaps in the Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,17 +34,34 @@ updates:
         dependency-type: production
         update-types: [minor, patch]
     ignore:
-      # Pinned intentionally, not drifting. tree-sitter grammars are matched to the
-      # web-tree-sitter/ABI version the analyzer loads, and a grammar bump has to be
-      # validated against the parse fixtures rather than merged on green CI alone.
+      # Pinned intentionally, not drifting. Every parser package is matched to the
+      # ABI/grammar version the analyzer loads, so a bump has to be validated against
+      # the parse fixtures rather than merged on green CI alone.
+      #
+      # The wildcard matters. The first version of this file listed only
+      # `web-tree-sitter` and `tree-sitter-wasms`, which left the native `tree-sitter`
+      # and all 18 `tree-sitter-*` grammars unignored — they landed in the
+      # production-minor-patch group and broke the build (`Cannot find module
+      # 'tree-sitter'`, then a cascade of implicit-any errors).
+      #
+      # Why they qualified as "minor" at all: for a 0.x package semver treats
+      # 0.22 -> 0.25 as a MINOR bump, so `update-types: [minor, patch]` does not mean
+      # "non-breaking" for anything below 1.0. Most of this repo's parser stack is 0.x.
       - dependency-name: web-tree-sitter
+      - dependency-name: tree-sitter
+      - dependency-name: 'tree-sitter-*'
       - dependency-name: tree-sitter-wasms
       - dependency-name: '@lancedb/lancedb'
 
   # ------------------------------------------------------- github actions
-  # Covers `.github/workflows/*` and the composite action in
-  # `.github/actions/openlore-review/action.yml`. Grouped: these are almost always
-  # the same handful of first-party actions moving together.
+  # Two entries, because one does not cover both places actions are referenced.
+  #
+  # `directory: /` covers `.github/workflows/*` ONLY. The composite action at
+  # `.github/actions/openlore-review/action.yml` is a separate Dependabot directory and
+  # was silently unmonitored — the first github-actions PR (#270) bumped every workflow
+  # to checkout v7 / setup-node v7 and left the composite action on setup-node v4.4.0
+  # and github-script v7.1.0. Actions there are pinned to commit SHAs like everywhere
+  # else, and a pinned SHA with nothing proposing upgrades just freezes.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -53,5 +70,16 @@ updates:
     open-pull-requests-limit: 5
     groups:
       github-actions:
+        applies-to: version-updates
+        patterns: ['*']
+
+  - package-ecosystem: github-actions
+    directory: /.github/actions/openlore-review
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      composite-action:
         applies-to: version-updates
         patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,10 +47,11 @@ updates:
       # Why they qualified as "minor" at all: for a 0.x package semver treats
       # 0.22 -> 0.25 as a MINOR bump, so `update-types: [minor, patch]` does not mean
       # "non-breaking" for anything below 1.0. Most of this repo's parser stack is 0.x.
+      # `tree-sitter-*` covers the grammars AND `tree-sitter-wasms`; the bare
+      # `tree-sitter` needs its own line because the wildcard requires the hyphen.
       - dependency-name: web-tree-sitter
       - dependency-name: tree-sitter
       - dependency-name: 'tree-sitter-*'
-      - dependency-name: tree-sitter-wasms
       - dependency-name: '@lancedb/lancedb'
 
   # ------------------------------------------------------- github actions

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -243,6 +243,46 @@ describe('workflow security: supply-chain automation is wired', () => {
     );
   });
 
+  it('watches every directory that references a third-party action', () => {
+    const cfg = parse(read(join(REPO_ROOT, '.github', 'dependabot.yml'))) as {
+      updates?: { 'package-ecosystem'?: string; directory?: string; directories?: string[] }[];
+    };
+
+    // Normalize to a set of watched directories, minus trailing slashes.
+    const watched = new Set(
+      (cfg.updates ?? [])
+        .filter(u => u['package-ecosystem'] === 'github-actions')
+        .flatMap(u => u.directories ?? [u.directory ?? '/'])
+        .map(d => (d === '/' ? '/' : d.replace(/\/$/, '')))
+    );
+
+    // A `directory: /` entry covers `.github/workflows` and nothing else. A composite
+    // action lives in its own directory and needs its own entry, or its SHA pins are
+    // frozen with nothing proposing upgrades. This is how the composite action went
+    // unmonitored initially — the config looked complete because the workflows were.
+    const offenders: string[] = [];
+    for (const file of COMPOSITE_ACTIONS) {
+      const hasThirdParty = read(file)
+        .split('\n')
+        .some(l => {
+          const m = l.match(/^\s*(?:-\s+)?uses:\s*(\S+)/);
+          return !!m && !m[1].replace(/['"]/g, '').startsWith('./');
+        });
+      if (!hasThirdParty) continue;
+      const dir = '/' + rel(dirname(file)).replace(/\\/g, '/');
+      if (!watched.has(dir)) offenders.push(`${dir} (from ${rel(file)})`);
+    }
+
+    expect(
+      offenders,
+      `These directories reference third-party actions but no github-actions Dependabot ` +
+        `entry watches them, so their pins will never be proposed for upgrade. Add to ` +
+        `.github/dependabot.yml:\n` +
+        offenders.map(d => `  - package-ecosystem: github-actions\n    directory: ${d.split(' ')[0]}`).join('\n') +
+        '\n'
+    ).toEqual([]);
+  });
+
   it('runs CodeQL on pull requests and on a schedule', () => {
     const wf = parse(read(join(WORKFLOW_DIR, 'codeql.yml'))) as { on?: Record<string, unknown> };
     // `parse` turns the YAML key `on` into the string key 'on' (not boolean true) for

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -19,7 +19,7 @@
  *   5. Every job declares its own `permissions` block.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { parse } from 'yaml';
@@ -40,8 +40,35 @@ const workflowFiles = readdirSync(WORKFLOW_DIR)
   .filter(f => f.endsWith('.yml') || f.endsWith('.yaml'))
   .sort();
 
-/** Composite actions live outside `workflows/` and cannot declare `permissions`. */
-const COMPOSITE_ACTIONS = [join(REPO_ROOT, '.github', 'actions', 'openlore-review', 'action.yml')];
+/**
+ * Composite actions live outside `workflows/` and cannot declare `permissions`.
+ *
+ * DISCOVERED, never listed. A hardcoded path only guards the actions that existed when
+ * the list was written: adding a second composite action would silently escape the
+ * pinning, version-comment, and Dependabot-coverage checks below — the exact drift
+ * these guards exist to catch, and a guard that quietly under-covers is worse than no
+ * guard, because the green check implies coverage it does not have.
+ */
+function findActionManifests(dir: string): string[] {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return []; // directory absent is fine — nothing to guard
+  }
+  return entries.flatMap(e => {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) return findActionManifests(full);
+    return e.name === 'action.yml' || e.name === 'action.yaml' ? [full] : [];
+  });
+}
+
+const COMPOSITE_ACTIONS = [
+  ...findActionManifests(join(REPO_ROOT, '.github', 'actions')),
+  // A repo can also publish a single action from its root. Checked directly rather than
+  // by walking from REPO_ROOT, which would descend into node_modules.
+  ...['action.yml', 'action.yaml'].map(f => join(REPO_ROOT, f)).filter(existsSync),
+].sort();
 
 const ALL_ACTION_FILES = [...workflowFiles.map(f => join(WORKFLOW_DIR, f)), ...COMPOSITE_ACTIONS];
 


### PR DESCRIPTION
## Status

LGTM. Config plus one guard fix — no runtime code. All checks green.

## What was wrong

Two gaps in the Dependabot config added in #267, both surfaced by the first week of real Dependabot output.

**1. The parser packages weren't actually ignored.** The ignore list named `web-tree-sitter` and `tree-sitter-wasms`, but not the native `tree-sitter` or any of the 18 `tree-sitter-*` grammars. They landed in the "low-risk" production group (#272, closed) and broke the build:

```
Cannot find module 'tree-sitter' or its corresponding type declarations
```

then a cascade of implicit-any errors.

Why they counted as low-risk is the part worth remembering: **for a 0.x package, semver treats `0.22 → 0.25` as a minor bump.** So `update-types: [minor, patch]` doesn't mean "non-breaking" below 1.0 — and most of this repo's parser stack is 0.x.

**2. The composite action wasn't being watched.** `directory: /` covers `.github/workflows` and nothing else. #270 bumped every workflow to checkout v7 / setup-node v7 and silently left `.github/actions/openlore-review/action.yml` on setup-node v4.4.0 and github-script v7.1.0. The config's own comment claimed that file was covered; it wasn't. Its actions are SHA-pinned like everywhere else, and a pinned SHA with nothing proposing upgrades just freezes.

**3. The guard meant to prevent that was itself only half-working** — found while reviewing this PR. It checked a hardcoded path, so it covered the one composite action that existed when the line was written and nothing else.

Dropping a second `action.yml` under `.github/actions/` with a tag-pinned `uses:` *and* an inline `${{ github.head_ref }}` in a `run:` block left **all 8 assertions green**. Pinning, version-comment, and Dependabot-coverage all skipped it. That's worse than no guard: the green check implies coverage it doesn't have, and the test's own name — "every directory that references a third-party action" — was untrue.

## What it does

- Adds `tree-sitter` and a `tree-sitter-*` wildcard to the ignore list, with the 0.x reasoning recorded. Drops the now-redundant `tree-sitter-wasms` (the wildcard covers it); bare `tree-sitter` keeps its own line since the wildcard needs the hyphen.
- Adds a second `github-actions` entry for `/.github/actions/openlore-review`.
- Composite actions are now **discovered** by walking `.github/actions` rather than listed. A root-level `action.yml` is checked directly rather than by walking from the repo root, which would descend into `node_modules`.

## Proof

The same probe that previously passed silently now fails all three checks with file and line:

```
× pins every third-party action to a full commit SHA
    .github/actions/probe/action.yml:6 — pinned to the moving ref "v4"
× passes untrusted values through env:, not inline ${{ }}
    .github/actions/probe/action.yml:8 — inline ${{ github.head_ref }} in a run: command
× watches every directory that references a third-party action
    /.github/actions/probe (from .github/actions/probe/action.yml)
```

And the Dependabot-coverage guard was checked by removing the new entry — it fails and prints the YAML to paste back.

`dependabot.yml` parses with the expected ignore list and both watched directories · `eslint src` clean · `tsc` clean · `npm run build` clean · both audit gates pass · 322 files / 6,184 tests.

## Notes

The `tree-sitter-*` packages are ignored, not frozen — they can still be upgraded deliberately. The point is that a grammar bump needs validating against the parse fixtures, since a grammar change can shift extraction results without failing a build.

GitHub validates `dependabot.yml` as its own check, so the second-directory **syntax** is confirmed by CI. That it actually produces update PRs for that path will be proven by the next weekly run, not by this PR.
