### PR TITLE
fix(analyzer): bound per-file parse cost and stop analyze dying of a native abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,18 @@ Dependency and workflow scanning now run automatically in CI.
 - Windows paths with backslashes no longer split incorrectly.
 - Four places where a tool reported `0` for something it had never actually computed.
 
+### Known issues
+
+Two defects an end-to-end pass found are **not** fixed here. Both are tracked and queued for the
+next release; neither is a regression from this one.
+
+- **The MCP stdio server doesn't exit when its client closes stdin**, once a call has started the
+  file watcher. Every agent session leaves a process holding a watcher and its caches. Workaround:
+  kill stray `openlore mcp` processes, or use `openlore serve`, which reaps itself when idle.
+- **A config missing its `analysis` section crashes `analyze`** with an internal `TypeError`, and
+  `doctor` reports that same config as healthy. If you hand-edit `.openlore/config.json`, keep the
+  `analysis` block — or re-run `openlore init`.
+
 ---
 
 **Upgrade:** `npm i -g openlore@2.1.7` — or `openlore update`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to OpenLore are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [2.1.7] - 2026-07-26
+
+**The release where `analyze` stopped dying and started explaining itself.**
+
+Three things this time: analysis got faster, it got harder to crash, and — the theme —
+it got much better at admitting what it *didn't* do. Everything is additive and
+backward-compatible. If OpenLore has been working for you, upgrade and it keeps working.
+
+### `openlore analyze` no longer dies on a hostile file
+
+One 300 KB file could kill the whole run with a single line of C++ and exit code 134:
+
+```
+libc++abi: terminating due to uncaught exception of type Napi::Error
+```
+
+No stack, no error line, no artifacts, no clue which file did it. Delightful.
+
+The culprit was a file that parsed into a tree **100,002 nodes deep**, which overflowed
+the stack inside a native call — where a JavaScript `try`/`catch` can't reach. Two fixes:
+the tree walk no longer uses the call stack, and every parse is now bounded by a per-file
+budget (20 s, generous on purpose; the slowest real file in this repo is under a second).
+A file that blows the budget is set aside and *reported*, not waited on.
+
+Same repository, before and after: **exit 134 → exit 0**, and **217 s → 52 s**.
+
+If you'd rather wait than be told, `OPENLORE_PARSE_BUDGET_MS=0` turns the bound off
+entirely and restores the old behavior exactly.
+
+### Fewer files skipped in silence
+
+"Files skipped: 3" told you nothing and worried you slightly. Now it says *why*
+(`pattern 2, gitignore 1`), and any file the analyzer set aside is recorded with a
+machine-readable reason that `analyze`, `doctor`, and the MCP tools all read from the
+same place — so they can't tell you three different stories about one repository.
+
+While a run is going, a file that's taking unusually long gets named on stderr, so
+"why is this slow" has an answer that isn't "attach a debugger."
+
+### Analysis got quicker
+
+- **Pass-1 extraction runs on a worker pool** — call-graph build 19.1 s → 7.3 s on this
+  repo; full `analyze --no-embed` 24.6 s → 18.1 s. Byte-identical output.
+- **Unchanged files aren't re-parsed.** A content-hash memo takes `--force` 45–54 s down
+  to 36–39 s on a re-run.
+- **Reachability is precomputed at analyze time**, so the tools that traverse it just look
+  things up: coverage-gaps 346 ms → 6.4 ms (54×), test selection 575 ms → 117 ms (4.9×),
+  measured at 50k nodes / 200k edges.
+
+### Security: analyzing a repo you don't trust
+
+OpenLore reads whatever you point it at, which means a repository can try things. Ten
+findings closed against that threat model, plus a separate fix for terminal control
+sequences. Highlights:
+
+- A cloned repo's `.openlore/config.json` could redirect the LLM endpoint and switch off
+  certificate verification — collecting your `ANTHROPIC_API_KEY` on your next `generate`,
+  `drift`, or commit. Repo-supplied values are now ignored unless they point at loopback;
+  your own `--api-base` / env vars still work, because those come from you.
+- A filename could carry raw terminal escapes into OpenLore's output. A forged
+  `[ok] all checks passed` is an attack, not a cosmetic glitch.
+- Two regexes could be made to hang on crafted input.
+
+Dependency and workflow scanning now run automatically in CI.
+
+### Also
+
+- Windows paths with backslashes no longer split incorrectly.
+- Four places where a tool reported `0` for something it had never actually computed.
+
+---
+
+**Upgrade:** `npm i -g openlore@2.1.7` — or `openlore update`.
+
+
 ## [2.1.6] - 2026-07-19
 
 **The boring release. We mean that as the highest compliment.**

--- a/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/proposal.md
+++ b/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/proposal.md
@@ -1,6 +1,6 @@
 # Analyze must not die of a native abort, and no single file may cost unbounded time
 
-> Status: PROPOSED (2026-07-26). Found by an adversarial end-to-end pass against a 622-file hostile
+> Status: **BUILT** (2026-07-26). Found by an adversarial end-to-end pass against a 622-file hostile
 > repository, then isolated to a 601-file minimal reproducer and **verified against an `origin/main`
 > build** — both failures predate the security-hardening work in PR #292 and are not regressions
 > from it. Deterministic, no LLM, no new dependency.
@@ -35,13 +35,17 @@ tool whose contract is that a quiet result means "nothing there" rather than "we
 | The 600 files without it | exit 0, 14 s |
 | The full hostile repo minus that file | exit 0, 424 s |
 
-So it requires the parallel extraction pool (`extraction-pool.ts`, change
-`add-parallel-extraction-pool`) to be engaged: a worker raises a `Napi::Error` that no boundary
-catches, and the process aborts rather than the pool degrading that one file.
+**Root cause, isolated during the build (this replaces the guess above).** The payload parses into a
+right-leaning chain **100,002 nodes deep**, and `tallyParseHealth` — which runs precisely on trees
+that carry errors — walked it recursively. It exhausts the stack, and the `RangeError` is raised
+while executing inside `unmarshalNode` / `new SyntaxNode`, i.e. inside the native binding. A throw
+raised in a native frame is not catchable as a JavaScript error; it becomes the C++ exception that
+`libc++abi` aborts on. The extraction pool is implicated only because a worker's stack is where it
+lands first — the same overflow is reachable on the main thread.
 
-The pool already has the right instinct elsewhere — its own guard comments describe never trusting
-"an unproven silence OR error" — but a native exception thrown across the worker boundary bypasses
-the JavaScript `try`/`catch` that would otherwise contain it.
+That makes the fix structural rather than probabilistic: the walk is iterative (depth stops being a
+correctness cliff), and the parse is bounded in-band so a 100,000-deep tree is never built in the
+first place.
 
 ### 2. One file can consume unbounded wall-clock, with no budget and no progress
 

--- a/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/specs/analyzer/spec.md
+++ b/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/specs/analyzer/spec.md
@@ -6,19 +6,35 @@
 
 A fault raised inside a parallel extraction worker — including one that crosses the worker boundary
 as a native exception, an `uncaughtException`, an unhandled rejection, or a non-zero worker exit —
-SHALL be converted into a structured per-file extraction failure and SHALL NOT terminate the
-analyzer process abnormally. The build SHALL continue over the remaining files, recording the
-faulting file as failed with its path and the fault's message. When the pool cannot continue at all,
+SHALL be converted into a structured per-file signal and SHALL NOT terminate the analyzer process
+abnormally. The build SHALL continue over the remaining files. When the pool cannot continue at all,
 the analyzer SHALL surface a JavaScript-level error identifying the file and a remedy, and exit with
 a non-zero status through the normal error path — never through `abort()`.
 
+A worker fault SHALL degrade the extraction LANE, not the file: the file SHALL be re-extracted on
+the main thread — the reference implementation — and the fault disclosed on the lane, rather than
+the file being recorded as failed. A fault is evidence about the thread, not about the source it was
+reading, and recording it against the file would silently shrink the graph by exactly one file.
+
+No traversal of a parsed tree SHALL be bounded by the call stack. Tree depth is not bounded by
+anything the analyzer controls, and error recovery — the condition under which the parse-health
+walk runs — is precisely what produces the deepest trees. A stack overflow raised while executing
+inside a native binding's node accessor is not catchable as a JavaScript error and terminates the
+process.
+
+#### Scenario: A deep tree is traversed without exhausting the stack
+
+- **GIVEN** a parsed tree far deeper than the available call stack
+- **WHEN** parse health is tallied over it
+- **THEN** the tally completes and reports the error regions it found
+
 #### Scenario: A native worker fault degrades one file instead of killing the run
 
-- **GIVEN** a repository containing one file whose extraction raises a `Napi::Error` inside a worker,
-  plus 600 files that extract cleanly
+- **GIVEN** a repository containing one file whose extraction faults inside a worker, plus 600 files
+  that extract cleanly
 - **WHEN** `openlore analyze` runs with the parallel extraction pool engaged
-- **THEN** the process exits 0, artifacts are written for the 600 clean files, and the faulting file
-  is recorded as a failed extraction naming the file and the fault
+- **THEN** the process exits 0, artifacts are written for all 601 files, and the fault is disclosed
+  on the extraction lane — the faulted file having been re-extracted on the main thread
 
 #### Scenario: A fatal pool failure is reported, not aborted
 
@@ -37,18 +53,42 @@ a non-zero status through the normal error path — never through `abort()`.
 ### Requirement: PerFileExtractionCostIsBounded
 
 Extraction of a single file SHALL be bounded by a wall-clock budget expressed as a named constant.
-A file exceeding the budget SHALL be abandoned, recorded with reason `budget-exceeded` and its
-elapsed time, and SHALL NOT block completion of the run. The default budget SHALL be generous enough
-that ordinary source files — including large generated and vendored files — are never affected, and
-SHALL be operator-overridable. Abandoning a file SHALL be reported, never silent: a bounded result is
-a lower bound and must read as one.
+The bound SHALL be enforced IN-BAND, inside the parse itself, rather than by an external timer or by
+terminating the thread holding the parse: a tree-sitter parse is one synchronous native call, so a
+timer cannot preempt it and terminating mid-parse is what converts a slow file into a process-level
+abort. A binding that cannot accept the deadline SHALL parse unbounded, as before, and SHALL NOT
+fail the file.
+
+A file exceeding the budget SHALL be abandoned, recorded with reason `budget-exceeded` and the
+budget it exceeded, and SHALL NOT block completion of the run. Abandoning a file SHALL cost that
+file's budget ONCE for the whole build: a later pass that would re-read the same content SHALL skip
+it rather than spend the budget again. The default budget SHALL be generous enough that ordinary
+source files — including large generated and vendored files — are never affected, and SHALL be
+operator-overridable, including a value that disables the bound entirely. Abandoning a file SHALL be
+reported, never silent: a bounded result is a lower bound and must read as one.
+
+Abandoning a parse SHALL leave the parser fit to parse the next file. A suspended parse that is
+resumed by the next file's parse would silently corrupt every subsequent file in that language,
+which is a worse failure than the unbounded parse this bound replaces.
 
 #### Scenario: A pathological file is abandoned rather than stalling the run
 
 - **GIVEN** a 300 KB file of a repeated unterminated block-comment opener, alongside ordinary sources
 - **WHEN** `openlore analyze` runs
-- **THEN** the run completes, that file is recorded as `budget-exceeded` with its elapsed time, and
-  the remaining files are analyzed normally
+- **THEN** the run completes, that file is recorded as `budget-exceeded` with the budget it
+  exceeded, and the remaining files are analyzed normally
+
+#### Scenario: The file after an abandoned one is unaffected
+
+- **GIVEN** an abandoned file followed by an ordinary file in the same language
+- **WHEN** extraction continues
+- **THEN** the ordinary file yields its symbols in full and carries no parse-health record
+
+#### Scenario: The record is the same on every run
+
+- **GIVEN** a repository containing a file that exceeds the budget
+- **WHEN** it is analyzed twice from the same repository state
+- **THEN** the persisted parse-health record is byte-identical across the two runs
 
 #### Scenario: Ordinary large files are unaffected
 
@@ -66,11 +106,18 @@ a lower bound and must read as one.
 
 ### Requirement: EveryExcludedFileIsRecordedWithAReason
 
-Every file the analyzer declines to include SHALL be recorded with a machine-readable reason — size
-cap, encoding, parse failure, worker fault, or budget exceeded — in the parse-health record. A bare
-count of skipped files with no reasons SHALL NOT be the only report. Any surface that reports on
-extraction health SHALL read that single record, so two surfaces cannot give contradictory answers
-about the same repository.
+Every file the analyzer declines to include SHALL be recorded with a machine-readable reason — parse
+failure, budget exceeded, or size cap — in the parse-health record, and every producer of that
+record (the full build and the incremental watcher alike) SHALL use the same vocabulary. The reason
+set SHALL name only causes that can actually occur: a cause with no code path SHALL NOT be listed.
+
+A bare count of skipped files with no reasons SHALL NOT be the only report. Any surface that reports
+on extraction health SHALL read that single record, so two surfaces cannot give contradictory
+answers about the same repository. Where the analyzer excludes files BEFORE extraction — the
+directory/pattern walk — the count SHALL likewise be reported by reason rather than bare.
+
+The record SHALL be deterministic: it is persisted, and re-analyzing an unchanged repository must
+reproduce it byte-for-byte, so a measured duration SHALL NOT be stored in it.
 
 #### Scenario: The skip summary names reasons
 

--- a/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/specs/cli/spec.md
+++ b/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/specs/cli/spec.md
@@ -35,8 +35,12 @@ waiting on a slow run SHALL be able to identify the responsible file without att
 - **WHEN** `openlore analyze` runs in a terminal
 - **THEN** the progress output names that file before the run completes
 
-#### Scenario: Machine-output modes stay clean
+#### Scenario: Protocol stdout stays clean
 
-- **GIVEN** the same repository
-- **WHEN** `openlore analyze --json` runs with stdout captured
-- **THEN** the progress disclosure is written to stderr and stdout remains valid JSON
+- **GIVEN** the same repository, analyzed by a host whose stdout carries a protocol rather than
+  human output — the stdio MCP server, which runs the same build
+- **WHEN** extraction of one file passes the disclosure threshold
+- **THEN** the disclosure is written to stderr and no protocol frame on stdout is disturbed
+
+> Note: `analyze` has no `--json` mode; the proposal named one. The real machine-output surface for
+> this code path is the stdio MCP server, and the requirement is stated against it.

--- a/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/tasks.md
+++ b/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/tasks.md
@@ -1,7 +1,10 @@
 # Tasks — contain worker faults, bound per-file cost, disclose every skip
 
 > Status: **BUILT** (2026-07-26). Measured on the 601-file reproducer: **exit 134 → exit 0**, and
-> **217 s → 44 s**. Full suite (6,458 tests), lint, typecheck and build pass.
+> **217 s → 52 s**. Full suite (6,480 tests), lint, typecheck and build pass.
+>
+> Hardened after four independent adversarial reviews found eight confirmed defects in the first
+> revision — see "Defects adversarial review found" below. Every fix is mutation-checked.
 
 ## Reproducers (written first — they are the acceptance criteria)
 - [x] Minimal abort reproducer: one 300 KB file of repeated `/*x` plus ~600 trivial `.ts` files.
@@ -53,6 +56,39 @@
       stays the separate `encodingFallback` signal it has always been
 - [x] **`analyze --json` does not exist**; the CLI requirement is stated against the real
       machine-output surface for this code path, the stdio MCP server
+
+## Defects adversarial review found in the FIRST revision (each now has a mutation-checked test)
+- [x] **The cost optimization silently deleted call edges in healthy files.** Dropping
+      budget-exceeded files from `buildResolvedImportMap` removed re-export information belonging
+      to files that parsed cleanly — `parseJSExports` is a REGEX scan and reads an abandoned file
+      perfectly well. Reproduced by two reviewers independently. The filter no longer applies to
+      that pass; it stays only on the passes that genuinely re-parse (where the file would
+      contribute the same nothing anyway). Correctness over the seconds it saved
+- [x] **The budget was charged twice on the pooled lane.** A budget overrun for a language the
+      worker had not yet proven fell through to the main-thread recheck, spending a second full
+      bound. A budget overrun is a property of the FILE, so it is trusted
+- [x] **A faulting worker stole a file from a healthy sibling.** The fault path used `continue`;
+      the worker's boundary closes its channel immediately after answering, so every later request
+      to it was a silent no-op. Now `break`, matching every other worker-death path. The stub lane
+      was also unfaithful here (it kept answering after "faulting") and now models the close
+- [x] **`slowFiles` double-counted** a file timed on both lanes, evicting genuinely distinct slow
+      files from the cap. Deduped, worst time kept
+- [x] **The WASM demotion never fired.** `deadlineUnsupported` was keyed on the parser INSTANCE,
+      and the WASM lane builds a fresh parser per file — so the throw was re-paid on every file,
+      exactly what the comment claimed it avoided. Keyed on the constructor now (not the prototype:
+      every object literal shares `Object.prototype`, which would demote unrelated parsers)
+- [x] **A budget overrun in a LATER pass was swallowed with no record.** A file that squeaks under
+      the bound in Pass 1 and overruns in the class-relationships pass now carries an exclusion
+- [x] **The watcher erased a `size-cap` exclusion**, so `doctor` reverted to a clean bill of health
+      after a touch. It applies the same bound instead of assuming the file became healthy
+- [x] **Excluded files were counted as "parsed with errors"** — a never-parsed file, with a remedy
+      pointing at tree-sitter grammars. Counted and worded separately now
+- [x] **Nine surviving mutations closed**, including: `reparsableFiles` was entirely untested; the
+      `sanitizeForTerminal` call on the stderr path was untested (this repo has a terminal-escape
+      history); the "worker faults, graph stays whole" test induced no fault and was a weaker
+      duplicate; the source-order test covered only the branch production never takes; the
+      analyze/doctor agreement tests were source greps that passed with both surfaces rendering
+      nothing; and the `size-cap` producer had no test at all
 
 ## Defects this change's own controls caught (each has a regression test)
 - [x] A timed-out tree-sitter parse is SUSPENDED, not discarded — the next file resumed it and

--- a/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/tasks.md
+++ b/openspec/changes/fix-analyze-native-abort-and-file-cost-budget/tasks.md
@@ -1,43 +1,73 @@
 # Tasks — contain worker faults, bound per-file cost, disclose every skip
 
-## Reproducers (write these first — they are the acceptance criteria)
-- [ ] Minimal abort reproducer as an integration fixture: one 300 KB file of repeated `/*x` plus
-      ~600 trivial `.ts` files; asserts exit 0 and artifacts present (today: exit 134,
-      `libc++abi: terminating due to uncaught exception of type Napi::Error`)
-- [ ] Budget reproducer: the same 300 KB file alone; asserts the run completes and the file is
-      recorded `budget-exceeded` (today: ~661 s, exit 0, no record)
-- [ ] Control: a large-but-ordinary generated file must NOT be recorded as `budget-exceeded`, and the
-      graph must match a run with the budget disabled — a bound that silently drops real files is the
-      failure mode this change is supposed to prevent
+> Status: **BUILT** (2026-07-26). Measured on the 601-file reproducer: **exit 134 → exit 0**, and
+> **217 s → 44 s**. Full suite (6,458 tests), lint, typecheck and build pass.
+
+## Reproducers (written first — they are the acceptance criteria)
+- [x] Minimal abort reproducer: one 300 KB file of repeated `/*x` plus ~600 trivial `.ts` files.
+      Isolated the cause exactly — the payload parses for **84 s** and yields a **100,002-deep**
+      tree, and the recursive parse-health walk overflowed on it. A `RangeError` raised inside the
+      native binding's node accessor is not catchable as a JS throw, which is how it surfaced as
+      `libc++abi: terminating due to uncaught exception of type Napi::Error`, exit 134
+- [x] Budget reproducer: the same file is abandoned at the budget and recorded `budget-exceeded`
+- [x] Control: an ordinary 1.4 MB generated file is NOT recorded, and its graph is byte-identical to
+      a run with the budget disabled. Differential over the whole 706-file repository: byte-identical
 
 ## Implementation
-- [ ] Extraction pool: install per-worker boundaries for the faults a plain `try`/`catch` cannot see
-      (`uncaughtException`, `unhandledRejection`, worker `error`, non-zero `exit`) and map each to a
-      structured per-file extraction failure
-- [ ] Extraction pool: a fault degrades ONE file and the run continues; a pool that cannot continue
-      surfaces a JS-level error through the CLI error path (never `abort()`)
-- [ ] Per-file wall-clock budget as a named constant, operator-overridable; abandon + record
-      `budget-exceeded` with elapsed time
-- [ ] Extend the parse-health record with the new reasons (`worker-fault`, `budget-exceeded`,
-      `size-cap`, `encoding`) so every exclusion has a machine-readable cause
-- [ ] `analyze` summary: replace the bare `Files skipped: N` with a per-reason breakdown
-- [ ] `doctor` extraction-health check reads the same record — no independent judgment, so the two
-      surfaces cannot contradict each other
-- [ ] Progress output names a file whose extraction exceeds a disclosure threshold; to stderr, so
-      `--json` stdout stays clean
-- [ ] Conclusion tools: a result touching a `budget-exceeded` or `worker-fault` file carries the
-      existing parse-health boundary disclosure (reuse `parse-health-boundary.ts`; no new mechanism)
+- [x] `parse-budget.ts`: the bound, in-band via tree-sitter's own deadline — the only bound that can
+      interrupt a synchronous native parse. `PER_FILE_PARSE_BUDGET_MS` (20 s), overridable with
+      `OPENLORE_PARSE_BUDGET_MS`; `0` restores the previous behaviour exactly
+- [x] Applied at **every** tree-sitter parse site: 9 per-language extractors, the generic native and
+      WASM grammar handles, 23 synthesis-pass re-parses, plus the three serve-time parses
+      (chunker, exception flow, error propagation) that would otherwise wedge the daemon
+- [x] The parse-health walk is iterative — depth stops being a correctness cliff, which is what
+      removes the abort's cause rather than racing it
+- [x] Extraction pool + worker: `uncaughtException` / `unhandledRejection` boundaries inside the
+      worker, attributed to the in-flight file; non-zero worker exit named in the failure
+- [x] A worker fault routes the file to the main thread regardless of proven language
+- [x] Parse-health record carries a machine-readable `exclusion` and a per-reason rollup
+- [x] `analyze` reports skipped files by reason, and excluded files with their cause
+- [x] `doctor` reads the same record through the same helper — the two cannot disagree
+- [x] Slow-file attribution: live on the pooled lane (to **stderr**, because `logger`'s non-error
+      levels go to stdout and the same build runs inside the stdio MCP server), and named on the
+      lane disclosure for both lanes
+- [x] Conclusion tools disclose an excluded file through the existing parse-health boundary
 
 ## Verification
-- [ ] Both reproducers fail on `origin/main` and pass after the change (the abort is verified
-      pre-existing — the fix must be demonstrated, not assumed)
-- [ ] `analyze` output on a clean repository is byte-identical to before (no new noise, no new
-      artifact when nothing was excluded)
-- [ ] Differential: analysis artifacts unchanged on a real repository, with timestamps normalized
+- [x] Both reproducers fail on `origin/main` and pass after the change
+- [x] Real repository unchanged: 997 files, 3,148 functions, 18,022 edges, 18.6 s, no new output
+- [x] Differential: serialized call graph byte-identical with the budget on vs. off
+- [x] `parse-health.json` byte-identical across two runs of the reproducer repository
+
+## Deviations from the proposal (measured, not assumed)
+- [x] **`worker-fault` is not a file-level exclusion reason.** The proposal listed one. A worker
+      fault no longer excludes a file at all: the pool hands it to the main thread, so the facts
+      stay whole and the fault is disclosed on the lane. Recording it against the file would blame
+      the source for a defect in the thread reading it
+- [x] **The record stores the budget, not the measured elapsed time.** `parse-health.json` is
+      persisted and must be byte-identical across re-analyses (change:
+      fix-artifact-output-determinism); a wall-clock number would break that on every repository
+      with such a file. Nothing is lost — a file is only recorded because it ran past the bound.
+      The measured time still reaches the operator live, on the (unpersisted) lane disclosure
+- [x] **`encoding` is not an exclusion either** — a lossy decode does not exclude a file, so it
+      stays the separate `encodingFallback` signal it has always been
+- [x] **`analyze --json` does not exist**; the CLI requirement is stated against the real
+      machine-output surface for this code path, the stdio MCP server
+
+## Defects this change's own controls caught (each has a regression test)
+- [x] A timed-out tree-sitter parse is SUSPENDED, not discarded — the next file resumed it and
+      silently produced zero symbols. The parser is now reset at the deadline
+- [x] `web-tree-sitter@0.25` exposes `setTimeoutMicros` and throws from inside it, which failed
+      every Dart and Lua file. Arming is now fail-soft and the refusal is remembered per parser
+- [x] The budget was being spent once per PASS, not once per file (92 s for one 20 s bound).
+      Abandoned files are dropped from the later re-reading passes
+- [x] A boundary rendered `undefined` for an exclusion reason written by a newer build
 
 ## Deliberately NOT in this change
-- [ ] Making the 661 s parse fast. That cost is in the grammar/extractor layer and needs its own
+- [x] Making the 84 s parse fast. That cost is in the grammar/extractor layer and needs its own
       investigation; this change makes it bounded, attributable and disclosed. The budget record is
-      what makes the follow-up measurable.
-- [ ] Nothing borrowed from another tool: the worker-boundary and per-file-budget shapes are ordinary
-      Node worker hygiene, not a competitor's design.
+      what makes the follow-up measurable
+- [x] Memoizing an abandoned file. The Pass-1 memo deliberately never caches a throw, so such a
+      file re-pays its budget each run — disclosed by the existing "will re-extract each run" note
+- [x] Nothing borrowed from another tool: the worker-boundary and per-file-budget shapes are
+      ordinary Node worker hygiene, not a competitor's design

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Persistent architectural memory and structural cognition for AI coding agents.",
   "type": "module",
   "main": "dist/api/index.js",

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -51,6 +51,7 @@ import { buildRouteInventory } from '../../core/analyzer/http-route-parser.js';
 import { extractMiddleware } from '../../core/analyzer/middleware-extractor.js';
 import { extractEnvVars } from '../../core/analyzer/env-extractor.js';
 import { generateAiConfigs, AI_TOOL_TARGETS, type AiTool, type AiConfigResult } from '../../core/analyzer/ai-config-generator.js';
+import { describeExclusions, EXCLUSION_REASON_LABEL } from '../../core/analyzer/parse-health.js';
 
 // ============================================================================
 // TYPES
@@ -163,7 +164,20 @@ export async function runAnalysis(
 
   logger.info('Files found', repoMap.summary.totalFiles);
   logger.info('Files analyzed', repoMap.summary.analyzedFiles);
-  logger.info('Files skipped', repoMap.summary.skippedFiles);
+  // A bare "Files skipped: 3" reads like a parse problem and is not actionable. The walker has
+  // always known WHY each file was skipped; report that instead (change:
+  // fix-analyze-native-abort-and-file-cost-budget). Reasons are ordered by count then name so the
+  // line is deterministic for a fixed repository state.
+  const skipReasons = Object.entries(repoMap.summary.skippedReasons ?? {})
+    .filter(([, n]) => n > 0)
+    .sort(([an, a], [bn, b]) => b - a || (an < bn ? -1 : 1))
+    .map(([reason, n]) => `${reason} ${n}`);
+  logger.info(
+    'Files skipped',
+    skipReasons.length > 0
+      ? `${repoMap.summary.skippedFiles} (${skipReasons.join(', ')})`
+      : repoMap.summary.skippedFiles,
+  );
   logger.blank();
 
   // Phase 2: Dependency Graph
@@ -226,6 +240,20 @@ export async function runAnalysis(
   // Present only when something actually degraded; a clean run says nothing.
   if (artifacts.extractionLaneNote) {
     logger.warning(artifacts.extractionLaneNote);
+  }
+
+  // Disclose files EXCLUDED from extraction, with their cause (change:
+  // fix-analyze-native-abort-and-file-cost-budget). Read from the same parse-health record
+  // `doctor` reads, so the two surfaces cannot give this repository different answers. Silent
+  // when nothing was excluded.
+  const excludedNote = describeExclusions(artifacts.parseHealth);
+  if (excludedNote) {
+    const worst = (artifacts.parseHealth?.files ?? []).filter(f => f.exclusion).slice(0, 3);
+    logger.warning(
+      `${excludedNote} — symbols and edges from these files are a LOWER BOUND: `
+      + worst.map(f => `${f.filePath} (${EXCLUSION_REASON_LABEL[f.exclusion!] ?? f.exclusion}`
+        + `${f.budgetMs !== undefined ? ` of ${(f.budgetMs / 1000).toFixed(1)}s` : ''})`).join('; '),
+    );
   }
 
   // Disclose the Pass-1 memo lane (change: optimize-hash-keyed-analyze). Unlike the lane

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -39,6 +39,7 @@ import {
   DEFAULT_COPILOT_MODEL,
 } from '../../constants.js';
 import { resolveTrustedSslVerify, rejectRepoConfiguredTlsOptOut, discloseRepoConfiguredEndpoint } from '../../core/services/repo-config-trust.js';
+import { describeExclusions, type ParseHealthReport } from '../../core/analyzer/parse-health.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -264,16 +265,19 @@ async function checkGraphStore(rootPath: string): Promise<CheckResult> {
  * errors (grammar drift, syntax errors, lossy encoding) so a degraded index isn't mistaken for a
  * genuinely small one. Absent artifact → clean (ok). A spike after a `tree-sitter-*` bump is the
  * signal this check exists to catch.
+ *
+ * Exclusions are read from the SAME record `analyze` reports from (change:
+ * fix-analyze-native-abort-and-file-cost-budget), and via the same `describeExclusions` helper, so
+ * this check cannot bless a repository whose analysis excluded files — the contradiction the
+ * `EveryExcludedFileIsRecordedWithAReason` requirement exists to prevent.
  */
 async function checkParseHealth(rootPath: string): Promise<CheckResult> {
   const path = join(rootPath, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_PARSE_HEALTH);
   try {
-    const report = JSON.parse(await readFile(path, 'utf-8')) as {
-      totalDegradedFiles?: number;
-      byLanguage?: Array<{ language: string; degradedFiles: number }>;
-    };
+    const report = JSON.parse(await readFile(path, 'utf-8')) as ParseHealthReport;
     const n = report.totalDegradedFiles ?? 0;
-    if (n === 0) return { name: 'Parse health', status: 'ok', detail: 'no files parsed with errors' };
+    const excluded = describeExclusions(report);
+    if (n === 0 && !excluded) return { name: 'Parse health', status: 'ok', detail: 'no files parsed with errors' };
     const langs = (report.byLanguage ?? [])
       .slice(0, 3)
       .map(l => `${l.language} (${l.degradedFiles})`)
@@ -281,7 +285,8 @@ async function checkParseHealth(rootPath: string): Promise<CheckResult> {
     return {
       name: 'Parse health',
       status: 'warn',
-      detail: `${n} file(s) parsed with errors — symbols/edges there are a lower bound: ${langs}`,
+      detail: `${n} file(s) parsed with errors — symbols/edges there are a lower bound: ${langs}`
+        + (excluded ? `; ${excluded}` : ''),
       fix: "Inspect via get_language_support; if this spiked after a grammar bump, revert or re-pin the tree-sitter-* dep",
     };
   } catch {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -39,7 +39,7 @@ import {
   DEFAULT_COPILOT_MODEL,
 } from '../../constants.js';
 import { resolveTrustedSslVerify, rejectRepoConfiguredTlsOptOut, discloseRepoConfiguredEndpoint } from '../../core/services/repo-config-trust.js';
-import { describeExclusions, type ParseHealthReport } from '../../core/analyzer/parse-health.js';
+import { describeExclusions, totalExcluded, type ParseHealthReport } from '../../core/analyzer/parse-health.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -60,7 +60,7 @@ type Remediation =
   | { kind: 'analyze'; label: string }
   | { kind: 'rewire-mcp'; label: string };
 
-interface CheckResult {
+export interface CheckResult {
   name: string;
   status: CheckStatus;
   detail: string;
@@ -271,23 +271,37 @@ async function checkGraphStore(rootPath: string): Promise<CheckResult> {
  * this check cannot bless a repository whose analysis excluded files — the contradiction the
  * `EveryExcludedFileIsRecordedWithAReason` requirement exists to prevent.
  */
-async function checkParseHealth(rootPath: string): Promise<CheckResult> {
+/** Exported for test: the exclusion-vs-degradation verdict must be pinned behaviorally. */
+export async function checkParseHealth(rootPath: string): Promise<CheckResult> {
   const path = join(rootPath, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_PARSE_HEALTH);
   try {
     const report = JSON.parse(await readFile(path, 'utf-8')) as ParseHealthReport;
-    const n = report.totalDegradedFiles ?? 0;
     const excluded = describeExclusions(report);
-    if (n === 0 && !excluded) return { name: 'Parse health', status: 'ok', detail: 'no files parsed with errors' };
+    const excludedCount = totalExcluded(report);
+    // A file the analyzer NEVER PARSED (size cap, budget) must not be counted as one that "parsed
+    // with errors" — it is a different cause with a different remedy, and the grammar-bump advice
+    // below would send the reader after the wrong subsystem entirely.
+    const degradedByParse = Math.max(0, (report.totalDegradedFiles ?? 0) - excludedCount);
+    if (degradedByParse === 0 && !excluded) {
+      return { name: 'Parse health', status: 'ok', detail: 'no files parsed with errors' };
+    }
     const langs = (report.byLanguage ?? [])
       .slice(0, 3)
       .map(l => `${l.language} (${l.degradedFiles})`)
       .join(', ');
+    const parts: string[] = [];
+    if (degradedByParse > 0) {
+      parts.push(`${degradedByParse} file(s) parsed with errors — symbols/edges there are a lower bound: ${langs}`);
+    }
+    if (excluded) parts.push(`${excluded} — those files were not analyzed at all`);
     return {
       name: 'Parse health',
       status: 'warn',
-      detail: `${n} file(s) parsed with errors — symbols/edges there are a lower bound: ${langs}`
-        + (excluded ? `; ${excluded}` : ''),
-      fix: "Inspect via get_language_support; if this spiked after a grammar bump, revert or re-pin the tree-sitter-* dep",
+      detail: parts.join('; '),
+      // Only a genuine parse degradation points at a grammar; an exclusion points at cost or size.
+      fix: degradedByParse > 0
+        ? "Inspect via get_language_support; if this spiked after a grammar bump, revert or re-pin the tree-sitter-* dep"
+        : 'Raise or disable the per-file bound with OPENLORE_PARSE_BUDGET_MS, or exclude the file from analysis',
     };
   } catch {
     // No artifact → nothing degraded (clean repos don't write it).

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -784,3 +784,39 @@ export const EXTRACTION_POOL_REQUEST_TIMEOUT_MS = 120_000;
  * cleanup into the hang the other deadlines exist to prevent.
  */
 export const EXTRACTION_POOL_TERMINATE_TIMEOUT_MS = 5_000;
+
+/**
+ * Wall-clock ceiling on the tree-sitter PARSE of ONE file (change:
+ * fix-analyze-native-abort-and-file-cost-budget).
+ *
+ * `MAX_READ_SIZE` bounds how much of a file is read; nothing bounded how long one file may
+ * be *worked on*. A 300 KB file of a repeated unterminated block-comment opener parses for
+ * 84 s and yields a 100,002-deep tree — measured, not hypothetical — and a minified bundle
+ * or generated client in an ordinary repository reaches the same path. So the parse itself
+ * is bounded, in-band: tree-sitter checks this deadline inside its own parse loop and
+ * returns no tree, which is the only bound that can actually interrupt a synchronous native
+ * parse (a `setTimeout` cannot preempt one, and terminating a worker mid-parse is what turns
+ * the failure into a process-level abort).
+ *
+ * Generous on purpose: it is a runaway bound, not a performance weight. The slowest file in
+ * this repository parses in well under a second, and the largest ordinary generated files
+ * measured (1.5 MB) stay far below it — so no real source file is affected, and any file that
+ * IS abandoned is disclosed with its elapsed time rather than silently dropped. Override with
+ * `OPENLORE_PARSE_BUDGET_MS`; `0` disables the bound entirely.
+ */
+export const PER_FILE_PARSE_BUDGET_MS = 20_000;
+
+/**
+ * Operator override for {@link PER_FILE_PARSE_BUDGET_MS}, in milliseconds. `0` disables the
+ * bound (restoring the pre-change unbounded behavior byte-for-byte).
+ */
+export const PARSE_BUDGET_ENV = 'OPENLORE_PARSE_BUDGET_MS';
+
+/**
+ * How long ONE file's extraction may run before the CLI names it in progress output. Purely a
+ * disclosure threshold — nothing is abandoned at this point — so a user waiting on a slow run
+ * can identify the responsible file without attaching a debugger. Well below
+ * {@link PER_FILE_PARSE_BUDGET_MS} so a file that will eventually be abandoned is named long
+ * before it is.
+ */
+export const SLOW_FILE_DISCLOSURE_MS = 5_000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -820,3 +820,15 @@ export const PARSE_BUDGET_ENV = 'OPENLORE_PARSE_BUDGET_MS';
  * before it is.
  */
 export const SLOW_FILE_DISCLOSURE_MS = 5_000;
+
+/**
+ * Largest HTML file whose inline `<script>` blocks are extracted. Bounds the same-length
+ * char-array allocation in `extractHtmlScripts` (the scan itself is O(N)).
+ *
+ * Shared rather than local to the analyzer because the incremental watcher must apply the SAME
+ * bound: it re-derives a changed file's parse-health record, and without this it would clear a
+ * `size-cap` exclusion the full build had recorded — leaving `doctor` reporting a clean repository
+ * that the next `analyze` excludes a file from again (change:
+ * fix-analyze-native-abort-and-file-cost-budget).
+ */
+export const MAX_HTML_INLINE_SCRIPT_CHARS = 1_000_000;

--- a/src/core/analyzer/artifact-generator.test.ts
+++ b/src/core/analyzer/artifact-generator.test.ts
@@ -13,6 +13,7 @@ import {
 import type { RepositoryMap, DetectedFramework, LanguageBreakdown, DirectoryStats } from './repository-mapper.js';
 import type { DependencyGraphResult, DependencyNode, DependencyEdge, FileCluster } from './dependency-graph.js';
 import type { ScoredFile, ProjectType } from '../../types/index.js';
+import { MAX_HTML_INLINE_SCRIPT_CHARS } from '../../constants.js';
 
 // ============================================================================
 // TEST HELPERS
@@ -239,6 +240,46 @@ describe('AnalysisArtifactGenerator', () => {
       const pathsB = b.llmContext.phase3_validation.files.map(f => f.path);
       expect(pathsA.length).toBe(8);
       expect(pathsA).toEqual(pathsB);
+    });
+  });
+
+  describe('size-cap exclusion (fix-analyze-native-abort-and-file-cost-budget)', () => {
+    it('records an oversized HTML file as size-cap instead of dropping it silently', async () => {
+      // HTML over MAX_HTML_INLINE_SCRIPT_CHARS never reaches the graph — the bound on the
+      // same-length char-array allocation in extractHtmlScripts. It used to vanish with no trace,
+      // so any inline <script> it contained read as genuinely absent.
+      await mkdir(join(tempDir, 'src'), { recursive: true });
+      const rel = 'src/huge.html';
+      const huge = `<html><body><script>function inlineFn(){ return 1; }</script>${'<p>x</p>'.repeat(200_000)}</body></html>`;
+      expect(huge.length).toBeGreaterThan(MAX_HTML_INLINE_SCRIPT_CHARS);
+      await writeFile(join(tempDir, rel), huge);
+
+      const repoMap = createMockRepoMap({
+        allFiles: [createScoredFile({ name: 'huge.html', path: rel, absolutePath: join(tempDir, rel) })],
+        highValueFiles: [],
+      });
+      const artifacts = await generateArtifacts(repoMap, createMockDepGraph({}), {
+        rootDir: tempDir, outputDir, maxDeepAnalysisFiles: 0, maxValidationFiles: 0,
+      });
+
+      const rec = artifacts.parseHealth?.files.find(f => f.filePath === rel);
+      expect(rec, 'the dropped file is recorded, not silent').toBeDefined();
+      expect(rec!.exclusion).toBe('size-cap');
+      expect(artifacts.parseHealth!.excludedByReason).toEqual({ 'size-cap': 1 });
+    });
+
+    it('leaves an ordinary HTML file alone — the cap must not catch real pages', async () => {
+      await mkdir(join(tempDir, 'src'), { recursive: true });
+      const rel = 'src/page.html';
+      await writeFile(join(tempDir, rel), '<html><body><script>function f(){ return g(); }</script></body></html>');
+      const repoMap = createMockRepoMap({
+        allFiles: [createScoredFile({ name: 'page.html', path: rel, absolutePath: join(tempDir, rel) })],
+        highValueFiles: [],
+      });
+      const artifacts = await generateArtifacts(repoMap, createMockDepGraph({}), {
+        rootDir: tempDir, outputDir, maxDeepAnalysisFiles: 0, maxValidationFiles: 0,
+      });
+      expect(artifacts.parseHealth?.files.find(f => f.filePath === rel)).toBeUndefined();
     });
   });
 

--- a/src/core/analyzer/artifact-generator.ts
+++ b/src/core/analyzer/artifact-generator.ts
@@ -25,6 +25,7 @@ import {
   ARTIFACT_CALL_GRAPH_DB,
   ARTIFACT_STYLE_FINGERPRINT,
   ARTIFACT_PARSE_HEALTH,
+  MAX_HTML_INLINE_SCRIPT_CHARS,
 } from '../../constants.js';
 import { writeTraversalIndexArtifact } from './condensation.js';
 import { buildStyleFingerprint, type StyleFingerprint } from './style-fingerprint.js';
@@ -1309,9 +1310,6 @@ export class AnalysisArtifactGenerator {
       // Azure IaC DSL (add-bicep-iac-graph).
       'Bicep',
     ]);
-    // Skip inline-script extraction for very large HTML files: bounds the
-    // same-length char-array allocation in extractHtmlScripts (the scan is O(N)).
-    const MAX_HTML_INLINE_SCRIPT_CHARS = 1_000_000;
     // Helm charts: every file under a directory containing Chart.yaml is Helm.
     const chartDirs = repoMap.allFiles
       .filter(f => /(^|\/)Chart\.ya?ml$/.test(f.path.replace(/\\/g, '/')))

--- a/src/core/analyzer/artifact-generator.ts
+++ b/src/core/analyzer/artifact-generator.ts
@@ -1345,6 +1345,10 @@ export class AnalysisArtifactGenerator {
     // one central read, since the call-graph extractors never see the raw bytes (change:
     // add-parse-health-boundary-disclosure).
     const encodingFallback = new Map<string, string>(); // path → language
+    // HTML files dropped whole because they exceeded MAX_HTML_INLINE_SCRIPT_CHARS. This was a
+    // silent exclusion — the file simply never reached the graph, and nothing said so (change:
+    // fix-analyze-native-abort-and-file-cost-budget).
+    const sizeCapped: Array<{ path: string; language: string }> = [];
 
     for (const file of repoMap.allFiles) {
       try {
@@ -1370,15 +1374,21 @@ export class AnalysisArtifactGenerator {
         if (CALL_GRAPH_LANGS.has(lang)) {
           if (isLossyUtf8(bytes)) encodingFallback.set(file.path, lang);
           callGraphFiles.push({ path: file.path, content, language: lang });
-        } else if (/\.html?$/i.test(file.path) && content.length <= MAX_HTML_INLINE_SCRIPT_CHARS) {
-          // Inline <script> JS (decision 5b38bad2): blank everything outside the
-          // script bodies (newlines preserved) so the JS extractor parses the
-          // islands at their true offsets and node line numbers map to the HTML
-          // file. Skip files with no inline JS. Oversized HTML is skipped (a
-          // bound on the per-file char-array allocation; the scan itself is O(N)).
-          const blanked = extractHtmlScripts(content);
-          if (blanked !== null) {
-            callGraphFiles.push({ path: file.path, content: blanked, language: 'JavaScript' });
+        } else if (/\.html?$/i.test(file.path)) {
+          if (content.length > MAX_HTML_INLINE_SCRIPT_CHARS) {
+            // Oversized HTML is skipped (a bound on the per-file char-array allocation; the scan
+            // itself is O(N)) — and now SAYS so. Dropping it silently made any inline script it
+            // contained read as genuinely absent.
+            sizeCapped.push({ path: file.path, language: lang === 'unknown' ? 'HTML' : lang });
+          } else {
+            // Inline <script> JS (decision 5b38bad2): blank everything outside the
+            // script bodies (newlines preserved) so the JS extractor parses the
+            // islands at their true offsets and node line numbers map to the HTML
+            // file. Skip files with no inline JS.
+            const blanked = extractHtmlScripts(content);
+            if (blanked !== null) {
+              callGraphFiles.push({ path: file.path, content: blanked, language: 'JavaScript' });
+            }
           }
         }
       } catch {
@@ -1436,6 +1446,12 @@ export class AnalysisArtifactGenerator {
       const existing = parseHealthRecords.get(path);
       if (existing) existing.encodingFallback = true;
       else parseHealthRecords.set(path, { filePath: path, language, errorCount: 0, missingCount: 0, errorLines: [], encodingFallback: true });
+    }
+    for (const { path, language } of sizeCapped) {
+      parseHealthRecords.set(path, {
+        filePath: path, language, errorCount: 0, missingCount: 0, errorLines: [],
+        exclusion: 'size-cap',
+      });
     }
     this._parseHealth = buildParseHealthReport([...parseHealthRecords.values()]);
 

--- a/src/core/analyzer/ast-chunker.test.ts
+++ b/src/core/analyzer/ast-chunker.test.ts
@@ -2,8 +2,9 @@
  * Tests for ast-chunker — blankLineChunk and astChunkContent
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { blankLineChunk, astChunkContent } from './ast-chunker.js';
+import { PARSE_BUDGET_ENV } from '../../constants.js';
 
 // ── blankLineChunk ────────────────────────────────────────────────────────────
 
@@ -254,4 +255,45 @@ end
     const joined = chunks.join('\n');
     expect(joined).toContain('def one');
   });
+});
+
+// ── per-file parse budget (change: fix-analyze-native-abort-and-file-cost-budget) ─────────────
+
+describe('astChunkContent under the per-file parse budget', () => {
+  /** The payload that reproduced the abort: a 300 KB unterminated block comment. */
+  const HOSTILE_TS = '/*x'.repeat(100_000);
+
+  afterEach(() => { delete process.env[PARSE_BUDGET_ENV]; });
+
+  it('falls back to blank-line chunking when the parse hits the budget, instead of throwing', async () => {
+    // This chunker only parses content ALREADY over the chunk size, so it is exactly where a
+    // pathological file shows up — and it runs at TOOL time, where an unbounded parse would wedge
+    // the daemon rather than one build. On the budget it must degrade to the grammar-free chunker,
+    // which is a worse chunking, never a failed call.
+    process.env[PARSE_BUDGET_ENV] = '300';
+    const started = Date.now();
+    const chunks = await astChunkContent(HOSTILE_TS, 'src/hostile.ts', 50_000);
+    const elapsed = Date.now() - started;
+
+    // Exactly the grammar-free fallback. NOTE: this alone does not prove the budget ran — measured
+    // against a deliberately unbounded build, the fallback is reached either way (the pathological
+    // tree yields no usable top-level nodes). It pins the OUTPUT shape.
+    expect(chunks).toEqual(blankLineChunk(HOSTILE_TS, 50_000, 10));
+    // THIS is the assertion that pins the bound: unbounded, the same call measured 85.7 s.
+    expect(elapsed).toBeLessThan(20_000);
+  }, 60_000);
+
+  it('CONTROL: ordinary content is still chunked by the grammar, unaffected by the budget', async () => {
+    // A bound that quietly demoted every file to blank-line chunking would be a silent quality
+    // regression with no symptom.
+    const content = Array.from(
+      { length: 400 },
+      (_, i) => `export function fn${i}(): number {\n  return ${i};\n}\n`,
+    ).join('\n');
+    const withBudget = await astChunkContent(content, 'src/ok.ts', 2_000);
+    process.env[PARSE_BUDGET_ENV] = '0';
+    const withoutBudget = await astChunkContent(content, 'src/ok.ts', 2_000);
+    expect(withBudget).toEqual(withoutBudget);
+    expect(withBudget.length).toBeGreaterThan(1);
+  }, 60_000);
 });

--- a/src/core/analyzer/ast-chunker.ts
+++ b/src/core/analyzer/ast-chunker.ts
@@ -11,6 +11,7 @@
 
 import type Parser from 'tree-sitter';
 import { detectLanguage } from './language-detection.js';
+import { parseWithBudget, type BudgetableParser } from './parse-budget.js';
 
 // ── Lazy parser singletons (one per language, created on first use) ─────────
 
@@ -181,7 +182,11 @@ export async function astChunkContent(
 
   let tree: Parser.Tree;
   try {
-    tree = parser.parse(content);
+    // Bounded like every other parse (change: fix-analyze-native-abort-and-file-cost-budget). This
+    // one only runs on content ALREADY over the chunk size, so it is exactly where a pathological
+    // file shows up; on the budget it falls through to the blank-line chunker below, which needs
+    // no grammar. Degraded chunking, never a stalled run.
+    tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
   } catch {
     return blankLineChunk(content, maxChars, overlapLines);
   }

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -33,7 +33,15 @@ import { stableSymbolId, stableClassId } from '../scip/moniker.js';
 import { synthesizeTypeHierarchyEdges, type RawMethodCall } from './cha.js';
 import { logger } from '../../utils/logger.js';
 import { tallyFileStyle, type FileStyleRaw, type StyleAstNode } from './style-fingerprint.js';
-import { tallyParseHealth, type FileParseHealth, type ParseHealthNode } from './parse-health.js';
+import {
+  tallyParseHealth,
+  type FileParseHealth,
+  type FileExclusionReason,
+  type ParseHealthNode,
+} from './parse-health.js';
+// Per-file parse budget (change: fix-analyze-native-abort-and-file-cost-budget). Bounds the one
+// synchronous native call nothing else can interrupt.
+import { parseWithBudget, parseBudgetOverrunMs, type BudgetableParser } from './parse-budget.js';
 // Pass-1 extraction lane (change: optimize-parallel-extraction-pool). The pool holds no
 // extraction logic of its own — it dispatches `dispatchFileExtract` to worker threads and
 // merges by input index, with the serial loop as both reference and fallback.
@@ -620,7 +628,7 @@ async function extractTSGraph(
   const r = await getTSParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
-  const tree = (parser as Parser).parse(content);
+  const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, TS_FN_QUERY);
   const callQuery = new _NativeQuery!(lang as unknown as Parser.Language, TS_CALL_QUERY);
@@ -805,7 +813,7 @@ async function extractPyGraph(
   const r = await getPyParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
-  const tree = (parser as Parser).parse(content);
+  const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, PY_FN_QUERY);
 
@@ -959,7 +967,7 @@ async function extractGoGraph(
   const r = await getGoParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
-  const tree = (parser as Parser).parse(content);
+  const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, GO_FN_QUERY);
   const callQuery = new _NativeQuery!(lang as unknown as Parser.Language, GO_CALL_QUERY);
@@ -1051,7 +1059,7 @@ async function extractRustGraph(
   const r = await getRustParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
-  const tree = (parser as Parser).parse(content);
+  const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
   const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, RUST_FN_QUERY);
@@ -1162,7 +1170,7 @@ async function extractRubyGraph(
   const r = await getRubyParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
-  const tree = (parser as Parser).parse(content);
+  const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
   const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, RUBY_FN_QUERY);
@@ -1368,7 +1376,7 @@ async function extractJavaGraph(
   const r = await getJavaParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
-  const tree = (parser as Parser).parse(content);
+  const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
   const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, JAVA_FN_QUERY);
@@ -1499,7 +1507,7 @@ async function extractCppGraph(
   const r = await getCppParser();
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
-  const tree = (parser as Parser).parse(content);
+  const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
   const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const nodes: FunctionNode[] = [];
@@ -1634,7 +1642,7 @@ async function extractSwiftGraph(
   const r = await getSwiftParser();
   if (!r) return { nodes: [], rawEdges: [] };
   const { parser, lang } = r;
-  const tree = (parser as Parser).parse(content);
+  const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
   const parseHealth = tallyParseHealth('', tree.rootNode as unknown as ParseHealthNode, filePath);
 
   const fnQuery = new _NativeQuery!(lang as unknown as Parser.Language, SWIFT_FN_QUERY);
@@ -1794,7 +1802,7 @@ async function loadGrammarSoft(
     parser.setLanguage(lang as unknown as Parser.Language);
     const handle: GrammarHandle = {
       withTree: (content, fn) => {
-        const tree = (parser as Parser).parse(content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);
         const root = tree.rootNode as unknown as TsNodeLike;
         const runQuery = (src: string): TsMatch[] => {
           if (!_NativeQuery) return [];
@@ -1858,7 +1866,16 @@ async function loadWasmGrammarSoft(
         // parse tree in WASM heap, which corrupts the next parse if not freed.
         const p = new ParserCtor() as { setLanguage(l: unknown): void; parse(s: string): { rootNode: TsNodeLike; delete?: () => void }; delete?: () => void };
         p.setLanguage(lang);
-        const tree = p.parse(content);
+        // The budget applies here only if this web-tree-sitter build exposes the deadline; it is
+        // feature-detected, never assumed. A throw (budget or otherwise) must still free the WASM
+        // parser — the tree/query disposal below cannot run if `tree` was never assigned.
+        let tree: { rootNode: TsNodeLike; delete?: () => void };
+        try {
+          tree = parseWithBudget(p as unknown as BudgetableParser<{ rootNode: TsNodeLike; delete?: () => void }>, content);
+        } catch (err) {
+          p.delete?.();
+          throw err;
+        }
         const queries: Array<{ delete?: () => void }> = [];
         const runQuery = (src: string): TsMatch[] => {
           try {
@@ -2369,7 +2386,7 @@ async function extractClassRelationships(
         const r = await getTSParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // class Foo extends Bar implements Baz, Qux
         const EXTENDS_Q = `
@@ -2396,7 +2413,7 @@ async function extractClassRelationships(
         const r = await getPyParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // class Foo(Bar, Baz):
         const Q = `
@@ -2413,7 +2430,7 @@ async function extractClassRelationships(
         const r = await getJavaParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         const EXTENDS_Q = `
           (class_declaration
@@ -2439,7 +2456,7 @@ async function extractClassRelationships(
         const r = await getCppParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // class Foo : public Bar
         const Q = `
@@ -2456,7 +2473,7 @@ async function extractClassRelationships(
         const r = await getCSharpParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // C# `class D : B, IFoo, IBar<T>` / `interface I : IBase` — the base_list holds
         // the base class AND interfaces with no syntactic distinction. Capture every
@@ -2481,7 +2498,7 @@ async function extractClassRelationships(
         const r = await getKotlinParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // Kotlin `class C : Base(), IFace` — every supertype is a `delegation_specifier`
         // with no syntactic class/interface distinction (a superclass may carry a
@@ -2507,7 +2524,7 @@ async function extractClassRelationships(
         const r = await getPhpParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // PHP distinguishes `extends` (base_clause, one parent) from `implements`
         // (class_interface_clause, many interfaces).
@@ -2528,7 +2545,7 @@ async function extractClassRelationships(
         const r = await getSwiftParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // Swift `class C: Base, Proto` — every supertype/protocol is an
         // `inheritance_specifier` with no syntactic distinction. (class_declaration in
@@ -2550,7 +2567,7 @@ async function extractClassRelationships(
         const r = await getScalaParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // Scala `class C extends Base with Trait` — the superclass and every mixed-in
         // trait sit in one `extends_clause`. Treat each as a subtype edge.
@@ -2567,7 +2584,7 @@ async function extractClassRelationships(
         const r = await getRubyParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // class Foo < Bar
         const Q = `
@@ -2585,7 +2602,7 @@ async function extractClassRelationships(
         const r = await getGoParser();
         if (!r) continue;
         const { parser, lang } = r;
-        const tree = (parser as Parser).parse(file.content);
+        const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
 
         // An EMBEDDED field is an ANONYMOUS field (a type with no field name):
         // `type Foo struct { Bar }` or `{ *Bar }`. A NAMED field `Name Bar` is NOT an
@@ -3537,7 +3554,7 @@ async function synthesizeEventChannelEdges(
       const { parser } = r;
       const sites: EventSites = { registrations: [], dispatches: [] };
       for (const file of tsFiles) {
-        try { collectTsEventSites((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+        try { collectTsEventSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
         catch { /* skip unparseable file */ }
       }
       edges.push(...pairAndEmitEventEdges(sites, allNodes, 'event-channel'));
@@ -3551,7 +3568,7 @@ async function synthesizeEventChannelEdges(
       const { parser } = r;
       const sites: EventSites = { registrations: [], dispatches: [] };
       for (const file of pyFiles) {
-        try { collectPyEventSites((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+        try { collectPyEventSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
         catch { /* skip unparseable file */ }
       }
       edges.push(...pairAndEmitEventEdges(sites, allNodes, 'event-channel'));
@@ -3565,7 +3582,7 @@ async function synthesizeEventChannelEdges(
       const { parser } = r;
       const sites: EventSites = { registrations: [], dispatches: [] };
       for (const file of rubyFiles) {
-        try { collectRubyEventSites((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+        try { collectRubyEventSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
         catch { /* skip unparseable file */ }
       }
       edges.push(...pairAndEmitEventEdges(sites, allNodes, 'event-channel'));
@@ -3579,7 +3596,7 @@ async function synthesizeEventChannelEdges(
       const { parser } = r;
       const sites: EventSites = { registrations: [], dispatches: [] };
       for (const file of phpFiles) {
-        try { collectPhpEventSites((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+        try { collectPhpEventSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
         catch { /* skip unparseable file */ }
       }
       edges.push(...pairAndEmitEventEdges(sites, allNodes, 'event-channel'));
@@ -3594,7 +3611,7 @@ async function synthesizeEventChannelEdges(
       const { parser } = r;
       const sites: EventSites = { registrations: [], dispatches: [] };
       for (const file of javaFiles) {
-        try { collectJavaTypeEventSites((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+        try { collectJavaTypeEventSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
         catch { /* skip unparseable file */ }
       }
       edges.push(...pairAndEmitEventEdges(sites, allNodes, 'type-event'));
@@ -3608,7 +3625,7 @@ async function synthesizeEventChannelEdges(
       const { parser } = r;
       const sites: EventSites = { registrations: [], dispatches: [] };
       for (const file of csFiles) {
-        try { collectCSharpTypeEventSites((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+        try { collectCSharpTypeEventSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
         catch { /* skip unparseable file */ }
       }
       edges.push(...pairAndEmitEventEdges(sites, allNodes, 'type-event'));
@@ -3622,7 +3639,7 @@ async function synthesizeEventChannelEdges(
       const { parser } = r;
       const sites: EventSites = { registrations: [], dispatches: [] };
       for (const file of ktFiles) {
-        try { collectKotlinTypeEventSites((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+        try { collectKotlinTypeEventSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
         catch { /* skip unparseable file */ }
       }
       edges.push(...pairAndEmitEventEdges(sites, allNodes, 'type-event'));
@@ -3636,7 +3653,7 @@ async function synthesizeEventChannelEdges(
       const { parser } = r;
       const sites: EventSites = { registrations: [], dispatches: [] };
       for (const file of swiftFiles) {
-        try { collectSwiftEventSites((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+        try { collectSwiftEventSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
         catch { /* skip unparseable file */ }
       }
       edges.push(...pairAndEmitEventEdges(sites, allNodes, 'event-channel'));
@@ -3834,7 +3851,7 @@ async function synthesizeCallbackRegistrationEdges(
     if (r) {
       const { parser } = r;
       for (const file of tsFiles) {
-        try { collectTsCallbackEdges((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, out, seen); }
+        try { collectTsCallbackEdges(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, out, seen); }
         catch { /* skip */ }
       }
     }
@@ -3846,7 +3863,7 @@ async function synthesizeCallbackRegistrationEdges(
     if (r) {
       const { parser } = r;
       for (const file of goFiles) {
-        try { collectGoCallbackEdges((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, out, seen); }
+        try { collectGoCallbackEdges(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, out, seen); }
         catch { /* skip */ }
       }
     }
@@ -3858,7 +3875,7 @@ async function synthesizeCallbackRegistrationEdges(
     if (r) {
       const { parser } = r;
       for (const file of cppFiles) {
-        try { collectCppCallbackEdges((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, out, seen); }
+        try { collectCppCallbackEdges(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, out, seen); }
         catch { /* skip */ }
       }
     }
@@ -3937,7 +3954,7 @@ async function synthesizeActorMessageEdges(
   const { parser } = r;
   const sites: EventSites = { registrations: [], dispatches: [] };
   for (const file of exFiles) {
-    try { collectElixirActorSites((parser as Parser).parse(file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+    try { collectElixirActorSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
     catch { /* skip */ }
   }
   return pairAndEmitEventEdges(sites, allNodes, 'actor-message');
@@ -4151,6 +4168,18 @@ export class CallGraphBuilder {
         // extraction worker crossed a structured-clone boundary, so its class, `code`, and
         // stack did not survive — an `instanceof`/`.code` check added below would behave
         // differently on the two lanes (change: optimize-parallel-extraction-pool).
+        //
+        // Which is exactly why the one cause that IS distinguishable from a message is read off it
+        // (change: fix-analyze-native-abort-and-file-cost-budget): a file abandoned at the parse
+        // budget carries its own reason and its elapsed time, rather than being flattened into a
+        // generic parse failure. Anything else stays `parse-failure` — a cause we cannot prove is
+        // never guessed at. A worker fault never reaches here: the pool routes that file to the
+        // main thread instead, so this message is always the main thread's own verdict.
+        const message = (error as Error | undefined)?.message;
+        const overrunBudgetMs = parseBudgetOverrunMs(message);
+        const exclusion: FileExclusionReason = overrunBudgetMs !== undefined
+          ? 'budget-exceeded'
+          : 'parse-failure';
         parseHealthByFile.set(file.path, {
           filePath: file.path,
           language: file.language,
@@ -4158,12 +4187,31 @@ export class CallGraphBuilder {
           missingCount: 0,
           errorLines: [],
           parseFailed: true,
+          exclusion,
+          ...(overrunBudgetMs !== undefined ? { budgetMs: overrunBudgetMs } : {}),
         });
         if (process.env.DEBUG) {
           console.debug(`[call-graph] Failed to parse ${file.path}: ${(error as Error).message}`);
         }
       }
     }
+
+    // A file abandoned at the parse budget contributed nothing to Pass 1, and several LATER passes
+    // re-read the same content (class relationships, event/callback/route/actor synthesis, and the
+    // export scan behind re-export-aware import resolution). Left in, each of those would spend the
+    // whole budget on it again — the cost is per PASS, not per file, which is how one 300 KB file
+    // turned a 20 s bound into a 92 s build. Dropped once, here, so the budget means roughly what
+    // it says. The export scan matters as much as the parses: it is a regex scan, so the parse
+    // budget cannot bound it at all — only not running it can.
+    // Everything about it is already recorded (parse-health, the CLI disclosure), so nothing goes
+    // silent — and when nothing was abandoned this is the same array, so ordinary runs are
+    // byte-identical (change: fix-analyze-native-abort-and-file-cost-budget).
+    const abandonedPaths = new Set(
+      [...parseHealthByFile.values()].filter(h => h.exclusion === 'budget-exceeded').map(h => h.filePath),
+    );
+    const reparsableFiles = abandonedPaths.size > 0
+      ? files.filter(f => !abandonedPaths.has(f.path))
+      : files;
 
     const pass1Cache: Pass1CacheDisclosure | undefined = cache
       ? {
@@ -4204,12 +4252,12 @@ export class CallGraphBuilder {
     // Reused for base-class resolution (Pass 7) below.
     const { map: callImportMap, reExported: reExportedNames } = importMap
       ? { map: importMap, reExported: new Set<string>() }
-      : buildResolvedImportMap(files);
+      : buildResolvedImportMap(reparsableFiles);
 
     // Class inheritance (`filePath::ClassName` → parent simple-names), computed once
     // here so the resolution loop can resolve `this.m()` / `super.m()` against the
     // enclosing class AND its ancestors, and reused for the Pass 7 hierarchy build.
-    const relationships = await extractClassRelationships(files);
+    const relationships = await extractClassRelationships(reparsableFiles);
 
     /** Resolve an intra-object method call (`this.m()` / `self.m()` / `super.m()`) to
      *  a concrete indexed method by walking the enclosing class chain. For `this`/
@@ -4590,7 +4638,7 @@ export class CallGraphBuilder {
         if (inFile) return inFile;
         return candidates.length === 1 ? candidates[0] : undefined;
       };
-      edges.push(...await synthesizeDynamicDispatchEdges(files, allNodes, resolveHandler));
+      edges.push(...await synthesizeDynamicDispatchEdges(reparsableFiles, allNodes, resolveHandler));
     } catch {
       // Synthesis is best-effort; a failure must never abort the build.
     }

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -41,7 +41,7 @@ import {
 } from './parse-health.js';
 // Per-file parse budget (change: fix-analyze-native-abort-and-file-cost-budget). Bounds the one
 // synchronous native call nothing else can interrupt.
-import { parseWithBudget, parseBudgetOverrunMs, type BudgetableParser } from './parse-budget.js';
+import { parseWithBudget, parseBudgetOverrunMs, parseBudgetMs, type BudgetableParser } from './parse-budget.js';
 // Pass-1 extraction lane (change: optimize-parallel-extraction-pool). The pool holds no
 // extraction logic of its own — it dispatches `dispatchFileExtract` to worker threads and
 // merges by input index, with the serial loop as both reference and fallback.
@@ -2363,6 +2363,14 @@ async function extractElixirGraph(
  */
 async function extractClassRelationships(
   files: Array<{ path: string; content: string; language: string }>,
+  /**
+   * Collects files this pass abandoned at the parse budget (change:
+   * fix-analyze-native-abort-and-file-cost-budget). A file can squeak under the budget in Pass 1
+   * and overrun HERE — the per-file `catch` below would then drop its inheritance data with no
+   * record anywhere, which is the silent loss this change exists to prevent. Reported so the
+   * builder can record it like any other exclusion.
+   */
+  budgetExceeded?: Set<string>,
 ): Promise<Map<string, { parentClasses: string[]; interfaces: string[] }>> {
   const out = new Map<string, { parentClasses: string[]; interfaces: string[] }>();
 
@@ -2639,8 +2647,13 @@ async function extractClassRelationships(
         }
       }
       // Rust: trait impls are structural but less like OOP inheritance; skip for now
-    } catch {
-      // Best-effort; skip unparseable files
+    } catch (err) {
+      // Best-effort; skip unparseable files — but a file abandoned at the BUDGET is reported, not
+      // swallowed. "We ran out of time on this file" and "the grammar rejected it" call for
+      // different actions, and only one of them used to leave any trace.
+      if (parseBudgetOverrunMs((err as Error | undefined)?.message) !== undefined) {
+        budgetExceeded?.add(file.path);
+      }
     }
   }
 
@@ -4196,16 +4209,25 @@ export class CallGraphBuilder {
       }
     }
 
-    // A file abandoned at the parse budget contributed nothing to Pass 1, and several LATER passes
-    // re-read the same content (class relationships, event/callback/route/actor synthesis, and the
-    // export scan behind re-export-aware import resolution). Left in, each of those would spend the
-    // whole budget on it again — the cost is per PASS, not per file, which is how one 300 KB file
-    // turned a 20 s bound into a 92 s build. Dropped once, here, so the budget means roughly what
-    // it says. The export scan matters as much as the parses: it is a regex scan, so the parse
-    // budget cannot bound it at all — only not running it can.
-    // Everything about it is already recorded (parse-health, the CLI disclosure), so nothing goes
-    // silent — and when nothing was abandoned this is the same array, so ordinary runs are
-    // byte-identical (change: fix-analyze-native-abort-and-file-cost-budget).
+    // A file abandoned at the parse budget contributed nothing to Pass 1, and several later passes
+    // RE-PARSE the same content (class relationships, and the event/callback/route/actor
+    // synthesizers). Left in, each would spend the whole budget on it again — the cost is per PASS,
+    // not per file, which is how one 300 KB file turned a 20 s bound into a 92 s build. Dropping it
+    // from those passes costs nothing in facts: its parse cannot complete there either, so it would
+    // contribute exactly the same nothing, only slower.
+    //
+    // This filter is deliberately NOT applied to `buildResolvedImportMap`. That pass is a REGEX
+    // scan (`parseJSExports`), not a parse — it reads a file tree-sitter gave up on perfectly well,
+    // and the parse budget was never what bounded it. An earlier revision of this change did filter
+    // it, and an adversarial review reproduced the consequence: a re-export barrel abandoned at the
+    // budget silently dropped `re_export` edges belonging to OTHER, perfectly-parsed files, which
+    // then resolved by name only or not at all. The loss landed on files carrying no parse-health
+    // record, so nothing connected the missing edge to the abandoned file — the exact
+    // absence-read-as-evidence-of-absence failure this change exists to prevent. Correctness over
+    // the few seconds it saves.
+    //
+    // When nothing was abandoned this is the same array, so ordinary runs are byte-identical
+    // (change: fix-analyze-native-abort-and-file-cost-budget).
     const abandonedPaths = new Set(
       [...parseHealthByFile.values()].filter(h => h.exclusion === 'budget-exceeded').map(h => h.filePath),
     );
@@ -4252,12 +4274,32 @@ export class CallGraphBuilder {
     // Reused for base-class resolution (Pass 7) below.
     const { map: callImportMap, reExported: reExportedNames } = importMap
       ? { map: importMap, reExported: new Set<string>() }
-      : buildResolvedImportMap(reparsableFiles);
+      // NOT `reparsableFiles` — see the note there. This is a regex scan, and an abandoned file's
+      // exports are still readable and still load-bearing for OTHER files' resolution.
+      : buildResolvedImportMap(files);
 
     // Class inheritance (`filePath::ClassName` → parent simple-names), computed once
     // here so the resolution loop can resolve `this.m()` / `super.m()` against the
     // enclosing class AND its ancestors, and reused for the Pass 7 hierarchy build.
-    const relationships = await extractClassRelationships(reparsableFiles);
+    // A file can pass Pass 1 under the budget and overrun HERE; that loss is recorded below
+    // rather than dropped (change: fix-analyze-native-abort-and-file-cost-budget).
+    const lateBudgetExceeded = new Set<string>();
+    const relationships = await extractClassRelationships(reparsableFiles, lateBudgetExceeded);
+    for (const path of lateBudgetExceeded) {
+      if (parseHealthByFile.has(path)) continue; // already recorded by Pass 1
+      const language = files.find(f => f.path === path)?.language ?? 'unknown';
+      parseHealthByFile.set(path, {
+        filePath: path,
+        language,
+        errorCount: 0,
+        missingCount: 0,
+        errorLines: [],
+        // NOT `parseFailed`: Pass 1 extracted this file fine. What was lost is its inheritance
+        // data, so its symbols are present but its class hierarchy is a lower bound.
+        exclusion: 'budget-exceeded',
+        budgetMs: parseBudgetMs(),
+      });
+    }
 
     /** Resolve an intra-object method call (`this.m()` / `self.m()` / `super.m()`) to
      *  a concrete indexed method by walking the enclosing class chain. For `this`/

--- a/src/core/analyzer/exception-flow.ts
+++ b/src/core/analyzer/exception-flow.ts
@@ -26,6 +26,7 @@
  */
 
 import type Parser from 'tree-sitter';
+import { parseWithBudget, type BudgetableParser } from './parse-budget.js';
 
 /** The languages whose exception flow is statically extractable here. This is the
  *  single authoritative source the language-support registry derives the
@@ -539,7 +540,11 @@ export async function extractExceptionFactsFromSource(
   if (!parser) {
     return { language, supported: false, throwSites: [], tryGuards: [], callSites: [], dynamicThrowCount: 0 };
   }
-  const tree = parser.parse(source);
+  // Bounded like every other parse (change: fix-analyze-native-abort-and-file-cost-budget). This
+  // runs at TOOL time inside the long-lived daemon, where an unbounded parse of one hostile file
+  // would wedge the whole server, not just one build. On the budget it throws, and the caller
+  // records the file as an analysis boundary rather than as "no exceptions here".
+  const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, source);
   return extractExceptionFacts(tree.rootNode, 0, source.length, language);
 }
 

--- a/src/core/analyzer/extraction-pool-threads.test.ts
+++ b/src/core/analyzer/extraction-pool-threads.test.ts
@@ -13,11 +13,19 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { Worker } from 'node:worker_threads';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { CallGraphBuilder, serializeCallGraph, dispatchFileExtract } from './call-graph.js';
-import { resolveWorkerEntry, type ExtractionFile } from './extraction-pool.js';
+import {
+  resolveWorkerEntry,
+  isWorkerFaultMessage,
+  WORKER_FAULT_MESSAGE_PREFIX,
+  type ExtractionFile,
+} from './extraction-pool.js';
+import { EXTRACTION_POOL_MIN_FILES } from '../../constants.js';
 import { PROBES } from './extraction-worker.js';
 
 const fixtures = join(__dirname, 'fixtures');
@@ -225,4 +233,102 @@ describe('extraction pool — the startup probe table', () => {
       expect(result.rawEdges.length, `${language} probe produced no call edge`).toBeGreaterThan(0);
     }, 30_000);
   }
+});
+
+describe('extraction pool — the worker fault boundary, on a real thread', () => {
+  /**
+   * The boundary this exercises exists to stop a fault inside a worker from killing the PROCESS
+   * (change: fix-analyze-native-abort-and-file-cost-budget). `extraction-pool.test.ts` proves the
+   * parent handles the resulting message, but it does so with a stub that *fabricates* the message
+   * — it cannot prove the worker ever sends one. Only a real thread can, because
+   * `process.on('uncaughtException')` is per-thread and a stub has no thread.
+   *
+   * The fault is induced by loading the REAL worker entry through a shim that throws from a timer
+   * callback. That throw is genuine: it originates outside the request handler's `try`/`catch`
+   * (which is exactly the class of fault the boundary was added for), and a worker with no
+   * listener would simply die there, taking its in-flight file with it.
+   *
+   * WHEN it is induced matters, and two earlier attempts at this test got it wrong in instructive
+   * ways. Scheduling the throw on a fixed delay while a large file extracted never fired DURING the
+   * extraction: the parse is one synchronous native call, so the worker's event loop does not run
+   * until it returns, and the parse budget always won the race — the very property that makes the
+   * budget in-band rather than a timer, demonstrated here rather than asserted. Deferring it to the
+   * next macrotask instead lost the opposite race: a small file's extraction completes entirely
+   * within microtasks, so the request was already answered by the time the throw landed.
+   *
+   * So the shim throws SYNCHRONOUSLY from its own `message` listener. Both listeners run in the
+   * same `emit`, the production one first — and it sets `inFlight` before its first `await` — so
+   * when this one throws, a file is in flight by construction, with no timing assumption at all.
+   * A throw out of an EventEmitter listener is a genuine `uncaughtException`.
+   */
+
+  it('answers for the in-flight file with the worker-fault marker instead of dying silently', async () => {
+    const entry = resolveWorkerEntry();
+    if (!entry) return; // no worker lane in this environment; the serial lane covers it
+
+    // A shim that IS the production worker (it imports and runs it), plus a genuine async throw.
+    // Its own `message` listener runs AFTER the production one, which sets `inFlight`
+    // synchronously before its first `await` — so by the time this schedules, a file is in flight.
+    const dir = mkdtempSync(join(tmpdir(), 'wfault-'));
+    const shim = join(dir, 'fault-shim.mjs');
+    writeFileSync(
+      shim,
+      `import { parentPort } from 'node:worker_threads';\n`
+      + `import ${JSON.stringify(entry.specifier.href)};\n`
+      + `parentPort.on('message', (m) => {\n`
+      + `  if (m && m.type === 'extract') throw new Error('induced worker fault');\n`
+      + `});\n`,
+    );
+
+    const worker = new Worker(pathToFileURL(shim), {
+      ...(entry.execArgv ? { execArgv: entry.execArgv } : {}),
+      workerData: { openloreExtractionWorker: true },
+      stdout: true,
+    });
+    worker.stdout.resume();
+
+    try {
+      const messages: Array<{ type: string; id?: number; message?: string }> = [];
+      const settled = new Promise<void>((resolve) => {
+        worker.on('message', (m: { type: string; id?: number; message?: string }) => {
+          messages.push(m);
+          if (m.type === 'ready') {
+            worker.postMessage({
+              type: 'extract',
+              id: 7,
+              file: { path: 'src/in-flight.ts', content: 'export function a(): void { b(); }\nfunction b(): void {}\n', language: 'TypeScript' },
+            });
+          }
+          if (m.type === 'failed') resolve();
+        });
+        worker.on('exit', () => resolve());
+      });
+
+      await settled;
+
+      const failure = messages.find(m => m.type === 'failed');
+      expect(failure, 'the worker answered for its in-flight file rather than vanishing').toBeDefined();
+      expect(failure!.id, 'attributed to the in-flight request, not an arbitrary one').toBe(7);
+      expect(failure!.message).toContain(WORKER_FAULT_MESSAGE_PREFIX);
+      // Attributed to the FILE, so the pool can route that one file to the main thread.
+      expect(failure!.message).toContain('src/in-flight.ts');
+      expect(failure!.message).toContain('induced worker fault');
+      // And the parent classifies it — the message is the only thing that survives the
+      // structured-clone boundary, so this is the whole contract.
+      expect(isWorkerFaultMessage(failure!.message)).toBe(true);
+    } finally {
+      await worker.terminate();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it('a worker that faults still leaves the graph whole — pooled output matches the serial lane', async () => {
+    // The end-to-end consequence: the pool routes the faulted file to the main thread (the
+    // reference implementation), so the FACTS are unchanged and only the lane degraded.
+    const files = tsFiles(EXTRACTION_POOL_MIN_FILES + 4);
+    process.env.OPENLORE_NO_WORKERS = '1';
+    const serial = await buildJson(files);
+    delete process.env.OPENLORE_NO_WORKERS;
+    expect(await buildJson(files, POOL_SIZE)).toBe(serial);
+  }, 180_000);
 });

--- a/src/core/analyzer/extraction-pool-threads.test.ts
+++ b/src/core/analyzer/extraction-pool-threads.test.ts
@@ -25,7 +25,7 @@ import {
   WORKER_FAULT_MESSAGE_PREFIX,
   type ExtractionFile,
 } from './extraction-pool.js';
-import { EXTRACTION_POOL_MIN_FILES } from '../../constants.js';
+
 import { PROBES } from './extraction-worker.js';
 
 const fixtures = join(__dirname, 'fixtures');
@@ -321,14 +321,4 @@ describe('extraction pool — the worker fault boundary, on a real thread', () =
       rmSync(dir, { recursive: true, force: true });
     }
   }, 120_000);
-
-  it('a worker that faults still leaves the graph whole — pooled output matches the serial lane', async () => {
-    // The end-to-end consequence: the pool routes the faulted file to the main thread (the
-    // reference implementation), so the FACTS are unchanged and only the lane degraded.
-    const files = tsFiles(EXTRACTION_POOL_MIN_FILES + 4);
-    process.env.OPENLORE_NO_WORKERS = '1';
-    const serial = await buildJson(files);
-    delete process.env.OPENLORE_NO_WORKERS;
-    expect(await buildJson(files, POOL_SIZE)).toBe(serial);
-  }, 180_000);
 });

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -20,6 +20,8 @@ import {
   plannedPoolSize,
   resolveWorkerEntry,
   describeExtractionLane,
+  isWorkerFaultMessage,
+  WORKER_FAULT_MESSAGE_PREFIX,
   __resetExtractionPoolStateForTests,
   type ExtractionFile,
   type ExtractionLaneDisclosure,
@@ -91,6 +93,12 @@ interface StubOptions {
   throwsFor?: (language: string) => boolean;
   /** Answer normally for the first N files, then throw — a worker that degrades mid-run. */
   throwsAfter?: number;
+  /**
+   * Report a WORKER FAULT for these files — what the worker's `uncaughtException` boundary sends
+   * when something faults inside the thread rather than inside the file's extraction (change:
+   * fix-analyze-native-abort-and-file-cost-budget).
+   */
+  faultsOn?: (file: ExtractionFile) => boolean;
   /** Records the input index of every answer, in the order the parent received it. */
   completionLog?: number[];
 }
@@ -128,6 +136,15 @@ function stubWorkerFactory(opts: StubOptions = {}): ExtractionWorkerFactory {
           if (opts.throwsAfter !== undefined && answered++ >= opts.throwsAfter) {
             opts.completionLog?.push(id);
             send({ type: 'failed', id: replyId, message: 'degraded mid-run' });
+            return;
+          }
+          if (opts.faultsOn?.(file)) {
+            opts.completionLog?.push(id);
+            send({
+              type: 'failed',
+              id: replyId,
+              message: `${WORKER_FAULT_MESSAGE_PREFIX}: uncaught exception while extracting ${file.path} — Maximum call stack size exceeded`,
+            });
             return;
           }
           if (opts.throwsFor?.(file.language)) {
@@ -183,7 +200,10 @@ function isEmpty(result: FileExtractResult | undefined): boolean {
 
 /** A disclosure with the routine fields filled in, for the describe-only assertions. */
 function disclosure(partial: Partial<ExtractionLaneDisclosure>): ExtractionLaneDisclosure {
-  return { lane: 'serial', poolSize: 0, workerFallbackFiles: [], laneDefectFiles: [], unprovenRechecks: 0, ...partial };
+  return {
+    lane: 'serial', poolSize: 0, workerFallbackFiles: [], laneDefectFiles: [], unprovenRechecks: 0,
+    slowFiles: [], ...partial,
+  };
 }
 
 afterEach(() => { vi.restoreAllMocks(); __resetExtractionPoolStateForTests(); });
@@ -628,5 +648,85 @@ describe('extraction pool — the disclosure reaches a human', () => {
     // — is computed and then silently discarded.
     expect(src('cli/commands/analyze.ts')).toContain('extractionLaneNote');
     expect(src('core/analyzer/artifact-generator.ts')).toContain('describeExtractionLane');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worker faults (change: fix-analyze-native-abort-and-file-cost-budget)
+// ---------------------------------------------------------------------------
+
+describe('extraction pool — a worker fault degrades the LANE, never the file', () => {
+  it('re-extracts a faulted file on the main thread even for a language the worker had proven', async () => {
+    // The pool trusts an ordinary throw from a worker that has proven the language — that is a
+    // real per-file parse failure. A WORKER FAULT is different in kind: it is evidence about the
+    // thread, not about the file. Trusting it would blame the source for a defect in the thread
+    // reading it, and would silently shrink the graph by exactly one file.
+    const files = corpus();
+    const faulted = files[files.length - 1].path; // last, so TypeScript is long since proven
+    const { outcomes, disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({ faultsOn: (f) => f.path === faulted }),
+      poolSize: 1,
+    });
+
+    expect(d.lane).toBe('pooled');
+    expect(d.workerFallbackFiles).toContain(faulted);
+    // Every file, including the faulted one, carries real facts from the main thread.
+    expect(outcomes.every(o => o.status === 'ok' && (o.value?.nodes.length ?? 0) > 0)).toBe(true);
+  }, 30_000);
+
+  it('yields a graph byte-identical to the serial lane when a worker faults', async () => {
+    const files = corpus();
+    const pooled = await buildJson(files, {
+      workerFactory: stubWorkerFactory({ faultsOn: (f) => f.path.endsWith('mod3.ts') }),
+      poolSize: 2,
+    });
+    expect(pooled).toBe(await buildJson(files));
+  }, 30_000);
+
+  it('classifies a fault message only by its marker, so an ordinary failure is never mistaken for one', () => {
+    // The marker is message-keyed because a throw crossing the worker boundary is
+    // structured-cloned — its class and properties do not survive.
+    expect(isWorkerFaultMessage(`${WORKER_FAULT_MESSAGE_PREFIX}: uncaught exception while extracting a.ts — x`)).toBe(true);
+    for (const m of [undefined, '', 'Unexpected token', "Cannot find module 'tree-sitter-python'"]) {
+      expect(isWorkerFaultMessage(m)).toBe(false);
+    }
+  });
+
+  it('the worker entry installs boundaries for the faults a try/catch cannot see', () => {
+    // A structural guard, because the failure it prevents is a PROCESS-level abort: a fault that
+    // reaches a worker's top level with no listener kills the thread, and (when raised inside a
+    // native frame) the process, with no JavaScript error anywhere to attribute it.
+    const worker = readFileSync(join(__dirname, 'extraction-worker.ts'), 'utf-8');
+    expect(worker).toContain("process.on('uncaughtException'");
+    expect(worker).toContain("process.on('unhandledRejection'");
+    expect(worker).toContain('WORKER_FAULT_MESSAGE_PREFIX');
+  });
+});
+
+describe('extraction pool — a slow file is attributable', () => {
+  it('names the slowest files in the lane note, and says nothing when none were slow', () => {
+    expect(describeExtractionLane(disclosure({ lane: 'pooled', poolSize: 4 }))).toBeUndefined();
+    const note = describeExtractionLane(disclosure({
+      lane: 'pooled', poolSize: 4, slowFiles: [{ path: 'src/big.ts', ms: 7_400 }],
+    }));
+    expect(note).toContain('src/big.ts');
+    expect(note).toContain('7.4s');
+  });
+
+  it('carries the slow-file note even on an otherwise ordinary serial run', () => {
+    // "too-few-files" is a routine choice and says nothing on its own — but a user who waited
+    // still deserves to know WHICH file they waited on.
+    const note = describeExtractionLane(disclosure({
+      lane: 'serial', serialReason: 'too-few-files', slowFiles: [{ path: 'src/vendor.js', ms: 12_000 }],
+    }));
+    expect(note).toContain('src/vendor.js');
+  });
+
+  it('writes the live in-flight disclosure to stderr, never stdout', () => {
+    // `logger`'s non-error levels go to STDOUT, and `build()` also runs inside `openlore mcp`,
+    // whose stdout carries JSON-RPC frames. A per-file line there would corrupt the protocol.
+    const pool = readFileSync(join(__dirname, 'extraction-pool.ts'), 'utf-8');
+    expect(pool).toContain('process.stderr.write');
+    expect(pool).not.toMatch(/logger\.\w+\([^)]*still extracting/);
   });
 });

--- a/src/core/analyzer/extraction-pool.test.ts
+++ b/src/core/analyzer/extraction-pool.test.ts
@@ -20,6 +20,7 @@ import {
   plannedPoolSize,
   resolveWorkerEntry,
   describeExtractionLane,
+  boundSlowFiles,
   isWorkerFaultMessage,
   WORKER_FAULT_MESSAGE_PREFIX,
   __resetExtractionPoolStateForTests,
@@ -31,7 +32,13 @@ import {
   type ExtractionResponse,
 } from './extraction-pool.js';
 import { CallGraphBuilder, serializeCallGraph, dispatchFileExtract, type FileExtractResult } from './call-graph.js';
-import { EXTRACTION_POOL_MAX, EXTRACTION_POOL_MIN_FILES, EXTRACTION_POOL_STARTUP_TIMEOUT_MS } from '../../constants.js';
+import { ParseBudgetExceededError } from './parse-budget.js';
+import {
+  EXTRACTION_POOL_MAX,
+  EXTRACTION_POOL_MIN_FILES,
+  EXTRACTION_POOL_STARTUP_TIMEOUT_MS,
+  SLOW_FILE_DISCLOSURE_MS,
+} from '../../constants.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -99,6 +106,8 @@ interface StubOptions {
    * fix-analyze-native-abort-and-file-cost-budget).
    */
   faultsOn?: (file: ExtractionFile) => boolean;
+  /** Report a PARSE BUDGET overrun for these files — what a worker sends when the bound fires. */
+  budgetOverrunOn?: (file: ExtractionFile) => boolean;
   /** Records the input index of every answer, in the order the parent received it. */
   completionLog?: number[];
 }
@@ -138,6 +147,11 @@ function stubWorkerFactory(opts: StubOptions = {}): ExtractionWorkerFactory {
             send({ type: 'failed', id: replyId, message: 'degraded mid-run' });
             return;
           }
+          if (opts.budgetOverrunOn?.(file)) {
+            opts.completionLog?.push(id);
+            send({ type: 'failed', id: replyId, message: new ParseBudgetExceededError(20_001, 20_000).message });
+            return;
+          }
           if (opts.faultsOn?.(file)) {
             opts.completionLog?.push(id);
             send({
@@ -145,6 +159,13 @@ function stubWorkerFactory(opts: StubOptions = {}): ExtractionWorkerFactory {
               id: replyId,
               message: `${WORKER_FAULT_MESSAGE_PREFIX}: uncaught exception while extracting ${file.path} — Maximum call stack size exceeded`,
             });
+            // Model the REAL worker: its fault boundary answers and then closes the channel, so
+            // the thread stops serving and exits shortly after. Without this the stub kept
+            // answering after "faulting" and the parent's retire-vs-continue distinction was
+            // invisible — which is how a `continue` that steals a file from a healthy sibling
+            // survived the stub suite while failing on a real thread.
+            dead = true;
+            setTimeout(() => emit('exit', 0), 0);
             return;
           }
           if (opts.throwsFor?.(file.language)) {
@@ -683,6 +704,54 @@ describe('extraction pool — a worker fault degrades the LANE, never the file',
     expect(pooled).toBe(await buildJson(files));
   }, 30_000);
 
+  it('a faulting worker retires without stealing a file from its siblings', async () => {
+    // The earlier version of this test induced no fault at all and was a strictly weaker duplicate
+    // of the byte-identity test above — it passed with the worker-fault routing deleted outright.
+    // This one drives the real routing through the stub lane, where the fault is deterministic.
+    //
+    // The specific regression: the worker's boundary closes its channel right after answering, so
+    // every later `postMessage` to it is a silent no-op. Continuing the loop would claim another
+    // index off the shared cursor and never get a reply — taking a file away from a healthy
+    // sibling and reporting it as a worker failure (measured on a real thread before the fix).
+    const files = corpus(12);
+    const faulted = files[3].path;
+    const { outcomes, disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      // TWO workers, so there IS a sibling to steal from: the faulted worker must retire and let
+      // the survivor drain the queue, rather than claiming indices it can no longer serve.
+      workerFactory: stubWorkerFactory({ faultsOn: (f) => f.path === faulted }),
+      poolSize: 2,
+    });
+
+    // Exactly the faulted file falls back — not it plus whatever the dead worker grabbed next.
+    expect(d.workerFallbackFiles).toEqual([faulted]);
+    // And every file still carries real facts, because the main thread re-extracted that one.
+    expect(outcomes.every(o => o.status === 'ok' && (o.value?.nodes.length ?? 0) > 0)).toBe(true);
+  }, 60_000);
+
+  it('does NOT re-run a budget-exceeded file on the main thread — one bound, not two', async () => {
+    // A budget overrun is a property of the FILE: the main thread would spend the identical
+    // budget reaching the identical nothing. The unproven-language recheck used to fire on it
+    // anyway (the language is unproven precisely because the file yielded nothing), turning one
+    // 20 s bound into two — against this change's own spec text.
+    let serialCalls = 0;
+    const files = corpus(4);
+    const budgetFile = files[0].path;
+    const serialExtract = async (f: ExtractionFile): Promise<FileExtractResult | undefined> => {
+      serialCalls++;
+      return dispatchFileExtract(f);
+    };
+    const { disclosure: d } = await extractFilesForPass1(files, serialExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({ budgetOverrunOn: (f) => f.path === budgetFile }),
+      poolSize: 1,
+    });
+    expect(d.lane).toBe('pooled');
+    // The abandoned file was NOT handed back to the main thread…
+    expect(d.workerFallbackFiles).not.toContain(budgetFile);
+    expect(d.unprovenRechecks).toBe(0);
+    // …and the main thread ran for nothing at all on this corpus.
+    expect(serialCalls).toBe(0);
+  }, 30_000);
+
   it('classifies a fault message only by its marker, so an ordinary failure is never mistaken for one', () => {
     // The marker is message-keyed because a throw crossing the worker boundary is
     // structured-cloned — its class and properties do not survive.
@@ -722,11 +791,68 @@ describe('extraction pool — a slow file is attributable', () => {
     expect(note).toContain('src/vendor.js');
   });
 
-  it('writes the live in-flight disclosure to stderr, never stdout', () => {
-    // `logger`'s non-error levels go to STDOUT, and `build()` also runs inside `openlore mcp`,
-    // whose stdout carries JSON-RPC frames. A per-file line there would corrupt the protocol.
-    const pool = readFileSync(join(__dirname, 'extraction-pool.ts'), 'utf-8');
-    expect(pool).toContain('process.stderr.write');
-    expect(pool).not.toMatch(/logger\.\w+\([^)]*still extracting/);
+  it('writes the live in-flight disclosure to stderr, and SANITIZES the repo-supplied path', async () => {
+    // Two hazards in one line. `logger`'s non-error levels go to STDOUT, and `build()` also runs
+    // inside `openlore mcp` whose stdout carries JSON-RPC frames — so this must not use `logger`.
+    // And the path comes from the analyzed repository: printed raw, a crafted filename can emit
+    // terminal escapes and forge OpenLore's own output (change: fix terminal-escape injection).
+    const stderrWrites: string[] = [];
+    const stdoutWrites: string[] = [];
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation((c: unknown) => { stderrWrites.push(String(c)); return true; });
+    const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation((c: unknown) => { stdoutWrites.push(String(c)); return true; });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { stdoutWrites.push(a.join(' ')); });
+    try {
+      // One file, named hostilely, whose worker answer arrives after the disclosure threshold.
+      const hostilePath = 'src/\u001b[2Kevil\u0007.ts';
+      const files: ExtractionFile[] = [{ path: hostilePath, language: 'TypeScript', content: 'export function z(): void {}\n' }];
+      await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+        workerFactory: stubWorkerFactory({ delayFor: () => SLOW_FILE_DISCLOSURE_MS + 200 }),
+        poolSize: 1,
+      });
+      const line = stderrWrites.find(w => w.includes('still extracting'));
+      expect(line, 'the in-flight disclosure fired past the threshold').toBeDefined();
+      expect(line).toContain('evil.ts');
+      // The escapes are gone — ESC and BEL must never reach a terminal from a repo-supplied path.
+      expect(line).not.toContain('\u001b');
+      expect(line).not.toContain('\u0007');
+      expect(stdoutWrites.join(''), 'nothing about this went to stdout').not.toContain('still extracting');
+    } finally {
+      errSpy.mockRestore(); outSpy.mockRestore(); logSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('measures slow files past the threshold, dedupes them, and keeps the slowest first', async () => {
+    // The measurement itself was untested: deleting both `slow.push` sites, or unsorting/uncapping
+    // the result, used to leave the suite green.
+    const slowMs = SLOW_FILE_DISCLOSURE_MS + 150;
+    const files: ExtractionFile[] = [
+      { path: 'src/fast.ts', language: 'TypeScript', content: 'export function f(): void {}\n' },
+      { path: 'src/slow.ts', language: 'TypeScript', content: 'export function s(): void {}\n' },
+    ];
+    const { disclosure: d } = await extractFilesForPass1(files, dispatchFileExtract, isEmpty, {
+      workerFactory: stubWorkerFactory({ delayFor: (i) => (i === 1 ? slowMs : 0) }),
+      poolSize: 1,
+    });
+    expect(d.slowFiles.map(s => s.path)).toEqual(['src/slow.ts']);
+    expect(d.slowFiles[0].ms).toBeGreaterThanOrEqual(SLOW_FILE_DISCLOSURE_MS);
+  }, 30_000);
+
+  it('never lists one file twice, even when it is timed on BOTH lanes', () => {
+    // A file handed back to the main thread (worker fault, unproven language, dead worker) is
+    // timed twice. Listing it twice spends two of the five slots on one file and evicts genuinely
+    // distinct slow files — the opposite of the attribution this exists for.
+    const d = disclosure({
+      lane: 'pooled',
+      poolSize: 2,
+      slowFiles: boundSlowFiles([
+        { path: 'src/dup.ts', ms: 5_200 },
+        { path: 'src/dup.ts', ms: 7_100 },
+        { path: 'src/other.ts', ms: 6_000 },
+      ]),
+    });
+    expect(d.slowFiles).toEqual([
+      { path: 'src/dup.ts', ms: 7_100 },   // deduped, worst time kept
+      { path: 'src/other.ts', ms: 6_000 }, // slowest-first ordering preserved
+    ]);
   });
 });

--- a/src/core/analyzer/extraction-pool.ts
+++ b/src/core/analyzer/extraction-pool.ts
@@ -53,8 +53,10 @@ import {
   EXTRACTION_POOL_STARTUP_TIMEOUT_MS,
   EXTRACTION_POOL_REQUEST_TIMEOUT_MS,
   EXTRACTION_POOL_TERMINATE_TIMEOUT_MS,
+  SLOW_FILE_DISCLOSURE_MS,
 } from '../../constants.js';
 import { logger } from '../../utils/logger.js';
+import { sanitizeForTerminal } from '../../utils/misc.js';
 
 /** One Pass-1 input record — the same shape `CallGraphBuilder.build` receives. */
 export interface ExtractionFile {
@@ -110,6 +112,25 @@ export interface ExtractionLaneDisclosure {
    * degradation: the cost of never trusting an unproven worker. See {@link runPooled}.
    */
   unprovenRechecks: number;
+  /**
+   * Files whose extraction took longer than {@link SLOW_FILE_DISCLOSURE_MS}, with their elapsed
+   * time — sorted slowest first and bounded (change: fix-analyze-native-abort-and-file-cost-budget).
+   *
+   * Attribution, not degradation: these files were extracted normally. Before this existed, a run
+   * that sat for minutes gave no way to learn WHICH file was responsible short of attaching a
+   * debugger. Empty on an ordinary run, so nothing is printed when there is nothing to say.
+   */
+  slowFiles: Array<{ path: string; ms: number }>;
+}
+
+/** How many slow files the disclosure retains. A bound on the payload, not on the measurement. */
+const SLOW_FILE_DISCLOSURE_CAP = 5;
+
+/** Keep the slowest {@link SLOW_FILE_DISCLOSURE_CAP} entries, slowest first, path-tiebroken. */
+function boundSlowFiles(slow: Array<{ path: string; ms: number }>): Array<{ path: string; ms: number }> {
+  return [...slow]
+    .sort((a, b) => b.ms - a.ms || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+    .slice(0, SLOW_FILE_DISCLOSURE_CAP);
 }
 
 /**
@@ -172,6 +193,22 @@ export type ExtractionResponse =
 
 /** Set to `1`/`true` to force the serial lane (the documented escape hatch). */
 const NO_WORKERS_ENV = 'OPENLORE_NO_WORKERS';
+
+/**
+ * Stable prefix on the message of a per-file failure caused by a WORKER FAULT rather than by the
+ * file itself (change: fix-analyze-native-abort-and-file-cost-budget).
+ *
+ * A throw crossing the `worker_threads` boundary is structured-cloned, so only its message
+ * survives — the same constraint that makes the parse-budget signal message-keyed. This prefix is
+ * what lets the builder record `worker-fault` instead of blaming the source file for a defect in
+ * the thread that was reading it.
+ */
+export const WORKER_FAULT_MESSAGE_PREFIX = 'openlore:extraction-worker-fault';
+
+/** Read a failure message as a worker fault. Any other message is not one. */
+export function isWorkerFaultMessage(message: string | undefined): boolean {
+  return !!message && message.startsWith(WORKER_FAULT_MESSAGE_PREFIX);
+}
 
 /** Resolved worker entry: the module a worker loads, plus any exec args it needs. */
 export interface ResolvedWorkerEntry {
@@ -282,12 +319,14 @@ export async function extractFilesForPass1<T>(
     disclosure: ExtractionLaneDisclosure;
   }> => {
     const outcomes: Array<ExtractOutcome<T>> = [];
-    for (const file of files) outcomes.push(await runSerial(file, serialExtract));
+    const slow: Array<{ path: string; ms: number }> = [];
+    for (const file of files) outcomes.push(await runSerial(file, serialExtract, slow));
     return {
       outcomes,
       disclosure: {
         lane: 'serial', poolSize: 0, serialReason: reason,
         workerFallbackFiles: [], laneDefectFiles: [], unprovenRechecks: 0,
+        slowFiles: boundSlowFiles(slow),
       },
     };
   };
@@ -338,14 +377,28 @@ function dominantLanguage(files: ExtractionFile[]): string | undefined {
   return best;
 }
 
+/**
+ * Run one file on the main thread, recording it in `slow` when it takes longer than
+ * {@link SLOW_FILE_DISCLOSURE_MS}.
+ *
+ * The measurement is taken AROUND the extraction, not by a timer: a main-thread parse is one
+ * synchronous native call, so no timer scheduled here could fire while it runs. That is why the
+ * serial lane names a slow file once it finishes rather than while it is running — and with the
+ * per-file parse budget in place, "once it finishes" is now bounded.
+ */
 async function runSerial<T>(
   file: ExtractionFile,
   serialExtract: (file: ExtractionFile) => Promise<T | undefined>,
+  slow?: Array<{ path: string; ms: number }>,
 ): Promise<ExtractOutcome<T>> {
+  const startedAt = Date.now();
   try {
     return { status: 'ok', value: await serialExtract(file) };
   } catch (error) {
     return { status: 'error', error };
+  } finally {
+    const ms = Date.now() - startedAt;
+    if (slow && ms >= SLOW_FILE_DISCLOSURE_MS) slow.push({ path: file.path, ms });
   }
 }
 
@@ -417,6 +470,8 @@ async function runPooled<T>(
   let sawStartupTimeout = false;
   /** Grammar-unavailable warnings relayed from workers, deduped across the pool. */
   const relayedWarnings = new Set<string>();
+  /** Files that took longer than the disclosure threshold, on either lane. */
+  const slow: Array<{ path: string; ms: number }> = [];
 
   const runOne = async (): Promise<void> => {
     let worker: ExtractionWorkerHandle;
@@ -486,7 +541,16 @@ async function runPooled<T>(
         else p.resolve({ status: 'error', error: new Error(msg.message) });
       });
       worker.on('error', (err) => die(err instanceof Error ? err : new Error(String(err))));
-      worker.on('exit', () => die(deadReason ?? new Error('extraction worker exited')));
+      // A non-zero exit code is named, so the file that fell to the main thread is attributable
+      // to a worker that died rather than to an unexplained gap. An already-recorded cause wins:
+      // it is the more specific one.
+      worker.on('exit', (code) => die(
+        deadReason ?? new Error(
+          typeof code === 'number' && code !== 0
+            ? `extraction worker exited with code ${code}`
+            : 'extraction worker exited',
+        ),
+      ));
     } catch (err) {
       await terminateQuietly(worker);
       release();
@@ -523,13 +587,27 @@ async function runPooled<T>(
         cursor = index + 1;
         const file = files[index];
         let outcome: ExtractOutcome<T>;
+        const startedAt = Date.now();
         try {
-          outcome = await requestExtract<T>(worker, index, file, (p) => { pending = p; });
+          outcome = await requestExtract<T>(worker, index, file, (p) => { pending = p; }, slow);
         } catch {
           // The worker died (or wedged past its deadline) holding this file. Leave the slot
           // for the main thread and stop feeding this worker.
           unfilled[index] = 'worker-died';
           break;
+        }
+        {
+          const ms = Date.now() - startedAt;
+          if (ms >= SLOW_FILE_DISCLOSURE_MS) slow.push({ path: file.path, ms });
+        }
+        // A fault INSIDE the thread is evidence about the worker, not about the file — so it is
+        // never trusted as this file's answer, proven language or not, and the main thread (the
+        // reference implementation) extracts it instead (change:
+        // fix-analyze-native-abort-and-file-cost-budget). Recording the file as failed here would
+        // blame the source for a defect in the thread that was reading it.
+        if (outcome.status === 'error' && isWorkerFaultMessage((outcome.error as Error | undefined)?.message)) {
+          unfilled[index] = 'worker-died';
+          continue;
         }
         // A worker that cannot handle a language reports it two ways, and BOTH are
         // indistinguishable from a real answer: an empty result (the core binding failed to
@@ -575,7 +653,7 @@ async function runPooled<T>(
     // A slot with no recorded reason belongs to a file no worker ever claimed (every
     // worker died first) — the same situation as a worker dying while holding it.
     const reason = unfilled[i] ?? 'worker-died';
-    const outcome = await runSerial(files[i], serialExtract);
+    const outcome = await runSerial(files[i], serialExtract, slow);
     if (reason === 'worker-died') {
       workerFallbackFiles.push(files[i].path);
     } else {
@@ -592,7 +670,10 @@ async function runPooled<T>(
 
   return {
     outcomes: slots as Array<ExtractOutcome<T>>,
-    disclosure: { lane: 'pooled', poolSize: started, workerFallbackFiles, laneDefectFiles, unprovenRechecks },
+    disclosure: {
+      lane: 'pooled', poolSize: started, workerFallbackFiles, laneDefectFiles, unprovenRechecks,
+      slowFiles: boundSlowFiles(slow),
+    },
   };
 }
 
@@ -608,13 +689,37 @@ function requestExtract<T>(
   index: number,
   file: ExtractionFile,
   arm: (pending: { id: number; resolve: (v: ExtractOutcome<T>) => void; reject: (e: Error) => void }) => void,
+  slow?: Array<{ path: string; ms: number }>,
 ): Promise<ExtractOutcome<T>> {
   return new Promise<ExtractOutcome<T>>((resolve, reject) => {
     const timer = setTimeout(() => {
       reject(new Error(`extraction worker did not answer for ${file.path} within ${EXTRACTION_POOL_REQUEST_TIMEOUT_MS}ms`));
     }, EXTRACTION_POOL_REQUEST_TIMEOUT_MS);
     timer.unref?.();
-    const settle = <R>(fn: (v: R) => void) => (v: R): void => { clearTimeout(timer); fn(v); };
+    // Live attribution: the parse runs in the WORKER, so unlike the serial lane this parent-side
+    // timer really does fire while the file is still being worked on — which is what lets the user
+    // see the responsible path before the run ends rather than after. Warning only; nothing is
+    // abandoned here (that is the parse budget's job). Only armed when the caller is collecting.
+    //
+    // Written straight to stderr rather than through `logger`, whose non-error levels go to
+    // STDOUT — and `build()` also runs inside `openlore mcp`, whose stdout carries JSON-RPC
+    // frames. This is the module's "nothing here writes to stdout" rule, and a per-file line is
+    // exactly the frequency at which breaking it would corrupt the protocol. The path comes from
+    // the analyzed repository, so it is sanitized before it reaches a terminal.
+    const slowTimer = slow
+      ? setTimeout(() => {
+          process.stderr.write(
+            `[warn] still extracting ${sanitizeForTerminal(file.path)} `
+            + `after ${Math.round(SLOW_FILE_DISCLOSURE_MS / 1000)}s\n`,
+          );
+        }, SLOW_FILE_DISCLOSURE_MS)
+      : undefined;
+    slowTimer?.unref?.();
+    const settle = <R>(fn: (v: R) => void) => (v: R): void => {
+      clearTimeout(timer);
+      if (slowTimer) clearTimeout(slowTimer);
+      fn(v);
+    };
     arm({ id: index, resolve: settle(resolve), reject: settle(reject) });
     worker.postMessage({ type: 'extract', id: index, file } satisfies ExtractionRequest);
   });
@@ -652,6 +757,14 @@ async function terminateQuietly(worker: ExtractionWorkerHandle): Promise<void> {
  * means analysis was slower than it should have been — never that it was less complete.
  */
 export function describeExtractionLane(d: ExtractionLaneDisclosure): string | undefined {
+  // Attribution for a slow run, on either lane. Not a degradation — these files were extracted
+  // normally — but it is the answer to "why did that take so long", which previously had none.
+  const slowNote = d.slowFiles.length > 0
+    ? `slowest file(s) to extract: ${d.slowFiles.map(s => `${s.path} (${(s.ms / 1000).toFixed(1)}s)`).join(', ')}`
+    : undefined;
+  const withSlow = (note: string | undefined): string | undefined =>
+    note && slowNote ? `${note}; ${slowNote}` : (note ?? slowNote);
+
   if (d.lane === 'pooled') {
     const parts: string[] = [];
     // A worker that reported nothing (an empty result OR a throw) where the main thread
@@ -666,7 +779,7 @@ export function describeExtractionLane(d: ExtractionLaneDisclosure): string | un
     if (d.workerFallbackFiles.length > 0) {
       parts.push(`extraction pool degraded: ${d.workerFallbackFiles.length} file(s) re-extracted on the main thread after a worker failed`);
     }
-    return parts.length > 0 ? parts.join('; ') : undefined;
+    return withSlow(parts.length > 0 ? parts.join('; ') : undefined);
   }
   // A small build, a small machine, a caller opting out, or an explicit env opt-out are
   // ordinary choices, not degradations — warning about them would be noise on every run.
@@ -675,6 +788,6 @@ export function describeExtractionLane(d: ExtractionLaneDisclosure): string | un
     d.serialReason === 'insufficient-cores' ||
     d.serialReason === 'pool-saturated' ||
     d.serialReason === 'disabled-by-env'
-  ) return undefined;
-  return `extraction ran on the serial lane (${d.serialReason}) — analysis is complete but slower`;
+  ) return withSlow(undefined);
+  return withSlow(`extraction ran on the serial lane (${d.serialReason}) — analysis is complete but slower`);
 }

--- a/src/core/analyzer/extraction-pool.ts
+++ b/src/core/analyzer/extraction-pool.ts
@@ -57,6 +57,7 @@ import {
 } from '../../constants.js';
 import { logger } from '../../utils/logger.js';
 import { sanitizeForTerminal } from '../../utils/misc.js';
+import { parseBudgetOverrunMs } from './parse-budget.js';
 
 /** One Pass-1 input record — the same shape `CallGraphBuilder.build` receives. */
 export interface ExtractionFile {
@@ -126,9 +127,22 @@ export interface ExtractionLaneDisclosure {
 /** How many slow files the disclosure retains. A bound on the payload, not on the measurement. */
 const SLOW_FILE_DISCLOSURE_CAP = 5;
 
-/** Keep the slowest {@link SLOW_FILE_DISCLOSURE_CAP} entries, slowest first, path-tiebroken. */
-function boundSlowFiles(slow: Array<{ path: string; ms: number }>): Array<{ path: string; ms: number }> {
-  return [...slow]
+/**
+ * Keep the slowest {@link SLOW_FILE_DISCLOSURE_CAP} entries, slowest first, path-tiebroken.
+ *
+ * Deduplicated by path, keeping the worst time. One file can be timed TWICE — once in a worker and
+ * again on the main thread when the pool hands it back (a worker fault, an unproven language, a
+ * dead worker) — and listing it twice would spend two of the five slots on one file and silently
+ * evict genuinely distinct slow files, which is the opposite of the attribution this exists for.
+ */
+export function boundSlowFiles(slow: Array<{ path: string; ms: number }>): Array<{ path: string; ms: number }> {
+  const worstByPath = new Map<string, number>();
+  for (const { path, ms } of slow) {
+    const prev = worstByPath.get(path);
+    if (prev === undefined || ms > prev) worstByPath.set(path, ms);
+  }
+  return [...worstByPath]
+    .map(([path, ms]) => ({ path, ms }))
     .sort((a, b) => b.ms - a.ms || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
     .slice(0, SLOW_FILE_DISCLOSURE_CAP);
 }
@@ -607,8 +621,20 @@ async function runPooled<T>(
         // blame the source for a defect in the thread that was reading it.
         if (outcome.status === 'error' && isWorkerFaultMessage((outcome.error as Error | undefined)?.message)) {
           unfilled[index] = 'worker-died';
-          continue;
+          // BREAK, not continue — this worker is gone. Its fault boundary closes the message
+          // channel right after answering, so every later `postMessage` to it is a silent no-op:
+          // continuing would claim the next index off the shared cursor, get no reply, and either
+          // steal that file from a healthy sibling (measured) or stall the lane for the full
+          // request timeout. Matches how every other worker-death path exits this loop.
+          break;
         }
+        // A file abandoned at the PARSE BUDGET is a property of the file, not of the worker, and
+        // the main thread would spend the identical budget reaching the identical nothing. Trust
+        // it — the unproven-language recheck below must not turn one bound into two (change:
+        // fix-analyze-native-abort-and-file-cost-budget). It is still recorded and disclosed by
+        // the builder, exactly as a serial-lane overrun is.
+        const budgetOverrun = outcome.status === 'error'
+          && parseBudgetOverrunMs((outcome.error as Error | undefined)?.message) !== undefined;
         // A worker that cannot handle a language reports it two ways, and BOTH are
         // indistinguishable from a real answer: an empty result (the core binding failed to
         // load) or a throw (the per-language grammar `import` failed — those loads are not
@@ -619,7 +645,7 @@ async function runPooled<T>(
           && !isEmptyResult(outcome.value);
         if (producedFacts) {
           proven.add(file.language);
-        } else if (outcome.status !== 'ok' || isEmptyResult(outcome.value)) {
+        } else if (!budgetOverrun && (outcome.status !== 'ok' || isEmptyResult(outcome.value))) {
           if (!proven.has(file.language)) {
             unfilled[index] = 'unproven';
             continue;

--- a/src/core/analyzer/extraction-worker.ts
+++ b/src/core/analyzer/extraction-worker.ts
@@ -31,6 +31,7 @@
 import { parentPort, workerData } from 'node:worker_threads';
 import { dispatchFileExtract } from './call-graph.js';
 import { logger } from '../../utils/logger.js';
+import { WORKER_FAULT_MESSAGE_PREFIX } from './extraction-pool.js';
 import type { ExtractionRequest, ExtractionResponse, ExtractionWorkerData } from './extraction-pool.js';
 
 /**
@@ -91,6 +92,51 @@ async function probeFailureReason(language: string | undefined): Promise<string 
   }
 }
 
+/**
+ * Convert the faults a plain `try`/`catch` around `dispatchFileExtract` cannot see into a
+ * structured per-file failure (change: fix-analyze-native-abort-and-file-cost-budget).
+ *
+ * The `catch` in the request handler covers a throw the extractor *returns through*. It does not
+ * cover a throw raised from a callback the native binding invoked, a rejection that escaped an
+ * un-awaited promise, or an error raised between turns — those reach the thread's top level, and
+ * a worker with no `uncaughtException` listener dies there. The parent notices (it listens for
+ * `error` and `exit`) but only as "the worker holding file N vanished", which costs the pool a
+ * worker and re-runs the file on the main thread — where, if the fault is deterministic, the same
+ * thing happens with no thread boundary left to absorb it.
+ *
+ * So the fault is answered for the file it happened on, with the marker that makes the parent
+ * record `worker-fault` rather than blaming the source. Then the thread retires: an
+ * `uncaughtException` means unknown state, and a worker that keeps serving from unknown state
+ * could return facts that are wrong rather than absent — which is the worse failure by this
+ * codebase's rules. Retiring is cheap; the parent already handles a worker leaving mid-run.
+ */
+function installFaultBoundaries(
+  peek: () => { id: number; path: string } | undefined,
+  clear: () => void,
+): void {
+  let retiring = false;
+  const onFault = (kind: string, err: unknown): void => {
+    if (retiring) return;
+    retiring = true;
+    const current = peek();
+    clear();
+    const detail = err instanceof Error ? err.message : String(err);
+    if (current) {
+      post({
+        type: 'failed',
+        id: current.id,
+        message: `${WORKER_FAULT_MESSAGE_PREFIX}: ${kind} while extracting ${current.path} — ${detail}`,
+      });
+    }
+    // Close the channel rather than `process.exit`: closing lets the queued `failed` message
+    // above actually flush, and the parent sees a clean `exit` it already knows how to handle.
+    // `process.exit` here would race the post and strip the file's attribution.
+    parentPort?.close();
+  };
+  process.on('uncaughtException', (err) => onFault('uncaught exception', err));
+  process.on('unhandledRejection', (reason) => onFault('unhandled rejection', reason));
+}
+
 async function main(): Promise<void> {
   // Serve only when this thread is an extraction worker THIS pool spawned. Importing this
   // module for its `PROBES` table (the probe-snippet guard test does) must never attach a
@@ -107,6 +153,12 @@ async function main(): Promise<void> {
     return;
   }
 
+  // The file this thread is currently working on. Read by the fault boundaries below so a fault
+  // can be attributed to a file rather than reaching the parent as an anonymous thread death.
+  let inFlight: { id: number; path: string } | undefined;
+
+  installFaultBoundaries(() => inFlight, () => { inFlight = undefined; });
+
   // Requests are served strictly one at a time: the parent never has more than one
   // in-flight file per worker, so no queueing or interleaving is needed here.
   parentPort.on('message', (raw: unknown) => {
@@ -118,6 +170,7 @@ async function main(): Promise<void> {
     }
     if (msg.type !== 'extract') return;
     void (async () => {
+      inFlight = { id: msg.id, path: msg.file.path };
       try {
         const value = await dispatchFileExtract(msg.file);
         post({ type: 'result', id: msg.id, value });
@@ -125,6 +178,8 @@ async function main(): Promise<void> {
         // Mirrors the serial lane: a throwing extractor is a parse failure for THIS file,
         // recorded as such by the parent — not a reason to fall back or retry.
         post({ type: 'failed', id: msg.id, message: (err as Error).message });
+      } finally {
+        inFlight = undefined;
       }
     })();
   });

--- a/src/core/analyzer/parse-budget.test.ts
+++ b/src/core/analyzer/parse-budget.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Per-file parse budget (change: fix-analyze-native-abort-and-file-cost-budget).
+ *
+ * The acceptance criterion of this change is a REPRODUCER, so the tests lead with the two
+ * behaviours that were broken on `origin/main`:
+ *
+ *   1. A 300 KB file of a repeated unterminated block-comment opener parses for ~84 s and yields a
+ *      100,002-deep tree. It must now be abandoned at the budget and RECORDED, not waited on.
+ *   2. The tree it does produce overflowed the recursive parse-health walk, and a `RangeError`
+ *      raised inside the native binding's node accessor is what turned it into
+ *      `libc++abi: terminating due to uncaught exception of type Napi::Error` (exit 134). The walk
+ *      must survive a tree far deeper than any call stack.
+ *
+ * And with them the CONTROL, which matters just as much: a bound that silently drops real files
+ * would be a worse bug than the one being fixed. So an ordinary large file must be unaffected, and
+ * the graph must be identical to a run with the budget disabled.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  parseWithBudget,
+  parseBudgetMs,
+  parseBudgetOverrunMs,
+  parseBudgetSupported,
+  ParseBudgetExceededError,
+  PARSE_BUDGET_MESSAGE_PREFIX,
+} from './parse-budget.js';
+import { tallyParseHealth, type ParseHealthNode } from './parse-health.js';
+import { CallGraphBuilder, serializeCallGraph } from './call-graph.js';
+import { PER_FILE_PARSE_BUDGET_MS, PARSE_BUDGET_ENV } from '../../constants.js';
+
+/** The exact payload that reproduced the failure: 100,000 unterminated block-comment openers. */
+const HOSTILE_TS = '/*x'.repeat(100_000);
+
+afterEach(() => { delete process.env[PARSE_BUDGET_ENV]; });
+
+// ---------------------------------------------------------------------------
+// The bound itself
+// ---------------------------------------------------------------------------
+
+describe('parseWithBudget', () => {
+  it('arms the deadline, returns the tree, and always disarms it', () => {
+    const calls: number[] = [];
+    const parser = {
+      setTimeoutMicros: (n: number) => calls.push(n),
+      parse: () => ({ ok: true }),
+    };
+    expect(parseWithBudget(parser, 'x')).toEqual({ ok: true });
+    // Armed to the budget, then cleared — a deadline left armed would charge the NEXT file the
+    // remainder of this one's budget on the same singleton parser.
+    expect(calls).toEqual([PER_FILE_PARSE_BUDGET_MS * 1000, 0]);
+  });
+
+  it('disarms the deadline even when the parse throws', () => {
+    const calls: number[] = [];
+    const parser = {
+      setTimeoutMicros: (n: number) => calls.push(n),
+      parse: () => { throw new Error('boom'); },
+    };
+    expect(() => parseWithBudget(parser, 'x')).toThrow('boom');
+    expect(calls).toEqual([PER_FILE_PARSE_BUDGET_MS * 1000, 0]);
+  });
+
+  it('turns a null tree from a BOUNDED parser into a budget-exceeded error carrying the bound', () => {
+    const parser = { setTimeoutMicros: () => {}, parse: () => null };
+    let thrown: unknown;
+    try { parseWithBudget(parser, 'x'); } catch (e) { thrown = e; }
+    expect(thrown).toBeInstanceOf(ParseBudgetExceededError);
+    expect((thrown as Error).message).toContain(PARSE_BUDGET_MESSAGE_PREFIX);
+    expect(parseBudgetOverrunMs((thrown as Error).message)).toBe(PER_FILE_PARSE_BUDGET_MS);
+  });
+
+  it('RESETS the parser when the deadline fires, so the next file does not resume the abandoned parse', () => {
+    // A timed-out tree-sitter parse is SUSPENDED, not discarded — calling `parse` again resumes
+    // it. Without the reset, the file AFTER a budget-exceeded one silently produced zero symbols.
+    let resets = 0;
+    const parser = { setTimeoutMicros: () => {}, reset: () => { resets++; }, parse: () => null };
+    expect(() => parseWithBudget(parser, 'x')).toThrow(ParseBudgetExceededError);
+    expect(resets).toBe(1);
+  });
+
+  it('does not reset on a successful parse — resetting is the timeout path only', () => {
+    let resets = 0;
+    const parser = { setTimeoutMicros: () => {}, reset: () => { resets++; }, parse: () => ({ ok: true }) };
+    parseWithBudget(parser, 'x');
+    expect(resets).toBe(0);
+  });
+
+  it('does NOT call a null tree from an UNBOUNDED parser a budget overrun', () => {
+    // No `setTimeoutMicros` — the deadline was never armed, so a missing tree is some other
+    // failure. Mislabelling it would attribute a real defect to a bound that never ran.
+    const parser = { parse: () => null };
+    expect(() => parseWithBudget(parser, 'x')).toThrow('tree-sitter returned no tree');
+    expect(parseBudgetSupported(parser)).toBe(false);
+  });
+
+  it('never arms a deadline the parser cannot enforce', () => {
+    let parsed = false;
+    const parser = { parse: () => { parsed = true; return { ok: true }; } };
+    expect(parseWithBudget(parser, 'x')).toEqual({ ok: true });
+    expect(parsed).toBe(true);
+  });
+
+  it('falls back to an unbounded parse when arming the deadline THROWS, and never asks that parser again', () => {
+    // `web-tree-sitter@0.25` exposes `setTimeoutMicros` and throws
+    // `TypeError: Cannot convert 0 to a BigInt` from inside it. Letting that propagate made every
+    // Dart and Lua file fail to extract — a bound that silently deleted real work.
+    let arms = 0;
+    const parser = {
+      setTimeoutMicros: () => { arms++; throw new TypeError('Cannot convert 0 to a BigInt'); },
+      parse: () => ({ ok: true }),
+    };
+    expect(parseWithBudget(parser, 'x')).toEqual({ ok: true });
+    expect(parseWithBudget(parser, 'y')).toEqual({ ok: true });
+    // Refused once, demoted for good: the throw is not re-paid per file.
+    expect(arms).toBe(1);
+    expect(parseBudgetSupported(parser)).toBe(false);
+  });
+
+  it('a parser that cannot arm a deadline reports a missing tree honestly, not as a budget overrun', () => {
+    const parser = {
+      setTimeoutMicros: () => { throw new TypeError('nope'); },
+      parse: () => null,
+    };
+    expect(() => parseWithBudget(parser, 'x')).toThrow('tree-sitter returned no tree');
+  });
+
+  it('is disabled by OPENLORE_PARSE_BUDGET_MS=0, restoring the previous unbounded behaviour', () => {
+    process.env[PARSE_BUDGET_ENV] = '0';
+    const calls: number[] = [];
+    const parser = { setTimeoutMicros: (n: number) => calls.push(n), parse: () => ({ ok: true }) };
+    expect(parseBudgetMs()).toBe(0);
+    parseWithBudget(parser, 'x');
+    expect(calls).toEqual([]); // no deadline armed at all
+  });
+});
+
+describe('parseBudgetMs', () => {
+  it('honours a valid override', () => {
+    process.env[PARSE_BUDGET_ENV] = '1500';
+    expect(parseBudgetMs()).toBe(1500);
+  });
+
+  it.each(['', '   ', 'abc', '-5', 'NaN', 'Infinity'])(
+    'ignores %o and keeps the default — a typo must not silently disable the bound',
+    (raw) => {
+      process.env[PARSE_BUDGET_ENV] = raw;
+      expect(parseBudgetMs()).toBe(PER_FILE_PARSE_BUDGET_MS);
+    },
+  );
+});
+
+describe('parseBudgetOverrunMs', () => {
+  it('reads the BUDGET off a message that crossed a worker boundary', () => {
+    // The class does not survive structured cloning, so classification is message-keyed. This is
+    // the exact shape the parent receives from a worker.
+    //
+    // The budget, not the measured elapsed time: the caller writes this into `parse-health.json`,
+    // which must be byte-identical across re-analyses of a fixed repository state. A wall-clock
+    // number there would make every run differ.
+    expect(parseBudgetOverrunMs(new ParseBudgetExceededError(19_977, 20_000).message)).toBe(20_000);
+  });
+
+  it('still classifies a marked message whose budget it cannot read', () => {
+    // Degrading to "ordinary parse failure" would mis-attribute the cause; falling back to the
+    // active budget keeps the reason right.
+    expect(parseBudgetOverrunMs(`${PARSE_BUDGET_MESSAGE_PREFIX}: mangled`)).toBe(PER_FILE_PARSE_BUDGET_MS);
+  });
+
+  it.each([undefined, '', 'Maximum call stack size exceeded', 'Unexpected token'])(
+    'returns undefined for %o so an ordinary failure is never re-labelled',
+    (msg) => expect(parseBudgetOverrunMs(msg)).toBeUndefined(),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Reproducer 1 — the pathological file is abandoned and recorded, not waited on
+// ---------------------------------------------------------------------------
+
+describe('reproducer: a pathological file is abandoned rather than stalling the run', () => {
+  it('records it as budget-exceeded with its elapsed time, and analyzes the rest normally', async () => {
+    // A small budget so the test is fast; the mechanism is identical at the 20 s default, which
+    // this same file exceeds (~84 s of parse on the machine that reproduced it).
+    process.env[PARSE_BUDGET_ENV] = '750';
+    const result = await new CallGraphBuilder({}).build([
+      { path: 'src/hostile.ts', content: HOSTILE_TS, language: 'TypeScript' },
+      { path: 'src/ok.ts', content: 'export function a(): void { b(); }\nfunction b(): void {}\n', language: 'TypeScript' },
+    ]);
+
+    const health = result.parseHealthByFile?.get('src/hostile.ts');
+    expect(health?.exclusion).toBe('budget-exceeded');
+    expect(health?.parseFailed).toBe(true);
+    expect(health?.budgetMs).toBe(750);
+
+    // The rest of the repository is analyzed normally — the bound costs one file, not the run.
+    // This assertion is the one that caught the missing parser reset: `ok.ts` follows the
+    // abandoned file through the SAME singleton parser, and without a reset it produced nothing.
+    expect([...result.nodes.values()].some(n => n.name === 'a')).toBe(true);
+    expect(result.parseHealthByFile?.has('src/ok.ts')).toBe(false);
+  }, 60_000);
+
+  it('records the same thing twice — a budget-exceeded file must not make the artifact non-deterministic', async () => {
+    // `parse-health.json` is persisted and must be byte-identical across re-analyses of a fixed
+    // repository state (change: fix-artifact-output-determinism). Recording the measured elapsed
+    // time here would break that on every repository that has one of these files.
+    process.env[PARSE_BUDGET_ENV] = '600';
+    const files = [{ path: 'src/hostile.ts', content: HOSTILE_TS, language: 'TypeScript' }];
+    const once = await new CallGraphBuilder({}).build(files.map(f => ({ ...f })));
+    const twice = await new CallGraphBuilder({}).build(files.map(f => ({ ...f })));
+    expect(JSON.stringify([...once.parseHealthByFile!]))
+      .toBe(JSON.stringify([...twice.parseHealthByFile!]));
+    expect(once.parseHealthByFile!.get('src/hostile.ts')?.budgetMs).toBe(600);
+  }, 60_000);
+
+  it('CONTROL: an ordinary large file is NOT recorded, and the graph matches a run with the budget disabled', async () => {
+    // ~1.4 MB of well-formed generated-client-shaped source — far larger than anything in this
+    // repository, and it must parse well inside the budget. A bound that dropped this would be a
+    // worse bug than the unbounded parse it replaced.
+    const big = Array.from(
+      { length: 20_000 },
+      (_, i) => `export function gen${i}(): number { return helper${i}(); }\nfunction helper${i}(): number { return ${i}; }`,
+    ).join('\n');
+    const files = [{ path: 'src/generated-client.ts', content: big, language: 'TypeScript' }];
+
+    process.env[PARSE_BUDGET_ENV] = '0';
+    const withoutBudget = serializeCallGraph(await new CallGraphBuilder({}).build(files.map(f => ({ ...f }))));
+    delete process.env[PARSE_BUDGET_ENV];
+    const withBudget = await new CallGraphBuilder({}).build(files.map(f => ({ ...f })));
+
+    expect(withBudget.parseHealthByFile?.get('src/generated-client.ts')).toBeUndefined();
+    expect(JSON.stringify(serializeCallGraph(withBudget))).toBe(JSON.stringify(withoutBudget));
+  }, 120_000);
+});
+
+// ---------------------------------------------------------------------------
+// Reproducer 2 — the deep tree that produced the exit-134 abort
+// ---------------------------------------------------------------------------
+
+describe('reproducer: the parse-health walk survives a tree deeper than any call stack', () => {
+  /**
+   * A right-leaning chain `depth` nodes deep, built lazily through the index accessors the real
+   * `SyntaxNode` exposes — the same shape the hostile file produced (measured: 100,002 deep). The
+   * recursive walk this replaced overflowed at roughly a tenth of this.
+   */
+  function deepChain(depth: number): ParseHealthNode {
+    const make = (level: number): ParseHealthNode => ({
+      type: level === depth ? 'ERROR' : 'binary_expression',
+      startPosition: { row: level },
+      hasError: true,
+      children: [],
+      childCount: level === depth ? 0 : 1,
+      child: (i: number) => (i === 0 && level < depth ? make(level + 1) : null),
+    });
+    return make(0);
+  }
+
+  it('tallies a 100,000-deep tree without a RangeError', () => {
+    // The unguarded `RangeError` here is what surfaced as a native abort with no JavaScript error
+    // anywhere: raised inside the binding's node accessor, it cannot be caught as a JS throw.
+    const health = tallyParseHealth('TypeScript', deepChain(100_000), 'src/hostile.ts');
+    expect(health?.errorCount).toBe(1);
+    expect(health?.errorLines).toEqual([100_001]);
+  });
+
+  it('visits children in source order, so the capped errorLines list is unchanged by the rewrite', () => {
+    const kid = (row: number, type: string): ParseHealthNode =>
+      ({ type, startPosition: { row }, children: [], hasError: true });
+    const root: ParseHealthNode = {
+      type: 'program',
+      startPosition: { row: 0 },
+      hasError: true,
+      // Deliberately more error regions than the cap, in ascending source order: if the walk ran
+      // children in reverse, the retained lines would be the LAST 25, not the first.
+      children: Array.from({ length: 40 }, (_, i) => kid(i, 'ERROR')),
+    };
+    const health = tallyParseHealth('TypeScript', root, 'a.ts');
+    expect(health?.errorCount).toBe(40);
+    expect(health?.truncated).toBe(true);
+    expect(health?.errorLines).toEqual(Array.from({ length: 25 }, (_, i) => i + 1));
+  });
+});

--- a/src/core/analyzer/parse-budget.test.ts
+++ b/src/core/analyzer/parse-budget.test.ts
@@ -117,6 +117,33 @@ describe('parseWithBudget', () => {
     expect(parseBudgetSupported(parser)).toBe(false);
   });
 
+  it('demotes the whole BINDING, not one instance — the WASM lane builds a fresh parser per file', () => {
+    // The lane this fallback was written for (`loadWasmGrammarSoft`) constructs a new parser for
+    // every file, because its WASM heap must not be shared. Recording the refusal against the
+    // INSTANCE therefore never helped: the entry from file N was never consulted on file N+1, and
+    // the throw was re-paid on every file — precisely what the demotion claims to avoid.
+    let arms = 0;
+    class WasmLikeParser {
+      setTimeoutMicros(): void { arms++; throw new TypeError('Cannot convert 0 to a BigInt'); }
+      parse(): { ok: boolean } { return { ok: true }; }
+    }
+    // Two files, two fresh parsers, one shared prototype — the real shape.
+    expect(parseWithBudget(new WasmLikeParser(), 'file-1')).toEqual({ ok: true });
+    expect(parseWithBudget(new WasmLikeParser(), 'file-2')).toEqual({ ok: true });
+    expect(parseWithBudget(new WasmLikeParser(), 'file-3')).toEqual({ ok: true });
+    expect(arms, 'the binding refused once and was not asked again').toBe(1);
+    // And a DIFFERENT binding is unaffected — this is a per-binding fact, not a global switch.
+    // (Keying on the prototype rather than the constructor got this wrong: every plain object
+    // literal shares `Object.prototype`, so one refusal demoted every unrelated parser.)
+    let healthyArms = 0;
+    class NativeLikeParser {
+      setTimeoutMicros(): void { healthyArms++; }
+      parse(): { ok: boolean } { return { ok: true }; }
+    }
+    parseWithBudget(new NativeLikeParser(), 'x');
+    expect(healthyArms, 'a healthy binding still arms and clears').toBe(2);
+  });
+
   it('a parser that cannot arm a deadline reports a missing tree honestly, not as a budget overrun', () => {
     const parser = {
       setTimeoutMicros: () => { throw new TypeError('nope'); },
@@ -262,20 +289,73 @@ describe('reproducer: the parse-health walk survives a tree deeper than any call
     expect(health?.errorLines).toEqual([100_001]);
   });
 
-  it('visits children in source order, so the capped errorLines list is unchanged by the rewrite', () => {
-    const kid = (row: number, type: string): ParseHealthNode =>
-      ({ type, startPosition: { row }, children: [], hasError: true });
+  /**
+   * Source order, on BOTH child-access shapes.
+   *
+   * The walk prefers the allocation-free `childCount`/`child(i)` accessors that a real
+   * `SyntaxNode` exposes, and falls back to `.children` for plain test objects. An earlier version
+   * of this test supplied only `.children`, so it exercised the fallback and left the branch that
+   * actually ships free to be reversed with no failure. Both are covered now.
+   */
+  it.each([
+    ['index accessors (the shape production takes)', true],
+    ['.children array (the test-double fallback)', false],
+  ])('visits children in source order via %s', (_label, useAccessors) => {
+    const kid = (row: number): ParseHealthNode =>
+      ({ type: 'ERROR', startPosition: { row }, children: [], hasError: true });
+    const kids = Array.from({ length: 40 }, (_, i) => kid(i));
     const root: ParseHealthNode = {
       type: 'program',
       startPosition: { row: 0 },
       hasError: true,
       // Deliberately more error regions than the cap, in ascending source order: if the walk ran
       // children in reverse, the retained lines would be the LAST 25, not the first.
-      children: Array.from({ length: 40 }, (_, i) => kid(i, 'ERROR')),
+      children: useAccessors ? [] : kids,
+      ...(useAccessors ? { childCount: kids.length, child: (i: number) => kids[i] ?? null } : {}),
     };
     const health = tallyParseHealth('TypeScript', root, 'a.ts');
     expect(health?.errorCount).toBe(40);
     expect(health?.truncated).toBe(true);
     expect(health?.errorLines).toEqual(Array.from({ length: 25 }, (_, i) => i + 1));
   });
+});
+
+// ---------------------------------------------------------------------------
+// Regressions found by adversarial review of the first revision of this change
+// ---------------------------------------------------------------------------
+
+describe('an abandoned file must not cost OTHER files their edges', () => {
+  /**
+   * The first revision dropped budget-exceeded files from `buildResolvedImportMap` to save time.
+   * `parseJSExports` is a REGEX scan — it reads a file tree-sitter gave up on perfectly well — so
+   * that filter deleted re-export information belonging to files that parsed cleanly. The loss
+   * landed on files carrying no parse-health record, so nothing connected the missing edge to the
+   * abandoned one: absence read as evidence of absence, which is the failure this change exists to
+   * prevent.
+   */
+  it('resolves a call through a barrel that was abandoned at the budget', async () => {
+    process.env[PARSE_BUDGET_ENV] = '700';
+    // The barrel is a re-export AND pathological: tree-sitter will abandon it, but its
+    // `export { … } from` line is still perfectly readable by the regex export scan.
+    const barrel = `export { realThing } from './impl';\n${HOSTILE_TS}`;
+    const files = [
+      { path: 'src/barrel.ts', content: barrel, language: 'TypeScript' },
+      { path: 'src/impl.ts', content: 'export function realThing(): number { return 1; }\n', language: 'TypeScript' },
+      { path: 'src/consumer.ts', content: "import { realThing } from './barrel';\nexport function consume(): number { return realThing(); }\n", language: 'TypeScript' },
+      // A same-named decoy elsewhere: without the barrel's re-export the resolver has two
+      // candidates and must fall back to name-only or refuse.
+      { path: 'src/decoy.ts', content: 'export function realThing(): string { return "x"; }\n', language: 'TypeScript' },
+    ];
+
+    const result = await new CallGraphBuilder({}).build(files);
+
+    // The barrel itself is abandoned and disclosed…
+    expect(result.parseHealthByFile?.get('src/barrel.ts')?.exclusion).toBe('budget-exceeded');
+    // …but consumer.ts parsed cleanly, and its call must still reach the true definition.
+    const edge = result.edges.find(e => e.callerId === 'src/consumer.ts::consume');
+    expect(edge, 'the call through the abandoned barrel still resolves').toBeDefined();
+    expect(edge!.calleeId).toBe('src/impl.ts::realThing');
+    // And the healthy files carry no parse-health record — they were never degraded.
+    expect(result.parseHealthByFile?.has('src/consumer.ts')).toBe(false);
+  }, 60_000);
 });

--- a/src/core/analyzer/parse-budget.ts
+++ b/src/core/analyzer/parse-budget.ts
@@ -24,10 +24,11 @@
  * bound is disabled by setting `OPENLORE_PARSE_BUDGET_MS=0`, which reproduces the previous
  * behavior exactly — the escape hatch for anyone who would rather wait than be told.
  *
- * A binding whose `setTimeoutMicros` is unavailable (older native builds, and the web-tree-sitter
- * WASM lane) simply parses unbounded, as it did before. That is disclosed by
- * {@link parseBudgetSupported} rather than assumed away: an unenforceable budget must not read
- * as an enforced one.
+ * A binding whose `setTimeoutMicros` is unavailable or unusable (older native builds, and the
+ * web-tree-sitter WASM lane) simply parses unbounded, as it did before — {@link parseBudgetSupported}
+ * reports which. That is a real limit of the bound, not a covered case: those languages keep the
+ * pre-change behaviour, including the unbounded cost. It is called out in the change's spec rather
+ * than papered over here.
  */
 
 import { PER_FILE_PARSE_BUDGET_MS, PARSE_BUDGET_ENV } from '../../constants.js';
@@ -104,22 +105,41 @@ export interface BudgetableParser<TTree> {
 }
 
 /**
- * Parsers whose `setTimeoutMicros` EXISTS but does not work.
+ * Constructors whose `setTimeoutMicros` EXISTS but does not work.
  *
  * Presence is not capability. `web-tree-sitter@0.25` exposes `setTimeoutMicros` and throws
  * `TypeError: Cannot convert 0 to a BigInt` from inside it — its WASM shim passes a Number where
  * the import demands a BigInt. Left to propagate, arming the deadline made every file in the
  * WASM-grammar languages (Dart, Lua) fail to extract: a bound that silently deleted real work,
  * which is the exact failure mode this change exists to prevent. So the first refusal demotes that
- * parser to unbounded for the rest of the process rather than being paid, and thrown, per file.
+ * KIND of parser to unbounded rather than being paid, and thrown, per file.
  *
- * A `WeakSet` so a parser that is discarded is not kept alive by this record.
+ * Keyed on the parser's PROTOTYPE, not the instance. Keying the instance looked right and was
+ * useless on the one lane it was written for: the WASM grammar handle constructs a fresh parser
+ * for every file (its heap must not be shared), so the instance recorded on file N was never
+ * consulted on file N+1 and the throw was re-paid every time. All instances from one binding share
+ * a prototype, so this records the binding's capability, which is what is actually being learned.
+ *
+ * A `WeakSet` so nothing here keeps a discarded binding alive.
  */
 const deadlineUnsupported = new WeakSet<object>();
 
+/**
+ * The key under which a parser's deadline capability is remembered — see above.
+ *
+ * The CONSTRUCTOR, so every instance from one binding shares an entry. Not the prototype: a plain
+ * object literal's prototype is `Object.prototype`, shared with every other object literal in the
+ * process, so one refusing parser would demote unrelated ones. Anything without a distinct
+ * constructor falls back to its own identity — narrower, and never wrong.
+ */
+function capabilityKey(parser: object): object {
+  const ctor = (parser as { constructor?: unknown }).constructor;
+  return typeof ctor === 'function' && ctor !== Object ? (ctor as object) : parser;
+}
+
 /** Can this parser actually enforce a deadline? `false` means it parses unbounded, as before. */
 export function parseBudgetSupported(parser: object): boolean {
-  if (deadlineUnsupported.has(parser)) return false;
+  if (deadlineUnsupported.has(capabilityKey(parser))) return false;
   return typeof (parser as { setTimeoutMicros?: unknown }).setTimeoutMicros === 'function';
 }
 
@@ -132,7 +152,7 @@ function setDeadline(parser: { setTimeoutMicros?(micros: number): void }, micros
     parser.setTimeoutMicros!(micros);
     return true;
   } catch {
-    deadlineUnsupported.add(parser);
+    deadlineUnsupported.add(capabilityKey(parser));
     return false;
   }
 }
@@ -165,7 +185,14 @@ export function parseWithBudget<TTree>(parser: BudgetableParser<TTree>, content:
   } finally {
     // Always clear the deadline, including on a throw: leaving it armed would apply this
     // file's remaining budget to the NEXT file on the same singleton parser.
-    if (bounded) setDeadline(parser, 0);
+    //
+    // A failure to CLEAR must not demote the parser. Arming already succeeded, so the binding
+    // demonstrably supports deadlines; demoting here would mean every later expiry of the
+    // still-armed deadline came back as a generic "no tree" and got filed as `parse-failure`
+    // instead of `budget-exceeded` — a wrong cause on top of a leaked deadline.
+    if (bounded) {
+      try { parser.setTimeoutMicros!(0); } catch { /* deadline leaked; the reset below still runs */ }
+    }
   }
   if (tree === null || tree === undefined) {
     // CRITICAL: a timed-out parse is SUSPENDED, not discarded. tree-sitter keeps the partial state

--- a/src/core/analyzer/parse-budget.ts
+++ b/src/core/analyzer/parse-budget.ts
@@ -1,0 +1,184 @@
+/**
+ * Per-file parse budget (change: fix-analyze-native-abort-and-file-cost-budget).
+ *
+ * Extraction of one file used to be unbounded in wall-clock time. Measured on a 300 KB file of
+ * a repeated unterminated block-comment opener: 84 s inside `parser.parse()` alone, yielding a
+ * 100,002-deep tree. A minified bundle or a generated client in an ordinary repository reaches
+ * the same path, so this is not only a hostile-input problem.
+ *
+ * ## Why the bound is in-band, not a timer
+ *
+ * `parser.parse()` is one synchronous call into a native binding. A `setTimeout` cannot preempt
+ * it — the event loop does not run until it returns — and terminating the worker that holds it
+ * is precisely what turns a slow parse into a process-level `abort()` (V8 can only interrupt a
+ * thread at a JS boundary; an interrupt delivered inside a native frame surfaces as a C++
+ * exception with nowhere to go). tree-sitter's own deadline is the only bound that can actually
+ * stop the work: it is checked inside the parse loop, and on expiry `parse()` simply returns no
+ * tree. Nothing is killed, and the parser stays reusable for the next file.
+ *
+ * ## Honesty
+ *
+ * A budgeted result is a LOWER BOUND and reads as one. An abandoned file is never silently
+ * dropped: {@link ParseBudgetExceededError} carries the elapsed time, the caller records the
+ * file with reason `budget-exceeded`, and conclusions built over it disclose the boundary. The
+ * bound is disabled by setting `OPENLORE_PARSE_BUDGET_MS=0`, which reproduces the previous
+ * behavior exactly — the escape hatch for anyone who would rather wait than be told.
+ *
+ * A binding whose `setTimeoutMicros` is unavailable (older native builds, and the web-tree-sitter
+ * WASM lane) simply parses unbounded, as it did before. That is disclosed by
+ * {@link parseBudgetSupported} rather than assumed away: an unenforceable budget must not read
+ * as an enforced one.
+ */
+
+import { PER_FILE_PARSE_BUDGET_MS, PARSE_BUDGET_ENV } from '../../constants.js';
+
+/**
+ * Stable prefix on {@link ParseBudgetExceededError}'s message.
+ *
+ * The message is the ONLY channel that survives an extraction worker: a throw crossing the
+ * `worker_threads` boundary is structured-cloned, so its class, prototype and properties are
+ * gone by the time the parent sees it. Keying the reason off a message prefix is what makes the
+ * pooled and serial lanes classify the same failure identically — an `instanceof` check would
+ * behave differently on the two lanes, which is the bug this prefix exists to avoid.
+ */
+export const PARSE_BUDGET_MESSAGE_PREFIX = 'openlore:parse-budget-exceeded';
+
+/** Thrown when tree-sitter abandoned a parse at the deadline. Carries the bound and what was spent. */
+export class ParseBudgetExceededError extends Error {
+  readonly elapsedMs: number;
+  readonly budgetMs: number;
+
+  constructor(elapsedMs: number, budgetMs: number) {
+    super(
+      `${PARSE_BUDGET_MESSAGE_PREFIX}: abandoned after ${elapsedMs}ms `
+      + `(budget ${budgetMs}ms; raise or disable with ${PARSE_BUDGET_ENV})`,
+    );
+    this.name = 'ParseBudgetExceededError';
+    this.elapsedMs = elapsedMs;
+    this.budgetMs = budgetMs;
+  }
+}
+
+/**
+ * Read `message` as a budget-exceeded signal, returning the BUDGET it names.
+ *
+ * Message-based on purpose — see {@link PARSE_BUDGET_MESSAGE_PREFIX}. Returns `undefined` for
+ * any other failure, so an ordinary parse failure is never re-labelled as a budget overrun.
+ *
+ * The budget rather than the elapsed time, because the caller records it in a persisted artifact
+ * that must be byte-identical across re-analyses of a fixed repository state — see
+ * `FileParseHealth.budgetMs`.
+ */
+export function parseBudgetOverrunMs(message: string | undefined): number | undefined {
+  if (!message || !message.startsWith(PARSE_BUDGET_MESSAGE_PREFIX)) return undefined;
+  const m = /budget (\d+)ms/.exec(message);
+  // A marked message with no readable budget is still a budget overrun — falling through to
+  // `undefined` would silently re-label it as an ordinary parse failure.
+  return m ? Number(m[1]) : parseBudgetMs();
+}
+
+/**
+ * The active budget in milliseconds, or `0` when disabled.
+ *
+ * Read per call rather than cached at module load: extraction workers inherit `process.env`, and
+ * tests set the override around a single build. A value that is not a finite, non-negative number
+ * is ignored in favour of the default — a typo must not silently disable the bound.
+ */
+export function parseBudgetMs(): number {
+  const raw = process.env[PARSE_BUDGET_ENV];
+  if (raw === undefined || raw.trim() === '') return PER_FILE_PARSE_BUDGET_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return PER_FILE_PARSE_BUDGET_MS;
+  return Math.floor(parsed);
+}
+
+/** The minimum shape {@link parseWithBudget} needs. Narrow so tests can supply a plain object. */
+export interface BudgetableParser<TTree> {
+  parse(content: string): TTree | null | undefined;
+  setTimeoutMicros?(micros: number): void;
+  /**
+   * Discard partial parse state. Load-bearing after a deadline fires — see
+   * {@link parseWithBudget}. Optional so a test double need not supply it.
+   */
+  reset?(): void;
+}
+
+/**
+ * Parsers whose `setTimeoutMicros` EXISTS but does not work.
+ *
+ * Presence is not capability. `web-tree-sitter@0.25` exposes `setTimeoutMicros` and throws
+ * `TypeError: Cannot convert 0 to a BigInt` from inside it — its WASM shim passes a Number where
+ * the import demands a BigInt. Left to propagate, arming the deadline made every file in the
+ * WASM-grammar languages (Dart, Lua) fail to extract: a bound that silently deleted real work,
+ * which is the exact failure mode this change exists to prevent. So the first refusal demotes that
+ * parser to unbounded for the rest of the process rather than being paid, and thrown, per file.
+ *
+ * A `WeakSet` so a parser that is discarded is not kept alive by this record.
+ */
+const deadlineUnsupported = new WeakSet<object>();
+
+/** Can this parser actually enforce a deadline? `false` means it parses unbounded, as before. */
+export function parseBudgetSupported(parser: object): boolean {
+  if (deadlineUnsupported.has(parser)) return false;
+  return typeof (parser as { setTimeoutMicros?: unknown }).setTimeoutMicros === 'function';
+}
+
+/**
+ * Arm (or clear) the deadline, returning whether it actually took. A parser that refuses is
+ * recorded and never asked again — see {@link deadlineUnsupported}.
+ */
+function setDeadline(parser: { setTimeoutMicros?(micros: number): void }, micros: number): boolean {
+  try {
+    parser.setTimeoutMicros!(micros);
+    return true;
+  } catch {
+    deadlineUnsupported.add(parser);
+    return false;
+  }
+}
+
+/**
+ * Parse `content` under the active per-file budget.
+ *
+ * Returns the tree on success. Throws {@link ParseBudgetExceededError} when the deadline fired,
+ * so the existing per-file `try`/`catch` in the builder — which already records a file that
+ * contributed nothing — classifies and discloses it without every extractor growing a new return
+ * shape.
+ *
+ * The deadline is re-applied before each parse rather than once at parser construction: these
+ * parsers are per-language singletons shared across a whole build (and reused by the watcher
+ * across builds), so a budget set once could be left stale by any other caller. Setting it is a
+ * single native field write.
+ */
+export function parseWithBudget<TTree>(parser: BudgetableParser<TTree>, content: string): TTree {
+  const budgetMs = parseBudgetMs();
+  // Arming can FAIL on a binding whose deadline API is nominally present but unusable. When it
+  // does, this parse is unbounded — the honest outcome, and the one that preserves today's
+  // behaviour — never a failed file.
+  const bounded = budgetMs > 0
+    && parseBudgetSupported(parser)
+    && setDeadline(parser, budgetMs * 1000);
+  const startedAt = Date.now();
+  let tree: TTree | null | undefined;
+  try {
+    tree = parser.parse(content);
+  } finally {
+    // Always clear the deadline, including on a throw: leaving it armed would apply this
+    // file's remaining budget to the NEXT file on the same singleton parser.
+    if (bounded) setDeadline(parser, 0);
+  }
+  if (tree === null || tree === undefined) {
+    // CRITICAL: a timed-out parse is SUSPENDED, not discarded. tree-sitter keeps the partial state
+    // so a caller may resume by calling `parse` again — which means the next file handed to this
+    // singleton parser would resume the ABANDONED file's parse instead of starting its own. That
+    // silently corrupts every subsequent file in the language (measured: the file after the
+    // pathological one produced zero symbols and a spurious parse-health record). Resetting is
+    // what makes the bound cost exactly one file.
+    parser.reset?.();
+    // A bounded parser returns no tree only at the deadline. An UNBOUNDED one returning no tree
+    // is a different failure — reported as such, never mislabelled as a budget overrun.
+    if (bounded) throw new ParseBudgetExceededError(Date.now() - startedAt, budgetMs);
+    throw new Error('tree-sitter returned no tree');
+  }
+  return tree;
+}

--- a/src/core/analyzer/parse-health.test.ts
+++ b/src/core/analyzer/parse-health.test.ts
@@ -8,14 +8,20 @@
  *      signal fires end-to-end AND that a clean file produces no record (clean repos pay zero).
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   tallyParseHealth,
   isLossyUtf8,
   buildParseHealthReport,
   isDegraded,
   compactParseHealthSummary,
+  describeExclusions,
+  totalExcluded,
+  EXCLUSION_REASON_LABEL,
   type ParseHealthNode,
   type FileParseHealth,
+  type FileExclusionReason,
 } from './parse-health.js';
 import { CallGraphBuilder } from './call-graph.js';
 
@@ -136,5 +142,85 @@ describe('CallGraphBuilder parse-health capture (build integration)', () => {
     const content = `function a() { return b(); }\nfunction b() { return 1; }\n`;
     const r = await new CallGraphBuilder().build([{ path: 'y.ts', content, language: 'TypeScript' }]);
     expect(r.parseHealthByFile?.get('y.ts')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exclusion reasons (change: fix-analyze-native-abort-and-file-cost-budget)
+// ---------------------------------------------------------------------------
+
+describe('exclusion reasons', () => {
+  const excluded = (path: string, exclusion: FileExclusionReason, budgetMs?: number): FileParseHealth => ({
+    filePath: path, language: 'TypeScript', errorCount: 0, missingCount: 0, errorLines: [],
+    exclusion, ...(budgetMs !== undefined ? { budgetMs } : {}),
+  });
+
+  it('counts exclusions per reason in the rolled-up report', () => {
+    const report = buildParseHealthReport([
+      excluded('a.ts', 'budget-exceeded', 20_000),
+      excluded('b.ts', 'budget-exceeded', 21_000),
+      excluded('c.ts', 'parse-failure'),
+    ]);
+    expect(report?.excludedByReason).toEqual({ 'budget-exceeded': 2, 'parse-failure': 1 });
+    expect(totalExcluded(report)).toBe(3);
+  });
+
+  it('omits the tally entirely when nothing was excluded, so an ordinary report is unchanged', () => {
+    // A repo whose only signal is error regions must not grow an empty tally — the artifact stays
+    // byte-identical to what it was before this change.
+    const report = buildParseHealthReport([
+      { filePath: 'a.ts', language: 'TypeScript', errorCount: 2, missingCount: 0, errorLines: [3, 9] },
+    ]);
+    expect(report).toBeDefined();
+    expect('excludedByReason' in report!).toBe(false);
+    expect(totalExcluded(report)).toBe(0);
+    expect(describeExclusions(report)).toBeUndefined();
+  });
+
+  it('describes exclusions in a fixed reason order so the line is deterministic', () => {
+    const report = buildParseHealthReport([
+      excluded('c.ts', 'size-cap'),
+      excluded('a.ts', 'budget-exceeded', 20_000),
+      excluded('b.ts', 'parse-failure'),
+    ]);
+    expect(describeExclusions(report)).toBe('3 files excluded (1 budget-exceeded, 1 parse-failure, 1 size-cap)');
+  });
+
+  it('treats an excluded file as degraded even with no error regions', () => {
+    // A budget-exceeded file has zero ERROR nodes — the parse never got far enough to produce any.
+    // If exclusion did not count as degradation it would vanish from the report entirely.
+    expect(isDegraded(excluded('a.ts', 'budget-exceeded', 20_000))).toBe(true);
+  });
+
+  it.each(['parse-failure', 'budget-exceeded', 'size-cap'] as FileExclusionReason[])(
+    'has a human label for %s, so no surface has to invent its own wording',
+    (reason) => expect(EXCLUSION_REASON_LABEL[reason]).toBeTruthy(),
+  );
+
+  it('never reports a worker fault as a file-level exclusion', () => {
+    // A worker fault degrades the LANE: the pool hands the file to the main thread, which is the
+    // reference implementation, so the file is not excluded at all. Recording it here would blame
+    // the source for a defect in the thread reading it.
+    expect(Object.keys(EXCLUSION_REASON_LABEL)).not.toContain('worker-fault');
+  });
+});
+
+describe('analyze and doctor cannot disagree about exclusions', () => {
+  // The requirement is that any surface reporting extraction health reads the SAME record. These
+  // are structural guards: the previous shape had `doctor` judging independently, which let it
+  // report a clean bill of health for a repository whose analysis had excluded files.
+  const src = (rel: string): string => readFileSync(join(__dirname, '..', '..', rel), 'utf-8');
+
+  it('doctor reads the shared record through the shared helper', () => {
+    const doctor = src('cli/commands/doctor.ts');
+    expect(doctor).toContain('describeExclusions');
+  });
+
+  it('analyze reports the same exclusions from the same helper', () => {
+    expect(src('cli/commands/analyze.ts')).toContain('describeExclusions');
+  });
+
+  it('analyze reports skipped files broken down by reason, not as a bare count', () => {
+    expect(src('cli/commands/analyze.ts')).toContain('skippedReasons');
   });
 });

--- a/src/core/analyzer/parse-health.test.ts
+++ b/src/core/analyzer/parse-health.test.ts
@@ -8,8 +8,11 @@
  *      signal fires end-to-end AND that a clean file produces no record (clean repos pay zero).
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { checkParseHealth } from '../../cli/commands/doctor.js';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_PARSE_HEALTH } from '../../constants.js';
 import {
   tallyParseHealth,
   isLossyUtf8,
@@ -22,6 +25,7 @@ import {
   type ParseHealthNode,
   type FileParseHealth,
   type FileExclusionReason,
+  type ParseHealthReport,
 } from './parse-health.js';
 import { CallGraphBuilder } from './call-graph.js';
 
@@ -205,22 +209,69 @@ describe('exclusion reasons', () => {
   });
 });
 
-describe('analyze and doctor cannot disagree about exclusions', () => {
-  // The requirement is that any surface reporting extraction health reads the SAME record. These
-  // are structural guards: the previous shape had `doctor` judging independently, which let it
-  // report a clean bill of health for a repository whose analysis had excluded files.
+describe('doctor reports exclusions from the shared record, behaviorally', () => {
+  // The previous version of this block was three source greps for an identifier. They passed with
+  // both CLI surfaces rendering nothing at all, which is exactly the failure they claimed to
+  // prevent. These drive the real check over a real artifact.
+  const withReport = (report: ParseHealthReport | null): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'doc-'));
+    if (report) {
+      const analysisDir = join(dir, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+      mkdirSync(analysisDir, { recursive: true });
+      writeFileSync(join(analysisDir, ARTIFACT_PARSE_HEALTH), JSON.stringify(report));
+    }
+    return dir;
+  };
+  const excludedReport = buildParseHealthReport([{
+    filePath: 'src/huge.html', language: 'HTML', errorCount: 0, missingCount: 0, errorLines: [],
+    exclusion: 'size-cap',
+  }])!;
+
+  it('WARNS about a repository whose analysis excluded a file', async () => {
+    const r = await checkParseHealth(withReport(excludedReport));
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('1 file excluded (1 size-cap)');
+    expect(r.detail).toContain('not analyzed at all');
+  });
+
+  it('does NOT call an excluded file "parsed with errors" — it was never parsed', async () => {
+    // Mixing an exclusion into a parse-error count sent the reader after a tree-sitter grammar
+    // bump for a file the grammar never saw.
+    const r = await checkParseHealth(withReport(excludedReport));
+    expect(r.detail).not.toMatch(/\d+ file\(s\) parsed with errors/);
+    expect(r.fix).not.toContain('tree-sitter');
+  });
+
+  it('still reports a genuine parse degradation as such, with the grammar remedy', async () => {
+    const degraded = buildParseHealthReport([{
+      filePath: 'src/broken.ts', language: 'TypeScript', errorCount: 3, missingCount: 0, errorLines: [7],
+    }])!;
+    const r = await checkParseHealth(withReport(degraded));
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('1 file(s) parsed with errors');
+    expect(r.fix).toContain('tree-sitter');
+  });
+
+  it('reports a clean repository as clean', async () => {
+    const r = await checkParseHealth(withReport(null));
+    expect(r.status).toBe('ok');
+  });
+});
+
+describe('analyze renders the skip and exclusion breakdowns', () => {
+  // Kept as source guards ONLY because rendering runs deep inside `runAnalysis`; they are paired
+  // with the behavioral doctor tests above so the shared record has coverage on both sides.
   const src = (rel: string): string => readFileSync(join(__dirname, '..', '..', rel), 'utf-8');
 
-  it('doctor reads the shared record through the shared helper', () => {
-    const doctor = src('cli/commands/doctor.ts');
-    expect(doctor).toContain('describeExclusions');
+  it('analyze renders the exclusion line, not merely imports the helper', () => {
+    const analyze = src('cli/commands/analyze.ts');
+    expect(analyze).toMatch(/const excludedNote = describeExclusions\(/);
+    expect(analyze).toMatch(/logger\.warning\(\s*`\$\{excludedNote\}/);
   });
 
-  it('analyze reports the same exclusions from the same helper', () => {
-    expect(src('cli/commands/analyze.ts')).toContain('describeExclusions');
-  });
-
-  it('analyze reports skipped files broken down by reason, not as a bare count', () => {
-    expect(src('cli/commands/analyze.ts')).toContain('skippedReasons');
+  it('analyze renders the per-reason skip breakdown, not a bare count', () => {
+    const analyze = src('cli/commands/analyze.ts');
+    expect(analyze).toContain('skippedReasons');
+    expect(analyze).toMatch(/logger\.info\(\s*'Files skipped',\s*\n?\s*skipReasons\.length/);
   });
 });

--- a/src/core/analyzer/parse-health.ts
+++ b/src/core/analyzer/parse-health.ts
@@ -31,6 +31,35 @@ export const PARSE_HEALTH_LINE_CAP = 25;
 
 
 /**
+ * Machine-readable cause for a file the analyzer declined to include (change:
+ * fix-analyze-native-abort-and-file-cost-budget).
+ *
+ * Before this existed, an exclusion reached the user as a bare count — "Files skipped: 3" — with
+ * no cause, while `doctor` judged the same repository independently and could report a clean bill
+ * of health for it. Recording the cause on the file, in the one artifact every health surface
+ * reads, is what makes the two surfaces unable to disagree.
+ *
+ * Each member is a path that actually exists in the code; the set is deliberately not aspirational:
+ *  - `parse-failure`   the extractor threw, or produced no usable tree
+ *  - `budget-exceeded` the parse hit {@link PER_FILE_PARSE_BUDGET_MS} and was abandoned
+ *  - `size-cap`        the file exceeded a size bound before extraction was attempted
+ *
+ * A **worker fault is deliberately absent**. The proposal listed one, but a worker fault no longer
+ * excludes a file: the pool hands the file back to the main thread — the reference implementation —
+ * which extracts it normally, so the facts stay whole and the fault is disclosed on the extraction
+ * LANE instead. If that main-thread attempt also fails, the reason recorded here is the one the
+ * main thread actually produced. Recording `worker-fault` on the file would have blamed the source
+ * for a defect in the thread reading it.
+ *
+ * `encoding` is likewise absent: a lossy decode does not exclude a file (it still parses, over
+ * replacement characters), so it stays the separate `encodingFallback` signal it has always been.
+ */
+export type FileExclusionReason =
+  | 'parse-failure'
+  | 'budget-exceeded'
+  | 'size-cap';
+
+/**
  * Per-file parse health. Present ONLY for a file with at least one signal (error region, parse
  * failure, or encoding fallback) — a clean file has no record. Absent fields mean "not observed."
  */
@@ -49,6 +78,22 @@ export interface FileParseHealth {
   parseFailed?: boolean;
   /** The source decoded lossily (contained U+FFFD) — parse output may be garbage. */
   encodingFallback?: boolean;
+  /**
+   * Why this file contributed nothing, when it contributed nothing. Absent on a file that WAS
+   * extracted and merely parsed with error regions — a degraded file is not an excluded one.
+   */
+  exclusion?: FileExclusionReason;
+  /**
+   * The budget, in ms, that this file exceeded. Present only for `budget-exceeded`.
+   *
+   * The BOUND, not the measured elapsed time — deliberately. This artifact must be byte-identical
+   * across re-analyses of a fixed repository state (change: fix-artifact-output-determinism), and
+   * a wall-clock measurement never is. Nothing is lost: a file is only recorded here because it
+   * ran past the bound, so "exceeded 20000ms" says everything the measurement would, and says it
+   * the same way every run. The measured time still reaches the operator live, on the CLI's
+   * extraction-lane disclosure, which is not persisted.
+   */
+  budgetMs?: number;
 }
 
 /**
@@ -91,6 +136,20 @@ function isMissingNode(n: ParseHealthNode): boolean {
  * tallying `ERROR` and `MISSING` nodes and collecting their start lines up to the cap.
  *
  * The walk fires only on the rare error tree, so its `children` allocation is not on the hot path.
+ *
+ * ## The walk is iterative, and that is load-bearing
+ *
+ * This walk used to recurse (change: fix-analyze-native-abort-and-file-cost-budget). Tree depth is
+ * not bounded by anything the analyzer controls: a 300 KB file of a repeated unterminated
+ * block-comment opener parses into a right-leaning chain 100,002 nodes deep, and error recovery is
+ * exactly the condition that produces such trees — which is also exactly when this walk runs. The
+ * recursion overflowed the stack there, and a `RangeError` raised while executing inside the
+ * native binding's node accessor is what turns a slow file into
+ * `libc++abi: terminating due to uncaught exception of type Napi::Error` and an exit-134 abort,
+ * with no JavaScript error anywhere. An explicit stack costs a heap array and cannot overflow, so
+ * depth stops being a correctness cliff. Order is unchanged: children are pushed in reverse so
+ * they pop in source order, which keeps `errorLines` (capped by insertion order) byte-identical
+ * to the recursive version.
  */
 export function tallyParseHealth(
   language: string,
@@ -104,7 +163,9 @@ export function tallyParseHealth(
   const lines = new Set<number>();
   let truncated = false;
 
-  const visit = (n: ParseHealthNode): void => {
+  const stack: ParseHealthNode[] = [rootNode];
+  while (stack.length > 0) {
+    const n = stack.pop()!;
     let isRegion = false;
     if (n.type === 'ERROR') { errorCount++; isRegion = true; }
     if (isMissingNode(n)) { missingCount++; isRegion = true; }
@@ -113,16 +174,17 @@ export function tallyParseHealth(
       else truncated = true;
     }
     // Prefer allocation-free index accessors (real SyntaxNode); fall back to `.children` (tests).
+    // Pushed in reverse so the first child is visited first — preserving the recursive order.
     if (typeof n.childCount === 'number' && typeof n.child === 'function') {
-      for (let i = 0; i < n.childCount; i++) {
+      for (let i = n.childCount - 1; i >= 0; i--) {
         const c = n.child(i);
-        if (c) visit(c);
+        if (c) stack.push(c);
       }
     } else {
-      for (const c of n.children) visit(c);
+      const kids = n.children;
+      for (let i = kids.length - 1; i >= 0; i--) stack.push(kids[i]);
     }
-  };
-  visit(rootNode);
+  }
 
   // `hasError` can read true on a tree that carries no actual ERROR/MISSING node (a binding/grammar
   // quirk observed on some grammars for well-formed input). Parse health is a SOUND LOWER BOUND —
@@ -158,8 +220,16 @@ export function isLossyUtf8(bytes: Uint8Array): boolean {
 
 /** A file is "degraded" if it carries any parse-health signal at all. */
 export function isDegraded(h: FileParseHealth): boolean {
-  return h.errorCount > 0 || h.missingCount > 0 || !!h.parseFailed || !!h.encodingFallback;
+  return h.errorCount > 0 || h.missingCount > 0 || !!h.parseFailed || !!h.encodingFallback
+    || h.exclusion !== undefined;
 }
+
+/** Human phrasing for one exclusion reason, used by every surface that renders one. */
+export const EXCLUSION_REASON_LABEL: Record<FileExclusionReason, string> = {
+  'parse-failure': 'parse failed — contributed no symbols',
+  'budget-exceeded': 'abandoned at the per-file parse budget',
+  'size-cap': 'exceeded a size cap — not extracted',
+};
 
 /** One language's rolled-up degradation, for the compact summary. */
 export interface ParseHealthLanguageSummary {
@@ -183,6 +253,34 @@ export interface ParseHealthReport {
   topFiles: FileParseHealth[];
   /** Every per-file record (the source of truth the watcher splices and consumers scan). */
   files: FileParseHealth[];
+  /**
+   * How many files were EXCLUDED, per reason (change:
+   * fix-analyze-native-abort-and-file-cost-budget). Omitted entirely when nothing was excluded,
+   * so a repository whose only signal is error regions carries no empty tally. This is the single
+   * record every health surface reads, which is what stops `analyze` and `doctor` disagreeing.
+   */
+  excludedByReason?: Partial<Record<FileExclusionReason, number>>;
+}
+
+/** Total files excluded (any reason). `0` when nothing was excluded. */
+export function totalExcluded(report: ParseHealthReport | null | undefined): number {
+  if (!report?.excludedByReason) return 0;
+  return Object.values(report.excludedByReason).reduce((a, b) => a + (b ?? 0), 0);
+}
+
+/**
+ * One-line "3 excluded (2 budget-exceeded, 1 parse-failure)" phrasing, or `undefined` when nothing
+ * was excluded. Shared so `analyze`, `doctor` and the boundary text cannot word it differently.
+ * Reason order is fixed (alphabetical) so the line is deterministic across runs.
+ */
+export function describeExclusions(report: ParseHealthReport | null | undefined): string | undefined {
+  const total = totalExcluded(report);
+  if (total === 0) return undefined;
+  const parts = Object.entries(report!.excludedByReason!)
+    .filter(([, n]) => (n ?? 0) > 0)
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([reason, n]) => `${n} ${reason}`);
+  return `${total} file${total === 1 ? '' : 's'} excluded (${parts.join(', ')})`;
 }
 
 function regionCount(h: FileParseHealth): number {
@@ -202,8 +300,10 @@ export function buildParseHealthReport(
   if (degraded.length === 0) return undefined;
 
   const byLang = new Map<string, ParseHealthLanguageSummary>();
+  const excludedByReason: Partial<Record<FileExclusionReason, number>> = {};
   let totalErrorRegions = 0;
   for (const h of degraded) {
+    if (h.exclusion) excludedByReason[h.exclusion] = (excludedByReason[h.exclusion] ?? 0) + 1;
     totalErrorRegions += regionCount(h);
     const s = byLang.get(h.language) ?? {
       language: h.language,
@@ -233,6 +333,9 @@ export function buildParseHealthReport(
     byLanguage,
     topFiles: sorted.slice(0, topN),
     files: sorted,
+    // Omitted when nothing was excluded, so a repo whose only signal is error regions carries no
+    // empty tally and its artifact stays byte-identical to before this change.
+    ...(Object.keys(excludedByReason).length > 0 ? { excludedByReason } : {}),
   };
 }
 

--- a/src/core/analyzer/repository-mapper.ts
+++ b/src/core/analyzer/repository-mapper.ts
@@ -89,6 +89,17 @@ export interface RepositoryMapSummary {
   totalFiles: number;
   analyzedFiles: number;
   skippedFiles: number;
+  /**
+   * Why each skipped file was skipped, keyed by reason (`gitignore`, `pattern`, `error`,
+   * `directory:<name>`). The walker has always tallied this; it stopped here and never reached a
+   * user, so `analyze` reported a bare count that read like a parse problem (change:
+   * fix-analyze-native-abort-and-file-cost-budget).
+   *
+   * Optional because a map reconstructed from a persisted `RepoStructure` genuinely does not know
+   * the breakdown — that artifact only ever stored the count. Absent there means "not recorded",
+   * which the renderer treats as "say nothing extra" rather than fabricating an empty tally.
+   */
+  skippedReasons?: Record<string, number>;
   languages: LanguageBreakdown[];
   frameworks: DetectedFramework[];
   directories: DirectoryStats[];
@@ -829,6 +840,7 @@ export class RepositoryMapper {
         totalFiles: walkResult.summary.totalFiles + walkResult.summary.skippedCount,
         analyzedFiles: walkResult.summary.totalFiles,
         skippedFiles: walkResult.summary.skippedCount,
+        skippedReasons: walkResult.summary.skippedReasons,
         languages,
         frameworks,
         directories,

--- a/src/core/services/mcp-handlers/error-propagation.ts
+++ b/src/core/services/mcp-handlers/error-propagation.ts
@@ -32,6 +32,7 @@ import {
   type FunctionExceptionFacts,
 } from '../../analyzer/exception-flow.js';
 import type { SerializedCallGraph, FunctionNode, CallEdge, AmbiguousCallSite } from '../../analyzer/call-graph.js';
+import { parseWithBudget, type BudgetableParser } from '../../analyzer/parse-budget.js';
 
 export interface AnalyzeErrorPropagationInput {
   directory: string;
@@ -214,14 +215,17 @@ export async function handleAnalyzeErrorPropagation(
       try {
         const content = await readFile(join(absDir, n.filePath), 'utf-8');
         const parser = await getExceptionParser(n.language);
-        tree = parser ? parser.parse(content) : null;
+        // Bounded (change: fix-analyze-native-abort-and-file-cost-budget): this parse runs inside
+        // the long-lived daemon, so one pathological file must not be able to wedge it. On the
+        // budget the file becomes a disclosed boundary below, never a silent "no exceptions".
+        tree = parser ? parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content) : null;
       } catch {
         tree = null;
       }
       treeByFile.set(n.filePath, tree);
     }
     if (!tree) {
-      boundaries.add(`source unreadable since analysis — re-run analyze_codebase (${n.filePath})`);
+      boundaries.add(`source unreadable or too costly to parse — re-run analyze_codebase (${n.filePath})`);
       factsById.set(n.id, null);
       return null;
     }

--- a/src/core/services/mcp-handlers/parse-health-boundary.test.ts
+++ b/src/core/services/mcp-handlers/parse-health-boundary.test.ts
@@ -64,3 +64,42 @@ describe('parseHealthBoundary', () => {
     expect(note).toContain('1 file');
   });
 });
+
+describe('boundary text names WHY a file was excluded (change: fix-analyze-native-abort-and-file-cost-budget)', () => {
+  const report = (files: ParseHealthReport['files']): ParseHealthReport => ({
+    version: 1, totalDegradedFiles: files.length, totalErrorRegions: 0, byLanguage: [], topFiles: files, files,
+  });
+
+  it('reports a budget-exceeded file with its elapsed time, not as a generic parse failure', () => {
+    // "parse failed" and "we gave up after 20 seconds" call for different actions from the reader,
+    // so a conclusion built over the file must say which one happened.
+    const text = parseHealthBoundary(report([{
+      filePath: 'src/vendor.js', language: 'JavaScript', errorCount: 0, missingCount: 0, errorLines: [],
+      parseFailed: true, exclusion: 'budget-exceeded', budgetMs: 20_000,
+    }]), ['src/vendor.js']);
+    expect(text).toContain('LOWER BOUND');
+    expect(text).toContain('abandoned at the per-file parse budget');
+    expect(text).toContain('of 20.0s');
+    expect(text).not.toContain('parse failed —');
+  });
+
+  it('still describes an ordinary parse failure the way it always did', () => {
+    const text = parseHealthBoundary(report([{
+      filePath: 'src/broken.ts', language: 'TypeScript', errorCount: 0, missingCount: 0, errorLines: [],
+      parseFailed: true,
+    }]), ['src/broken.ts']);
+    expect(text).toContain('parse failed — contributed no symbols');
+  });
+
+  it('echoes an exclusion reason it has no label for, rather than rendering "undefined"', () => {
+    // The record comes off disk and may have been written by a newer OpenLore. A boundary that
+    // reads "src/x.ts (undefined)" would be worse than one naming a reason this build cannot
+    // explain.
+    const text = parseHealthBoundary(report([{
+      filePath: 'src/x.ts', language: 'TypeScript', errorCount: 0, missingCount: 0, errorLines: [],
+      exclusion: 'reason-from-the-future' as never,
+    }]), ['src/x.ts']);
+    expect(text).toContain('reason-from-the-future');
+    expect(text).not.toContain('undefined');
+  });
+});

--- a/src/core/services/mcp-handlers/parse-health-boundary.ts
+++ b/src/core/services/mcp-handlers/parse-health-boundary.ts
@@ -12,7 +12,7 @@
 import { join } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_PARSE_HEALTH } from '../../../constants.js';
-import type { ParseHealthReport, FileParseHealth } from '../../analyzer/parse-health.js';
+import { EXCLUSION_REASON_LABEL, type ParseHealthReport, type FileParseHealth } from '../../analyzer/parse-health.js';
 
 /** Load the persisted parse-health report, or `null` when absent/unreadable (a clean repo). */
 export async function loadParseHealthReport(absDir: string): Promise<ParseHealthReport | null> {
@@ -29,6 +29,16 @@ export async function loadParseHealthReport(absDir: string): Promise<ParseHealth
 const BOUNDARY_FILE_CAP = 5;
 
 function describe(h: FileParseHealth): string {
+  // An EXCLUDED file names its cause (change: fix-analyze-native-abort-and-file-cost-budget) —
+  // "abandoned at the per-file parse budget of 20.0s" is actionable in a way "parse failed" is
+  // not, and it distinguishes a file the analyzer gave up on from one the grammar rejected.
+  //
+  // The reason comes off a file on disk, which a newer OpenLore (or a hand edit) may have written
+  // with a value this build has no label for. Echoing the raw reason beats rendering `undefined`.
+  if (h.exclusion) {
+    const bound = h.budgetMs !== undefined ? ` of ${(h.budgetMs / 1000).toFixed(1)}s` : '';
+    return `${h.filePath} (${EXCLUSION_REASON_LABEL[h.exclusion] ?? h.exclusion}${bound})`;
+  }
   if (h.parseFailed) return `${h.filePath} (parse failed — contributed no symbols)`;
   const parts: string[] = [];
   if (h.errorCount) parts.push(`${h.errorCount} error region${h.errorCount === 1 ? '' : 's'}`);

--- a/src/core/services/mcp-watcher-parse-health.test.ts
+++ b/src/core/services/mcp-watcher-parse-health.test.ts
@@ -19,7 +19,12 @@ import { mkdtempSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { McpWatcher } from './mcp-watcher.js';
-import { ARTIFACT_PARSE_HEALTH, PARSE_BUDGET_ENV, PER_FILE_PARSE_BUDGET_MS } from '../../constants.js';
+import {
+  ARTIFACT_PARSE_HEALTH,
+  PARSE_BUDGET_ENV,
+  PER_FILE_PARSE_BUDGET_MS,
+  MAX_HTML_INLINE_SCRIPT_CHARS,
+} from '../../constants.js';
 import type { ParseHealthReport } from '../analyzer/parse-health.js';
 
 /** The payload that reproduced the abort: a 300 KB unterminated block comment. */
@@ -105,6 +110,34 @@ describe('watcher parse-health lane — the exclusion vocabulary matches the ful
       { rel: 'src/hostile.ts', content: 'export function a(): void { b(); }\nfunction b(): void {}\n' },
     ]);
     expect(readReport(outputPath), 'the last degraded file was repaired — artifact removed').toBeNull();
+  }, 60_000);
+
+
+  it('does NOT erase a size-cap exclusion when the oversized file is touched', async () => {
+    // The watcher re-derives a changed file's record. An oversized HTML file is excluded BEFORE
+    // extraction, so `extractFileParseHealth` returns nothing for it — and the lane used to read
+    // that as "now clean" and delete the record, leaving `doctor` blessing a repository the next
+    // `analyze` excludes a file from again. The watcher applies the same bound instead.
+    const { watcher, outputPath } = watcherIn();
+    const huge = `<html><body>${'<p>x</p>'.repeat(200_000)}</body></html>`;
+    expect(huge.length).toBeGreaterThan(MAX_HTML_INLINE_SCRIPT_CHARS);
+
+    await spliceParseHealth(watcher, [{ rel: 'src/huge.html', content: huge }]);
+    const rec = readReport(outputPath)?.files.find(f => f.filePath === 'src/huge.html');
+    expect(rec?.exclusion).toBe('size-cap');
+    expect(readReport(outputPath)!.excludedByReason).toEqual({ 'size-cap': 1 });
+  }, 60_000);
+
+  it('clears the size-cap once the file actually shrinks below the bound', async () => {
+    // The other direction: the bound is re-evaluated, not merely remembered, so a genuinely
+    // repaired file stops being reported.
+    const { watcher, outputPath } = watcherIn();
+    const huge = `<html><body>${'<p>x</p>'.repeat(200_000)}</body></html>`;
+    await spliceParseHealth(watcher, [{ rel: 'src/huge.html', content: huge }]);
+    expect(readReport(outputPath)?.excludedByReason).toEqual({ 'size-cap': 1 });
+
+    await spliceParseHealth(watcher, [{ rel: 'src/huge.html', content: '<html><body>ok</body></html>' }]);
+    expect(readReport(outputPath)).toBeNull();
   }, 60_000);
 
   it('CONTROL: an ordinary file is unaffected by the default budget', async () => {

--- a/src/core/services/mcp-watcher-parse-health.test.ts
+++ b/src/core/services/mcp-watcher-parse-health.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The watcher's parse-health lane, as a SECOND PRODUCER of the exclusion vocabulary
+ * (change: fix-analyze-native-abort-and-file-cost-budget).
+ *
+ * `parse-health.json` is read by `doctor`, by `analyze`'s exclusion summary and by every
+ * conclusion tool's boundary disclosure — and it has two writers: the full build, and this
+ * incremental lane, which splices a changed file's record into the existing artifact on every
+ * save. If the two disagree about how to record the same file, the record stops being a single
+ * source of truth and the surfaces that read it start contradicting each other again — which is
+ * the whole failure the `EveryExcludedFileIsRecordedWithAReason` requirement exists to close.
+ *
+ * So these tests pin the watcher lane against the same vocabulary the full build uses. Before this
+ * change, this lane recorded a bare `parseFailed: true` with no reason at all, and there was no
+ * test over it whatsoever.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { McpWatcher } from './mcp-watcher.js';
+import { ARTIFACT_PARSE_HEALTH, PARSE_BUDGET_ENV, PER_FILE_PARSE_BUDGET_MS } from '../../constants.js';
+import type { ParseHealthReport } from '../analyzer/parse-health.js';
+
+/** The payload that reproduced the abort: a 300 KB unterminated block comment. */
+const HOSTILE_TS = '/*x'.repeat(100_000);
+
+afterEach(() => { delete process.env[PARSE_BUDGET_ENV]; });
+
+/** A watcher over a throwaway root, with its analysis dir created. */
+function watcherIn(): { watcher: McpWatcher; outputPath: string } {
+  const root = mkdtempSync(join(tmpdir(), 'wph-'));
+  const outputPath = join(root, '.openlore', 'analysis');
+  mkdirSync(outputPath, { recursive: true });
+  return { watcher: new McpWatcher({ rootPath: root, outputPath }), outputPath };
+}
+
+/** Drive the private incremental lane directly — it is the unit under test. */
+async function spliceParseHealth(
+  watcher: McpWatcher,
+  changed: Array<{ rel: string; content: string }>,
+): Promise<void> {
+  await (watcher as unknown as {
+    updateParseHealth(c: Array<{ rel: string; content: string }>, d?: string[]): Promise<void>;
+  }).updateParseHealth(changed);
+}
+
+function readReport(outputPath: string): ParseHealthReport | null {
+  const p = join(outputPath, ARTIFACT_PARSE_HEALTH);
+  return existsSync(p) ? (JSON.parse(readFileSync(p, 'utf-8')) as ParseHealthReport) : null;
+}
+
+describe('watcher parse-health lane — the exclusion vocabulary matches the full build', () => {
+  it('records a budget overrun as budget-exceeded, not as a bare parse failure', async () => {
+    process.env[PARSE_BUDGET_ENV] = '400';
+    const { watcher, outputPath } = watcherIn();
+
+    await spliceParseHealth(watcher, [{ rel: 'src/hostile.ts', content: HOSTILE_TS }]);
+
+    const report = readReport(outputPath);
+    const rec = report?.files.find(f => f.filePath === 'src/hostile.ts');
+    expect(rec, 'the changed file is spliced into the artifact').toBeDefined();
+    expect(rec!.exclusion).toBe('budget-exceeded');
+    expect(rec!.parseFailed).toBe(true);
+    // The BUDGET, never the measured elapsed time — this artifact is persisted and must be
+    // byte-identical across re-analyses of a fixed repository state.
+    expect(rec!.budgetMs).toBe(400);
+    expect(report!.excludedByReason).toEqual({ 'budget-exceeded': 1 });
+  }, 60_000);
+
+  it('still records an ordinary syntax error as a degraded file, not an exclusion', async () => {
+    // The classifier must not launder every failure into "budget-exceeded". A file the grammar
+    // merely struggled with is degraded, and a degraded file is not an excluded one.
+    const { watcher, outputPath } = watcherIn();
+
+    await spliceParseHealth(watcher, [
+      { rel: 'src/broken.ts', content: 'function good() { return 1; }\nfunction broken( {\n' },
+    ]);
+
+    const rec = readReport(outputPath)?.files.find(f => f.filePath === 'src/broken.ts');
+    expect(rec).toBeDefined();
+    expect(rec!.exclusion).toBeUndefined();
+    expect(rec!.errorCount + rec!.missingCount).toBeGreaterThan(0);
+    expect(readReport(outputPath)!.excludedByReason).toBeUndefined();
+  }, 60_000);
+
+  it('writes NO artifact for a clean file — a clean repo still pays zero', async () => {
+    const { watcher, outputPath } = watcherIn();
+    await spliceParseHealth(watcher, [
+      { rel: 'src/ok.ts', content: 'export function a(): void { b(); }\nfunction b(): void {}\n' },
+    ]);
+    expect(readReport(outputPath)).toBeNull();
+  }, 60_000);
+
+  it('drops the exclusion when the offending file is repaired', async () => {
+    // The lane must be able to CLEAR a record, not only add one — otherwise a repository stays
+    // permanently marked as having excluded a file it no longer contains.
+    process.env[PARSE_BUDGET_ENV] = '400';
+    const { watcher, outputPath } = watcherIn();
+    await spliceParseHealth(watcher, [{ rel: 'src/hostile.ts', content: HOSTILE_TS }]);
+    expect(readReport(outputPath)?.excludedByReason).toEqual({ 'budget-exceeded': 1 });
+
+    delete process.env[PARSE_BUDGET_ENV];
+    await spliceParseHealth(watcher, [
+      { rel: 'src/hostile.ts', content: 'export function a(): void { b(); }\nfunction b(): void {}\n' },
+    ]);
+    expect(readReport(outputPath), 'the last degraded file was repaired — artifact removed').toBeNull();
+  }, 60_000);
+
+  it('CONTROL: an ordinary file is unaffected by the default budget', async () => {
+    // Guards the direction that would be worst: a bound tight enough to start excluding real
+    // source. The default is 20 s; nothing ordinary comes close.
+    expect(PER_FILE_PARSE_BUDGET_MS).toBeGreaterThanOrEqual(10_000);
+    const { watcher, outputPath } = watcherIn();
+    const big = Array.from(
+      { length: 4_000 },
+      (_, i) => `export function fn${i}(): number { return helper${i}(); }\nfunction helper${i}(): number { return ${i}; }`,
+    ).join('\n');
+    await spliceParseHealth(watcher, [{ rel: 'src/generated.ts', content: big }]);
+    expect(readReport(outputPath)).toBeNull();
+  }, 60_000);
+});

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -54,6 +54,7 @@ import {
   WATCH_EMBED_FILE_CEILING,
   WATCH_VCS_SETTLE_MS,
   INCREMENTAL_CLOSURE_BUDGET,
+  MAX_HTML_INLINE_SCRIPT_CHARS,
 } from '../../constants.js';
 
 // Languages the watcher incrementally re-graphs on edit. MUST include every
@@ -1246,6 +1247,19 @@ export class McpWatcher {
           };
         }
         const priorEncoding = byPath.get(f.rel)?.encodingFallback;
+        // A size-capped HTML file is EXCLUDED before extraction, so `extractFileParseHealth`
+        // returns nothing for it and the delete below would silently clear the exclusion the full
+        // build recorded — `doctor` would then bless a repository the next `analyze` excludes a
+        // file from again. The watcher applies the same bound rather than assuming the file became
+        // healthy (change: fix-analyze-native-abort-and-file-cost-budget).
+        if (/\.html?$/i.test(f.rel) && f.content.length > MAX_HTML_INLINE_SCRIPT_CHARS) {
+          byPath.set(f.rel, {
+            filePath: f.rel, language, errorCount: 0, missingCount: 0, errorLines: [],
+            exclusion: 'size-cap',
+          });
+          touched = true;
+          continue;
+        }
         if (health && priorEncoding) health.encodingFallback = true;
         if (health) { health.language = language; byPath.set(f.rel, health); touched = true; }
         else if (priorEncoding) { byPath.set(f.rel, { filePath: f.rel, language, errorCount: 0, missingCount: 0, errorLines: [], encodingFallback: true }); touched = true; }

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -36,6 +36,7 @@ import type { FunctionNode } from '../analyzer/call-graph.js';
 import { extractFileStyle, extractFileParseHealth } from '../analyzer/call-graph.js';
 import { assembleFromRegions, type StyleFingerprint, type FileStyleRaw } from '../analyzer/style-fingerprint.js';
 import { buildParseHealthReport, type ParseHealthReport, type FileParseHealth } from '../analyzer/parse-health.js';
+import { parseBudgetOverrunMs } from '../analyzer/parse-budget.js';
 import { isTestFile } from '../analyzer/test-file.js';
 import { EdgeStore } from './edge-store.js';
 import { refreshAttestationCounts } from '../analyzer/index-attestation.js';
@@ -1231,8 +1232,18 @@ export class McpWatcher {
           // (ERROR/MISSING, parse failure); the byte-level encoding-fallback signal is recomputed at
           // the next full analyze. A prior encoding-fallback flag on this file is preserved.
           health = await extractFileParseHealth({ path: f.rel, content: f.content, language });
-        } catch {
-          health = { filePath: f.rel, language, errorCount: 0, missingCount: 0, errorLines: [], parseFailed: true };
+        } catch (err) {
+          // Classify the same way the full build does, off the same message marker, so the record
+          // this splices into `parse-health.json` is indistinguishable from the one a full analyze
+          // would have written for the same file (change:
+          // fix-analyze-native-abort-and-file-cost-budget). Two producers, one vocabulary.
+          const overrunBudgetMs = parseBudgetOverrunMs((err as Error | undefined)?.message);
+          health = {
+            filePath: f.rel, language, errorCount: 0, missingCount: 0, errorLines: [],
+            parseFailed: true,
+            exclusion: overrunBudgetMs !== undefined ? 'budget-exceeded' : 'parse-failure',
+            ...(overrunBudgetMs !== undefined ? { budgetMs: overrunBudgetMs } : {}),
+          };
         }
         const priorEncoding = byPath.get(f.rel)?.encodingFallback;
         if (health && priorEncoding) health.encodingFallback = true;


### PR DESCRIPTION
**Status:** LGTM — ready to merge. Full suite (6,480 tests), lint, typecheck, build, and the real-threads pool test all pass locally; verified end to end on both a hostile reproducer and this repository.

Closes the first of the three runtime failures proposed in #293.

## What was wrong

`openlore analyze` died like this, 3/3 deterministically:

```
$ openlore analyze
… Generating analysis artifacts…
libc++abi: terminating due to uncaught exception of type Napi::Error
$ echo $?
134
```

One line of C++ runtime noise. No stack, no `[error]` line, no partial artifacts, no indication of which file caused it, and no remedy. For a tool whose contract is that a quiet result means "nothing there" rather than "we broke", this is the worst available failure mode — it is indistinguishable from a crash in the host.

Alongside it, two smaller failures with the same root: **one file could consume unbounded wall clock** (the isolated payload alone took 84 s of parse on the measuring machine, 661 s on the reporter's), with no budget, no progress line naming it, and no way to interrupt short of Ctrl-C. And **skips were reported as a bare count** — `Files skipped: 3`, no reasons — while `doctor` judged the same repository independently and could report a clean bill of health for it.

## Root cause

The proposal guessed "a worker raises a `Napi::Error` that no boundary catches". The build isolated something more specific and more fixable.

A 300 KB file of a repeated unterminated block-comment opener parses into a right-leaning chain **100,002 nodes deep**. `tallyParseHealth` — which runs *precisely* on trees that carry errors, i.e. exactly this case — walked it **recursively**:

```
RangeError: Maximum call stack size exceeded
    at new SyntaxNode (node_modules/tree-sitter/index.js:63:14)
    at unmarshalNode (node_modules/tree-sitter/index.js:798:18)
    at BinaryExpressionNode.child (node_modules/tree-sitter/index.js:244:12)
    at visit (dist/core/analyzer/parse-health.js:77:29)
    at visit (dist/core/analyzer/parse-health.js:79:21)   ← ×100,000
```

The `RangeError` is raised **inside the native binding's node accessor**. A throw raised in a native frame is not catchable as a JavaScript error; it becomes the C++ exception `libc++abi` aborts on. The extraction pool is implicated only because a worker's stack is where it lands first — the same overflow is reachable on the main thread.

## How it was fixed

Two structural fixes, so this is not a race that got luckier:

**1. The parse-health walk is iterative.** An explicit stack cannot overflow, so tree depth stops being a correctness cliff. Order is preserved exactly (children pushed in reverse), which keeps the capped `errorLines` list byte-identical.

**2. Every tree-sitter parse is bounded in-band**, by tree-sitter's own deadline. This is the only bound that *can* interrupt the work: a `parser.parse()` is one synchronous native call, so a `setTimeout` never runs until it returns, and terminating the worker holding it is precisely what converts a slow parse into a process-level abort. On the deadline `parse()` simply returns no tree; nothing is killed. `PER_FILE_PARSE_BUDGET_MS` is 20 s, overridable via `OPENLORE_PARSE_BUDGET_MS`, and `0` restores the previous behaviour exactly.

Applied at **all 36 parse sites**: the 9 per-language extractors, the generic native and WASM grammar handles, the 23 synthesis-pass re-parses, and the three serve-time parses (chunker, exception flow, error propagation) that would otherwise wedge the long-lived daemon rather than one build.

**Around that, the run now says what it did:**

- Every excluded file carries a machine-readable `exclusion` (`parse-failure` · `budget-exceeded` · `size-cap`) in the parse-health record, with a per-reason rollup. Both producers — the full build and the incremental watcher — use the same vocabulary.
- `analyze` reports skipped files **by reason**, and excluded files with their cause and the bound they exceeded.
- `doctor` reads that same record through the same helper, so the two surfaces cannot give a repository different answers.
- A file whose extraction passes a disclosure threshold is **named live, on stderr**, while it is still running — so a slow run is attributable without attaching a debugger. Deliberately not through `logger`, whose non-error levels go to stdout, because this build also runs inside `openlore mcp` where stdout carries JSON-RPC frames.
- A conclusion touching an excluded file discloses it through the existing parse-health boundary, naming the cause rather than a generic "parse failed".
- Oversized HTML — previously dropped whole and silently — is now recorded as `size-cap`.

## Replication / proof

| | before | after |
|---|---|---|
| 601-file reproducer | **exit 134**, `libc++abi: terminating…` | **exit 0** |
| same, wall clock | 217 s | **44 s** |
| the hostile file alone, inside `build()` | 92 s (one 20 s bound, paid per pass) | **20.03 s** |

To reproduce the original: 600 trivial `.ts` files plus one of `'/*x'.repeat(100_000)`, then `openlore analyze`.

After, the same run is legible:

```
Files skipped: 3 (directory:.git 1, directory:.openlore 1, directory:openspec 1)
[warn] still extracting src/hostile.ts after 5s          ← stderr, while it runs
[warn] slowest file(s) to extract: src/hostile.ts (20.3s)
[warn] 1 file excluded (1 budget-exceeded) — symbols and edges from these files are a
       LOWER BOUND: src/hostile.ts (abandoned at the per-file parse budget of 20.0s)
```

and `doctor` agrees instead of contradicting: `⚠ Parse health … ; 1 file excluded (1 budget-exceeded)`.

**Controls — a bound that silently drops real files would be worse than the bug it replaces:**

- **Differential over this whole repository (706 files):** serialized call graph **byte-identical** with the budget on and off.
- **End to end on this repository:** 997 files, 3,148 functions, 18,022 edges, 18.6 s — no exclusions, no new output, `orient` and `doctor` unchanged.
- **Control test:** a 1.4 MB generated-client-shaped file is *not* recorded, and its graph matches a budget-disabled run.
- **Determinism:** `parse-health.json` is byte-identical across two runs of the reproducer repository.
- 6,458 tests pass (up from 6,455), including the real-`worker_threads` pool test CI runs separately.

## Defects the change's own controls caught

Each has a regression test. These are the reason the control tests were written first.

1. **A timed-out tree-sitter parse is *suspended*, not discarded.** Calling `parse` again resumes it — so the next file handed to the same singleton parser resumed the *abandoned* file's parse. The file after the pathological one produced **zero symbols** and a spurious parse-health record. The parser is now reset at the deadline.
2. **`web-tree-sitter@0.25` exposes `setTimeoutMicros` and throws from inside it** (`TypeError: Cannot convert 0 to a BigInt` — its WASM shim passes a Number where the import demands a BigInt). Left to propagate, arming the deadline failed **every Dart and Lua file**. Arming is now fail-soft, and a parser that refuses is demoted to unbounded once rather than throwing per file. Caught by the language-conformance suite.
3. **The budget was spent once per *pass*, not once per file** — 92 s for a 20 s bound, because several later passes re-read the same content (class relationships, event/callback/route/actor synthesis, and the regex export scan behind re-export-aware import resolution, which the parse budget cannot bound at all). Abandoned files are dropped from those passes.
4. A boundary rendered `undefined` for an exclusion reason written by a newer build.

## Notes / deviations from the proposal

All four are measured, not preference, and are recorded in `tasks.md`:

- **`worker-fault` is not a file-level exclusion reason.** The proposal listed one. A worker fault no longer excludes a file at all: the pool routes it to the main thread — the reference implementation — so the facts stay whole and the fault is disclosed on the *lane*. Recording it against the file would blame the source for a defect in the thread reading it. This is strictly stronger than the proposal asked for.
- **The record stores the budget, not the measured elapsed time.** `parse-health.json` is persisted and must be byte-identical across re-analyses (change `fix-artifact-output-determinism`); a wall-clock number would break that on every repository containing such a file. Nothing is lost — a file is only recorded because it ran past the bound. The measured time still reaches the operator live, on the unpersisted lane disclosure.
- **`encoding` is not an exclusion** — a lossy decode does not exclude a file, so it stays the separate `encodingFallback` signal it always was.
- **`analyze --json` does not exist**; the proposal named it. The real machine-output surface for this code path is the stdio MCP server, and the CLI requirement is now stated against that.

**Scope limits, stated plainly:**

- Making the 84 s parse *fast* is explicitly out of scope — that cost is in the grammar/extractor layer and warrants its own investigation. This change makes it bounded, attributable and disclosed; the budget record is what makes the follow-up measurable.
- An abandoned file re-pays its budget on every run: the Pass-1 memo deliberately never caches a throw. Disclosed by the existing "will re-extract each run" note.
- The `size-cap` producer (oversized HTML) has unit coverage for the reason, rollup and rendering, but no end-to-end test — it needs a >1 MB HTML fixture. This is the one remaining untested producer.
- `extractExceptionFactsFromSource` is now budgeted but has **no production callers** (it is test-only); the live serve-time site is `error-propagation.ts`, which already caught the throw.
- **`openspec archive` could not run.** It aborts on pre-existing structural invalidity in the *main* spec corpus (requirements without `SHALL`/scenarios, e.g. `FlipDefaultMcpSurfaceToTheSubstrate…`, `SpecstoreBindingResolvesDeclaredTargets…`), none of which this change touches. That needs a dedicated corpus-repair change; the change is marked **BUILT** in its own proposal and tasks instead.

## Follow-up commit: closing the untested paths

A second review pass asked where the change was weakest, and the honest answer was coverage, not logic: three paths it added had **no behavioral test** — verified only by typecheck or by a structural `grep`. `847d375` closes all three, and each was **mutation-checked** (removing the code under test makes the test fail).

| Path | Why the existing coverage was insufficient |
|---|---|
| Worker `uncaughtException` boundary | The stub lane *fabricates* the `failed` message, so it proved the parent handles one — never that the worker sends one. `process.on('uncaughtException')` is per-thread; a stub has no thread. Now driven on a real `worker_threads` worker loading the production entry |
| Watcher parse-health lane | The **second producer** of the exclusion vocabulary, with no test at all. If it disagrees with the full build, the record stops being a single source of truth and the surfaces reading it start contradicting each other again — the exact failure this change closes |
| ast-chunker budget fallback | Added late; unbounded, that call measures **85.7 s** on the hostile payload. That is a serve-time hang, not a slow build |

Two things worth recording from writing them:

- **The real-thread test failed twice first, instructively.** A timer scheduled while a large file extracted never fired *during* the extraction — the parse is one synchronous native call, so the worker's event loop does not run and the parse budget always won the race. That is a direct demonstration of why the budget has to be in-band rather than a timer, and the test now documents it. Deferring to the next macrotask lost the opposite race, because a small file's extraction completes entirely within microtasks. The shim throws synchronously from its own message listener instead, so a file is in flight by construction with no timing assumption.
- **One of my own comments was wrong and is corrected.** The ast-chunker test claimed its output comparison proved the budget ran. The mutation check showed the fallback is reached with or without the budget (the pathological tree yields no usable top-level nodes), so the elapsed-time bound is the assertion doing the work. The comment now says so.

## Round 2: four adversarial reviews, eight defects, all fixed

Four independent reviewers (budget correctness · concurrency · honesty contract · test quality by mutation testing) went at the first revision. They found **eight confirmed defects and nine surviving mutations**. All are fixed, and every fix is mutation-checked — the mutation is applied, the test is confirmed to fail, the mutation is reverted.

**The worst one was mine, and it was this change's own failure mode.** Dropping budget-exceeded files from `buildResolvedImportMap` looked free. But `parseJSExports` is a *regex scan* — it reads a file tree-sitter gave up on perfectly well — so filtering it removed re-export information belonging to **other, healthy files**, which then resolved by name only or not at all. Two reviewers reproduced it independently:

```
WITH barrel   : edges ["user.ts::bar->def.ts::foo[re_export]"]  ambiguous 0
WITHOUT barrel: edges []                                        ambiguous 1  (name_only)
```

The loss landed on files carrying no parse-health record, so nothing connected the missing edge to the abandoned one — absence read as evidence of absence. The filter now applies only to passes that genuinely re-parse, where the file contributes the same nothing either way. It costs ~8 s on the reproducer (44 s → 52 s) and I'll take that trade every time.

| # | Defect | Fix |
|---|---|---|
| 2 | Budget charged **twice** on the pooled lane (unproven-language recheck re-ran the abandoned file) | a budget overrun is a property of the file, so it's trusted |
| 3 | A faulting worker **stole a file from a healthy sibling** — `continue` after the boundary closed the channel | `break`, matching every other worker-death path |
| 4 | `slowFiles` double-counted a file timed on both lanes | deduped, worst time kept |
| 5 | The WASM deadline demotion **never fired** — keyed on the instance, and that lane builds a fresh parser per file | keyed on the constructor |
| 6 | A budget overrun in a **later pass** was swallowed with no record | recorded as an exclusion |
| 7 | The watcher **erased** a `size-cap` exclusion, so doctor reverted to clean | the watcher applies the same bound |
| 8 | Excluded files counted as "parsed with errors", with a tree-sitter remedy | counted and worded separately |

**Nine surviving mutations closed**, including: `reparsableFiles` was entirely untested; `sanitizeForTerminal` on the stderr path was untested despite this repo's terminal-escape history; the "worker faults, graph stays whole" test **induced no fault**; the source-order test covered only the branch production never takes; the analyze/doctor agreement tests were source greps that passed with both surfaces rendering nothing; and the `size-cap` producer had no test at all.

The stub worker lane was also **unfaithful to production** — it kept answering after "faulting" — which is exactly why the stolen-file bug survived it. It now models the channel close.

Two things fixing this taught me, both now in comments:
- Keying the deadline demotion on the *prototype* was also wrong: every object literal shares `Object.prototype`, so one refusing parser would demote unrelated ones. The constructor is the right key.
- `serve.test.ts` is load-flaky under the full suite (passes in isolation, on this branch and on main). Not introduced here, but worth knowing.

**Re-verified after the fixes:** 6,480 tests pass; byte-identity differential over 707 files still identical with the budget on and off; the real repository is unchanged at 997 files / 3,148 functions / 18,022 edges.

## Release

The final commit stages **v2.1.7** — version bump plus release notes covering the 28 commits on main since v2.1.6 and this PR. Tag after merge, as with v2.1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


