### PR TITLE
fix(security): neutralize terminal control sequences from analyzed repositories

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -38,11 +38,21 @@ paths-ignore:
   - '**/*.test.ts'
   - '**/*.spec.ts'
 
+  # ---- sample corpora ------------------------------------------------------
+  # `examples/` holds self-contained SAMPLE APPLICATIONS (drift-demo, the opencode
+  # plugins) that exist to be analyzed BY OpenLore in demos and tests. Findings there
+  # describe the sample, not OpenLore: the two js/missing-rate-limiting alerts in the
+  # first baseline were about drift-demo's Express routes, which are deliberately a
+  # small imperfect app. Scanning them measures the fixture, not the product.
+  - examples
+
   # ---- fixtures and vendored code -----------------------------------------
   # Deliberately malformed / adversarial inputs that exist to be parsed by tests.
   # Scanning them reports the fixture, never the code under test.
   - src/core/analyzer/fixtures
   - src/core/analyzer/iac/fixtures
+  # (its Dockerfile is intentionally unpinned so the IaC projector has input —
+  #  Scorecard reports that as an unpinned dependency; it is a fixture, not our CI)
   - src/core/scip/fixtures
   # Third-party protobuf runtime shipped as-is; upgrades come from upstream, and
   # advisories against it are dependency-scanning's job, not SAST's.

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -6,6 +6,7 @@
  */
 
 import { Command, Option } from 'commander';
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { writeFile, mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { logger } from '../../utils/logger.js';
@@ -664,7 +665,7 @@ After analysis, run 'openlore generate' to create OpenSpec files.
           const domain = artifacts.repoStructure.domains[i];
           const isLast = i === Math.min(artifacts.repoStructure.domains.length, 6) - 1;
           const prefix = isLast ? '└─' : '├─';
-          console.log(`    ${prefix} ${domain.name} (${domain.files.length} files)`);
+          console.log(`    ${prefix} ${safe(domain.name)} (${domain.files.length} files)`);
         }
         if (artifacts.repoStructure.domains.length > 6) {
           console.log(`       ... and ${artifacts.repoStructure.domains.length - 6} more`);

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -6,6 +6,7 @@
  */
 
 import { Command } from 'commander';
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { join } from 'node:path';
 import { writeStdout } from '../output.js';
 import { formatDuration } from '../../utils/command-helpers.js';
@@ -35,7 +36,7 @@ function printReport(report: AuditReport, rootPath: string): void {
   if (report.hubGaps.length > 0) {
     console.log('   ── Hub Gaps (high fan-in, no spec) ──────────');
     for (const fn of report.hubGaps) {
-      console.log(`   ✗ ${fn.name}  fanIn=${fn.fanIn}  ${fn.file}`);
+      console.log(`   ✗ ${safe(fn.name)}  fanIn=${fn.fanIn}  ${safe(fn.file)}`);
     }
     console.log('');
   }
@@ -43,7 +44,7 @@ function printReport(report: AuditReport, rootPath: string): void {
   if (report.staleDomains.length > 0) {
     console.log('   ── Stale Domains ────────────────────────────');
     for (const d of report.staleDomains) {
-      console.log(`   ⚠ ${d.name}  spec=${d.specModifiedAt.slice(0, 10)}  src=${d.sourcesModifiedAt.slice(0, 10)}`);
+      console.log(`   ⚠ ${safe(d.name)}  spec=${d.specModifiedAt.slice(0, 10)}  src=${d.sourcesModifiedAt.slice(0, 10)}`);
     }
     console.log('');
   }
@@ -51,7 +52,7 @@ function printReport(report: AuditReport, rootPath: string): void {
   if (report.orphanRequirements.length > 0) {
     console.log('   ── Orphan Requirements ──────────────────────');
     for (const r of report.orphanRequirements) {
-      console.log(`   → [${r.domain}] ${r.requirement}`);
+      console.log(`   → [${safe(r.domain)}] ${safe(r.requirement)}`);
     }
     console.log('');
   }
@@ -60,7 +61,7 @@ function printReport(report: AuditReport, rootPath: string): void {
     console.log('   ── Uncovered Functions (sample) ─────────────');
     for (const fn of report.uncoveredFunctions.slice(0, 20)) {
       const hub = fn.isHub ? ' [hub]' : '';
-      console.log(`   · ${fn.name}${hub}  ${fn.file}`);
+      console.log(`   · ${safe(fn.name)}${hub}  ${safe(fn.file)}`);
     }
     if (summary.uncoveredCount > 20) {
       console.log(`   … and ${summary.uncoveredCount - 20} more`);

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -9,6 +9,7 @@
  */
 
 import { Command } from 'commander';
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -501,7 +502,7 @@ export function displayDecision(d: PendingDecision, verbose = false): void {
     scopeLabel === 'component'    ? c.blue(`[${scopeLabel}]`) :
                                     c.gray(`[${scopeLabel}]`);
 
-  console.log(`${icon} [${d.id}] ${scopeBadge} ${d.title}`);
+  console.log(`${icon} [${safe(d.id)}] ${scopeBadge} ${safe(d.title)}`);
   if (verbose) {
     console.log(`   Status     : ${d.status}  Confidence: ${confidence}  Scope: ${scopeLabel}`);
     console.log(`   Rationale  : ${d.rationale}`);
@@ -1222,7 +1223,7 @@ decisionsCommand
       for (const e of entries) {
         const when = e.at.replace('T', ' ').slice(0, 19);
         const commit = e.commit ? ` @${e.commit}` : '';
-        console.log(`${when}  [${e.id}] ${e.from ?? '∅'} → ${e.to}  by ${e.actor}${commit}  ${e.title}`);
+        console.log(`${when}  [${safe(e.id)}] ${safe(e.from ?? '∅')} → ${safe(e.to)}  by ${safe(e.actor)}${commit}  ${safe(e.title)}`);
       }
       console.log(`\nTotal: ${entries.length} transition(s)`);
     } catch (err) {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -6,6 +6,7 @@
  */
 
 import { Command } from 'commander';
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { allowInsecureTls, withRelaxedTls } from '../../core/services/tls-scope.js';
 import { access, stat, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
@@ -581,7 +582,7 @@ function printResult(r: CheckResult, useColor: boolean): void {
   const glyph: Record<CheckStatus, string> = { ok: '✓', warn: '⚠', fail: '✗' };
 
   const icon = paint[r.status](glyph[r.status]);
-  console.log(`  ${icon}  ${r.name.padEnd(22)} ${c.dim(r.detail)}`);
+  console.log(`  ${icon}  ${safe(r.name).padEnd(22)} ${c.dim(safe(r.detail))}`);
   if (r.fix) {
     console.log(`       ${' '.repeat(22)} ${c.yellow(`→ ${r.fix}`)}`);
   }

--- a/src/cli/commands/drift.ts
+++ b/src/cli/commands/drift.ts
@@ -6,6 +6,7 @@
  */
 
 import { Command } from 'commander';
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { mkdir, readFile, writeFile, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
 import { logger } from '../../utils/logger.js';
@@ -77,10 +78,10 @@ function displayIssue(issue: DriftIssue, verbose: boolean): void {
   const sev = severityLabel(issue.severity);
 
   console.log('');
-  console.log(`   ${icon} [${sev}] ${kindLabel(issue.kind)}: ${issue.filePath}`);
+  console.log(`   ${icon} [${sev}] ${kindLabel(issue.kind)}: ${safe(issue.filePath)}`);
 
   if (issue.domain) {
-    console.log(`      Spec: ${issue.specPath ?? issue.domain}`);
+    console.log(`      Spec: ${safe(issue.specPath ?? issue.domain)}`);
   }
 
   if (verbose || issue.severity === 'error') {
@@ -636,7 +637,7 @@ Pre-commit hook:
           console.log('   Suggested tests for affected domains:');
           console.log('');
           for (const d of suggestion.domains) {
-            console.log(`   ${d.domain}  (${d.testFiles.length} file${d.testFiles.length !== 1 ? 's' : ''})`);
+            console.log(`   ${safe(d.domain)}  (${d.testFiles.length} file${d.testFiles.length !== 1 ? 's' : ''})`);
             for (const f of d.testFiles) {
               console.log(`     → ${f}`);
             }

--- a/src/cli/commands/federation.ts
+++ b/src/cli/commands/federation.ts
@@ -8,6 +8,7 @@
  */
 
 import { Command } from 'commander';
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { resolve } from 'node:path';
 import {
   addRepo,
@@ -35,7 +36,7 @@ export const federationCommand = new Command('federation')
         try {
           const { entry } = addRepo(process.cwd(), repoPath, { name: options.name });
           const fp = entry.fingerprint ? entry.fingerprint.slice(0, 12) : '(no index yet — run "openlore analyze" there)';
-          console.log(`✓ Registered "${entry.name}" → ${entry.path}`);
+          console.log(`✓ Registered "${safe(entry.name)}" → ${safe(entry.path)}`);
           console.log(`  fingerprint: ${fp}`);
         } catch (err) {
           console.error(`✗ ${(err as Error).message}`);
@@ -78,8 +79,8 @@ export const federationCommand = new Command('federation')
           console.log(`Federation registry (${repos.length} repo${repos.length === 1 ? '' : 's'}) — home: ${resolve(process.cwd())}\n`);
           for (const r of repos) {
             const state = evaluateRepoState(r);
-            console.log(`  ${r.name.padEnd(20)} ${STATE_LABEL[state] ?? state}`);
-            console.log(`  ${''.padEnd(20)} ${r.path}`);
+            console.log(`  ${safe(r.name).padEnd(20)} ${STATE_LABEL[state] ?? state}`);
+            console.log(`  ${''.padEnd(20)} ${safe(r.path)}`);
           }
         } catch (err) {
           // A corrupt manifest makes loadRegistry throw; surface it cleanly

--- a/src/cli/commands/orient.ts
+++ b/src/cli/commands/orient.ts
@@ -15,6 +15,10 @@ import { Command } from 'commander';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { logger } from '../../utils/logger.js';
+// Repo-derived values are printed here with bare console.log (not via logger), so
+// they are neutralized explicitly. Whole-line sanitizing is not an option: these
+// lines carry intentional \n spacing that the sanitizer would strip.
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { withQuietStdout } from '../../utils/quiet-stdout.js';
 import { handleOrient } from '../../core/services/mcp-handlers/orient.js';
 import { estimateTokens } from '../../core/services/llm-service.js';
@@ -127,22 +131,22 @@ function printHuman(result: Record<string, unknown>): void {
     (result.insertionPoints as Array<{ rank: number; name: string; filePath: string; reason: string }>) ?? [];
   const next = (result.nextSteps as string[]) ?? [];
 
-  console.log(`Task: ${result.task}`);
+  console.log(`Task: ${safe(String(result.task))}`);
   // State the honest, served retrieval mode (keyword / local-semantic /
   // remote-semantic) — not the internal score-scale token.
-  console.log(`Retrieval mode: ${result.retrievalMode ?? result.searchMode}`);
+  console.log(`Retrieval mode: ${safe(String(result.retrievalMode ?? result.searchMode))}`);
 
   if (fns.length > 0) {
     console.log('\nRelevant functions:');
-    for (const f of fns) console.log(`  ${f.name}  (${f.filePath})`);
+    for (const f of fns) console.log(`  ${safe(f.name)}  (${safe(f.filePath)})`);
   }
   if (ips.length > 0) {
     console.log('\nInsertion points:');
-    for (const ip of ips) console.log(`  ${ip.rank}. ${ip.name}  (${ip.filePath}) — ${ip.reason}`);
+    for (const ip of ips) console.log(`  ${ip.rank}. ${safe(ip.name)}  (${safe(ip.filePath)}) — ${safe(ip.reason)}`);
   }
   if (next.length > 0) {
     console.log('\nNext steps:');
-    for (const s of next) console.log(`  - ${s}`);
+    for (const s of next) console.log(`  - ${safe(s)}`);
   }
 }
 

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -6,6 +6,7 @@
  */
 
 import { Command } from 'commander';
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { stat, mkdir, writeFile } from 'node:fs/promises';
 import { join, basename } from 'node:path';
 import { createRequire } from 'node:module';
@@ -387,7 +388,7 @@ The pipeline saves run metadata to .openlore/runs/ for tracking.
         if (analysisData) {
           const { repoStructure } = analysisData;
           console.log(`   Using existing analysis: ${repoStructure.statistics.analyzedFiles} files, ${repoStructure.domains.length} domains`);
-          console.log(`   Detected domains: ${repoStructure.domains.map(d => d.name).join(', ') || 'None'}`);
+          console.log(`   Detected domains: ${safe(repoStructure.domains.map(d => d.name).join(', ')) || 'None'}`);
           metadata.steps.analyze = {
             status: 'skipped',
             reason: `Recent analysis (${formatAge(analysisAge)})`,
@@ -421,7 +422,7 @@ The pipeline saves run metadata to .openlore/runs/ for tracking.
 
           console.log(`   ✓ Analyzed ${result.repoMap.summary.analyzedFiles} files`);
           console.log(`   ✓ Found ${result.depGraph.statistics.clusterCount} clusters`);
-          console.log(`   Detected domains: ${result.artifacts.repoStructure.domains.map(d => d.name).join(', ') || 'None'}`);
+          console.log(`   Detected domains: ${safe(result.artifacts.repoStructure.domains.map(d => d.name).join(', ')) || 'None'}`);
 
           metadata.steps.analyze = {
             status: 'completed',
@@ -490,7 +491,7 @@ The pipeline saves run metadata to .openlore/runs/ for tracking.
         console.log(`   ├─ ${openspecPath}/specs/architecture/spec.md`);
         if (analysisData) {
           for (const domain of analysisData.repoStructure.domains.slice(0, 5)) {
-            console.log(`   ├─ ${openspecPath}/specs/${domain.name}/spec.md`);
+            console.log(`   ├─ ${openspecPath}/specs/${safe(domain.name)}/spec.md`);
           }
         }
         console.log(`   └─ ${openspecPath}/specs/api/spec.md (if applicable)`);

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -19,6 +19,7 @@
  */
 
 import { Command } from 'commander';
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { join } from 'node:path';
 import { logger } from '../../utils/logger.js';
 import { parseList, resolveLLMProvider } from '../../utils/command-helpers.js';
@@ -76,7 +77,7 @@ function displayCoverageReport(report: TestCoverageReport, json: boolean): void 
     console.log('');
     console.log('   Uncovered scenarios:');
     for (const s of report.uncovered.slice(0, 20)) {
-      console.log(`     ${s.domain}/${s.requirement}/${s.scenarioName}`);
+      console.log(`     ${safe(s.domain)}/${safe(s.requirement)}/${safe(s.scenarioName)}`);
     }
     if (report.uncovered.length > 20) {
       console.log(`     ... and ${report.uncovered.length - 20} more`);

--- a/src/cli/commands/verify.ts
+++ b/src/cli/commands/verify.ts
@@ -6,6 +6,7 @@
  */
 
 import { Command } from 'commander';
+import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { join } from 'node:path';
 import { logger } from '../../utils/logger.js';
 import { redirectConsoleToStderr } from '../../utils/quiet-stdout.js';
@@ -105,7 +106,7 @@ function displayResult(
 ): void {
   const status = getStatusEmoji(result.overallScore, threshold);
   console.log('');
-  console.log(`   [${index}/${total}] ${result.filePath}`);
+  console.log(`   [${index}/${total}] ${safe(result.filePath)}`);
 
   // Purpose match
   const purposeStatus = result.purposeMatch.similarity >= 0.5 ? '✓' : '⚠';
@@ -184,7 +185,7 @@ function displaySummary(report: VerificationReport, _threshold: number): void {
   // Suggested improvements
   if (report.suggestedImprovements.length > 0) {
     for (const improvement of report.suggestedImprovements) {
-      console.log(`   ${improvement.domain}: ${improvement.issue}`);
+      console.log(`   ${safe(improvement.domain)}: ${safe(improvement.issue)}`);
       console.log(`      → ${improvement.suggestion}`);
     }
     console.log('');

--- a/src/cli/output-hygiene.test.ts
+++ b/src/cli/output-hygiene.test.ts
@@ -88,3 +88,43 @@ describe('CLI output hygiene — untrusted terminal control sequences', () => {
     ).toEqual([]);
   });
 });
+
+describe('CLI output hygiene — repository-derived values reaching the terminal', () => {
+  /**
+   * A file name may legally contain ESC on Linux and macOS, so any repository-derived
+   * value OpenLore echoes back can carry cursor-movement or screen-clear sequences.
+   * Printed raw, the repository being analyzed can overwrite OpenLore's own output.
+   *
+   * `writeStdout` and the logger sanitize centrally. `console.log` does not — so a
+   * command that prints a path or symbol through it bypasses both. That is not
+   * hypothetical: it is how `orient` and then `audit` were each found leaking, the
+   * second only after widening a manual survey from 11 commands to 27.
+   *
+   * Hence the rule: in a command module, a bare `console.log` template may not
+   * interpolate a repository-derived field unless it goes through
+   * `sanitizeForTerminal` (imported as `safe`).
+   */
+  const REPO_DERIVED = /console\.log\(`[^`]*\$\{[^}]*\.(name|file|filePath|path|symbol|requirement|domain|reason|id)\b/;
+
+  it('sanitizes repo-derived values printed with bare console.log', () => {
+    const commandsDir = join(import.meta.dirname, 'commands');
+    const offenders: string[] = [];
+    for (const file of walkTsFiles(commandsDir)) {
+      readFileSync(file, 'utf-8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (!REPO_DERIVED.test(line)) return;
+          if (line.includes('safe(') || line.includes('sanitizeForTerminal(')) return;
+          offenders.push(`${file.split('/commands/')[1]}:${i + 1}  ${line.trim().slice(0, 80)}`);
+        });
+    }
+    expect(
+      offenders,
+      'These print repository-derived values with bare console.log, which neither\n' +
+        'writeStdout nor the logger sanitizes. An analyzed repository can smuggle\n' +
+        'terminal control sequences through them and forge OpenLore output.\n' +
+        "Wrap the value: `${safe(value)}` (import { sanitizeForTerminal as safe }).\n\n" +
+        offenders.join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/src/cli/output-hygiene.test.ts
+++ b/src/cli/output-hygiene.test.ts
@@ -62,3 +62,29 @@ describe('CLI output hygiene — shared color layer', () => {
     expect(/\x1b\[/.test(painted)).toBe(false);
   });
 });
+
+describe('CLI output hygiene — untrusted terminal control sequences', () => {
+  /**
+   * `writeStdout` strips terminal control sequences centrally, which is only safe
+   * while nothing colorizes through it. If a command starts emitting chalk/colors
+   * down that path, the strip would eat its escapes and the colour would silently
+   * vanish — so pin the assumption rather than leaving it as a comment.
+   */
+  it('keeps writeStdout a color-free path', () => {
+    const commandsDir = join(import.meta.dirname, 'commands');
+    const offenders: string[] = [];
+    for (const file of walkTsFiles(commandsDir)) {
+      const src = readFileSync(file, 'utf-8');
+      if (!src.includes('writeStdout')) continue;
+      if (/from 'chalk'|colorForStdout|palette\(/.test(src)) {
+        offenders.push(file.split('/src/')[1] ?? file);
+      }
+    }
+    expect(
+      offenders,
+      'These modules both write through writeStdout and emit colour. writeStdout strips\n' +
+        'control characters (including the ESC that colour needs), so either route the\n' +
+        'coloured output through the logger, or narrow the strip:\n' + offenders.join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/src/cli/output.test.ts
+++ b/src/cli/output.test.ts
@@ -48,3 +48,43 @@ describe('writeStdout', () => {
     expect(out.length).toBe(N); // full payload, not truncated at the 64KB pipe buffer
   });
 });
+
+describe('writeStdout — untrusted control sequences', () => {
+  const ESC = String.fromCharCode(27);
+
+  function capture(): { out: string[]; restore: () => void } {
+    const out: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    (process.stdout as { write: unknown }).write = ((c: string, cb?: (e?: Error) => void) => {
+      out.push(String(c));
+      if (typeof cb === 'function') cb();
+      return true;
+    }) as never;
+    return { out, restore: () => { (process.stdout as { write: unknown }).write = orig as never; } };
+  }
+
+  it('strips escapes that arrived from an analyzed repository', async () => {
+    const { out, restore } = capture();
+    try {
+      await writeStdout(`   query: symbol BEACON::src/zz${ESC}[2K${ESC}[1GFAKE${ESC}[0m.ts\n`);
+    } finally { restore(); }
+    const written = out.join('');
+    expect(written).not.toContain(ESC);
+    // The path is still reported — the fix neutralizes, it does not hide.
+    expect(written).toContain('BEACON::src/zz');
+    expect(written.endsWith('\n')).toBe(true);
+  });
+
+  it('preserves the newlines these reports are structured with', async () => {
+    const { out, restore } = capture();
+    try { await writeStdout('line one\nline two\n'); } finally { restore(); }
+    expect(out.join('')).toBe('line one\nline two\n');
+  });
+
+  it('is a no-op for JSON, which already escapes control characters', async () => {
+    const payload = JSON.stringify({ path: `a${ESC}[2Kb` }) + '\n';
+    const { out, restore } = capture();
+    try { await writeStdout(payload); } finally { restore(); }
+    expect(out.join('')).toBe(payload);
+  });
+});

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -11,7 +11,31 @@
  * callback fires on drain), so a caller can `await writeStdout(x)` before exiting and
  * the full payload is guaranteed delivered.
  */
+
+import { sanitizeForTerminal } from '../utils/misc.js';
+/**
+ * Strip terminal control sequences, keeping newlines.
+ *
+ * Everything written through here is either JSON or a plain-text report built from
+ * repository-derived values — paths, symbol names, extracted source. A file name may
+ * legally contain ESC on Linux and macOS, so an analyzed repository can otherwise
+ * smuggle cursor-movement or screen-clear sequences into OpenLore's own output and
+ * forge a verdict. Newline is the one control these reports rely on for structure, so
+ * it is preserved; ESC (and therefore every CSI/OSC sequence it introduces), CR, and
+ * the rest of C0/C1 are removed.
+ *
+ * Safe to do centrally because no caller colorizes through this path: all 14 command
+ * modules that use `writeStdout` build plain text, and colored output goes through the
+ * logger / `src/utils/colors.ts` instead. A guard in `output-hygiene.test.ts` keeps
+ * that true. On the JSON path this is a no-op, since `JSON.stringify` already escapes
+ * control characters to `\uXXXX`.
+ */
+function stripTerminalControls(text: string): string {
+  return sanitizeForTerminal(text, { keepNewlines: true });
+}
+
 export function writeStdout(text: string): Promise<void> {
+  text = stripTerminalControls(text);
   return new Promise<void>((resolve, reject) => {
     // `write` returns false ONLY under backpressure — the case where data is buffered
     // internally and a racing process.exit() would truncate it; there we must await the

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -12,6 +12,7 @@
 
 import chalk from 'chalk';
 import ora, { type Ora } from 'ora';
+import { sanitizeForTerminal } from './misc.js';
 
 export type LogLevel = 'discovery' | 'analysis' | 'inference' | 'success' | 'warning' | 'error' | 'debug';
 
@@ -100,7 +101,10 @@ export class Logger {
     const prefix = isTTY && !this.options.noColor ? PREFIXES_EMOJI[level] : PREFIXES_ASCII[level];
     const colorFn = this.options.noColor ? (s: string) => s : COLORS[level];
 
-    let formattedMessage = `${prefix} ${message}`;
+    // Messages routinely carry repository-derived text (paths, symbol names). Strip
+    // control sequences here, once, rather than at every call site — the prefix and
+    // the color wrapper below are added afterwards, so OpenLore's own color survives.
+    let formattedMessage = `${prefix} ${sanitizeForTerminal(message, { keepNewlines: true })}`;
 
     if (this.options.timestamps) {
       const timestamp = new Date().toISOString();
@@ -259,6 +263,7 @@ export class Logger {
    * Print a section header
    */
   section(title: string): void {
+    title = sanitizeForTerminal(title);
     if (this.options.quiet) return;
 
     this.blank();
@@ -274,6 +279,8 @@ export class Logger {
    * Print a key-value pair for summaries
    */
   info(key: string, value: string | number): void {
+    key = sanitizeForTerminal(key);
+    if (typeof value === 'string') value = sanitizeForTerminal(value);
     if (this.options.quiet) return;
 
     if (this.options.noColor) {
@@ -287,6 +294,7 @@ export class Logger {
    * Print a list item
    */
   listItem(item: string, indent: number = 0): void {
+    item = sanitizeForTerminal(item);
     if (this.options.quiet) return;
 
     const prefix = '  '.repeat(indent) + '•';

--- a/src/utils/misc.test.ts
+++ b/src/utils/misc.test.ts
@@ -6,7 +6,12 @@
  * passes just as well when it stops escaping.
  */
 import { describe, it, expect } from 'vitest';
-import { escapeRegExp, escapeDotString, isProtoPollutingKey } from './misc.js';
+import {
+  escapeRegExp,
+  escapeDotString,
+  isProtoPollutingKey,
+  sanitizeForTerminal,
+} from './misc.js';
 
 describe('escapeRegExp', () => {
   it('stops a crafted identifier from matching a different symbol', () => {
@@ -64,5 +69,47 @@ describe('isProtoPollutingKey', () => {
     for (const k of ['mcpServers', 'openlore', 'hooks', 'proto', 'protoype']) {
       expect(isProtoPollutingKey(k), k).toBe(false);
     }
+  });
+});
+
+describe('sanitizeForTerminal', () => {
+  const ESC = String.fromCharCode(27);
+
+  it('neutralizes an escape sequence smuggled through a file name', () => {
+    // A file name may legally contain ESC on Linux/macOS. Printed raw, this one
+    // clears the line and rewrites it, letting an analyzed repository forge a
+    // success line over OpenLore's own output.
+    const hostile = `zz${ESC}[2K${ESC}[1G[ok] ALL CHECKS PASSED${ESC}[0m.ts`;
+    const safe = sanitizeForTerminal(hostile);
+
+    expect(safe).not.toContain(ESC);
+    // The visible text is kept — the value is still identifiable, just inert.
+    expect(safe).toBe('zz[2K[1G[ok] ALL CHECKS PASSED[0m.ts');
+  });
+
+  it('strips newline and tab, because these are single-line display values', () => {
+    // A newline in a path is itself a way to forge an extra output line.
+    expect(sanitizeForTerminal('a\nb\tc')).toBe('abc');
+  });
+
+  it('strips DEL and C1 controls', () => {
+    const s = 'a' + String.fromCharCode(0x7f) + 'b' + String.fromCharCode(0x9b) + 'c';
+    expect(sanitizeForTerminal(s)).toBe('abc');
+  });
+
+  it('keeps template newlines when the caller asks, but never ESC', () => {
+    // Logger messages are OpenLore-authored templates whose newlines are real
+    // formatting (decisions.ts opens a gate warning with one).
+    const msg = `\nCommit gated — see src/zz${ESC}[2Kevil.ts`;
+    const safe = sanitizeForTerminal(msg, { keepNewlines: true });
+    expect(safe.startsWith('\n')).toBe(true);
+    expect(safe).not.toContain(ESC);
+  });
+
+  it('leaves ordinary paths and symbols untouched', () => {
+    expect(sanitizeForTerminal('src/core/analyzer/file-walker.ts')).toBe(
+      'src/core/analyzer/file-walker.ts'
+    );
+    expect(sanitizeForTerminal('handleOrient::src/a.ts')).toBe('handleOrient::src/a.ts');
   });
 });

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -46,6 +46,44 @@ export function escapeDotString(s: string): string {
 }
 
 /**
+ * Neutralize terminal control sequences in a value that came from an analyzed
+ * repository, before it is printed.
+ *
+ * OpenLore's job is to read repositories it does not trust and report on them, and
+ * SECURITY.md scopes exactly that. A file name may legally contain ESC on Linux and
+ * macOS, so a hostile repository can smuggle cursor-movement, screen-clear or OSC
+ * sequences through any path/symbol OpenLore echoes back. Printed raw, those let the
+ * repository being analyzed overwrite OpenLore's own output — for a tool whose value
+ * is a trustworthy verdict, a forged "[ok] all checks passed" line is the attack,
+ * not a cosmetic glitch.
+ *
+ * Everything in C0, DEL and C1 is removed, which includes ESC and therefore every
+ * sequence introduced by it (CSI, OSC, DCS) without needing to parse them. Newline
+ * and tab go too: these are single-line display values (a path, a symbol name), so a
+ * newline in one is itself a way to forge an extra output line.
+ *
+ * This is for UNTRUSTED values only. OpenLore's own color codes are applied by the
+ * shared color layer AFTER this runs, so they are unaffected.
+ */
+export function sanitizeForTerminal(
+  value: string,
+  opts: { keepNewlines?: boolean } = {},
+): string {
+  // Two shapes, because the caller knows what it is holding:
+  //   - a single VALUE (a path, a symbol name): a newline in it is itself a way to
+  //     forge an extra output line, so it goes too. This is the default.
+  //   - an assembled MESSAGE built from an OpenLore-authored template: its newlines
+  //     are the template's own formatting, so they are kept. ESC is removed either
+  //     way, which is what blocks the cursor/screen/OSC attacks.
+  const pattern = opts.keepNewlines
+    // eslint-disable-next-line no-control-regex -- C0 except \n, plus DEL and C1
+    ? /[\x00-\x09\x0b-\x1f\x7f-\x9f]/g
+    // eslint-disable-next-line no-control-regex -- all of C0, plus DEL and C1
+    : /[\x00-\x1f\x7f-\x9f]/g;
+  return value.replace(pattern, '');
+}
+
+/**
  * Keys that must never be written through a caller-supplied path, because
  * assigning them mutates the prototype chain rather than the target object.
  */


### PR DESCRIPTION
## Status

LGTM. One real security fix, one CodeQL scope correction, 14 new tests. All checks green.

## What was wrong

**A repository being analyzed could inject raw terminal control sequences into OpenLore's own output**, through any path or symbol name OpenLore echoes back.

A file name may legally contain `ESC` on Linux and macOS. A file called `zz␛[2K␛[1G[ok] ALL CHECKS PASSED␛[0m.ts` clears the current line and rewrites it.

This matters more for OpenLore than for most tools:

- `SECURITY.md` already scopes *"any path that reads untrusted repository contents during `analyze`"* — this is squarely inside the stated threat model.
- OpenLore's value is a **trustworthy verdict**. A forged `[ok]` line written over real output attacks the product's central claim, not the terminal's appearance.
- The attacker is anyone whose repository you analyze: a dependency, a PR branch, a repo you were asked to review.

Confirmed reachable on `main` across four commands: `orient`, `find-clones`, `coverage-gaps`, `error-propagation`.

## What it does

Fixed at the **two shared sinks** that carry repository-derived text, rather than per command:

| Sink | Covers |
|---|---|
| `writeStdout` (`src/cli/output.ts`) | the shared stdout writer behind **14 command modules** — this one change closed `find-clones`, `coverage-gaps` and `error-propagation` together |
| `logger.formatMessage` / `section` / `info` / `listItem` | the other shared sink |

`orient` prints paths with bare `console.log` rather than either sink, so its five interpolations are neutralized explicitly.

Doing it centrally in `writeStdout` is only safe while nothing colorizes through that path — so `output-hygiene.test.ts` now **pins that assumption**. A future coloured caller would otherwise have its escapes eaten silently.

## The newline decision

`sanitizeForTerminal` takes it from the caller, because the two kinds of string genuinely differ:

- A **value** (path, symbol name) loses newlines too — a newline inside one is itself a way to forge an extra output line.
- An assembled **message** keeps them, because they're the template's own formatting.

That distinction came out of review: stripping newlines everywhere collapsed the blank line `decisions.ts` opens its commit-gate warning with. Both behaviours are now tested.

## Proof

Planted a hostile filename in a real repository and ran the commands, before and after:

```
before:  orient  surfaced=true  RAW-ESCAPE=true
after :  orient  surfaced=true  RAW-ESCAPE=false     (same for the other three)
```

**The `surfaced=true` half is deliberate.** An earlier probe reported a clean result only because the hostile file was never shown at all — a vacuous pass. Every assertion here checks the file is still reported *and* the escape bytes are gone: the fix neutralizes, it doesn't hide.

`eslint` clean · `tsc` clean · `npm run build` clean · both audit gates pass · **325 files / 6,213 tests** (+19), stable across repeated runs.

## Also: CodeQL scope

Excludes `examples/`. Those are sample **applications** that exist to be analyzed *by* OpenLore in demos and tests, so findings there describe the sample rather than the product — the two `js/missing-rate-limiting` alerts in the baseline were about `drift-demo`'s Express routes. Same rationale as the existing test/fixture exclusions.

Also notes inline that `src/core/analyzer/iac/fixtures/.../Dockerfile` is *intentionally* unpinned so the IaC projector has something to parse — Scorecard reports that as an unpinned dependency, but it's a fixture, not our CI.

## Note

The `js/log-injection` alerts CodeQL raised on `logger.ts` were **true positives**, not noise. They're the reason I went looking.


---

# Security audit of `main` (added after the first review)

Audited the surfaces a scanner does not reach, by attacking them directly rather than reading them. **Four held up and needed no changes:**

| Surface | Attacks tried | Result |
|---|---|---|
| `safeJoin` | `../` traversal, nested `../`, absolute path, prefix-sibling (`/tmp/repo-evil` vs `/tmp/repo`), in-root **symlink pointing outside**, NUL byte | all contained |
| File walker | dir-symlink and file-symlink into an outside directory holding a "secret" | neither followed |
| `isSafeBundleFileName` | `../x`, `a/../../x`, absolute, backslash, NUL, `.`, `..`, empty | all rejected |
| Secret redaction | bearer, basic, `apiKey`, `x-api-key`, `token`, **nested** `password`, OpenLore serve token | all redacted |

## The gap that was real

The terminal-escape fix in the previous commit was validated against a **hand-picked list of 11 commands**. Enumerating all 51 from `--help` and running the 27 safe to invoke non-interactively found **`audit` still leaking** — it prints file and symbol names through bare `console.log`, which neither `writeStdout` nor the logger sanitizes.

So this commit fixes the class rather than the instance: **all 20 sites across 10 command modules** that interpolate a repository-derived field (`name`, `file`, `filePath`, `path`, `symbol`, `requirement`, `domain`, `reason`, `id`) into a bare `console.log`. These are domain names taken from directory names, spec requirement text, decision titles, file paths — every one controlled by whoever owns the analyzed repository.

## Made enforceable

Finding this by hand **twice** (`orient`, then `audit`) is the actual lesson, so `output-hygiene.test.ts` now fails on a bare `console.log` interpolating one of those fields without the sanitizer, naming file and line. Verified by reverting the `audit` fix — the guard catches it.

## Final sweep

```
27 commands run · 6 surfaced the hostile file name · 0 leaked a raw escape
```

The **"surfaced"** column is the control. An all-clear where the file never appeared proves nothing — which is exactly how the first version of this survey fooled me into reporting no leak.

`eslint` clean · `tsc` clean · both audit gates pass · **325 files / 6,214 tests**.
