### PR TITLE
docs(openspec): propose three changes for the runtime failures found by end-to-end testing

### DIFF
--- a/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/proposal.md
+++ b/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/proposal.md
@@ -1,0 +1,93 @@
+# Analyze must not die of a native abort, and no single file may cost unbounded time
+
+> Status: PROPOSED (2026-07-26). Found by an adversarial end-to-end pass against a 622-file hostile
+> repository, then isolated to a 601-file minimal reproducer and **verified against an `origin/main`
+> build** — both failures predate the security-hardening work in PR #292 and are not regressions
+> from it. Deterministic, no LLM, no new dependency.
+
+## The gap
+
+Two failures, one shared root: the analyzer treats a single file's extraction as unbounded in both
+time and blast radius, and the worker pool has no boundary that converts a native fault into a
+reported one.
+
+### 1. A worker fault kills the process with no JavaScript error
+
+```
+$ openlore analyze
+… Generating analysis artifacts…
+libc++abi: terminating due to uncaught exception of type Napi::Error
+$ echo $?
+134
+```
+
+Reproduced 3/3 deterministically. The user gets one line of C++ runtime noise: no stack, no
+`[error]` line, no partial artifacts, no indication of which file caused it, and no remedy. For a
+tool whose contract is that a quiet result means "nothing there" rather than "we broke", an
+`abort()` is the worst available failure mode — it is indistinguishable from a crash in the host.
+
+**Isolation (each run on a clean directory):**
+
+| Input | Result |
+|---|---|
+| One 300 KB file of repeated `/*x` + 600 trivial `.ts` files | **abort, exit 134, ~163 s** |
+| That 300 KB file alone | exit 0, **661 s** |
+| The 600 files without it | exit 0, 14 s |
+| The full hostile repo minus that file | exit 0, 424 s |
+
+So it requires the parallel extraction pool (`extraction-pool.ts`, change
+`add-parallel-extraction-pool`) to be engaged: a worker raises a `Napi::Error` that no boundary
+catches, and the process aborts rather than the pool degrading that one file.
+
+The pool already has the right instinct elsewhere — its own guard comments describe never trusting
+"an unproven silence OR error" — but a native exception thrown across the worker boundary bypasses
+the JavaScript `try`/`catch` that would otherwise contain it.
+
+### 2. One file can consume unbounded wall-clock, with no budget and no progress
+
+| Payload (single 300 KB file) | Time |
+|---|---|
+| `/*x` repeated (unterminated block comment) | **661 s** |
+| `import {` repeated | 156 s |
+| `app.use(` repeated | 149 s |
+| `<script ` repeated | 12 s |
+
+Measured identically on `origin/main` and on PR #292's build (60 KB of `/*x` → 25 s on both), so
+this is the tree-sitter parse and/or an extractor that is not one of the regex sites PR #292
+bounded. `MAX_READ_SIZE` (`file-walker.ts`) caps how much is *read*; nothing caps how long one file
+may be *worked on*. There is no per-file time budget, no progress line naming the file, and no way
+to interrupt short of `Ctrl-C`.
+
+This is not only a hostile-input problem: a minified bundle, a generated client, or a vendored
+single-file library in an ordinary repository hits the same path.
+
+### 3. Skips are reported as a bare count, and `doctor` contradicts them
+
+`analyze` prints `Files skipped: 3` with no reason and writes no `parse-health.json`, while `doctor`
+on the same repository reports `✓ Parse health  no files parsed with errors`. Two surfaces, two
+answers, neither actionable — the same silent-under-extraction shape that
+`add-parse-health-boundary-disclosure` closed for parse errors, still open for skips.
+
+## What changes
+
+**Contain the fault, bound the cost, and name what was dropped.**
+
+- **A worker fault becomes a reported per-file failure, never a process abort.** The extraction pool
+  installs boundaries for the failure modes that bypass a normal `catch` — `uncaughtException` /
+  `unhandledRejection` inside the worker, non-zero `exit`, and `error` on the worker handle — and
+  maps each to a structured per-file extraction failure. The build continues with that file recorded
+  as failed. If the pool cannot continue at all, `analyze` exits non-zero with an `[error]` line
+  naming the file and the remedy, never via `abort()`.
+- **A per-file extraction budget, disclosed when it fires.** A file whose extraction exceeds a
+  configurable wall-clock budget is abandoned and recorded as `budget-exceeded`, with its path and
+  the elapsed time. The budget is generous by default (seconds, not milliseconds) so no ordinary
+  file is affected, and is expressed as a named constant rather than a magic number.
+- **Skips become a disclosed, structured record.** Every excluded file — size cap, encoding, parse
+  failure, worker fault, budget — appears in the existing parse-health artifact with a reason, and
+  `analyze`'s summary line names the reason breakdown instead of a bare count. `doctor` reads the
+  same record, so the two surfaces cannot disagree.
+
+**Explicitly out of scope:** making the 661 s parse itself fast. The cost lives in the grammar/
+extractor layer and warrants its own investigation; this change makes it *bounded and disclosed*
+rather than unbounded and silent. Fixing the underlying cost is a follow-up, and this change's
+budget disclosure is what will make it measurable.

--- a/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/specs/analyzer/spec.md
+++ b/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/specs/analyzer/spec.md
@@ -1,0 +1,86 @@
+# analyzer spec delta
+
+## ADDED Requirements
+
+### Requirement: ExtractionWorkerFaultsAreContainedNotFatal
+
+A fault raised inside a parallel extraction worker — including one that crosses the worker boundary
+as a native exception, an `uncaughtException`, an unhandled rejection, or a non-zero worker exit —
+SHALL be converted into a structured per-file extraction failure and SHALL NOT terminate the
+analyzer process abnormally. The build SHALL continue over the remaining files, recording the
+faulting file as failed with its path and the fault's message. When the pool cannot continue at all,
+the analyzer SHALL surface a JavaScript-level error identifying the file and a remedy, and exit with
+a non-zero status through the normal error path — never through `abort()`.
+
+#### Scenario: A native worker fault degrades one file instead of killing the run
+
+- **GIVEN** a repository containing one file whose extraction raises a `Napi::Error` inside a worker,
+  plus 600 files that extract cleanly
+- **WHEN** `openlore analyze` runs with the parallel extraction pool engaged
+- **THEN** the process exits 0, artifacts are written for the 600 clean files, and the faulting file
+  is recorded as a failed extraction naming the file and the fault
+
+#### Scenario: A fatal pool failure is reported, not aborted
+
+- **GIVEN** an extraction pool that cannot continue after a worker fault
+- **WHEN** `openlore analyze` runs
+- **THEN** it prints an `[error]` line naming the file and the remedy and exits non-zero
+- **AND** the output contains no native runtime abort text and the exit status is not 134
+
+#### Scenario: Worker faults never corrupt the artifact set
+
+- **GIVEN** a run in which one of several workers faults mid-extraction
+- **WHEN** the analyzer writes its artifacts
+- **THEN** the artifacts describe exactly the files that extracted successfully, and the failed file
+  is absent from the graph and present in the parse-health record — never half-written into both
+
+### Requirement: PerFileExtractionCostIsBounded
+
+Extraction of a single file SHALL be bounded by a wall-clock budget expressed as a named constant.
+A file exceeding the budget SHALL be abandoned, recorded with reason `budget-exceeded` and its
+elapsed time, and SHALL NOT block completion of the run. The default budget SHALL be generous enough
+that ordinary source files — including large generated and vendored files — are never affected, and
+SHALL be operator-overridable. Abandoning a file SHALL be reported, never silent: a bounded result is
+a lower bound and must read as one.
+
+#### Scenario: A pathological file is abandoned rather than stalling the run
+
+- **GIVEN** a 300 KB file of a repeated unterminated block-comment opener, alongside ordinary sources
+- **WHEN** `openlore analyze` runs
+- **THEN** the run completes, that file is recorded as `budget-exceeded` with its elapsed time, and
+  the remaining files are analyzed normally
+
+#### Scenario: Ordinary large files are unaffected
+
+- **GIVEN** a repository containing a 1.5 MB generated client and a large minified vendor bundle that
+  extract within the budget
+- **WHEN** `openlore analyze` runs
+- **THEN** no file is recorded as `budget-exceeded` and the graph is identical to a run with the
+  budget disabled
+
+#### Scenario: A conclusion over an abandoned file discloses the boundary
+
+- **GIVEN** an analysis in which one file was abandoned for exceeding the budget
+- **WHEN** a conclusion tool returns a result whose reachable set touches that file
+- **THEN** the response discloses that symbols and edges from that file are a lower bound
+
+### Requirement: EveryExcludedFileIsRecordedWithAReason
+
+Every file the analyzer declines to include SHALL be recorded with a machine-readable reason — size
+cap, encoding, parse failure, worker fault, or budget exceeded — in the parse-health record. A bare
+count of skipped files with no reasons SHALL NOT be the only report. Any surface that reports on
+extraction health SHALL read that single record, so two surfaces cannot give contradictory answers
+about the same repository.
+
+#### Scenario: The skip summary names reasons
+
+- **GIVEN** a repository in which three files are excluded for two different reasons
+- **WHEN** `openlore analyze` completes
+- **THEN** the summary reports the count broken down by reason rather than a bare total
+
+#### Scenario: Health surfaces agree
+
+- **GIVEN** a repository in which at least one file was excluded
+- **WHEN** `openlore doctor` reports extraction health for that repository
+- **THEN** it reports the same excluded files and reasons the analysis recorded, and does not report
+  a clean bill of health

--- a/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/specs/cli/spec.md
+++ b/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/specs/cli/spec.md
@@ -1,0 +1,42 @@
+# cli spec delta
+
+## ADDED Requirements
+
+### Requirement: AnalyzeFailsThroughTheNormalErrorPath
+
+`openlore analyze` SHALL report every failure through its own error path — a rendered `[error]` line
+and a non-zero exit status — rather than allowing a runtime-level abort to reach the user. Output
+that identifies a failure SHALL name what failed, where, and what to do next. A run that produces no
+artifacts SHALL say so explicitly rather than exiting after partial progress messages.
+
+#### Scenario: An extraction fault is legible to the user
+
+- **GIVEN** a repository containing a file that faults the extraction worker
+- **WHEN** `openlore analyze` runs and cannot complete
+- **THEN** stderr carries an `[error]` line naming the file and a remedy, the exit status is non-zero,
+  and the output contains no unhandled native runtime text
+
+#### Scenario: A partial run states what was produced
+
+- **GIVEN** a run in which some files were excluded but artifacts were still written
+- **WHEN** the command finishes
+- **THEN** it reports success, the count of analyzed files, and the excluded count broken down by
+  reason — so "fewer symbols than expected" is attributable rather than mysterious
+
+### Requirement: LongRunningExtractionIsAttributable
+
+While analyzing, the CLI SHALL make a long-running file attributable: when extraction of a single
+file exceeds a disclosure threshold, the file's path SHALL be surfaced in progress output. A user
+waiting on a slow run SHALL be able to identify the responsible file without attaching a debugger.
+
+#### Scenario: The slow file is named while the run is still going
+
+- **GIVEN** a repository containing one file whose extraction takes far longer than any other
+- **WHEN** `openlore analyze` runs in a terminal
+- **THEN** the progress output names that file before the run completes
+
+#### Scenario: Machine-output modes stay clean
+
+- **GIVEN** the same repository
+- **WHEN** `openlore analyze --json` runs with stdout captured
+- **THEN** the progress disclosure is written to stderr and stdout remains valid JSON

--- a/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/tasks.md
+++ b/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/tasks.md
@@ -1,0 +1,43 @@
+# Tasks — contain worker faults, bound per-file cost, disclose every skip
+
+## Reproducers (write these first — they are the acceptance criteria)
+- [ ] Minimal abort reproducer as an integration fixture: one 300 KB file of repeated `/*x` plus
+      ~600 trivial `.ts` files; asserts exit 0 and artifacts present (today: exit 134,
+      `libc++abi: terminating due to uncaught exception of type Napi::Error`)
+- [ ] Budget reproducer: the same 300 KB file alone; asserts the run completes and the file is
+      recorded `budget-exceeded` (today: ~661 s, exit 0, no record)
+- [ ] Control: a large-but-ordinary generated file must NOT be recorded as `budget-exceeded`, and the
+      graph must match a run with the budget disabled — a bound that silently drops real files is the
+      failure mode this change is supposed to prevent
+
+## Implementation
+- [ ] Extraction pool: install per-worker boundaries for the faults a plain `try`/`catch` cannot see
+      (`uncaughtException`, `unhandledRejection`, worker `error`, non-zero `exit`) and map each to a
+      structured per-file extraction failure
+- [ ] Extraction pool: a fault degrades ONE file and the run continues; a pool that cannot continue
+      surfaces a JS-level error through the CLI error path (never `abort()`)
+- [ ] Per-file wall-clock budget as a named constant, operator-overridable; abandon + record
+      `budget-exceeded` with elapsed time
+- [ ] Extend the parse-health record with the new reasons (`worker-fault`, `budget-exceeded`,
+      `size-cap`, `encoding`) so every exclusion has a machine-readable cause
+- [ ] `analyze` summary: replace the bare `Files skipped: N` with a per-reason breakdown
+- [ ] `doctor` extraction-health check reads the same record — no independent judgment, so the two
+      surfaces cannot contradict each other
+- [ ] Progress output names a file whose extraction exceeds a disclosure threshold; to stderr, so
+      `--json` stdout stays clean
+- [ ] Conclusion tools: a result touching a `budget-exceeded` or `worker-fault` file carries the
+      existing parse-health boundary disclosure (reuse `parse-health-boundary.ts`; no new mechanism)
+
+## Verification
+- [ ] Both reproducers fail on `origin/main` and pass after the change (the abort is verified
+      pre-existing — the fix must be demonstrated, not assumed)
+- [ ] `analyze` output on a clean repository is byte-identical to before (no new noise, no new
+      artifact when nothing was excluded)
+- [ ] Differential: analysis artifacts unchanged on a real repository, with timestamps normalized
+
+## Deliberately NOT in this change
+- [ ] Making the 661 s parse fast. That cost is in the grammar/extractor layer and needs its own
+      investigation; this change makes it bounded, attributable and disclosed. The budget record is
+      what makes the follow-up measurable.
+- [ ] Nothing borrowed from another tool: the worker-boundary and per-file-budget shapes are ordinary
+      Node worker hygiene, not a competitor's design.

--- a/openspec/changes/fix-config-validation-completeness/proposal.md
+++ b/openspec/changes/fix-config-validation-completeness/proposal.md
@@ -1,0 +1,66 @@
+# Config validation must catch what actually breaks the run, and `doctor` must not bless a config that does
+
+> Status: PROPOSED (2026-07-26). Found by an end-to-end pass against a hostile repository; the
+> failures reproduce on an ordinary hand-edited config and predate PR #292. Deterministic, no LLM,
+> no new dependency.
+
+## The gap
+
+`add-config-schema-validation` gave `.openlore/config.json` a validator and a `doctor` check. It
+catches unknown keys and some wrong types. It does not catch the two shapes that actually stop the
+tool from working, and `doctor` reports a clean bill of health for a config that makes `analyze`
+crash.
+
+### 1. A config missing a required section crashes the run with an internal error
+
+```
+$ echo '{}' > .openlore/config.json && openlore analyze
+  Project: undefined
+[error] Analysis failed: Cannot read properties of undefined (reading 'excludePatterns')
+```
+
+This is not exotic: any hand-written or hand-trimmed config missing the `analysis` block does it, as
+does a config written by an older version, or one a user reduced while debugging. The user gets a
+JavaScript `TypeError` naming an internal property — no indication that the *config* is the problem,
+which key is missing, or how to repair it.
+
+### 2. `doctor` gives that exact config a clean bill of health
+
+```
+$ openlore doctor          # same '{}' config
+✓  Config schema          all keys known and well-typed
+```
+
+The one check whose job is to tell the user their config is sound reports success for a config that
+crashes the primary command. That is worse than having no check: it actively directs the user away
+from the cause. The validator's model is "known keys, well-typed *when present*" — it has no notion
+of a section being *required*, so absence reads as valid.
+
+### 3. Type checking is incomplete where it does exist
+
+`analysis.maxFiles: "lots"` passes validation. The validator flagged the unknown key in the same
+file but not this type error, so the type coverage is partial in a way the output does not admit —
+a user who sees "all keys known and well-typed" reasonably concludes their values were checked.
+
+## What changes
+
+**Validate what the code actually requires, and make `doctor`'s verdict answer the question the user
+is really asking: "will this config work?"**
+
+- **Required sections are part of the schema.** The validator distinguishes *absent* from *present
+  and wrong*, and reports a missing required section as a finding naming the key and the fix. Where
+  a section is genuinely optional, the code that reads it SHALL tolerate its absence — so "required"
+  in the schema and "dereferenced unconditionally" in the code cannot drift apart.
+- **Reads of config are defensive at the boundary.** A missing or malformed section produces a
+  diagnosed, actionable error attributing the failure to the config file and the key — never a raw
+  `TypeError` naming an internal property.
+- **Type coverage is complete for declared fields, and honest where it is not.** Every field the
+  schema declares is type-checked; a field the validator cannot check does not get counted in a
+  "well-typed" claim.
+- **`doctor`'s summary line cannot outrun its evidence.** The check reports "all keys known and
+  well-typed" only when it actually verified that; a config with a missing required section reports
+  a finding with the key and the remedy.
+
+The through-line matches the substrate's existing contract: a green check is a claim, and a claim
+must be supported. `doctor` blessing a config that crashes `analyze` is the same class of defect as
+a conclusion tool reporting `0` for something it never computed.

--- a/openspec/changes/fix-config-validation-completeness/specs/cli/spec.md
+++ b/openspec/changes/fix-config-validation-completeness/specs/cli/spec.md
@@ -1,0 +1,43 @@
+# cli spec delta
+
+## ADDED Requirements
+
+### Requirement: DoctorsConfigVerdictIsSupportedByItsEvidence
+
+`openlore doctor`'s configuration check SHALL report a passing verdict only when the configuration it
+examined would actually be usable by the commands that read it. A configuration that causes a primary
+command to fail SHALL NOT receive a passing verdict from `doctor`. The check's summary text SHALL
+describe what it verified, and SHALL NOT claim coverage — such as "all keys known and well-typed" —
+broader than the validation it performed.
+
+#### Scenario: A config that crashes analyze does not pass doctor
+
+- **GIVEN** a `.openlore/config.json` missing a section `openlore analyze` requires
+- **WHEN** `openlore doctor` runs in that repository
+- **THEN** its configuration check reports a finding naming the missing key and the remedy, and does
+  not report a clean verdict
+
+#### Scenario: A sound config still passes
+
+- **GIVEN** a configuration written by `openlore init`
+- **WHEN** `openlore doctor` runs
+- **THEN** the configuration check passes and adds no findings
+
+#### Scenario: The verdict text matches the coverage
+
+- **GIVEN** a configuration containing a field the validator does not type-check
+- **WHEN** `openlore doctor` reports the configuration check
+- **THEN** its summary does not assert that every value was type-checked
+
+### Requirement: DoctorAndTheCommandsAgreeAboutConfiguration
+
+`doctor` and the commands that consume configuration SHALL derive their verdicts from the same
+validator, so the two cannot disagree about the same file. A configuration rejected by a command
+SHALL be reported as a finding by `doctor`, and one `doctor` passes SHALL be accepted by the
+commands.
+
+#### Scenario: Both surfaces reach the same conclusion
+
+- **GIVEN** any `.openlore/config.json`
+- **WHEN** `openlore doctor` and `openlore analyze` are both run against it
+- **THEN** either both accept it, or `doctor` reports a finding describing why the command rejected it

--- a/openspec/changes/fix-config-validation-completeness/specs/config/spec.md
+++ b/openspec/changes/fix-config-validation-completeness/specs/config/spec.md
@@ -1,0 +1,63 @@
+# config spec delta
+
+## ADDED Requirements
+
+### Requirement: RequiredConfigSectionsAreValidatedAsRequired
+
+The configuration schema SHALL distinguish a section that is absent from one that is present and
+malformed, and SHALL report a missing required section as a finding naming the key and the remedy. A
+section the schema marks required SHALL be one the code may dereference; a section the code tolerates
+being absent SHALL NOT be marked required. The two SHALL be kept in agreement by a check that fails
+when they drift, so "required by the schema" and "dereferenced unconditionally by the code" cannot
+diverge silently.
+
+#### Scenario: An empty config is diagnosed, not blessed
+
+- **GIVEN** a `.openlore/config.json` containing `{}`
+- **WHEN** the configuration is validated
+- **THEN** a finding names each missing required section and how to restore it
+
+#### Scenario: An optional section may be absent without a finding
+
+- **GIVEN** a config omitting a section the code reads defensively
+- **WHEN** the configuration is validated
+- **THEN** no finding is produced for that section
+
+#### Scenario: Schema and code cannot drift
+
+- **GIVEN** a section marked required in the schema
+- **WHEN** the drift check runs
+- **THEN** it passes only while the code dereferences that section unconditionally, and fails if
+  either side changes without the other
+
+### Requirement: DeclaredFieldsAreTypeCheckedOrNotClaimed
+
+Every field the schema declares SHALL be type-checked against its declared type. A field the
+validator does not check SHALL NOT be counted toward any claim that the configuration is well-typed.
+A validation summary SHALL describe only what was actually verified.
+
+#### Scenario: A wrong scalar type is reported
+
+- **GIVEN** a config setting a numeric field to a string, such as `analysis.maxFiles: "lots"`
+- **WHEN** the configuration is validated
+- **THEN** a finding names the key, the declared type, and the type received
+
+#### Scenario: Unchecked fields are not counted as verified
+
+- **GIVEN** a schema containing a field the validator cannot check
+- **WHEN** the configuration is validated and reported
+- **THEN** the report does not describe that field as verified
+
+### Requirement: ConfigReadsFailWithAttributableErrors
+
+A read of configuration that encounters a missing or malformed section SHALL produce an error
+attributing the failure to the configuration file and the offending key, with a remedy. A raw
+runtime `TypeError` naming an internal property SHALL NOT be the user-visible failure for a
+configuration problem.
+
+#### Scenario: A missing section produces an attributable error
+
+- **GIVEN** a config missing the section a command requires
+- **WHEN** that command runs
+- **THEN** the error names `.openlore/config.json`, the missing key, and the remedy
+- **AND** the message contains no internal property-access text such as `Cannot read properties of undefined`

--- a/openspec/changes/fix-config-validation-completeness/tasks.md
+++ b/openspec/changes/fix-config-validation-completeness/tasks.md
@@ -1,0 +1,36 @@
+# Tasks — validate what breaks the run; never bless a config that crashes
+
+## Reproducers (write these first)
+- [ ] `{}` config → `openlore analyze` must fail with an attributable error naming the file and the
+      missing key. Today: `Analysis failed: Cannot read properties of undefined (reading 'excludePatterns')`
+- [ ] `{}` config → `openlore doctor` must report a finding. Today: `✓ Config schema  all keys known
+      and well-typed`
+- [ ] `analysis.maxFiles: "lots"` → must be reported as a type error. Today: passes silently while an
+      unknown key in the same file IS reported
+- [ ] Control: a config produced by `openlore init` must produce zero findings and byte-identical
+      output to today — a validator that starts flagging healthy configs is a worse bug than the one
+      being fixed
+
+## Implementation
+- [ ] Schema: mark required sections as required and distinguish absent from present-and-malformed
+- [ ] Drift check binding "required in schema" to "dereferenced unconditionally in code", so the two
+      cannot diverge (the same self-enforcing shape used by the CLI `--base`/staleness parity guard)
+- [ ] Complete type checks for every declared field; a field the validator cannot check must not be
+      counted toward a well-typed claim
+- [ ] Config read boundary: raise an attributable error naming `.openlore/config.json`, the key, and
+      the remedy instead of letting a `TypeError` escape
+- [ ] `doctor`'s config check derives its verdict from the same validator the commands use, and its
+      summary text describes only what it verified
+
+## Verification
+- [ ] Every reproducer fails on `origin/main` and passes after the change
+- [ ] Cross-surface agreement test: for a set of configs (valid, empty, missing-section, wrong-type,
+      unknown-key), `doctor` and `analyze` never disagree about acceptability
+- [ ] Diagnostics continue to go to stderr, so `--json` stdout stays valid (the machine-output
+      contract that motivated the original config-warning placement)
+
+## Notes
+- [ ] Related but out of scope: `analyze` reporting `Architecture: unknown` and domain names derived
+      from filenames (`tsconfig`, `order-service-test`). That is inference quality, not validation.
+- [ ] Nothing borrowed from another tool: this is completing OpenLore's own
+      `add-config-schema-validation`, not adopting an external schema system.

--- a/openspec/changes/fix-process-exit-lifecycle/proposal.md
+++ b/openspec/changes/fix-process-exit-lifecycle/proposal.md
@@ -1,0 +1,69 @@
+# A process must exit when its work is done: no zombie MCP servers, no post-failure hangs
+
+> Status: PROPOSED (2026-07-26). Found by end-to-end passes against the built CLI (ordinary and
+> hostile repositories). Both failures predate PR #292. Deterministic, no LLM, no new dependency.
+
+## The gap
+
+Two commands keep the Node event loop alive after they have finished their work. Neither is a
+correctness bug in the analysis; both are the kind of defect that only appears when you run the
+product rather than test it, and both cost the user something real.
+
+### 1. The MCP server never exits on stdin EOF once the watcher starts
+
+An MCP stdio server's lifetime is its stdin. When the client closes the pipe, the server must exit.
+
+```
+$ echo '<jsonrpc initialize>' | openlore mcp        # fails before the watcher starts
+   → returns immediately
+
+$ echo '<initialize + orient>' | openlore mcp       # any successful orient
+   → still running at 60 s, still running at 120 s (killed both times)
+```
+
+After any call that starts the file watcher, stdin EOF no longer ends the process. Every agent
+session that wires OpenLore as an MCP server therefore leaves a **zombie process holding a watcher
+and its caches**. Over a working day of agent sessions these accumulate; each one holds file handles
+and memory for a repository nobody is looking at any more.
+
+The watcher is the thing keeping the loop alive (`chokidar` handles are not `unref`'d), and nothing
+tears it down on EOF. `serve` solved the adjacent problem for *its* transport with an idle-timeout
+reaper (`DEFAULT_IDLE_TIMEOUT_MIN`, added precisely because orphaned daemons "pile up in RAM"); the
+stdio server has no equivalent because its natural signal — EOF — is simply not wired.
+
+### 2. `generate` hangs for the full request timeout after a fatal error
+
+```
+$ time openlore generate            # no API key reachable
+[error] Failed to connect to LLM API              ← t+0.4 s
+…
+                                                   ← 120 s of nothing
+$ echo $?
+1
+```
+
+Verified as an unclosed handle rather than a slow retry: with `--timeout 120` the process is killed
+by the outer timeout at exactly 120 s (exit 124), and with `--timeout 240` it exits 1 at exactly
+120 s. The command decided it had failed in under half a second and then sat there for two minutes.
+
+In CI this is two minutes of billed time per failed run; interactively it reads as a hang, and the
+natural user response — `Ctrl-C` — is indistinguishable from the tool having crashed.
+
+## What changes
+
+**Make "the work is finished" and "the process exits" the same event.**
+
+- **Stdio transport lifetime is bound to stdin.** The MCP server treats stdin `end`/`close` as
+  shutdown: it stops the watcher, closes the edge store, and exits. Shutdown is idempotent and shares
+  one path with the existing signal handlers, so `SIGINT`/`SIGTERM`/EOF cannot each implement their
+  own partial teardown.
+- **Long-lived resources do not by themselves keep the process alive.** Watcher and timer handles are
+  `unref`'d where the process should not outlive its transport, so a missed teardown degrades to
+  "exits slightly early" rather than "never exits".
+- **A command that has decided it failed exits.** After a fatal error, `generate` (and any sibling
+  with the same shape) tears down its in-flight resources rather than waiting out a request timeout
+  that no longer has a request behind it.
+
+Both are verified by asserting the *observable* property — the process exits within a bounded time
+of the triggering event — rather than by asserting internal state, because the failure mode here is
+precisely that internal state looks fine while the process refuses to die.

--- a/openspec/changes/fix-process-exit-lifecycle/specs/architecture/spec.md
+++ b/openspec/changes/fix-process-exit-lifecycle/specs/architecture/spec.md
@@ -1,0 +1,30 @@
+# architecture spec delta
+
+## ADDED Requirements
+
+### Requirement: EveryLongLivedSurfaceHasOneTeardownPath
+
+Each surface that acquires process-lifetime resources — a file watcher, a graph-store handle, an
+interval, a listening socket — SHALL expose exactly one teardown path, and every way that surface can
+end SHALL route through it. A surface SHALL NOT acquire a resource whose handle keeps the process
+alive beyond its own transport unless it also owns the signal that releases it. Where a teardown may
+be missed, the handle SHALL be `unref`'d so the failure mode is an early exit rather than a process
+that never exits.
+
+This generalizes the lesson each surface has learned separately: `serve` grew an idle-timeout reaper
+because orphaned daemons accumulated in RAM, and the stdio server exhibits the same accumulation
+through a different door (stdin EOF). The requirement is on the shape, so a future surface inherits
+it instead of rediscovering it.
+
+#### Scenario: A new local surface cannot leak its watcher
+
+- **GIVEN** a surface that starts a file watcher during request handling
+- **WHEN** its transport closes
+- **THEN** the watcher is stopped by the surface's single teardown path and the process exits
+
+#### Scenario: A missed teardown degrades safely
+
+- **GIVEN** a timer or watcher handle acquired by a surface whose transport has closed
+- **WHEN** teardown does not run for that handle
+- **THEN** the handle does not by itself keep the process alive, so the observable failure is an
+  early exit rather than a hang

--- a/openspec/changes/fix-process-exit-lifecycle/specs/cli/spec.md
+++ b/openspec/changes/fix-process-exit-lifecycle/specs/cli/spec.md
@@ -1,0 +1,56 @@
+# cli spec delta
+
+## ADDED Requirements
+
+### Requirement: StdioServerLifetimeIsBoundToStdin
+
+The MCP stdio server's lifetime SHALL be its stdin. On stdin `end` or `close` the server SHALL run
+its shutdown path — stopping the file watcher, closing the graph store, clearing timers — and exit,
+regardless of which tool calls preceded it. Shutdown SHALL be idempotent and SHALL be the same path
+used by `SIGINT` and `SIGTERM`, so no signal implements a partial teardown of its own. No resource
+acquired during tool dispatch SHALL, by itself, keep the process alive after its transport closes.
+
+#### Scenario: EOF ends the server after a watcher-starting tool call
+
+- **GIVEN** an MCP stdio server that has served an `orient` call and started its file watcher
+- **WHEN** the client closes stdin
+- **THEN** the server stops the watcher, releases the graph store, and the process exits within a
+  bounded shutdown window
+
+#### Scenario: EOF ends the server before any tool call
+
+- **GIVEN** an MCP stdio server that has completed `initialize` and served no tools
+- **WHEN** the client closes stdin
+- **THEN** the process exits — the behavior is the same whether or not a watcher was ever started
+
+#### Scenario: An agent session leaves no zombie
+
+- **GIVEN** a client that spawns the stdio server, issues several tool calls, and exits
+- **WHEN** the client's process ends and its pipe closes
+- **THEN** no OpenLore server process for that repository remains running
+
+#### Scenario: Signals and EOF converge on one teardown
+
+- **GIVEN** a running stdio server with a watcher and an open graph store
+- **WHEN** it is shut down by stdin EOF, by `SIGINT`, or by `SIGTERM`
+- **THEN** the same teardown runs in each case and running it twice is harmless
+
+### Requirement: AFailedCommandExitsWithoutWaitingOutItsTimeout
+
+A command that has reported a fatal error SHALL release its in-flight resources and exit promptly.
+It SHALL NOT remain alive until an unrelated request timeout expires. The delay between the error
+being reported and the process exiting SHALL be bounded and unrelated to the configured request
+timeout.
+
+#### Scenario: Generate exits after an unreachable provider
+
+- **GIVEN** `openlore generate` configured with a request timeout of 120 seconds and a provider it
+  cannot reach
+- **WHEN** it reports `Failed to connect to LLM API`
+- **THEN** the process exits non-zero promptly after that message rather than at the 120-second mark
+
+#### Scenario: The exit delay does not track the timeout setting
+
+- **GIVEN** the same failure
+- **WHEN** the command is run with a larger configured request timeout
+- **THEN** the time from the error message to process exit is unchanged

--- a/openspec/changes/fix-process-exit-lifecycle/tasks.md
+++ b/openspec/changes/fix-process-exit-lifecycle/tasks.md
@@ -1,0 +1,35 @@
+# Tasks — bind process lifetime to transport lifetime
+
+## Reproducers (write these first — assert the OBSERVABLE property)
+- [ ] Stdio EOF test: spawn the real `mcp` server, complete `initialize`, issue an `orient` (so the
+      watcher starts), close stdin, assert the process exits within a bounded window. Today it is
+      still running at 120 s.
+- [ ] Stdio EOF before any tool call: same assertion, no `orient` — proves the fix is not
+      watcher-specific
+- [ ] `generate` post-failure exit: with an unreachable provider, assert the interval between the
+      error line and process exit is bounded AND does not change when `--timeout` is raised
+      (the two-run comparison is what distinguishes an unclosed handle from a slow retry)
+- [ ] Assert on process exit, never on internal state: the failure mode is that internal state looks
+      correct while the process refuses to die
+
+## Implementation
+- [ ] One idempotent `shutdown()` per long-lived surface; wire stdin `end`/`close` to it alongside
+      the existing `SIGINT`/`SIGTERM` handlers
+- [ ] Stdio server shutdown stops the watcher, closes the edge store, clears timers
+- [ ] `unref` watcher/timer handles that must not outlive their transport, so a missed teardown is an
+      early exit rather than a hang
+- [ ] `generate` (and siblings with the same shape): tear down in-flight LLM resources on the fatal
+      error path instead of waiting out the request timeout
+- [ ] Audit the other long-lived surfaces (`serve`, `view`, the watcher itself) for the same shape and
+      route each through its single teardown path
+
+## Verification
+- [ ] Every reproducer fails on `origin/main` and passes after the change
+- [ ] No zombie after a scripted agent session: spawn, call, exit, then assert no server process for
+      that repository remains
+- [ ] `serve --stop`, `view` shutdown, and MCP EOF all still remove their descriptors
+
+## Notes
+- [ ] `serve`'s existing idle-timeout reaper stays as defence in depth: it covers a client that dies
+      without closing the pipe, which EOF cannot.
+- [ ] Nothing borrowed from another tool — this is ordinary Node transport-lifetime hygiene.


### PR DESCRIPTION
## Status

LGTM to merge as a spec-only change — no code, no behavior change. It proposes three changes; each is independently implementable and independently reviewable.

## What was missing / the motivation

An adversarial end-to-end pass over the built CLI (a 622-file hostile repository, an ordinary Express+Prisma+React/Vue+Django+Java+IaC app, and both local HTTP surfaces) surfaced a set of runtime failures. The security-relevant ones are fixed in #292. **These are the ones that are not regressions from that work** — each was reproduced against an `origin/main` build before being written up, so putting them in #292 would have mixed unrelated fixes into an already-large security PR.

| Change | The defect, in one line |
|---|---|
| `fix-analyze-native-abort-and-file-cost-budget` | `analyze` dies with a native `Napi::Error` abort (exit 134) and one line of C++ noise; separately, one file can cost 661 s with no budget |
| `fix-process-exit-lifecycle` | The MCP stdio server never exits on stdin EOF once the watcher starts — a zombie per agent session; `generate` hangs 120 s after failing in 0.4 s |
| `fix-config-validation-completeness` | `{}` as a config crashes `analyze` with a raw `TypeError`, while `doctor` reports `✓ all keys known and well-typed` for that same file |

## What it does

Three change directories in the repo's OpenSpec format — `proposal.md`, spec deltas under `specs/<domain>/`, and `tasks.md`.

Each proposal leads with **measured evidence**, not a description. The abort proposal carries the four-way isolation table (file alone → 661 s exit 0; 600 files alone → 14 s exit 0; both → abort at 163 s) that localises the fault to the extraction pool. The lifecycle proposal shows the two-run `--timeout` comparison that distinguishes an unclosed handle from a slow retry. The config proposal shows the two commands' contradictory verdicts on the same file.

Three deliberate choices in how these are written:

- **Tasks lead with the reproducer**, because the reproducer *is* the acceptance criterion. Each set requires the test to fail on `origin/main` and pass after — a fix that cannot be demonstrated to fix something is not done.
- **Every task list carries an explicit control.** A per-file budget that silently drops real files, or a validator that starts flagging healthy configs, would be a worse bug than the one being fixed. That trap is exactly what the recall regressions in #292's review round found, so it is written into the plan rather than left to reviewer vigilance.
- **Scope limits are stated, not implied.** The abort change explicitly does *not* try to make the 661 s parse fast — that cost lives in the grammar/extractor layer and needs its own investigation. This change makes it bounded, attributable and disclosed, which is what makes the follow-up measurable.

The architecture delta in `fix-process-exit-lifecycle` generalises rather than patches: `serve` already grew an idle-timeout reaper because orphaned daemons accumulated, and the stdio server exhibits the same accumulation through a different door. The requirement is on the shape, so a future surface inherits it.

## Proof it works

Spec-only, so the checks that apply are the corpus ones:

- `openspec validate` passes on all three changes.
- No requirement name collides with the existing corpus (checked against every `Requirement:` in `openspec/specs/`).
- No placeholder-template scenarios (the `spec-corpus-lint` vacuity markers appear zero times).
- `spec-corpus-lint`, `honesty-contract`, and `doc-claim-sync` suites pass (79 tests).

## Notes / nits

- **Not included here:** the recall gaps the same pass found — Vue props, Prisma timestamp-named fields, `/static/*` middleware, Express router routes producing no graph nodes. Those are inference-quality questions rather than failure modes, and each needs its own investigation into whether the current behavior is intended.
- `openspec/` is gitignored in this repo, so these were added with `git add -f` — consistent with how the existing change directories are tracked.
- These are **proposals**: no `tasks.md` box is checked, and nothing here claims to be implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
