### PR TITLE
refactor: adopt eslint 10's new rules and tighten the Node range

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,25 +6,6 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    // @eslint/js 10 promoted two rules into `recommended`. Both flag real hygiene
-    // issues, and both are off HERE ONLY so that adopting them is its own reviewed
-    // change rather than 48 edits across 31 files riding along with a version bump.
-    //
-    //   preserve-caught-error  — 12 sites / 7 files. Wants `{ cause }` when rethrowing
-    //                            from a catch. Genuinely worth adopting: it preserves
-    //                            the diagnostic chain.
-    //   no-useless-assignment  — 36 sites / 24 files. Mostly defensive initializers
-    //                            (`let x = []` where every branch reassigns) and dead
-    //                            stores. Sampled several; none indicated a bug.
-    //
-    // Turning these on is a code change, not a config change. Remove these two lines
-    // in the PR that does the fixes.
-    rules: {
-      'preserve-caught-error': 'off',
-      'no-useless-assignment': 'off',
-    },
-  },
-  {
     files: ['src/**/*.ts'],
     ignores: ['src/**/*.test.ts'],
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "openlore": "dist/cli/index.js"
   },
   "engines": {
-    "node": ">=22.13.0"
+    "node": "^22.13.0 || >=23.5.0"
   },
   "scripts": {
     "dev": "tsx watch src/cli/index.ts",

--- a/src/api/generate.ts
+++ b/src/api/generate.ts
@@ -187,7 +187,7 @@ export async function openloreGenerate(options: GenerateApiOptions = {}): Promis
       logDir: join(rootPath, OPENLORE_DIR, OPENLORE_LOGS_SUBDIR),
     });
   } catch (error) {
-    throw new Error(`Failed to create LLM service: ${(error as Error).message}`);
+    throw new Error(`Failed to create LLM service: ${(error as Error).message}`, { cause: error });
   }
   progress(onProgress, 'Creating LLM service', 'complete', `${effectiveProvider}/${effectiveModel}`);
 
@@ -231,7 +231,7 @@ export async function openloreGenerate(options: GenerateApiOptions = {}): Promis
     pipelineResult = await pipeline.run(repoStructure, llmContext, depGraph, refactorReport);
   } catch (error) {
     await llm.saveLogs().catch(() => {});
-    throw new Error(`Pipeline failed: ${(error as Error).message}`);
+    throw new Error(`Pipeline failed: ${(error as Error).message}`, { cause: error });
   }
   progress(onProgress, 'Running LLM generation pipeline', 'complete');
 

--- a/src/api/run.ts
+++ b/src/api/run.ts
@@ -272,7 +272,7 @@ export async function openloreRun(options: RunApiOptions = {}): Promise<RunResul
       logDir: join(rootPath, OPENLORE_DIR, OPENLORE_LOGS_SUBDIR),
     });
   } catch (error) {
-    throw new Error(`Failed to create LLM service: ${(error as Error).message}`);
+    throw new Error(`Failed to create LLM service: ${(error as Error).message}`, { cause: error });
   }
 
   // Load analysis data for pipeline
@@ -302,7 +302,7 @@ export async function openloreRun(options: RunApiOptions = {}): Promise<RunResul
     pipelineResult = await pipeline.run(repoStructure, llmContext, analyzeResult.depGraph);
   } catch (error) {
     await llm.saveLogs().catch(() => {});
-    throw new Error(`Pipeline failed: ${(error as Error).message}`);
+    throw new Error(`Pipeline failed: ${(error as Error).message}`, { cause: error });
   }
 
   // Format and write specs

--- a/src/api/verify.ts
+++ b/src/api/verify.ts
@@ -104,7 +104,7 @@ export async function openloreVerify(options: VerifyApiOptions = {}): Promise<Ve
       logDir: join(rootPath, OPENLORE_DIR, OPENLORE_LOGS_SUBDIR),
     });
   } catch (error) {
-    throw new Error(`Failed to create LLM service: ${(error as Error).message}`);
+    throw new Error(`Failed to create LLM service: ${(error as Error).message}`, { cause: error });
   }
 
   // Run verification

--- a/src/cli/commands/blast-radius.ts
+++ b/src/cli/commands/blast-radius.ts
@@ -201,7 +201,7 @@ export async function runBlastRadiusCli(opts: BlastRadiusCliOptions): Promise<nu
     // never block a commit. `readOpenLoreConfig` already tolerates unparseable JSON
     // (returns null); we additionally coerce `block` to an array so a valid-JSON but
     // wrong-typed value (e.g. `"block": {}` or a bare string) cannot throw on iteration.
-    let block: BlastRadiusBlockPattern[] = [];
+    let block: BlastRadiusBlockPattern[];
     try {
       const config = await readOpenLoreConfig(cwd);
       const raw = config?.blastRadius?.block;

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -216,7 +216,7 @@ export async function installPreCommitHook(rootPath: string): Promise<void> {
 
   await mkdir(hooksDir, { recursive: true });
 
-  let existingContent = '';
+  let existingContent: string;
   if (await fileExists(hookPath)) {
     existingContent = await readFile(hookPath, 'utf-8');
     if (existingContent.includes(HOOK_MARKER)) {
@@ -247,7 +247,7 @@ export async function installPreCommitHook(rootPath: string): Promise<void> {
 
   // Install post-commit hook to detect --no-verify bypass
   const postCommitPath = join(hooksDir, 'post-commit');
-  let existingPostContent = '';
+  let existingPostContent: string;
   if (await fileExists(postCommitPath)) {
     existingPostContent = await readFile(postCommitPath, 'utf-8');
     if (!existingPostContent.includes(POST_COMMIT_HOOK_MARKER)) {

--- a/src/cli/commands/drift.ts
+++ b/src/cli/commands/drift.ts
@@ -184,7 +184,7 @@ async function installPreCommitHook(rootPath: string): Promise<void> {
   await mkdir(hooksDir, { recursive: true });
 
   // Check if hook already exists
-  let existingContent = '';
+  let existingContent: string;
   if (await fileExists(hookPath)) {
     existingContent = await readFile(hookPath, 'utf-8');
 

--- a/src/cli/commands/enforce.ts
+++ b/src/cli/commands/enforce.ts
@@ -254,7 +254,7 @@ export async function runEnforceCli(opts: EnforceCliOptions): Promise<number> {
   if (opts.uninstallHook) { await uninstallEnforcementHook(cwd); return 0; }
 
   configureLogger({ quiet: true });
-  let config: OpenLoreConfig | null = null;
+  let config: OpenLoreConfig | null;
   try { config = await readOpenLoreConfig(cwd); } catch { config = null; }
   const policy = effectivePolicy(config);
   const unknown = unknownPolicyCodes(normalizeEnforcementPolicy(config?.enforcement));

--- a/src/cli/commands/impact-certificate.ts
+++ b/src/cli/commands/impact-certificate.ts
@@ -191,7 +191,7 @@ export async function runImpactCertificateCli(opts: ImpactCertificateCliOptions)
 
   if (opts.hook) {
     // Config read is advisory-safe: a throw or wrong-typed `block` must never block.
-    let block: CoveringSurfaceSeverity[] = [];
+    let block: CoveringSurfaceSeverity[];
     try {
       const config = await readOpenLoreConfig(cwd);
       const raw = config?.impactCertificate?.block;

--- a/src/cli/commands/orient-inject.ts
+++ b/src/cli/commands/orient-inject.ts
@@ -75,7 +75,7 @@ export function extractPrompt(stdin: string): string {
  * invokes it cannot break the user's turn.
  */
 export async function buildInjection(directory: string, prompt: string): Promise<string> {
-  let cfg = INJECTION_DEFAULTS;
+  let cfg: ReturnType<typeof resolveInjectionConfig>;
   try {
     const loaded = await readOpenLoreConfig(directory);
     cfg = resolveInjectionConfig(loaded?.contextInjection);

--- a/src/cli/commands/refresh-stories.ts
+++ b/src/cli/commands/refresh-stories.ts
@@ -42,7 +42,7 @@ async function installPostCommitHook(rootPath: string): Promise<void> {
 
   await mkdir(hooksDir, { recursive: true });
 
-  let existingContent = '';
+  let existingContent: string;
   if (await fileExists(hookPath)) {
     existingContent = await readFile(hookPath, 'utf-8');
 

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -388,7 +388,7 @@ export async function runReviewCli(opts: ReviewCliOptions): Promise<number> {
   // Opt-in gating: reuse the exact `blastRadius.block` convention — no second config
   // dialect. Advisory unless --hook AND a configured pattern actually fires.
   if (opts.hook && !('error' in briefing.blast)) {
-    let block: BlastRadiusBlockPattern[] = [];
+    let block: BlastRadiusBlockPattern[];
     try {
       const config = await readOpenLoreConfig(cwd);
       const raw = config?.blastRadius?.block;

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -512,7 +512,7 @@ The pipeline saves run metadata to .openlore/runs/ for tracking.
           logDir: join(rootPath, OPENLORE_DIR, OPENLORE_LOGS_SUBDIR),
         });
       } catch (error) {
-        throw new Error(`Failed to create LLM service: ${(error as Error).message}`);
+        throw new Error(`Failed to create LLM service: ${(error as Error).message}`, { cause: error });
       }
 
       console.log('');
@@ -534,7 +534,7 @@ The pipeline saves run metadata to .openlore/runs/ for tracking.
         );
       } catch (error) {
         await llm.saveLogs().catch((e) => logger.debug(`Failed to save LLM logs: ${(e as Error).message}`));
-        throw new Error(`Pipeline failed: ${(error as Error).message}`);
+        throw new Error(`Pipeline failed: ${(error as Error).message}`, { cause: error });
       }
 
       console.log('   ├─ Project Survey ✓');
@@ -584,7 +584,7 @@ The pipeline saves run metadata to .openlore/runs/ for tracking.
       try {
         report = await writer.writeSpecs(generatedSpecs, pipelineResult.survey);
       } catch (error) {
-        throw new Error(`Failed to write specs: ${(error as Error).message}`);
+        throw new Error(`Failed to write specs: ${(error as Error).message}`, { cause: error });
       }
 
       // Display written files

--- a/src/cli/install/adapters/cursor.ts
+++ b/src/cli/install/adapters/cursor.ts
@@ -69,7 +69,7 @@ export const cursorAdapter: Adapter = {
 
     const mdcPath = join(ctx.root, MDC_FILE);
     const desired = await renderMdc(ctx.instructionTemplate);
-    let existing: string | null = null;
+    let existing: string | null;
     try {
       existing = await readFile(mdcPath, 'utf8');
     } catch {

--- a/src/cli/install/adapters/markdown-block.ts
+++ b/src/cli/install/adapters/markdown-block.ts
@@ -45,7 +45,7 @@ export async function applyMarkdownBlock(
 ): Promise<ApplyResult> {
   const filePath = join(ctx.root, opts.fileName);
   const warnings: string[] = [];
-  let existing: string | null = null;
+  let existing: string | null;
   try {
     existing = await readFile(filePath, 'utf8');
   } catch {

--- a/src/cli/node-version-guard.ts
+++ b/src/cli/node-version-guard.ts
@@ -17,8 +17,14 @@
 /** Minimum supported Node. This is the first line where `node:sqlite` — imported
  * at module load by EdgeStore, the epistemic lease, and preflight scoring — is
  * available WITHOUT `--experimental-sqlite` (unflagged in Node 22.13.0 / 23.4.0,
- * nodejs/node#55854). MUST stay in sync with package.json `engines.node` and
- * constants.ts's `MIN_NODE_*` (a test asserts all three). */
+ * nodejs/node#55854). MUST stay in sync with the FLOOR in package.json
+ * `engines.node` (`^22.13.0 || >=23.5.0`) and constants.ts's `MIN_NODE_*` (a test
+ * asserts all three).
+ *
+ * This is a major.minor floor, so it admits 23.0-23.4 even though `node:sqlite` was
+ * still flagged there. That gap is deliberate and covered: the capability probe
+ * below has the final word, so such a runtime fails naming the missing builtin
+ * rather than passing the arithmetic and crashing later. */
 export const MIN_NODE = { major: 22, minor: 13 } as const;
 
 /** Stable, dedicated exit code for "unsupported Node" (documented contract). */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -281,9 +281,16 @@ export const DEFAULT_CHAT_OPENAI_MODEL = 'gpt-4o-mini';
  * Minimum Node.js version required. The floor is 22.13, not 20: the EdgeStore
  * refactor moved onto `node:sqlite` / `DatabaseSync`, which was available only
  * behind `--experimental-sqlite` until Node 22.13.0 / 23.4.0 (unflagged in
- * nodejs/node#55854) — and nothing in the tree passes that flag. Must equal
- * `engines.node` in package.json and `MIN_NODE` in node-version-guard.ts (a test
- * asserts all three). doctor checks the minor version AND probes `node:sqlite`
+ * nodejs/node#55854) — and nothing in the tree passes that flag. Must equal the
+ * FLOOR declared by `engines.node` in package.json and `MIN_NODE` in
+ * node-version-guard.ts (a test asserts all three).
+ *
+ * `engines.node` is a two-branch range (`^22.13.0 || >=23.5.0`) rather than a bare
+ * `>=22.13.0`, because that floor alone also admits 23.0-23.4, where `node:sqlite`
+ * was still flagged. The 23.x branch sits at 23.5 rather than 23.4 because
+ * @inquirer/prompts requires it. This constant is the 22.x floor; the capability
+ * probe below is what actually rejects a version that satisfies the arithmetic but
+ * cannot load the builtin. doctor checks the minor version AND probes `node:sqlite`
  * so an unsupported Node fails fast with a clear `nvm use` remediation instead of
  * a cryptic module-load crash (Spec 26 B7).
  */

--- a/src/core/analyzer/env-extractor.ts
+++ b/src/core/analyzer/env-extractor.ts
@@ -98,7 +98,7 @@ function extractFromSource(source: string, relPath: string, ext: string): Array<
   const found: Array<{ name: string; required: boolean }> = [];
 
   let re: RegExp;
-  let hasFallback = false;
+  let hasFallback: boolean;
 
   if (['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'].includes(ext)) {
     re = new RegExp(TS_ENV_RE.source, 'g');

--- a/src/core/analyzer/iac/cdk.ts
+++ b/src/core/analyzer/iac/cdk.ts
@@ -84,7 +84,7 @@ function findConstructions(content: string, names: Map<string, Flavor>, syntax: 
 
   for (const m of content.matchAll(re)) {
     const varName = m[1];
-    let dotted = m[2];
+    const dotted = m[2];
     const id = m[3];
     // Go constructors are `pkg.NewService` → strip the `New` prefix.
     const segs = dotted.split('.');
@@ -92,7 +92,8 @@ function findConstructions(content: string, names: Map<string, Flavor>, syntax: 
       const last = segs[segs.length - 1];
       if (!last.startsWith('New')) continue;
       segs[segs.length - 1] = last.slice(3);
-      dotted = segs.join('.');
+      // No write back to `dotted`: everything below reads `segs`, so re-joining it
+      // was a dead store left from an earlier shape of this loop.
     }
     const root = segs[0];
     const service = segs[segs.length - 1];

--- a/src/core/analyzer/iac/helm.ts
+++ b/src/core/analyzer/iac/helm.ts
@@ -178,7 +178,7 @@ function extractTemplateManifests(f: InFile, chartName: string, module: IacModul
     return;
   }
   for (const doc of docs) {
-    let obj: Record<string, unknown> | null = null;
+    let obj: Record<string, unknown> | null;
     try { obj = doc.toJS() as Record<string, unknown> | null; } catch { continue; }
     if (!obj || typeof obj !== 'object') continue;
     const kind = typeof obj.kind === 'string' ? obj.kind : '';

--- a/src/core/analyzer/local-embedding-service.ts
+++ b/src/core/analyzer/local-embedding-service.ts
@@ -85,7 +85,8 @@ export class LocalEmbeddingService implements Embedder {
           `Local embeddings need the optional "${TRANSFORMERS_PACKAGE}" package, which is not available ` +
             `(${(err as Error).message}). Install it with:\n` +
             `  npm install ${TRANSFORMERS_PACKAGE}\n` +
-            `Keyword (BM25) search continues to work without it.`
+            `Keyword (BM25) search continues to work without it.`,
+          { cause: err }
         );
       }
       // Resolve weights from the on-disk cache or the HF hub; never from an
@@ -101,7 +102,8 @@ export class LocalEmbeddingService implements Embedder {
         throw new Error(
           `Could not load the local embedding model "${this.model}" (${(err as Error).message}). ` +
             `Check the model id (--model) and your network for the one-time download. ` +
-            `Keyword (BM25) search continues to work without it.`
+            `Keyword (BM25) search continues to work without it.`,
+          { cause: err }
         );
       }
     })();

--- a/src/core/analyzer/spec-vector-index.test.ts
+++ b/src/core/analyzer/spec-vector-index.test.ts
@@ -106,7 +106,9 @@ function makeMockEmbedSvc(): EmbeddingService {
   const callCount = 0;
   return {
     embed: vi.fn().mockImplementation(async (texts: string[]) =>
-      texts.map((_, i) => makeVector(callCount + i++))
+      // `i++` here incremented the map callback's own index parameter and threw the
+      // result away; the expression value is unchanged by dropping it.
+      texts.map((_, i) => makeVector(callCount + i))
     ),
   } as unknown as EmbeddingService;
 }

--- a/src/core/analyzer/vector-index.ts
+++ b/src/core/analyzer/vector-index.ts
@@ -103,7 +103,7 @@ function metaFilePath(outputDir: string): string {
 function readMeta(outputDir: string): VectorIndexMeta | null {
   const dbPath = join(outputDir, DB_FOLDER);
   if (_metaCache.has(dbPath)) return _metaCache.get(dbPath) ?? null;
-  let meta: VectorIndexMeta | null = null;
+  let meta: VectorIndexMeta | null;
   try {
     meta = JSON.parse(readFileSync(metaFilePath(outputDir), 'utf-8')) as VectorIndexMeta;
   } catch {
@@ -364,7 +364,7 @@ function deleteCorpusSidecar(dbPath: string): void {
  * incremental patch deletes it).
  */
 function loadOrBuildBm25Corpus(dbPath: string, allRows: Record<string, unknown>[]): Bm25Corpus {
-  let loaded: Bm25Corpus | null = null;
+  let loaded: Bm25Corpus | null;
   try {
     loaded = deserializeBm25Corpus(readFileSync(corpusFilePath(dbPath), 'utf-8'));
   } catch {

--- a/src/core/decisions/atomic-store.ts
+++ b/src/core/decisions/atomic-store.ts
@@ -126,6 +126,10 @@ async function withCommitLock<T>(lockPath: string, fn: () => Promise<T>): Promis
         throw new Error(
           `store lock: timed out after ${LOCK_MAX_WAIT_MS}ms waiting for ${lockPath} ` +
             `(sustained write contention) — retry the operation`,
+          // `err` is the EEXIST from the last failed acquisition, i.e. the reason we
+          // kept waiting. Carrying it forward surfaces the errno and path behind a
+          // timeout that otherwise reads as unexplained.
+          { cause: err },
         );
       }
       await sleep(LOCK_POLL_MS);

--- a/src/core/federation/registry.ts
+++ b/src/core/federation/registry.ts
@@ -81,7 +81,7 @@ export function loadRegistry(homeDir: string): FederationRegistry {
   try {
     parsed = JSON.parse(readFileSync(manifest, 'utf8'));
   } catch (err) {
-    throw new Error(`Federation manifest is not valid JSON (${manifest}): ${(err as Error).message}`);
+    throw new Error(`Federation manifest is not valid JSON (${manifest}): ${(err as Error).message}`, { cause: err });
   }
   if (!parsed || typeof parsed !== 'object' || !Array.isArray((parsed as FederationRegistry).repos)) {
     throw new Error(`Federation manifest has an unexpected shape (${manifest}); expected { schemaVersion, repos[] }.`);

--- a/src/core/generator/openspec-compat.ts
+++ b/src/core/generator/openspec-compat.ts
@@ -468,7 +468,7 @@ export class OpenSpecConfigManager {
       version: '1.0.0',
     }
   ): Promise<OpenSpecConfig> {
-    let raw: string | null = null;
+    let raw: string | null;
     try {
       raw = await readFile(this.configPath, 'utf-8');
     } catch {

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -1203,7 +1203,7 @@ export class GeminiCLIProvider implements LLMProvider {
     }
 
     // Format: {response: string, stats: {models: {[name]: {tokens: {input, candidates, total}}}}}
-    let content = '';
+    let content: string;
     let inputTokens: number | undefined;
     let outputTokens: number | undefined;
     let modelUsed = this.model ?? 'gemini-cli';
@@ -1293,7 +1293,7 @@ export class CursorAgentProvider implements LLMProvider {
       throw Object.assign(new Error(`cursor-agent CLI failed: ${detail}`), { retryable: false });
     }
 
-    let content = '';
+    let content: string;
     let inputTokens: number | undefined;
     let outputTokens: number | undefined;
 

--- a/src/core/services/mcp-handlers/blast-radius.ts
+++ b/src/core/services/mcp-handlers/blast-radius.ts
@@ -151,12 +151,12 @@ export async function computeBlastRadius(
   const maxSymbols = Math.max(1, Math.min(input.maxSymbols ?? DEFAULT_MAX_SYMBOLS, 50));
 
   // ── 1. Resolve the diff → changed files → seed production symbols ───────────
-  let changedFiles: string[] = [];
+  let changedFiles: string[];
   // Resolve-or-disclose through the one shared helper (fix-cli-conclusion-honesty):
   // an explicit ref that git can't resolve falls back (main → master → HEAD~1) and is
   // disclosed, so the advisory briefing never misrepresents the base it diffed against.
-  let resolvedBaseRef = baseRef;
-  let baseFellBack = false;
+  let resolvedBaseRef: string;
+  let baseFellBack: boolean;
   try {
     const { getChangedFiles, resolveBaseRefDisclosed } = await import('../../drift/git-diff.js');
     const base = await resolveBaseRefDisclosed(absDir, baseRef);

--- a/src/core/services/mcp-handlers/impact-certificate.ts
+++ b/src/core/services/mcp-handlers/impact-certificate.ts
@@ -666,7 +666,7 @@ export interface CertificateLeaseStatus {
  * be treated as silently still-true (mcp-handlers: ImpactCertificateDecaysWithLease).
  */
 export function recheckCertificate(absDir: string, cert: ImpactCertificate): CertificateLeaseStatus {
-  let anchorCtx: ReturnType<typeof AnchorContext.open> = null;
+  let anchorCtx: ReturnType<typeof AnchorContext.open>;
   try { anchorCtx = AnchorContext.open(absDir); } catch { anchorCtx = null; }
   if (!anchorCtx) {
     // No graph to check against → cannot prove fresh; treat as stale (never silently current).
@@ -705,7 +705,7 @@ export function recheckPersistedCertificates(absDir: string): StaleCertificate[]
   const dir = certDir(absDir);
   if (!existsSync(dir)) return [];
   const out: StaleCertificate[] = [];
-  let entries: string[] = [];
+  let entries: string[];
   try { entries = readdirSync(dir).filter(f => f.endsWith('.json')); } catch { return []; }
   for (const file of entries) {
     let cert: ImpactCertificate;
@@ -803,7 +803,7 @@ export async function computeImpactCertificate(
   }
 
   // ── 1. Declared surfaces config (additive; absent = nothing to assess against) ─
-  let surfaceCfg: CoveringSurfaceConfig[] = [];
+  let surfaceCfg: CoveringSurfaceConfig[];
   try {
     const cfg = await readOpenLoreConfig(absDir);
     surfaceCfg = surfacesFromConfig(cfg?.impactCertificate);

--- a/src/core/services/mcp-handlers/interference-map.ts
+++ b/src/core/services/mcp-handlers/interference-map.ts
@@ -507,7 +507,7 @@ async function buildBaseSymbols(
     if (!lang || lang === 'Unknown' || lang === 'unknown') continue; // non-code file → no symbols
     const content = await fileAtRef(repoPath, baseContentRef, basePath);
     if (content === null) { unreadable.push(f.path); continue; } // read FAILURE, not empty
-    let snap: SerializedCallGraph | null = null;
+    let snap: SerializedCallGraph | null;
     try {
       // Parse under the BASE path so symbol ids are base-identity ids (rename-safe).
       snap = serializeCallGraph(await new CallGraphBuilder().build([{ path: basePath, content, language: lang }]));
@@ -562,12 +562,12 @@ async function defaultEnumerateBranches(
   for (const branch of names.sort()) {
     if (branch === baseRef) continue;
     if (wanted && !wanted.has(branch)) continue;
-    let mergeBase = '';
+    let mergeBase: string;
     try { mergeBase = (await git(repoPath, ['merge-base', baseRef, branch])).trim(); } catch { continue; }
-    let tip = '';
+    let tip: string;
     try { tip = (await git(repoPath, ['rev-parse', branch])).trim(); } catch { continue; }
     if (!mergeBase || mergeBase === tip) continue; // branch not ahead of base → nothing in flight
-    let patch = '';
+    let patch: string;
     try { patch = await git(repoPath, ['diff', '--unified=0', '--no-color', `${mergeBase}..${branch}`]); } catch { continue; }
     const files = parseUnifiedDiff(patch);
     if (files.length === 0) continue;
@@ -599,7 +599,7 @@ async function defaultEnumeratePullRequests(
   for (const pr of prs.sort((a, b) => a.number - b.number)) {
     const ref = `PR #${pr.number}`;
     const actor = pr.author?.login || 'unknown';
-    let patch = '';
+    let patch: string;
     try {
       const { stdout } = await execFileAsync('gh', ['pr', 'diff', String(pr.number), '--patch'], { cwd: repoPath, maxBuffer: 64 * 1024 * 1024 });
       patch = stdout;
@@ -663,7 +663,7 @@ async function resolveRepos(
   if (!input.federation) return { repos, unusable, caveats };
 
   interface SpecStoreStatusLike { bound?: boolean; targets?: Array<{ name: string; resolved: boolean; state?: string; path?: string }> }
-  let status: SpecStoreStatusLike | null = null;
+  let status: SpecStoreStatusLike | null;
   try {
     const { handleSpecStoreStatus } = await import('./spec-store.js');
     status = (await handleSpecStoreStatus(absDir)) as unknown as SpecStoreStatusLike;

--- a/src/core/services/mcp-handlers/public-surface.ts
+++ b/src/core/services/mcp-handlers/public-surface.ts
@@ -236,7 +236,7 @@ async function buildSurface(
   // (the symbol is gone) apart from a visibility reduction (still defined, no longer exported).
   const allFnNames = new Map<string, Set<string>>();
   if (files.length === 0) return { exported, normBodyCount, allFnNames };
-  let snap: SerializedCallGraph | null = null;
+  let snap: SerializedCallGraph | null;
   try {
     snap = serializeCallGraph(await new CallGraphBuilder().build(files));
   } catch {

--- a/src/core/services/mcp-handlers/spec-store.ts
+++ b/src/core/services/mcp-handlers/spec-store.ts
@@ -328,7 +328,7 @@ export async function handleSpecStoreStatus(directory: string): Promise<SpecStor
     // nothing for repos that never opted into certificates. An expired certificate is
     // surfaced as a finding so it is never trusted past the state it was computed against.
     if (status.resolved && status.state === 'indexed' && status.path) {
-      let stales: ReturnType<typeof recheckPersistedCertificates> = [];
+      let stales: ReturnType<typeof recheckPersistedCertificates>;
       // Hard no-throw boundary: a target repo's corrupt anchor graph / certificate
       // must never break this read-only health check (handler contract: never throws).
       try { stales = recheckPersistedCertificates(status.path); } catch { stales = []; }

--- a/src/core/services/mcp-handlers/test-impact.ts
+++ b/src/core/services/mcp-handlers/test-impact.ts
@@ -114,7 +114,7 @@ export async function handleSelectTests(input: SelectTestsInput): Promise<unknow
   const baseRef = input.diffRef && input.diffRef.length > 0 ? input.diffRef : 'HEAD';
   const defaultedToHead = !hasSymbols && (input.diffRef === undefined || input.diffRef === '');
 
-  let seeds: FunctionNode[] = [];
+  let seeds: FunctionNode[];
   let changedFiles: string[] = [];
   if (hasSymbols) {
     seeds = seedsFromSymbols(cg, input.changedSymbols!);

--- a/src/core/verifier/verification-engine.ts
+++ b/src/core/verifier/verification-engine.ts
@@ -609,7 +609,8 @@ Respond in JSON:
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i].trim();
       if (trimmed.startsWith('/**')) { inBlockComment = true; continue; }
-      if (trimmed.startsWith('*/') || trimmed.endsWith('*/')) { inBlockComment = false; break; }
+      // `break` ends the scan, so clearing the flag here would be a dead store.
+      if (trimmed.startsWith('*/') || trimmed.endsWith('*/')) break;
       if (inBlockComment) {
         const comment = trimmed.replace(/^\*\s*/, '').trim();
         if (comment && !comment.startsWith('@')) parts.push(comment);


### PR DESCRIPTION
## Status

LGTM. Two hygiene items #282 deferred. No behavior changes — messages are byte-identical, and every removed assignment is proven dead by the compiler.

## What this does

**1. Turns on the two rules `@eslint/js` 10 added to `recommended`**, and fixes all 48 sites.

`preserve-caught-error` — 12 sites / 7 files. Every one was `throw new Error(<message>)` inside a `catch`, discarding the original error. Each now attaches `{ cause }`. The messages don't change; this only adds the error chain, which matters for a tool whose value is honest diagnostics.

`no-useless-assignment` — 36 sites / 24 files. 33 were dead initializers on `let` declarations that every branch reassigns before any read.

**2. Tightens `engines.node`** from `>=22.13.0` to `^22.13.0 || >=23.5.0`.

The old floor admitted Node 23.0–23.4, where `node:sqlite` — loaded at module init by EdgeStore — was still behind `--experimental-sqlite`. So the declared range was already wrong before `@inquirer/prompts` v8 (which is why the 23.x branch sits at 23.5 rather than 23.4).

## How the risky part was made safe

The 33 initializer removals are the only part that could have changed behavior, so **tsc is the oracle**: removing an initializer that *is* read on some path fails definite-assignment analysis. Typecheck is clean, so all 33 were provably dead rather than dead-looking.

Three of the 36 weren't declarations and were checked individually. None was a bug, but all three were genuinely dead:

| Site | What it was doing |
|---|---|
| `iac/cdk.ts` | re-joined `segs` back into `dotted` *after* the last read of it |
| `verification-engine.ts` | cleared `inBlockComment` immediately before `break`, ending the only loop that reads it |
| `spec-vector-index.test.ts` | incremented the `map` callback's own index parameter; post-increment returns the old value, so the expression is unchanged |

`atomic-store.ts` was the one judgment call in the `cause` set: that throw is a lock-wait timeout, not a wrapper. It sits inside `catch (err)` where `err` is the EEXIST from the last failed acquisition — the reason we kept waiting — so carrying it forward surfaces the errno and path behind a timeout that otherwise reads as unexplained.

`MIN_NODE` and `checkNodeVersion` are deliberately **unchanged**. Version arithmetic there is documented as a proxy, and the `node:sqlite` capability probe has the final word — so the 23.0–23.4 band already fails with a legible "missing builtin" message rather than a crash. Only the declaration was wrong, so only the declaration changed. The two comments describing `engines` as a bare floor are updated to match.

## Proof

`eslint src` clean with both rules **on** · `tsc` clean · `npm run build` clean · both audit gates pass · 322 files / 6,184 tests · the `MIN_NODE`↔`engines`↔`constants.ts` coherence guard still passes (its regex reads the `22.13` floor from the new range).

## One pre-existing issue found, not fixed here

`mcp-watcher-parity.test.ts` → "Scenario 3: all direct callers refresh past the old depth-1 limit of 10" **fails intermittently under full-suite concurrency — roughly 1 run in 5.**

It is not from this change: it reproduces on pristine `main` with the identical failure, and passes 3/3 when run in isolation. So it's concurrency- or ordering-sensitive, not a real regression.

Worth fixing on its own, since a ~20% flake will eventually redden CI for an unrelated PR and train people to re-run rather than read failures. Left out of this PR to keep the diff reviewable.
