### PR TITLE
docs(readme): replace the broken star-history embed with a live badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,11 +550,9 @@ New contributor? See **[CONTRIBUTING.md](CONTRIBUTING.md)** for setup, the agent
 If OpenLore saves your agents from re-reading the same files — or catches one risky change before it lands — **star the repo**. It's the signal that tells us to keep building, and it helps other engineers find it.
 
 <p align="center">
-  <a href="https://star-history.com/#clay-good/OpenLore&Date">
-    <img src="https://api.star-history.com/svg?repos=clay-good/OpenLore&type=Date" alt="OpenLore star history — open the live chart on star-history.com" width="70%">
-  </a>
+  <a href="https://github.com/clay-good/OpenLore/stargazers"><img src="https://img.shields.io/github/stars/clay-good/OpenLore?style=flat-square&logo=github&label=stars" alt="GitHub stars"></a>
   <br>
-  <sub><a href="https://star-history.com/#clay-good/OpenLore&Date">Live star history</a> · <a href="https://github.com/clay-good/OpenLore/stargazers">stargazers</a> — the chart above is rendered by star-history.com; if their API is rate-limited, these links still work.</sub>
+  <sub><a href="https://www.star-history.com/clay-good/openlore">Star history chart</a> · <a href="https://github.com/clay-good/OpenLore/stargazers">stargazers</a></sub>
 </p>
 
 - ⭐ **Star** to follow along: [github.com/clay-good/OpenLore](https://github.com/clay-good/OpenLore)


### PR DESCRIPTION
## Status

LGTM. README only, 2 lines changed.

## What was wrong

The embedded star-history chart was returning **503** — verified directly:

```
api.star-history.com/svg?repos=clay-good/OpenLore  -> 503
"All GitHub API tokens are rate-limited, try again later"
```

It's **not specific to this repo** — `facebook/react` and `sveltejs/svelte` return the same. star-history's shared server-side token pool is exhausted.

**A personal access token cannot fix it.** The token a reader adds on star-history.com lives in their browser and only affects their own view there. The README `<img>` is rendered server-side for anonymous visitors using star-history's own pool, which no visitor token reaches.

Net effect: broken-image alt text on the repo front page, sitting under a caption that asserted *"the chart above is rendered by star-history.com"* — describing something that wasn't there.

## What it does

Replaces the embed with a shields.io star badge and keeps the link to the live chart, which still works interactively for anyone signed in on star-history.com.

Verified before committing:

| | |
|---|---|
| shields badge | HTTP 200, `image/svg+xml`, renders the real count (**207**) |
| star-history page link | HTTP 200 |
| remaining `api.star-history` refs | none |

The `languages-` and `tests-` badges pinned by `doc-claim-sync.test.ts` are untouched.

Same information, nothing that can render broken.