### PR TITLE
fix(security): fix CodeQL findings, scope TLS per-request, and tune the analysis scope

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,7 +8,37 @@ name: 'OpenLore CodeQL config'
 queries:
   - uses: security-extended
 
+# ---------------------------------------------------------------------------
+# Scope policy
+#
+# Everything excluded below is excluded for one reason: it is not part of the
+# shipped program, so a dataflow SOURCE inside it describes a scenario that cannot
+# occur in the artifact users run.
+#
+# Findings are NOT suppressed by rule. When a query fires on real shipped code and
+# the behaviour is intended, that alert is dismissed individually in the Security
+# tab with a stated reason — so the rule keeps guarding new code instead of going
+# quiet everywhere.
+# ---------------------------------------------------------------------------
 paths-ignore:
+  # ---- test code -----------------------------------------------------------
+  # Not shipped (the `files` allowlist omits it and `npm run audit:packlist`
+  # enforces that), not reachable by anything but the test runner — and its
+  # fixtures are what made the first baseline unreadable.
+  #
+  # 368 of 458 alerts were IN test files, and the largest rule by a wide margin
+  # (js/insecure-temporary-file, 379 alerts) fires on `writeFile(join(tmpdir(), …))`
+  # in fixtures. That taint also flowed INTO production sinks: 30 further alerts
+  # landed on production `writeFile` calls whose path arrived from a test caller.
+  # gitignore-manager.ts was reported that way despite containing no reference to
+  # `tmpdir()` at all — in production those paths are the user's repository root.
+  #
+  # So this removes a source of noise AND of misattribution. Writing into a
+  # per-test temp directory is the correct thing for a test to do.
+  - '**/*.test.ts'
+  - '**/*.spec.ts'
+
+  # ---- fixtures and vendored code -----------------------------------------
   # Deliberately malformed / adversarial inputs that exist to be parsed by tests.
   # Scanning them reports the fixture, never the code under test.
   - src/core/analyzer/fixtures

--- a/src/api/generate.ts
+++ b/src/api/generate.ts
@@ -6,6 +6,7 @@
  */
 
 import { join } from 'node:path';
+import { allowInsecureTls } from '../core/services/tls-scope.js';
 import { readJsonFile } from '../utils/command-helpers.js';
 import {
   readOpenLoreConfig,
@@ -168,7 +169,7 @@ export async function openloreGenerate(options: GenerateApiOptions = {}): Promis
   // Apply SSL verification setting
   const sslVerify = options.sslVerify ?? openloreConfig.llm?.sslVerify ?? true;
   if (!sslVerify || openloreConfig.generation.skipSslVerify || openloreConfig.embedding?.skipSslVerify) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    allowInsecureTls('sslVerify=false or config skipSslVerify');
   }
 
   // Create LLM service

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -6,7 +6,7 @@
  */
 
 import { Command } from 'commander';
-import { allowInsecureTls } from '../../core/services/tls-scope.js';
+import { allowInsecureTls, withRelaxedTls } from '../../core/services/tls-scope.js';
 import { access, stat, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { execFile } from 'node:child_process';
@@ -496,12 +496,12 @@ async function checkEmbeddingConnection(rootPath: string): Promise<CheckResult |
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DOCTOR_TIMEOUT_MS);
-    const response = await fetch(`${url}/embeddings`, {
+    const response = await withRelaxedTls(() => fetch(`${url}/embeddings`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
       body: JSON.stringify({ model, input: 'ping' }),
       signal: controller.signal,
-    }).finally(() => clearTimeout(timeout));
+    })).finally(() => clearTimeout(timeout));
 
     const ms = Date.now() - t0;
     if (!response.ok) {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -6,6 +6,7 @@
  */
 
 import { Command } from 'commander';
+import { allowInsecureTls } from '../../core/services/tls-scope.js';
 import { access, stat, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { execFile } from 'node:child_process';
@@ -418,7 +419,7 @@ async function checkLLMConnection(rootPath: string): Promise<CheckResult> {
   // Apply SSL setting before creating provider
   const sslVerify = config?.llm?.sslVerify ?? true;
   if (!sslVerify || gen?.skipSslVerify) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    allowInsecureTls('llm.sslVerify=false or generation.skipSslVerify');
   }
 
   const baseUrl = gen?.openaiCompatBaseUrl ?? process.env.OPENAI_COMPAT_BASE_URL;
@@ -484,7 +485,7 @@ async function checkEmbeddingConnection(rootPath: string): Promise<CheckResult |
   if (!baseUrl) return null; // Embedding not configured — keyword default; skip
 
   if (emb?.skipSslVerify) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    allowInsecureTls('embedding.skipSslVerify');
   }
 
   const apiKey = emb?.apiKey ?? process.env.EMBED_API_KEY ?? 'none';

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -6,6 +6,7 @@
  */
 
 import { Command } from 'commander';
+import { allowInsecureTls } from '../../core/services/tls-scope.js';
 import { confirm } from '@inquirer/prompts';
 import { stat, rm } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -386,8 +387,7 @@ Each spec.md follows OpenSpec conventions:
 
       // Apply SSL verification setting (CLI --insecure or config skipSslVerify)
       if (globalOpts.insecure || openloreConfig.generation.skipSslVerify || openloreConfig.embedding?.skipSslVerify) {
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-        logger.warning('SSL verification disabled');
+        allowInsecureTls('--insecure or config skipSslVerify');
       }
 
       // Estimate cost

--- a/src/cli/commands/view.ts
+++ b/src/cli/commands/view.ts
@@ -6,6 +6,7 @@
  */
 
 import { Command } from 'commander';
+import { withRelaxedTls } from '../../core/services/tls-scope.js';
 import { readFile, writeFile, unlink, mkdir } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import { fileExists } from '../../utils/command-helpers.js';
@@ -577,10 +578,10 @@ export const viewCommand = new Command('view')
                   const modelTimeout = AbortSignal.timeout(10_000);
                   let models: string[] = [];
                   if (cfg.kind === 'gemini') {
-                    const r = await fetch(
+                    const r = await withRelaxedTls(() => fetch(
                       `https://generativelanguage.googleapis.com/v1beta/models?key=${cfg.apiKey}`,
                       { signal: modelTimeout }
-                    );
+                    ));
                     if (r.ok) {
                       const data = await r.json() as { models?: Array<{ name: string; supportedGenerationMethods?: string[] }> };
                       models = (data.models ?? [])
@@ -588,10 +589,10 @@ export const viewCommand = new Command('view')
                         .map(m => m.name.replace('models/', ''));
                     }
                   } else if (cfg.kind === 'anthropic') {
-                    const r = await fetch(`${cfg.baseUrl}/models`, {
+                    const r = await withRelaxedTls(() => fetch(`${cfg.baseUrl}/models`, {
                       headers: { 'x-api-key': cfg.apiKey, 'anthropic-version': '2023-06-01' },
                       signal: modelTimeout,
-                    });
+                    }));
                     if (r.ok) {
                       const data = await r.json() as { data?: Array<{ id: string }> };
                       models = (data.data ?? []).map(m => m.id);
@@ -611,7 +612,7 @@ export const viewCommand = new Command('view')
                     }
                     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
                     if (cfg.apiKey) headers['Authorization'] = `Bearer ${cfg.apiKey}`;
-                    const r = await fetch(`${cfg.baseUrl}/models`, { headers, signal: modelTimeout });
+                    const r = await withRelaxedTls(() => fetch(`${cfg.baseUrl}/models`, { headers, signal: modelTimeout }));
                     if (r.ok) {
                       const data = await r.json() as { data?: Array<{ id: string }> };
                       models = (data.data ?? []).map(m => m.id).sort();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@
 // `openspec lore generate` under Node 20) gets one legible stderr line and a
 // stable exit code, never a stack trace. Keep this the first import.
 import './node-version-bootstrap.js';
+import { allowInsecureTls } from '../core/services/tls-scope.js';
 
 import { Command } from 'commander';
 import { createRequire } from 'node:module';
@@ -130,7 +131,9 @@ program.hook('preAction', (thisCommand, actionCommand) => {
 
   // Warn when SSL verification is disabled — it's a security trade-off
   if (opts.insecure) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    // The CLI prints its own colorized, quiet-aware notice below, so the shared
+    // helper stays silent here rather than duplicating it (and writing in --quiet).
+    allowInsecureTls('--insecure', { announce: false });
     // Only print if we're not in quiet mode
     if (!opts.quiet) {
       const c = colorForStderr();

--- a/src/cli/install/json-managed.test.ts
+++ b/src/cli/install/json-managed.test.ts
@@ -72,4 +72,21 @@ describe('json-managed', () => {
   it('canonicalJsonHash is stable across key order', () => {
     expect(canonicalJsonHash({ a: 1, b: 2 })).toBe(canonicalJsonHash({ b: 2, a: 1 }));
   });
+
+  // A managed path is written key-by-key into a plain object, so a `__proto__`
+  // segment would assign onto Object.prototype and leak into every object in the
+  // process rather than into the config document.
+  it('refuses a prototype-polluting managed path', () => {
+    expect(() => mergeEntries({}, [{ path: '__proto__.polluted', value: 'x' }])).toThrow(
+      /prototype-polluting/
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('refuses to remove through a prototype-polluting path', () => {
+    const doc = {
+      _openlore: { managed: true, version: 1, fingerprint: 'x', paths: ['constructor.bad'] },
+    } as Record<string, unknown>;
+    expect(() => removeManaged(doc)).toThrow(/prototype-polluting/);
+  });
 });

--- a/src/cli/install/json-managed.test.ts
+++ b/src/cli/install/json-managed.test.ts
@@ -76,17 +76,41 @@ describe('json-managed', () => {
   // A managed path is written key-by-key into a plain object, so a `__proto__`
   // segment would assign onto Object.prototype and leak into every object in the
   // process rather than into the config document.
-  it('refuses a prototype-polluting managed path', () => {
+  //
+  // The two directions are treated differently ON PURPOSE, because the paths come
+  // from different places:
+  //   - entries[].path is chosen by OUR code (install adapters, internal constants),
+  //     so an unsafe value there is a programmer error and should be loud.
+  //   - _openlore.paths is read back off the user's config file, so it is untrusted
+  //     data. Throwing on it would turn a hand-edited file into a crashed install;
+  //     OpenLore never writes such a path, so it cannot describe anything we manage
+  //     and is simply ignored.
+  it('throws on a prototype-polluting path supplied by our own code', () => {
     expect(() => mergeEntries({}, [{ path: '__proto__.polluted', value: 'x' }])).toThrow(
       /prototype-polluting/
     );
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 
-  it('refuses to remove through a prototype-polluting path', () => {
+  it('ignores a prototype-polluting path found in the document, without crashing', () => {
     const doc = {
-      _openlore: { managed: true, version: 1, fingerprint: 'x', paths: ['constructor.bad'] },
+      _openlore: {
+        managed: true,
+        version: 1,
+        fingerprint: 'x',
+        paths: ['__proto__.bad', 'mcpServers.openlore'],
+      },
+      mcpServers: { openlore: { command: 'x' } },
     } as Record<string, unknown>;
-    expect(() => removeManaged(doc)).toThrow(/prototype-polluting/);
+
+    // Uninstall proceeds and still removes the real managed path.
+    const { next, removed } = removeManaged(doc);
+    expect(removed).toBe(true);
+    expect(next.mcpServers).toBeUndefined();
+
+    // Install-over also proceeds rather than throwing.
+    expect(() => mergeEntries(doc, [{ path: 'mcpServers.openlore', value: { command: 'y' } }])).not.toThrow();
+
+    expect(({} as Record<string, unknown>).bad).toBeUndefined();
   });
 });

--- a/src/cli/install/json-managed.ts
+++ b/src/cli/install/json-managed.ts
@@ -107,12 +107,25 @@ export function readMeta(doc: Record<string, unknown>): ManagedJsonMeta | null {
 }
 
 /**
+ * A managed path taken from the DOCUMENT rather than from our own constants.
+ *
+ * `_openlore.paths` is read back off disk, so it is user-editable data, not a value
+ * this code chose. It can therefore name a prototype-polluting path — and OpenLore
+ * never writes one, so such an entry cannot describe anything we manage. Dropping it
+ * is the correct reading; `setPath`/`deletePath` still throw for internal callers,
+ * where an unsafe path would be a programmer error rather than untrusted input.
+ */
+function managedPathsFrom(meta: ManagedJsonMeta): string[] {
+  return meta.paths.filter((p) => !p.split('.').some(isProtoPollutingKey));
+}
+
+/**
  * Verify the meta fingerprint still matches the values we previously wrote.
  * If not, the user has hand-edited one of our managed paths.
  */
 export function isHandEdited(doc: Record<string, unknown>, meta: ManagedJsonMeta): boolean {
   const subset: Record<string, unknown> = {};
-  for (const path of meta.paths) {
+  for (const path of managedPathsFrom(meta)) {
     const value = getPath(doc, path);
     if (value !== undefined) setPath(subset, path, value);
   }
@@ -159,7 +172,7 @@ export function removeManaged(doc: Record<string, unknown>): {
   const meta = readMeta(doc);
   if (!meta) return { next: doc, removed: false };
   const next = structuredClone(doc) as Record<string, unknown>;
-  for (const path of meta.paths) deletePath(next, path);
+  for (const path of managedPathsFrom(meta)) deletePath(next, path);
   delete next[META_KEY];
   return { next, removed: true };
 }

--- a/src/cli/install/json-managed.ts
+++ b/src/cli/install/json-managed.ts
@@ -8,6 +8,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { isProtoPollutingKey } from '../../utils/misc.js';
 import { modify, applyEdits, type FormattingOptions } from 'jsonc-parser';
 
 /** A minimal edit into an existing JSON document: set `path` to `value`, or delete it when `value` is undefined. */
@@ -177,6 +178,14 @@ function getPath(obj: Record<string, unknown>, path: string): unknown {
 
 function setPath(obj: Record<string, unknown>, path: string, value: unknown): void {
   const parts = path.split('.');
+  // A `__proto__` / `constructor` / `prototype` segment would walk out of `obj` and
+  // mutate the prototype chain instead, so every process that later reads an
+  // unrelated object sees the injected value. Refuse rather than silently skip: a
+  // caller asking to write that path is either confused or hostile, and these paths
+  // are internal constants, so a throw can only surface a bug.
+  if (parts.some(isProtoPollutingKey)) {
+    throw new Error(`Refusing to write unsafe config path "${path}" (prototype-polluting segment)`);
+  }
   let cur: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const k = parts[i];
@@ -191,6 +200,10 @@ function setPath(obj: Record<string, unknown>, path: string, value: unknown): vo
 
 function deletePath(obj: Record<string, unknown>, path: string): void {
   const parts = path.split('.');
+  // Same guard as setPath: `delete Object.prototype.x` is as damaging as writing it.
+  if (parts.some(isProtoPollutingKey)) {
+    throw new Error(`Refusing to delete unsafe config path "${path}" (prototype-polluting segment)`);
+  }
   const chain: Array<{ container: Record<string, unknown>; key: string }> = [];
   let cur: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i++) {

--- a/src/core/analyzer/continuity.ts
+++ b/src/core/analyzer/continuity.ts
@@ -36,6 +36,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { escapeRegExp } from '../../utils/misc.js';
 import type { ContinuityReason, ContinuityBasis } from '../../types/index.js';
 
 /**
@@ -49,10 +50,6 @@ function spanHash(text: string): string {
 
 /** A sentinel that cannot occur in source — used to name-normalize a body. */
 const NAME_SENTINEL = '\uFFFF'; // U+FFFF noncharacter — cannot occur in source identifiers, ASCII-safe in this file
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /**
  * Identifier-character class for whole-word boundaries. Unicode-aware (`\p{L}\p{N}`)

--- a/src/core/analyzer/dependency-graph.ts
+++ b/src/core/analyzer/dependency-graph.ts
@@ -9,6 +9,7 @@
 import { ImportExportParser, resolveImport, type ExportInfo, type FileAnalysis } from './import-parser.js';
 import { extractAllHttpEdges, type HttpEdge } from './http-route-parser.js';
 import { deriveDomainFromPath } from './domain-naming.js';
+import { escapeDotString } from '../../utils/misc.js';
 import type { ScoredFile } from '../../types/index.js';
 import {
   PAGERANK_DAMPING_FACTOR,
@@ -999,17 +1000,24 @@ export function toDotFormat(result: DependencyGraphResult): string {
   lines.push('    rankdir=LR;');
   lines.push('    node [shape=box];');
 
-  // Create node definitions with labels
+  // Every value below is a repository-derived path or symbol name interpolated into a
+  // double-quoted DOT string, so all of them go through the same escape. Escaping only
+  // the visible label (the previous behaviour) left the node/edge ids able to terminate
+  // their own quoted string and corrupt the rest of the graph.
   for (const node of result.nodes) {
-    const name = node.file.name.replace(/"/g, '\\"');
+    const name = escapeDotString(node.file.name);
     const color = node.metrics.pageRank > 0.5 ? 'lightblue' : 'white';
-    lines.push(`    "${node.id}" [label="${name}" fillcolor="${color}" style="filled"];`);
+    lines.push(
+      `    "${escapeDotString(node.id)}" [label="${name}" fillcolor="${color}" style="filled"];`
+    );
   }
 
   // Create edges
   for (const edge of result.edges) {
     const style = edge.isTypeOnly ? 'dashed' : 'solid';
-    lines.push(`    "${edge.source}" -> "${edge.target}" [style="${style}"];`);
+    lines.push(
+      `    "${escapeDotString(edge.source)}" -> "${escapeDotString(edge.target)}" [style="${style}"];`
+    );
   }
 
   lines.push('}');

--- a/src/core/analyzer/embedding-service.ts
+++ b/src/core/analyzer/embedding-service.ts
@@ -13,6 +13,7 @@
  */
 
 import type { OpenLoreConfig } from '../../types/index.js';
+import { allowInsecureTls, withRelaxedTls } from '../services/tls-scope.js';
 
 // ============================================================================
 // TYPES
@@ -71,8 +72,8 @@ export class EmbeddingService implements Embedder {
     this.model = config.model;
     this.apiKey = config.apiKey ?? '';
     this.batchSize = config.batchSize ?? 64;
-    if (config.skipSslVerify && process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0') {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    if (config.skipSslVerify) {
+      allowInsecureTls('embedding.skipSslVerify');
     }
   }
 
@@ -154,11 +155,11 @@ export class EmbeddingService implements Embedder {
       headers['Authorization'] = `Bearer ${this.apiKey}`;
     }
 
-    const response = await fetch(url, {
+    const response = await withRelaxedTls(() => fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify({ input: truncated, model: this.model }),
-    });
+    }));
 
     if (!response.ok) {
       const body = await response.text().catch(() => '');

--- a/src/core/analyzer/file-walker.ts
+++ b/src/core/analyzer/file-walker.ts
@@ -387,7 +387,13 @@ export class FileWalker {
   private skippedReasons: Record<string, number> = {};
   private directoriesScanned = 0;
   private extensionCounts: Record<string, number> = {};
-  private directoryCounts: Record<string, number> = {};
+  /**
+   * Keyed by directory path, which comes from the scanned repository — so a directory
+   * literally named `__proto__` would otherwise read and write `Object.prototype`
+   * instead of this table. `Object.create(null)` has no prototype to reach, and still
+   * serializes as a plain object for `byDirectory`.
+   */
+  private directoryCounts: Record<string, number> = Object.create(null) as Record<string, number>;
 
   constructor(rootPath: string, options: FileWalkerOptions = {}) {
     this.rootPath = rootPath;

--- a/src/core/analyzer/repository-mapper.ts
+++ b/src/core/analyzer/repository-mapper.ts
@@ -461,7 +461,13 @@ function detectLayer(file: ScoredFile): keyof typeof LAYER_PATTERNS | null {
  * Infer domains from file paths and names
  */
 function inferDomains(files: ScoredFile[]): Record<string, ScoredFile[]> {
-  const domains: Record<string, ScoredFile[]> = {};
+  // Prototype-less: keys are domain names derived from repository directory names,
+  // so the `!domains[domain]` guard below would otherwise read Object.prototype for a
+  // directory named `__proto__` and then throw on `.push`.
+  const domains: Record<string, ScoredFile[]> = Object.create(null) as Record<
+    string,
+    ScoredFile[]
+  >;
 
   // Common domain prefixes to look for
   const domainPrefixes = new Map<string, string[]>();
@@ -716,8 +722,15 @@ export class RepositoryMapper {
    * Cluster files by various dimensions
    */
   private clusterFiles(files: ScoredFile[]): FileClusters {
-    // By directory
-    const byDirectory: Record<string, ScoredFile[]> = {};
+    // By directory. Prototype-less for the same reason as FileWalker.directoryCounts:
+    // the keys are directory names from the scanned repository, and for a directory
+    // named `__proto__` the guard below would read Object.prototype (truthy), skip the
+    // array init, and then throw on `.push`. `Object.create(null)` has no prototype to
+    // hit, and still serializes as a plain object.
+    const byDirectory: Record<string, ScoredFile[]> = Object.create(null) as Record<
+      string,
+      ScoredFile[]
+    >;
     for (const file of files) {
       const dir = file.directory || '(root)';
       if (!byDirectory[dir]) {

--- a/src/core/services/chat-agent.ts
+++ b/src/core/services/chat-agent.ts
@@ -19,6 +19,7 @@
  */
 
 import { CHAT_TOOLS, toChatToolDefinitions } from './chat-tools.js';
+import { withRelaxedTls } from './tls-scope.js';
 import { readOpenLoreConfig } from './config-manager.js';
 import {
   DEFAULT_ANTHROPIC_MODEL,
@@ -206,7 +207,7 @@ async function fetchWithRetry(
       await new Promise(r => setTimeout(r, delay));
       if (signal?.aborted) throw new Error('Aborted');
     }
-    const response = await fetch(url, { ...init, signal });
+    const response = await withRelaxedTls(() => fetch(url, { ...init, signal }));
     if (response.ok || !isRetryable(response.status)) return response;
     const errText = await response.text().catch(() => '');
     lastError = new Error(`${response.status}: ${errText.slice(0, 200)}`);

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -8,6 +8,7 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import logger from '../../utils/logger.js';
+import { allowInsecureTls, withRelaxedTls } from './tls-scope.js';
 import {
   CLAUDE_MAX_CONTEXT_TOKENS,
   CLAUDE_MAX_OUTPUT_TOKENS,
@@ -335,22 +336,12 @@ interface RetryConfig {
 // ============================================================================
 
 /**
- * Disable TLS certificate verification for all fetch requests in this process.
- *
- * Node.js native fetch does not support per-request TLS configuration.
- * The only reliable cross-version approach is the NODE_TLS_REJECT_UNAUTHORIZED
- * environment variable, which is process-global.  This is set once and logged
- * prominently so the user is aware.
+ * Record the user's TLS opt-out. The relaxation itself is applied per request by
+ * `withRelaxedTls` around each `fetch`, so verification is not left off for the
+ * lifetime of the process (see tls-scope.ts).
  */
 function disableSslVerification(): void {
-  if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') return; // already disabled
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-  // Warn prominently: this is process-global and affects all fetch calls.
-  console.warn(
-    '[openlore] WARNING: TLS certificate verification is DISABLED for this process.' +
-    ' All HTTPS connections (including LLM API calls) are vulnerable to MITM attacks.' +
-    ' Only use --insecure on trusted private networks with self-signed certificates.'
-  );
+  allowInsecureTls('--insecure or llm.sslVerify=false');
 }
 
 /**
@@ -585,7 +576,7 @@ export class AnthropicProvider implements LLMProvider {
   }
 
   async generateCompletion(request: CompletionRequest): Promise<CompletionResponse> {
-    const response = await fetch(`${this.baseUrl}/messages`, {
+    const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/messages`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -602,7 +593,7 @@ export class AnthropicProvider implements LLMProvider {
         ],
         stop_sequences: request.stopSequences,
       }),
-    });
+    }));
 
     if (!response.ok) {
       const error = await response.text();
@@ -802,14 +793,14 @@ export class OpenAIProvider implements LLMProvider {
       body.response_format = { type: 'json_object' };
     }
 
-    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+    const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(body),
-    });
+    }));
 
     if (!response.ok) {
       const error = await response.text();
@@ -894,13 +885,13 @@ export class OpenAICompatibleProvider implements LLMProvider {
    */
   private async fetchAvailableModels(): Promise<string[]> {
     try {
-      const response = await fetch(`${this.baseUrl}/models`, {
+      const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/models`, {
         method: 'GET',
         headers: {
           'Authorization': `Bearer ${this.apiKey}`,
           'Content-Type': 'application/json',
         },
-      });
+      }));
 
       if (!response.ok) {
         return [];
@@ -984,14 +975,14 @@ export class OpenAICompatibleProvider implements LLMProvider {
       }
     }
 
-    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+    const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(body),
-    });
+    }));
 
     if (!response.ok) {
       const error = await response.text();
@@ -1111,14 +1102,14 @@ export class CopilotProvider implements LLMProvider {
       body.response_format = { type: 'json_object' };
     }
 
-    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+    const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(body),
-    });
+    }));
 
     if (!response.ok) {
       const error = await response.text();
@@ -1382,11 +1373,11 @@ export class GeminiProvider implements LLMProvider {
     };
 
     const url = `${this.baseUrl}/${this.model}:generateContent?key=${this.apiKey}`;
-    const response = await fetch(url, {
+    const response = await withRelaxedTls(() => fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-    });
+    }));
 
     if (!response.ok) {
       const error = await response.text();

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -11,6 +11,7 @@ import { join, relative } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, openSync, closeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { escapeRegExp } from '../../../utils/misc.js';
 import {
   DEFAULT_MAX_FILES,
   DEFAULT_DRIFT_MAX_FILES,
@@ -497,7 +498,9 @@ export async function handleGetFunctionBody(
 
   // Fallback: find the function by scanning for its declaration line
   const lines = source.split('\n');
-  const declPattern = new RegExp(`\\b${functionName}\\s*[(<]`);
+  // `functionName` is a caller-supplied MCP argument: escape it so a value containing
+  // regex metacharacters cannot change what this matches or backtrack pathologically.
+  const declPattern = new RegExp(`\\b${escapeRegExp(functionName)}\\s*[(<]`);
   const startLine = lines.findIndex(l => declPattern.test(l));
   if (startLine === -1) {
     return { error: `Function "${functionName}" not found in ${filePath}. Run analyze_codebase first for exact byte-range extraction.` };

--- a/src/core/services/tls-coverage.test.ts
+++ b/src/core/services/tls-coverage.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Every outbound HTTPS request must go through `withRelaxedTls`.
+ *
+ * WHY THIS IS A TEST AND NOT A CONVENTION
+ * When TLS relaxation moved from "set an env var once at start-up" to "relax around
+ * each request", the set of `fetch` calls that needed wrapping became something a
+ * person has to remember. That failed twice while writing the change itself:
+ * `doctor.ts` opted in and never wrapped (so its probe would have started FAILING for
+ * exactly the users who configured `skipSslVerify`), and `view.ts`'s model listing
+ * silently lost the relaxation it used to inherit from the global variable.
+ *
+ * Neither broke a test, because nothing in the suite probes a self-signed endpoint
+ * through those paths. A reviewer would have had to notice an absence. So the rule is
+ * enforced here instead: add an https-capable `fetch` without wrapping it, and this
+ * fails with the file and line.
+ *
+ * The failure mode being prevented is quiet and one-directional — the request simply
+ * starts rejecting certificates the user chose to accept, in a code path most CI
+ * never exercises.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const SRC = join(REPO_ROOT, 'src');
+
+/**
+ * Calls that cannot involve TLS, with the reason each is exempt.
+ *
+ * Only loopback HTTP to OpenLore's own daemon qualifies: `serve-client` builds
+ * `http://<host>:<port>` from the serve descriptor, and the Pi extension talks to
+ * that same daemon. There is no certificate to verify, so wrapping would be noise.
+ *
+ * `pi/extension.ts` `fetchModels` is listed for a different reason and is NOT an
+ * endorsement: the Pi host never calls `allowInsecureTls`, so its provider probe has
+ * never honoured `skipSslVerify` — before or after the scoping change. Wrapping it
+ * alone would change nothing; making it work needs the Pi host to read the config and
+ * opt in, which is a behaviour change in its own right.
+ */
+const EXEMPT: { file: string; line: number; why: string }[] = [
+  { file: 'src/core/services/serve-client.ts', line: 64, why: 'loopback http:// health probe' },
+  { file: 'src/core/services/serve-client.ts', line: 132, why: 'loopback http:// daemon call' },
+  { file: 'src/cli/commands/serve.ts', line: 187, why: 'loopback http:// health probe' },
+  { file: 'src/pi/extension.ts', line: 414, why: 'loopback http:// health probe' },
+  { file: 'src/pi/extension.ts', line: 463, why: 'loopback http:// daemon call' },
+  { file: 'src/pi/extension.ts', line: 1206, why: 'loopback http:// health probe' },
+  {
+    file: 'src/pi/extension.ts',
+    line: 165,
+    why: 'pre-existing: the Pi host never opts in, so skipSslVerify is not honoured there at all',
+  },
+];
+
+function sourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      if (name === 'fixtures' || name === 'vendor' || name === 'node_modules') continue;
+      sourceFiles(full, acc);
+    } else if (name.endsWith('.ts') && !name.includes('.test.') && !name.includes('.spec.')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe('TLS coverage', () => {
+  it('wraps every outbound fetch that could negotiate TLS', () => {
+    const offenders: string[] = [];
+    const exemptSeen = new Set<string>();
+
+    for (const abs of sourceFiles(SRC)) {
+      const rel = relative(REPO_ROOT, abs).replace(/\\/g, '/');
+      readFileSync(abs, 'utf-8')
+        .split('\n')
+        .forEach((line, i) => {
+          // Only real call sites: `await fetch(` preceded by nothing that already
+          // wraps it. Comments and doc blocks start with `*` or `//`.
+          const trimmed = line.trim();
+          if (trimmed.startsWith('*') || trimmed.startsWith('//')) return;
+          if (!/\bawait fetch\(/.test(line) && !/\bvoid fetch\(/.test(line)) return;
+
+          const key = `${rel}:${i + 1}`;
+          const exempt = EXEMPT.find((e) => e.file === rel && e.line === i + 1);
+          if (exempt) {
+            exemptSeen.add(key);
+            return;
+          }
+          offenders.push(`${key} — ${trimmed.slice(0, 80)}`);
+        });
+    }
+
+    expect(
+      offenders,
+      `These outbound requests are not wrapped in withRelaxedTls, so they ignore the\n` +
+        `user's --insecure / skipSslVerify opt-in and will reject a self-signed\n` +
+        `certificate the user chose to accept:\n\n` +
+        offenders.join('\n') +
+        `\n\nWrap as: await withRelaxedTls(() => fetch(...))\n` +
+        `If the call genuinely cannot use TLS (loopback http:// only), add it to EXEMPT\n` +
+        `in this file with the reason.`
+    ).toEqual([]);
+  });
+
+  it('has no stale exemptions', () => {
+    // An exemption whose line no longer holds a fetch is worse than none: it reads as
+    // "reviewed and fine" while guarding nothing.
+    const stale: string[] = [];
+    for (const e of EXEMPT) {
+      const abs = join(REPO_ROOT, e.file);
+      let line: string | undefined;
+      try {
+        line = readFileSync(abs, 'utf-8').split('\n')[e.line - 1];
+      } catch {
+        stale.push(`${e.file}:${e.line} — file not found`);
+        continue;
+      }
+      if (!line || !/\b(await|void) fetch\(/.test(line)) {
+        stale.push(`${e.file}:${e.line} — no fetch( on this line any more`);
+      }
+    }
+    expect(stale, `Stale TLS exemptions:\n${stale.join('\n')}`).toEqual([]);
+  });
+});

--- a/src/core/services/tls-scope.test.ts
+++ b/src/core/services/tls-scope.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Guards for scoped TLS relaxation.
+ *
+ * These assert the two runtime behaviours the design depends on, rather than
+ * assuming them:
+ *   - deleting NODE_TLS_REJECT_UNAUTHORIZED genuinely re-enables verification
+ *     (Node does not cache the previous value), and
+ *   - restoring it after `fetch()` resolves does not break an in-flight response
+ *     body, because verification happens during the handshake.
+ *
+ * If either stopped holding, `withRelaxedTls` would silently be either useless or
+ * harmful, and nothing else in the suite would notice.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:https';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  allowInsecureTls,
+  isInsecureTlsAllowed,
+  withRelaxedTls,
+  resetTlsScopeForTests,
+} from './tls-scope.js';
+
+const ENV_KEY = 'NODE_TLS_REJECT_UNAUTHORIZED';
+
+describe('tls-scope: state machine', () => {
+  beforeEach(() => resetTlsScopeForTests());
+  afterEach(() => resetTlsScopeForTests());
+
+  it('is a no-op until the user opts in', async () => {
+    expect(isInsecureTlsAllowed()).toBe(false);
+    let seen: string | undefined = 'unset';
+    await withRelaxedTls(async () => {
+      seen = process.env[ENV_KEY];
+    });
+    // Never touched the variable, because nothing opted in.
+    expect(seen).toBeUndefined();
+    expect(process.env[ENV_KEY]).toBeUndefined();
+  });
+
+  it('relaxes only inside the scope and restores afterwards', async () => {
+    allowInsecureTls('test');
+    expect(process.env[ENV_KEY]).toBeUndefined(); // opting in alone changes nothing
+
+    let inside: string | undefined;
+    await withRelaxedTls(async () => {
+      inside = process.env[ENV_KEY];
+    });
+
+    expect(inside).toBe('0');
+    expect(process.env[ENV_KEY]).toBeUndefined();
+  });
+
+  it('restores even when the wrapped call throws', async () => {
+    allowInsecureTls('test');
+    await expect(withRelaxedTls(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    expect(process.env[ENV_KEY]).toBeUndefined();
+  });
+
+  it('keeps the scope open until the LAST concurrent request finishes', async () => {
+    allowInsecureTls('test');
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+
+    const slow = withRelaxedTls(async () => { await gate; return process.env[ENV_KEY]; });
+    // A second, fast request opens and closes while `slow` is still in flight.
+    const fast = await withRelaxedTls(async () => process.env[ENV_KEY]);
+
+    expect(fast).toBe('0');
+    // The inner scope closing must NOT have restored verification under `slow`.
+    expect(process.env[ENV_KEY]).toBe('0');
+
+    release();
+    expect(await slow).toBe('0');
+    expect(process.env[ENV_KEY]).toBeUndefined();
+  });
+
+  it('announces once, and not at all when the caller owns the message', () => {
+    const written: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as { write: unknown }).write = ((c: string) => { written.push(String(c)); return true; }) as never;
+    try {
+      // The CLI prints its own quiet-aware notice, so the helper must stay silent —
+      // and must not let a later opt-in in the same run print a duplicate.
+      allowInsecureTls('--insecure', { announce: false });
+      allowInsecureTls('config skipSslVerify');
+    } finally {
+      (process.stderr as { write: unknown }).write = orig as never;
+    }
+    expect(written.join('')).toBe('');
+    expect(isInsecureTlsAllowed()).toBe(true);
+  });
+
+  it('announces exactly once when it owns the message', () => {
+    const written: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as { write: unknown }).write = ((c: string) => { written.push(String(c)); return true; }) as never;
+    try {
+      allowInsecureTls('reason one');
+      allowInsecureTls('reason two');
+    } finally {
+      (process.stderr as { write: unknown }).write = orig as never;
+    }
+    expect(written.filter((l) => l.includes('WARNING')).length).toBe(1);
+  });
+
+  it('restores a pre-existing value verbatim rather than deleting it', async () => {
+    process.env[ENV_KEY] = '1';
+    allowInsecureTls('test');
+    await withRelaxedTls(async () => undefined);
+    expect(process.env[ENV_KEY]).toBe('1');
+  });
+});
+
+/**
+ * Generate a throwaway self-signed cert at run time via openssl.
+ *
+ * Deliberately NOT a committed fixture: a checked-in private key is exactly what
+ * secret scanning exists to reject, and push protection would block it. Generating
+ * per-run keeps no key material in the repository. Skips cleanly where openssl is
+ * unavailable rather than failing.
+ */
+function makeSelfSigned(): { key: string; cert: string } | null {
+  try {
+    const dir = mkdtempSync(join(tmpdir(), 'openlore-tls-'));
+    const keyPath = join(dir, 'k.pem');
+    const certPath = join(dir, 'c.pem');
+    const r = spawnSync(
+      'openssl',
+      ['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-keyout', keyPath, '-out', certPath,
+       '-days', '1', '-subj', '/CN=localhost', '-addext', 'subjectAltName=IP:127.0.0.1'],
+      { stdio: 'ignore' }
+    );
+    if (r.status !== 0) return null;
+    return { key: readFileSync(keyPath, 'utf-8'), cert: readFileSync(certPath, 'utf-8') };
+  } catch {
+    return null;
+  }
+}
+
+const tlsFixture = makeSelfSigned();
+
+describe('tls-scope: real TLS behaviour', () => {
+  let server: Server | undefined;
+
+  beforeEach(() => resetTlsScopeForTests());
+  afterEach(() => {
+    server?.close();
+    server = undefined;
+    resetTlsScopeForTests();
+  });
+
+  // The whole design rests on these two Node behaviours. Asserted against a real
+  // handshake, not mocked: a mock would keep passing if either changed.
+  it.skipIf(!tlsFixture)(
+    'rejects a self-signed cert outside the scope, accepts inside, and re-rejects after',
+    async () => {
+      const { key, cert } = tlsFixture!;
+      server = createServer({ key, cert }, (_req, res) => {
+        res.writeHead(200);
+        res.write('chunk1');
+        // Finish the body AFTER the scope has closed, proving the restore does not
+        // interrupt an in-flight response.
+        setTimeout(() => res.end('chunk2'), 50);
+      });
+      await new Promise<void>((r) => server!.listen(0, '127.0.0.1', () => r()));
+      const port = (server.address() as { port: number }).port;
+      const url = `https://127.0.0.1:${port}/`;
+
+      // 1. Strict by default.
+      await expect(fetch(url)).rejects.toThrow();
+
+      // 2. Relaxed only inside the scope.
+      allowInsecureTls('test');
+      const res = await withRelaxedTls(() => fetch(url));
+      expect(res.status).toBe(200);
+
+      // 3. Verification is already restored while the body is still streaming.
+      expect(process.env[ENV_KEY]).toBeUndefined();
+      expect(await res.text()).toBe('chunk1chunk2');
+
+      // 4. A NEW request is rejected again — the relaxation did not persist.
+      await expect(fetch(url)).rejects.toThrow();
+    },
+    20_000
+  );
+});

--- a/src/core/services/tls-scope.ts
+++ b/src/core/services/tls-scope.ts
@@ -1,0 +1,117 @@
+/**
+ * Scoped TLS relaxation for `--insecure` / `skipSslVerify`.
+ *
+ * WHY THIS EXISTS
+ * Disabling certificate verification used to be done by setting
+ * `NODE_TLS_REJECT_UNAUTHORIZED = '0'` at start-up and leaving it set. That is
+ * process-global and permanent: from the first LLM call onward, EVERY https
+ * connection in the process was unverified — the update check, a git helper, any
+ * later request — not just the endpoint the user opted out for. In the long-lived
+ * `openlore mcp` daemon that meant the rest of the session.
+ *
+ * WHY IT IS DONE THIS WAY
+ * Node's built-in `fetch` accepts no per-request TLS options, and an `Agent` from
+ * the npm `undici` package is rejected by it (`UND_ERR_INVALID_ARG`) because the
+ * built-in fetch is a separate undici instance. Verified on Node 25. So the env var
+ * is still the only lever available without either adding `undici` as a dependency
+ * AND switching these call sites to its `fetch` export, or rewriting them onto
+ * `https.request`. Both are real options; see the note at the bottom.
+ *
+ * What changed is the LIFETIME. The variable is now set immediately before a
+ * request and restored immediately after, which is safe because:
+ *   - certificate verification happens during the TLS handshake, inside `fetch()`,
+ *     so restoring once `fetch()` resolves does not affect an in-flight body — a
+ *     streamed response continues to read fine afterwards, and
+ *   - deleting the variable genuinely re-enables verification; Node does not cache
+ *     the previous value.
+ * Both behaviours are asserted in `tls-scope.test.ts` rather than assumed.
+ *
+ * REMAINING EXPOSURE, stated plainly: the variable is still process-global while a
+ * scope is open. An unrelated https request that happens to be in flight during
+ * that window is also unverified. The window is now one request rather than the
+ * process lifetime, which is a large reduction but not elimination. Eliminating it
+ * requires per-request TLS options, i.e. one of the two migrations above.
+ */
+
+const ENV_KEY = 'NODE_TLS_REJECT_UNAUTHORIZED';
+
+/** Set once the user has explicitly opted out of verification. */
+let insecureAllowed = false;
+/** The opt-out is announced once, not once per request. */
+let warned = false;
+/**
+ * Open-scope count. Concurrent or nested relaxed requests must not restore
+ * verification while a sibling request is still mid-handshake, so the value is
+ * restored only when the last scope closes.
+ */
+let openScopes = 0;
+/** The caller's original value, restored verbatim (including "was unset"). */
+let savedValue: string | undefined;
+
+/**
+ * Record that the user opted out of TLS verification, and say so once.
+ *
+ * This deliberately does NOT disable anything by itself — it only grants
+ * `withRelaxedTls` permission to relax verification around individual requests.
+ *
+ * `announce: false` is for callers that print their own (better) notice — the CLI
+ * renders a colorized one and honours `--quiet`. Without that opt-out this would
+ * both duplicate the message and write to stderr in quiet mode.
+ */
+export function allowInsecureTls(reason: string, opts: { announce?: boolean } = {}): void {
+  insecureAllowed = true;
+  // `announce: false` means the caller owns the message, so it counts as announced.
+  // Without marking it, a later opt-in from deeper in the same run (generate.ts after
+  // the CLI's `--insecure` hook) would print a second notice.
+  if (opts.announce === false) {
+    warned = true;
+    return;
+  }
+  if (warned) return;
+  warned = true;
+  process.stderr.write(
+    `[openlore] WARNING: TLS certificate verification is disabled for outbound requests (${reason}).\n` +
+      `[openlore] Those requests are exposed to interception. Use this only on a trusted\n` +
+      `[openlore] network with a self-signed certificate.\n`
+  );
+}
+
+/** Whether the user has opted out of certificate verification. */
+export function isInsecureTlsAllowed(): boolean {
+  return insecureAllowed;
+}
+
+/**
+ * Run `fn` with certificate verification relaxed, if and only if the user opted in.
+ *
+ * Wrap the `await fetch(...)` itself — not the surrounding bookkeeping and not the
+ * body read. That is the narrowest span that still covers the handshake.
+ */
+export async function withRelaxedTls<T>(fn: () => Promise<T>): Promise<T> {
+  if (!insecureAllowed) return fn();
+
+  if (openScopes === 0) {
+    savedValue = process.env[ENV_KEY];
+    process.env[ENV_KEY] = '0';
+  }
+  openScopes++;
+  try {
+    return await fn();
+  } finally {
+    openScopes--;
+    if (openScopes === 0) {
+      if (savedValue === undefined) delete process.env[ENV_KEY];
+      else process.env[ENV_KEY] = savedValue;
+      savedValue = undefined;
+    }
+  }
+}
+
+/** Test-only: clear module state between cases. */
+export function resetTlsScopeForTests(): void {
+  insecureAllowed = false;
+  warned = false;
+  openScopes = 0;
+  savedValue = undefined;
+  delete process.env[ENV_KEY];
+}

--- a/src/utils/misc.test.ts
+++ b/src/utils/misc.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Guards for the sanitizing helpers in misc.ts.
+ *
+ * Each test below encodes the concrete failure the helper exists to prevent, not
+ * just its happy path — an escape function that is only tested with safe input
+ * passes just as well when it stops escaping.
+ */
+import { describe, it, expect } from 'vitest';
+import { escapeRegExp, escapeDotString, isProtoPollutingKey } from './misc.js';
+
+describe('escapeRegExp', () => {
+  it('stops a crafted identifier from matching a different symbol', () => {
+    // The reported defect: `functionName` is a caller-supplied MCP argument spliced
+    // into `\b<name>\s*[(<]`. Unescaped, alternation makes the pattern match a
+    // function the caller never named, so the wrong body is returned.
+    const attacker = 'foo(.*)|bar';
+
+    expect(new RegExp(`\\b${attacker}\\s*[(<]`).test('bar(')).toBe(true);
+    expect(new RegExp(`\\b${escapeRegExp(attacker)}\\s*[(<]`).test('bar(')).toBe(false);
+  });
+
+  it('still matches the literal identifier it was given', () => {
+    expect(new RegExp(`\\b${escapeRegExp('handleOrient')}\\s*[(<]`).test('function handleOrient(')).toBe(
+      true
+    );
+  });
+
+  it('escapes every regex metacharacter', () => {
+    const escaped = escapeRegExp('.*+?^${}()|[]\\');
+    // Round-trips as a literal: the escaped form matches the raw string exactly.
+    expect(new RegExp(`^${escaped}$`).test('.*+?^${}()|[]\\')).toBe(true);
+  });
+});
+
+describe('escapeDotString', () => {
+  it('escapes the backslash before the quote', () => {
+    // Escaping only quotes leaves a trailing backslash escaping the closing quote
+    // that follows it, so the rest of the DOT document is swallowed by the string.
+    const quoteOnly = (s: string) => s.replace(/"/g, '\\"');
+
+    expect(`"${quoteOnly('a\\')}" [label="x"]`).toBe('"a\\" [label="x"]'); // broken
+    expect(`"${escapeDotString('a\\')}" [label="x"]`).toBe('"a\\\\" [label="x"]'); // closed
+  });
+
+  it('escapes embedded quotes', () => {
+    expect(escapeDotString('say "hi"')).toBe('say \\"hi\\"');
+  });
+
+  it('leaves ordinary identifiers untouched', () => {
+    expect(escapeDotString('src/core/analyzer/file-walker.ts')).toBe(
+      'src/core/analyzer/file-walker.ts'
+    );
+  });
+});
+
+describe('isProtoPollutingKey', () => {
+  it('flags the keys that escape an object into its prototype', () => {
+    expect(isProtoPollutingKey('__proto__')).toBe(true);
+    expect(isProtoPollutingKey('constructor')).toBe(true);
+    expect(isProtoPollutingKey('prototype')).toBe(true);
+  });
+
+  it('does not flag ordinary config keys', () => {
+    for (const k of ['mcpServers', 'openlore', 'hooks', 'proto', 'protoype']) {
+      expect(isProtoPollutingKey(k), k).toBe(false);
+    }
+  });
+});

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -18,12 +18,31 @@ export function escapeRegExp(s: string): string {
 /**
  * Quote a value for use inside a double-quoted Graphviz DOT string.
  *
- * The backslash must be escaped BEFORE the quote, or a trailing `\` in the input
- * escapes the closing `"` that follows it and corrupts the rest of the document.
- * Escaping only quotes (the obvious-looking fix) leaves exactly that hole.
+ * Three things have to happen, in this order:
+ *
+ *  1. `\` first. Escaping quotes first would leave a trailing `\` escaping the
+ *     closing `"` that follows it, swallowing the rest of the document.
+ *  2. `"`, so the value cannot terminate its own string.
+ *  3. Control characters. The emitter is line-oriented (statements are joined with
+ *     `\n`), and a file name may legally contain a newline on Linux and macOS — so
+ *     an unescaped one splits the statement in two and the tail is parsed as new
+ *     DOT. Escaping quotes alone does not prevent that, which is why this is done
+ *     here rather than left to the caller.
+ *
+ * Newline/CR/tab become their DOT escape sequences (the backslash is emitted after
+ * step 1, so it stays a real escape). Any other control character has no DOT
+ * representation and is dropped; two names differing only by such a character would
+ * collide, which is accepted as strictly better than emitting a corrupt graph.
  */
 export function escapeDotString(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    // eslint-disable-next-line no-control-regex -- deliberately matching C0/C7F controls
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
 }
 
 /**

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -4,6 +4,40 @@
  */
 
 /**
+ * Escape a string for literal use inside a `RegExp`.
+ *
+ * Needed wherever a caller-supplied identifier is interpolated into a pattern: an
+ * unescaped `.` or `(` silently changes what the pattern matches, and a crafted
+ * value can produce catastrophic backtracking. Callers are not always trusted —
+ * MCP tool arguments reach some of these paths.
+ */
+export function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Quote a value for use inside a double-quoted Graphviz DOT string.
+ *
+ * The backslash must be escaped BEFORE the quote, or a trailing `\` in the input
+ * escapes the closing `"` that follows it and corrupts the rest of the document.
+ * Escaping only quotes (the obvious-looking fix) leaves exactly that hole.
+ */
+export function escapeDotString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Keys that must never be written through a caller-supplied path, because
+ * assigning them mutates the prototype chain rather than the target object.
+ */
+const PROTO_POLLUTING_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** True when a path segment would escape the target object into its prototype. */
+export function isProtoPollutingKey(key: string): boolean {
+  return PROTO_POLLUTING_KEYS.has(key);
+}
+
+/**
  * Parse JSON from LLM output, handling markdown code fences.
  * Strips ``` fences, extracts JSON array or object, returns fallback on failure.
  */


### PR DESCRIPTION
## Status

LGTM. All 7 checks green. 324 files / 6,204 tests.

Two parts: the CodeQL triage, and a follow-up adversarial pass that found two defects **in this PR's own first commit** plus the TLS scoping.

---

# Part 1 — CodeQL triage

The first baseline was **458 alerts**. All triaged.

## Why 80% was noise

**368 of 458 were in test files**, and one rule — `js/insecure-temporary-file` (379) — accounts for most: fixtures legitimately write to `tmpdir()`.

That taint then flowed **into production sinks**: 30 alerts landed on production `writeFile` calls whose path came from a *test caller*. `gitignore-manager.ts` was reported despite containing **no reference to `tmpdir()` at all**. So the noise was misattributing findings to files that don't have the problem.

`paths-ignore` now excludes `*.test.ts` / `*.spec.ts`, justified on **scope**: tests aren't shipped (the `files` allowlist omits them, `audit:packlist` enforces it) and aren't reachable outside the runner. The config records the policy: **exclude non-shipped code, dismiss individual accepted findings with a reason, never silence a rule.**

## Four real fixes

| Rule | The actual failure |
|---|---|
| `js/regex-injection` | `functionName` is a caller-supplied MCP argument spliced into `\b<name>\s*[(<]`. Unescaped, `foo(.*)\|bar` matches `bar(` — `get_function_body` returns **a different function than asked for**. |
| `js/incomplete-sanitization` | DOT output escaped `"` but not `\`, so a trailing backslash escaped its own closing quote. |
| `js/prototype-pollution-utility` | `setPath` walks a dotted path into a plain object; a `__proto__` segment assigns onto `Object.prototype`. |
| `js/remote-property-injection` | `directoryCounts` is keyed by repository directory names. |

Two went past what CodeQL flagged: the DOT fix also covers node/edge ids (interpolated with *no* escaping — same hole, unflagged), and the pollution guard covers `deletePath` too.

---

# Part 2 — Adversarial pass

## Two defects in this PR's own first commit

**1. The pollution guard turned a vulnerability into a crash.** `setPath`/`deletePath` throwing is right for the entries *we* pass (internal constants). But `isHandEdited` and `removeManaged` feed them `_openlore.paths` — read back off the **user's config file**. A hand-edited file made `openlore install` and `--uninstall` throw instead of proceeding. Reproduced, then fixed: file-derived paths are filtered and ignored (OpenLore never writes such a path, so it can't describe anything we manage); our own paths still throw.

**2. `escapeDotString` was still incomplete.** It escaped `\` and `"` but not control characters — and the emitter joins statements with newlines, so a file name containing a newline (legal on Linux/macOS) split the statement and the tail parsed as new DOT. Demonstrated, then closed.

## One more instance of the same class

`repository-mapper`'s `clusterFiles` and `inferDomains` build the same repo-keyed lookup tables, and **CodeQL did not flag them**. For a directory named `__proto__`, `!map[key]` reads `Object.prototype` (truthy), skips the array init, then throws on `.push`. Both are now prototype-less — verified against a real repository containing a `__proto__` directory.

---

# Part 3 — TLS is now scoped per request

`NODE_TLS_REJECT_UNAUTHORIZED = '0'` was set at start-up and **left set**. From the first LLM call onward, every https connection in the process was unverified — not just the endpoint the user opted out for. In `openlore mcp`, that meant the rest of the session.

New `tls-scope.ts` centralises it. `allowInsecureTls()` records the opt-in without disabling anything; `withRelaxedTls()` sets the variable immediately before a request and restores it immediately after, refcounted so a concurrent request can't restore it early. All 8 fetch sites are wrapped, and **no module writes the variable directly** any more.

### Verified against a real handshake, not assumed

The design rests on two Node behaviours, both asserted in tests using a self-signed cert **generated at run time** — not committed, since a checked-in key is exactly what push protection exists to reject:

```
self-signed rejected outside the scope   ✓
accepted inside the scope                ✓
verification restored while body streams ✓  (handshake already done)
new request rejected after               ✓  (relaxation did not persist)
```

Plus the state machine: no-op until opt-in, restores on throw, restores a pre-existing value verbatim, and keeps the scope open until the **last** concurrent request finishes.

### The limit, stated plainly

The variable is still process-global while a scope is open, so an unrelated request in flight during that window is also unverified. **The window is one request instead of the process lifetime** — a large reduction, not elimination.

Removing it entirely needs per-request TLS options, which Node's built-in `fetch` does not expose. I tested the obvious alternative: an npm `undici` `Agent` passed as `dispatcher` is **rejected with `UND_ERR_INVALID_ARG`**, because the built-in fetch is a separate undici instance. Undici's *own* `fetch` does honour it (also verified), so that route means adopting `undici` as a dependency and switching these call sites to its fetch — a behaviour-affecting change that belongs in its own PR.

`--quiet` stays honest: the helper takes `announce: false` so the CLI's colorized, quiet-aware notice isn't duplicated and nothing is written in quiet mode. Verified end to end — `--insecure doctor` prints exactly one notice, `--insecure --quiet doctor` prints none.

---

## Remaining production alerts — intentional

| Count | Rule | Why |
|---|---|---|
| 7 | `js/disabling-certificate-validation` | The opt-in path above. Now scoped per request, still opt-in and default-secure. |
| 1 (critical) | `js/command-line-injection` | `spawn()` with an args array and **no shell**; `cmd` is one of three known values gated by `existsSync`. |
| ~5 | `js/file-access-to-http` | Reading your code and sending it to a configured LLM provider **is the product**. |
| 14 | `js/file-system-race` | Check-then-use on the user's own repo in a local CLI; one site is deliberate (token-checked lock release). |

For individual dismissal with stated reasons once the new baseline lands.

## Note

`mcp-watcher-parity.test.ts` "Scenario 3" still flakes under full-suite concurrency (~1 in 5). Pre-existing — reproduces on pristine `main`, passes in isolation. Unrelated to this PR.


---

# Part 4 — Adversarial review passes

Three passes over this PR's own diff. They found real defects each time, which is why they were worth running.

## Two regressions the TLS scoping introduced

Hand-enumerating which `fetch` calls needed wrapping was wrong **twice**:

- **`doctor.ts`** opted in via `allowInsecureTls` but never wrapped its `/embeddings` probe. Under the old process-global variable it inherited the relaxation; under per-request scoping it did not. Net effect: `openlore doctor` would report a **failed embedding connection to exactly the users who set `skipSslVerify`**.
- **`view.ts`**'s three provider model lookups lost the relaxation they used to inherit from `--insecure`, so `openlore --insecure view` would stop listing models from a self-signed endpoint.

Neither broke a test, because nothing in the suite probes a self-signed endpoint through those paths. Proven end to end against a real self-signed server:

```
withRelaxedTls neutralized  ->  Embedding connection: fetch failed
scoping restored            ->  Embedding connection: 2 dims, 17ms
```

## Made structural instead of remembered

`tls-coverage.test.ts` fails when an https-capable `fetch` is not wrapped, naming file and line. Loopback `http://` calls to OpenLore's own daemon are exempt **with a stated reason**, and a second assertion fails if an exemption stops pointing at a `fetch` — so the list cannot rot into "reviewed and fine" while guarding nothing. Verified against the exact bug above.

One exemption is explicitly **not** an endorsement: `pi/extension.ts` `fetchModels` is recorded as a **pre-existing** gap. The Pi host never calls `allowInsecureTls`, so its provider probe has never honoured `skipSslVerify` — before or after this change. Wrapping it alone would do nothing; making it work needs the Pi host to read config and opt in, which is a behaviour change in its own right.

## Verified nothing else breaks

| Check | Result |
|---|---|
| `init` + `analyze` on a fresh repo | artifacts generate (exercises `file-walker` + `repository-mapper` after `Object.create(null)`) |
| `get_function_body` | `validate` resolves; `foo(.*)\|validate` correctly **not-found** rather than matching the wrong declaration |
| `toDotFormat` with a newline-bearing name | 6 statements, no injected line, balanced quotes |
| `--insecure doctor` / `--insecure --quiet` | exactly one notice / none |
| Public API surface | unchanged — neither new module is reachable through the `exports` map |
| 7 full-suite runs | only intermittent failure is the pre-existing `mcp-watcher-parity` flake, which reproduces on pristine `main` |
