### PR TITLE
fix(analyze): bound repository-wide enrichment scans

### DIFF
--- a/openspec/changes/fix-unbounded-file-scan-oom/proposal.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/proposal.md
@@ -79,11 +79,26 @@ line later on an extension test.
 
 ## Deliberately NOT in this change
 
-The call-graph build (`analyze` phase 4) holds every file's content resident because Pass 2 type
-inference, import resolution, and class-hierarchy extraction all read it after Pass 1. That is a
-real ceiling on very large repositories and it is **architectural** — bounding it means streaming
-per-file facts through the store between passes, not adding a limiter. It is out of scope here and
-should be its own change; this one fixes the reported crash and the shape that caused it.
+The call-graph build (`analyze` phase 4) has its own ceiling on very large repositories, and it is
+NOT the same defect. Measured on a 4,000-file / 203 MB repository (32,001 functions), peak was
+**2,323 MB**, composed of:
+
+| Term | Retained |
+|---|---|
+| File content held for Pass 2 (type inference, import resolution, class hierarchy) | 196 MB |
+| Serialized nodes + edges | 18 MB |
+| **Intra-procedural CFG / def-use overlay** | **1,594 MB** |
+
+The overlay dominates by an order of magnitude: it is built unconditionally for every function in
+every supported language (~50 KB live per function), accumulated for the WHOLE repository, written
+to SQLite, and then discarded. It is transient by design and never needs to be fully resident.
+
+Bounding it is a distinct change with its own risk: the store is opened and `clearAll()`-ed only
+after the build completes — deliberately, so a failed build cannot leave a wiped index
+(change: harden-index-store-lifecycle) — so the overlay cannot simply be streamed into the store as
+it is produced. It needs either a spill-to-disk hand-off or a gate, and it touches the artifact the
+whole product reads. This change fixes the reported crash and the unbounded-scan shape that caused
+it; the overlay belongs in its own change.
 
 ## Why it stays fixed
 

--- a/openspec/changes/fix-unbounded-file-scan-oom/proposal.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/proposal.md
@@ -1,0 +1,95 @@
+# A repository-wide scan must not hold the whole repository in memory
+
+> Status: **BUILT** (2026-07-30). Full suite green (6,511 passed / 336 files), lint, typecheck,
+> build. Reported as issue #302: `openlore install` dies with
+> `FATAL ERROR: Ineffective mark-compacts near heap limit — JavaScript heap out of memory` during
+> the enrichment-extraction phase. Reproduced, fixed, and verified against an `origin/main` build.
+> Deterministic, no LLM, no new dependency.
+
+## The gap
+
+Every enrichment extractor fanned out over the repository like this:
+
+```ts
+await Promise.all(filePaths.map(async fp => {
+  const source = await readFile(fp, 'utf-8');   // one read per file, ALL issued at once
+  …
+}))
+```
+
+`Promise.all` issues every read simultaneously, so at the peak the entire repository is resident in
+the heap. `analyze` then ran **five** such scans concurrently (components, schemas, routes,
+middleware, env vars), multiplying that peak by five. Nothing bounded how many files were in
+flight, and nothing bounded how large a single file could be.
+
+Past a few hundred megabytes of source this is a fatal OOM, not a slowdown. V8 aborts inside the
+read-completion path — the user gets a C++ stack trace, no partial artifacts, no indication of
+which phase died, and no remedy. The reporter's stack ends in `v8::String::NewFromOneByte`: a
+`readFile` materializing a string.
+
+Two independent failure axes, either of which is sufficient on its own:
+
+| Axis | Trigger | Why concurrency alone doesn't fix it |
+|---|---|---|
+| Fan-out | Many ordinary files | Peak scales with file COUNT |
+| Per-file size | One generated/minified blob | A single read exhausts the heap at any width |
+
+**Measured on a 300-file / 439 MB repository, Node's default heap:**
+
+| Build | Phase 3 result |
+|---|---|
+| `origin/main` | **FATAL ERROR — heap out of memory** (reproduced 3/3) |
+| This change | completes; peak 635 MB, and still completes under a **512 MB** heap |
+
+**Measured on a 6,000-file / 234 MB repository (peak RSS, same work):**
+
+| Build | Peak RSS |
+|---|---|
+| `origin/main` | 3,112 MB |
+| This change | **437 MB** (417 MB under a 384 MB heap) |
+
+The peak stopped being a function of the repository and became a function of the bound.
+
+## What changes
+
+One module, `bounded-file-scan.ts`, is now the only way this codebase fans a read across a
+repository. It carries the two bounds the failure needs, plus the ordering guarantee the artifacts
+already depended on:
+
+- **`mapFilesBounded`** — at most `SOURCE_SCAN_CONCURRENCY` (8) callbacks in flight, results
+  returned in **input order** exactly like `Promise.all`. Input ordering is load-bearing: several
+  scans document that their artifacts must be byte-identical across runs of a fixed repository
+  state, and under a concurrency limit completion order additionally depends on which worker frees
+  a slot first.
+- **`readSourceCapped`** — `stat` before read, so a file above `SOURCE_SCAN_MAX_FILE_BYTES` (4 MB)
+  is never materialized. Measuring after reading would already have allocated what the cap exists
+  to prevent.
+
+`analyze` runs the five extractors **sequentially** rather than as one `Promise.all`. Each is
+internally bounded, but running five together multiplies that bound by five. This costs no extra
+I/O — all five always read the same files.
+
+An oversized file is **disclosed**, never silently dropped: `analyze` reports the count and the
+worst offenders and marks the affected inventories a LOWER BOUND, using the sizes the walker
+already recorded and the same predicate the scan applies.
+
+The env-var scan additionally decides whether a file can contribute **before** reading it. It used
+to decode every file in the repository — images, archives, model weights — only to discard it one
+line later on an extension test.
+
+## Deliberately NOT in this change
+
+The call-graph build (`analyze` phase 4) holds every file's content resident because Pass 2 type
+inference, import resolution, and class-hierarchy extraction all read it after Pass 1. That is a
+real ceiling on very large repositories and it is **architectural** — bounding it means streaming
+per-file facts through the store between passes, not adding a limiter. It is out of scope here and
+should be its own change; this one fixes the reported crash and the shape that caused it.
+
+## Why it stays fixed
+
+The bug was not one bad line — it was a SHAPE, written independently in eight places, and it is
+the natural way to write a repository scan. So the guards are structural as well as behavioural:
+`bounded-computation.test.ts` fails the build if a scan module reintroduces a raw `readFile` or an
+unbounded `Promise.all(x.map(…))`, if `analyze` puts the five extractors back on one `Promise.all`,
+if the disclosure is dropped, or if either bound is widened past the point of being a bound. Every
+guard was mutation-tested: each was confirmed to FAIL when the defect is reintroduced.

--- a/openspec/changes/fix-unbounded-file-scan-oom/proposal.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/proposal.md
@@ -1,4 +1,4 @@
-# A repository-wide scan must not hold the whole repository in memory
+# A repository-wide enrichment scan must not hold the whole repository in memory
 
 > Status: **BUILT** (2026-07-30). Full suite green (6,511 passed / 336 files), lint, typecheck,
 > build. Reported as issue #302: `openlore install` dies with
@@ -52,9 +52,9 @@ The peak stopped being a function of the repository and became a function of the
 
 ## What changes
 
-One module, `bounded-file-scan.ts`, is now the only way this codebase fans a read across a
-repository. It carries the two bounds the failure needs, plus the ordering guarantee the artifacts
-already depended on:
+One module, `bounded-file-scan.ts`, is now the shared way analyzer and indexing entry points fan
+reads across repository files. It carries the bounds the failure needs, plus the ordering guarantee
+the artifacts already depended on:
 
 - **`mapFilesBounded`** — at most `SOURCE_SCAN_CONCURRENCY` (8) callbacks in flight, results
   returned in **input order** exactly like `Promise.all`. Input ordering is load-bearing: several
@@ -69,9 +69,14 @@ already depended on:
 internally bounded, but running five together multiplies that bound by five. This costs no extra
 I/O — all five always read the same files.
 
-An oversized file is **disclosed**, never silently dropped: `analyze` reports the count and the
-worst offenders and marks the affected inventories a LOWER BOUND, using the sizes the walker
-already recorded and the same predicate the scan applies.
+An oversized enrichment file is **disclosed**, never silently dropped: `analyze` reports the count
+and the worst offenders and marks the affected inventories a LOWER BOUND. The observation comes
+from the exact open-handle `stat` that enforced the cap, so a file rewritten after repository
+walking but before that scan-time observation cannot be silently omitted or falsely reported.
+
+The production CLI/install function index, the MCP live-data function index, the import rebuild,
+and text-line indexing also use the bounded worker pool. These indexes retain their corpus by
+design, but they no longer issue every repository read simultaneously.
 
 The env-var scan additionally decides whether a file can contribute **before** reading it. It used
 to decode every file in the repository — images, archives, model weights — only to discard it one
@@ -97,8 +102,9 @@ Bounding it is a distinct change with its own risk: the store is opened and `cle
 after the build completes — deliberately, so a failed build cannot leave a wiped index
 (change: harden-index-store-lifecycle) — so the overlay cannot simply be streamed into the store as
 it is produced. It needs either a spill-to-disk hand-off or a gate, and it touches the artifact the
-whole product reads. This change fixes the reported crash and the unbounded-scan shape that caused
-it; the overlay belongs in its own change.
+whole product reads. This change fixes the reported phase-3 crash site and the unbounded-scan shape
+that caused it; the overlay belongs in its own change, and issue #302 must remain open until that
+follow-up makes the reporter's full `install` path complete.
 
 ## Why it stays fixed
 

--- a/openspec/changes/fix-unbounded-file-scan-oom/specs/analyzer/spec.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/specs/analyzer/spec.md
@@ -1,0 +1,77 @@
+# analyzer spec delta
+
+## ADDED Requirements
+
+### Requirement: RepositoryWideScansAreBoundedInConcurrencyAndFileSize
+
+A scan that reads every file in a repository SHALL bound both the number of files it holds in
+memory at once and the size of any single file it will read. Neither bound alone is sufficient: a
+repository of many ordinary files exhausts the heap through fan-out, and a repository containing
+one generated blob exhausts it through a single read.
+
+The per-file size SHALL be measured BEFORE the file is read. Reading first and measuring after has
+already allocated exactly what the cap exists to prevent.
+
+Peak residency SHALL be a function of the bounds, not of the repository's file count or total
+bytes.
+
+#### Scenario: A large repository is scanned under a small heap
+
+- **GIVEN** a repository of several hundred megabytes of source across hundreds of files
+- **WHEN** the enrichment extractors scan it under a heap far smaller than the repository
+- **THEN** every extractor completes, and peak memory tracks the concurrency bound rather than the
+  repository size
+
+#### Scenario: One oversized file cannot exhaust the heap
+
+- **GIVEN** a repository containing a single generated file far larger than the per-file cap
+- **WHEN** a repository-wide scan runs
+- **THEN** that file is skipped without being read into memory, and the other files are scanned
+  normally
+
+### Requirement: BoundedScansPreserveInputOrder
+
+A bounded repository-wide scan SHALL return its results in INPUT order, identically to an unbounded
+`Promise.all`, and independently of its concurrency width.
+
+This is a correctness property, not a convenience. Artifacts built from these scans must be
+byte-identical across runs of a fixed repository state; under a concurrency bound, completion order
+depends on which worker frees a slot first, so input-order aggregation is the only thing keeping
+those bytes stable.
+
+#### Scenario: Adversarial completion order does not reorder output
+
+- **GIVEN** a file list longer than the concurrency bound, whose reads complete in reverse order
+- **WHEN** the route and env-var inventories are built from it
+- **THEN** both are ordered by the file list, and repeated runs produce identical bytes
+
+### Requirement: FilesTooLargeToScanAreDisclosed
+
+A file excluded from an enrichment scan because it exceeds the per-file size cap SHALL be disclosed
+to the operator with its path and size, and the affected inventories SHALL be described as a LOWER
+BOUND.
+
+A silently dropped file makes a component, route, or environment variable that genuinely exists
+read as genuinely absent — the failure mode the analyzer's disclosure discipline exists to prevent.
+The disclosure SHALL be derived from the same threshold the scan applies, so the two surfaces
+cannot report different answers for the same repository.
+
+#### Scenario: An oversized file is reported rather than dropped
+
+- **GIVEN** a repository containing a file above the scan's per-file cap
+- **WHEN** `openlore analyze` runs
+- **THEN** the run completes and reports the excluded file, its size, and that the enrichment
+  inventories are a lower bound
+
+### Requirement: EnrichmentExtractorsDoNotMultiplyTheScanBound
+
+The enrichment extractors SHALL NOT run as one concurrent batch. Each is internally bounded;
+running them together multiplies that bound by the number of extractors, which is what exhausted
+the heap. Running them in sequence costs no additional I/O, since they read the same file set.
+
+#### Scenario: Adding an extractor does not raise peak memory
+
+- **GIVEN** the enrichment phase of `openlore analyze`
+- **WHEN** the extractors run
+- **THEN** peak residency is that of a single bounded scan, regardless of how many extractors the
+  phase contains

--- a/openspec/changes/fix-unbounded-file-scan-oom/specs/analyzer/spec.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/specs/analyzer/spec.md
@@ -4,16 +4,16 @@
 
 ### Requirement: RepositoryWideScansAreBoundedInConcurrencyAndFileSize
 
-A scan that reads every file in a repository SHALL bound both the number of files it holds in
-memory at once and the size of any single file it will read. Neither bound alone is sufficient: a
-repository of many ordinary files exhausts the heap through fan-out, and a repository containing
-one generated blob exhausts it through a single read.
+An enrichment scan that reads source files across a repository SHALL bound both the number of
+files it holds in memory at once and the size of any single file it will read. Neither bound alone
+is sufficient: a repository of many ordinary files exhausts the heap through fan-out, and a
+repository containing one generated blob exhausts it through a single read.
 
 The per-file size SHALL be measured BEFORE the file is read. Reading first and measuring after has
 already allocated exactly what the cap exists to prevent.
 
-Peak residency SHALL be a function of the bounds, not of the repository's file count or total
-bytes.
+Transient source-read residency during enrichment SHALL be a function of the bounds, not of the
+repository's file count or total bytes.
 
 #### Scenario: A large repository is scanned under a small heap
 
@@ -53,8 +53,8 @@ BOUND.
 
 A silently dropped file makes a component, route, or environment variable that genuinely exists
 read as genuinely absent — the failure mode the analyzer's disclosure discipline exists to prevent.
-The disclosure SHALL be derived from the same threshold the scan applies, so the two surfaces
-cannot report different answers for the same repository.
+The disclosure SHALL be emitted from the same scan-time size observation that applies the
+threshold, so an earlier repository-walk snapshot cannot make the two surfaces disagree.
 
 #### Scenario: An oversized file is reported rather than dropped
 

--- a/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
@@ -1,0 +1,61 @@
+# Tasks — bound every repository-wide file scan
+
+> Status: **BUILT** (2026-07-30). Issue #302. Full suite green — **6,511 passed, 0 failed,
+> 336/336 files** — plus lint, typecheck and build. (Earlier runs showed a handful of timeouts in
+> `parse-budget` / `mcp-watcher-parity`; those were contention from the multi-gigabyte analyze
+> reproducers running alongside the suite. They also appeared on a clean `origin/main` worktree
+> under the same load, and all pass on an uncontended run of either branch.)
+
+## Reproducers (written first — they are the acceptance criteria)
+- [x] Fan-out reproducer: 300 files × 1.5 MB (439 MB). `origin/main` dies with
+      `FATAL ERROR: … JavaScript heap out of memory` under a 2 GB heap, aborting inside the
+      `readFile` completion path — the same frame the issue reports. Reproduced 3/3
+- [x] Per-file reproducer: one 666 MB generated file. Confirmed load-bearing by running the same
+      code path with the cap disabled (`readSourceCapped(p, MAX_SAFE_INTEGER)`) — OOM with the cap
+      off, skipped cleanly with it on
+- [x] Scale measurement: 6,000 files / 234 MB — peak RSS **3,112 MB → 437 MB**
+
+## The fix
+- [x] `bounded-file-scan.ts`: `mapFilesBounded` (bounded width, input-order results),
+      `readSourceCapped` (stat-before-read), `isOversizedForScan` (the threshold, defined once)
+- [x] `SOURCE_SCAN_CONCURRENCY` (8) and `SOURCE_SCAN_MAX_FILE_BYTES` (4 MB) in `constants.ts`, each
+      documented with why it is that size and why the other bound cannot replace it
+- [x] All five enrichment extractors converted: UI components, schemas, routes, middleware, env vars
+- [x] `call-graph.ts` `synthesizeRouteHandlerEdges` — re-reads every file from disk, same hazard
+- [x] `live-data/analyze-repo.ts` — read every node's file at once to build the vector index
+- [x] `extractAllHttpEdges` — its nested `Promise.all` read the SAME file twice concurrently,
+      doubling per-slot residency; now sequential
+- [x] `analyze.ts` phase 3: five extractors run sequentially, not as one `Promise.all`
+- [x] `analyze.ts`: oversized files disclosed with path + size, inventories marked a LOWER BOUND
+- [x] env scan: decide from the extension BEFORE reading — it used to decode every binary asset in
+      the repository and discard it one line later
+- [x] Schema and middleware scans changed from shared-array push to per-file-then-flatten. They
+      aggregated in I/O-COMPLETION order, a latent byte-determinism defect that the concurrency
+      bound would otherwise have made reproducible
+
+## Verification
+- [x] `bounded-file-scan.test.ts` (12): width is never exceeded (including with one slow file);
+      every path visited exactly once; nonsensical widths clamped; input order held under reversed
+      completion and at every width; failure matches `Promise.all` with no unhandled rejection;
+      cap boundary exact; missing path and directory both null
+- [x] `artifact-output-determinism.test.ts`: added cases with file lists **longer than** the
+      concurrency bound. The existing cases used 3 files — under the bound of 8, so no worker ever
+      waited for a slot and the bounded path was never exercised
+- [x] `bounded-computation.test.ts`: structural guards — no raw `readFile` and no
+      `Promise.all(x.map(` in any scan module (comments stripped first, so prose explaining the
+      hazard cannot fail the guard and code cannot hide behind it); `analyze` awaits the five
+      extractors separately; the disclosure is present; both bounds are still bounds
+- [x] End-to-end oversized-file test through all five extractors, with the oversized file carrying
+      content each one would otherwise match — so an empty result cannot pass by accident
+- [x] **Mutation-tested**: every guard confirmed to FAIL when the defect is reintroduced (unbounded
+      fan-out, raw `readFile`, `Promise.all` phase 3, widened cap, completion-order aggregation)
+- [x] **Equivalence proof**: on a real 770-file / 198,964-line codebase, all five inventories AND
+      `llm-context.json` (call graph, signatures, all three phases) are **byte-identical** to
+      `origin/main`'s output
+
+## Out of scope (recorded, not fixed)
+- [ ] The call-graph build holds all file content resident for Pass 2 (type inference, import
+      resolution, class hierarchy). On a 6,000-file / 234 MB repository this OOMs at a 2 GB heap on
+      `main` and on this branch alike — the ceiling moves one phase later, it does not move away.
+      Bounding it is a redesign (stream per-file facts through the store between passes), not a
+      limiter, and belongs in its own change

--- a/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
@@ -1,4 +1,4 @@
-# Tasks — bound every repository-wide file scan
+# Tasks — bound enrichment and indexing read fan-out
 
 > Status: **BUILT** (2026-07-30). Issue #302. Full suite green — **6,511 passed, 0 failed,
 > 336/336 files** — plus lint, typecheck and build. (Earlier runs showed a handful of timeouts in
@@ -28,10 +28,14 @@
 - [x] All five enrichment extractors converted: UI components, schemas, routes, middleware, env vars
 - [x] `call-graph.ts` `synthesizeRouteHandlerEdges` — re-reads every file from disk, same hazard
 - [x] `live-data/analyze-repo.ts` — read every node's file at once to build the vector index
+- [x] `analyze.ts` function-index and text-line-index paths — the production CLI/install path also
+      read every file at once; both now use the bounded pool
+- [x] `import.ts` keyword-index rebuild — bounded for parity with fresh analysis
 - [x] `extractAllHttpEdges` — its nested `Promise.all` read the SAME file twice concurrently,
       doubling per-slot residency; now sequential
 - [x] `analyze.ts` phase 3: five extractors run sequentially, not as one `Promise.all`
-- [x] `analyze.ts`: oversized files disclosed with path + size, inventories marked a LOWER BOUND
+- [x] `analyze.ts`: oversized files disclosed with path + size from the exact scan-time stat,
+      inventories marked a LOWER BOUND even when a file changes after repository walking
 - [x] env scan: decide from the extension BEFORE reading — it used to decode every binary asset in
       the repository and discard it one line later
 - [x] Schema and middleware scans changed from shared-array push to per-file-then-flatten. They

--- a/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
@@ -59,7 +59,12 @@
       `origin/main`'s output
 
 ## Out of scope (measured, recorded, not fixed)
-- [ ] The call-graph build has its own ceiling, and it is NOT this defect. Measured on a
+- [ ] The call-graph build has its own ceiling, and it is NOT this defect. **It is now the binding
+      constraint**: on a 3,500-file / 205 MB repository at a 2 GB heap, `openlore install` dies in
+      phase 4 on `origin/main` AND on this branch alike (194 MB content + 1,574 MB overlay, peak
+      2,354 MB). Any repository large enough for the phase-3 fan-out to have OOM'd at that heap is
+      also large enough for the overlay to OOM, so this change fixes the reported CRASH SITE but a
+      reporter with a repository that big needs #304 as well. Measured on a
       4,000-file / 203 MB repository (32,001 functions): peak **2,323 MB** = 196 MB retained file
       content + 18 MB nodes/edges + **1,594 MB intra-procedural CFG/def-use overlay**. The overlay
       is built unconditionally for every function (~50 KB live each), accumulated for the whole

--- a/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
@@ -58,9 +58,14 @@
       `llm-context.json` (call graph, signatures, all three phases) are **byte-identical** to
       `origin/main`'s output
 
-## Out of scope (recorded, not fixed)
-- [ ] The call-graph build holds all file content resident for Pass 2 (type inference, import
-      resolution, class hierarchy). On a 6,000-file / 234 MB repository this OOMs at a 2 GB heap on
-      `main` and on this branch alike — the ceiling moves one phase later, it does not move away.
-      Bounding it is a redesign (stream per-file facts through the store between passes), not a
-      limiter, and belongs in its own change
+## Out of scope (measured, recorded, not fixed)
+- [ ] The call-graph build has its own ceiling, and it is NOT this defect. Measured on a
+      4,000-file / 203 MB repository (32,001 functions): peak **2,323 MB** = 196 MB retained file
+      content + 18 MB nodes/edges + **1,594 MB intra-procedural CFG/def-use overlay**. The overlay
+      is built unconditionally for every function (~50 KB live each), accumulated for the whole
+      repository, written to SQLite, then discarded — transient by design, never needing to be
+      fully resident. Retaining it pre-serialized does NOT help (JSON measures 1,819 MB, larger
+      than the live form). It cannot simply be streamed into the store either: `clearAll()` runs
+      only AFTER the build, deliberately, so a failed build cannot leave a wiped index
+      (change: harden-index-store-lifecycle). Needs its own change — spill-to-disk hand-off, an
+      opt-in gate, or a more compact overlay representation

--- a/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
+++ b/openspec/changes/fix-unbounded-file-scan-oom/tasks.md
@@ -17,7 +17,12 @@
 
 ## The fix
 - [x] `bounded-file-scan.ts`: `mapFilesBounded` (bounded width, input-order results),
-      `readSourceCapped` (stat-before-read), `isOversizedForScan` (the threshold, defined once)
+      `readSourceCapped` (size-before-read), `isOversizedForScan` (the threshold, defined once)
+- [x] `readSourceCapped` sizes and reads through ONE open handle, not `stat(path)` +
+      `readFile(path)`. CodeQL flagged the two-resolution form (`js/file-system-race`, high) and
+      it is a real boundary for a tool that analyzes untrusted repositories: a file grown or
+      replaced between the two calls is read at a size that was never checked, stepping around
+      the cap. Guarded and mutation-tested
 - [x] `SOURCE_SCAN_CONCURRENCY` (8) and `SOURCE_SCAN_MAX_FILE_BYTES` (4 MB) in `constants.ts`, each
       documented with why it is that size and why the other bound cannot replace it
 - [x] All five enrichment extractors converted: UI components, schemas, routes, middleware, env vars

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -8,7 +8,7 @@
 import { Command, Option } from 'commander';
 import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { writeFile, mkdir, readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { extname, join } from 'node:path';
 import { logger } from '../../utils/logger.js';
 import { fileExists, formatDuration, formatAge, getAnalysisAge } from '../../utils/command-helpers.js';
 import {
@@ -25,7 +25,9 @@ import {
   OPENSPEC_DECISIONS_SUBDIR,
   OPENLORE_ANALYSIS_REL_PATH,
   OPENLORE_CONFIG_REL_PATH,
+  SOURCE_SCAN_MAX_FILE_BYTES,
 } from '../../constants.js';
+import { isOversizedForScan, SCANNED_SOURCE_EXTENSIONS } from '../../core/analyzer/bounded-file-scan.js';
 import { computeProjectFingerprint, isCacheFresh } from '../../core/services/mcp-handlers/utils.js';
 import type { AnalyzeOptions, OpenLoreConfig } from '../../types/index.js';
 import { readOpenLoreConfig } from '../../core/services/config-manager.js';
@@ -197,18 +199,42 @@ export async function runAnalysis(
   }
   logger.blank();
 
-  // Phase 3: Run new enrichment extractors in parallel
+  // Phase 3: Run the enrichment extractors
   logger.analysis('Extracting UI components, schemas, routes, and env vars...');
 
   const allFilePaths = repoMap.allFiles.map(f => f.path);
 
-  const [uiComponents, schemas, routeInventory, middleware, envVars] = await Promise.all([
-    extractUIComponents(allFilePaths, rootPath),
-    extractSchemas(allFilePaths, rootPath),
-    buildRouteInventory(allFilePaths, rootPath),
-    extractMiddleware(allFilePaths, rootPath),
-    extractEnvVars(allFilePaths, rootPath),
-  ]);
+  // SEQUENTIALLY, not `Promise.all` (change: fix-unbounded-file-scan-oom). Each extractor is
+  // now an internally bounded scan, but running five of them together multiplies that bound by
+  // five — and the five together are what exhausted the heap on a large repository (issue #302).
+  // Serialized, the peak is one scan's bound no matter how many extractors are added here.
+  //
+  // This costs no extra I/O: the five always read the same files, so overlapping them shared
+  // nothing beyond what the OS page cache already gives the later passes for free.
+  const uiComponents = await extractUIComponents(allFilePaths, rootPath);
+  const schemas = await extractSchemas(allFilePaths, rootPath);
+  const routeInventory = await buildRouteInventory(allFilePaths, rootPath);
+  const middleware = await extractMiddleware(allFilePaths, rootPath);
+  const envVars = await extractEnvVars(allFilePaths, rootPath);
+
+  // Disclose files the extractors were too large to scan. The walker already stat'd every file,
+  // so this is the same predicate the scan applies, evaluated for free — and saying nothing
+  // would leave a component/route/env var that genuinely exists reading as genuinely absent.
+  // Scoped to extensions an extractor actually reads: `allFiles` also carries assets and data
+  // blobs, and reporting a 6 MB `.bin` as "excluded" is noise that teaches operators to ignore
+  // the line.
+  const oversized = repoMap.allFiles.filter(
+    f => isOversizedForScan(f.size) && SCANNED_SOURCE_EXTENSIONS.has(extname(f.path).toLowerCase()),
+  );
+  if (oversized.length > 0) {
+    const worst = [...oversized].sort((a, b) => b.size - a.size || (a.path < b.path ? -1 : 1)).slice(0, 3);
+    logger.warning(
+      `${oversized.length} file${oversized.length === 1 ? '' : 's'} exceeded the `
+      + `${(SOURCE_SCAN_MAX_FILE_BYTES / 1024 / 1024).toFixed(0)} MB scan cap — components, schemas, `
+      + `routes, middleware and env vars from them are a LOWER BOUND: `
+      + worst.map(f => `${f.path} (${(f.size / 1024 / 1024).toFixed(1)} MB)`).join('; '),
+    );
+  }
 
   // Phase 4: Generate Artifacts
   logger.analysis('Generating analysis artifacts...');

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -8,7 +8,7 @@
 import { Command, Option } from 'commander';
 import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { writeFile, mkdir, readFile } from 'node:fs/promises';
-import { extname, join } from 'node:path';
+import { join } from 'node:path';
 import { logger } from '../../utils/logger.js';
 import { fileExists, formatDuration, formatAge, getAnalysisAge } from '../../utils/command-helpers.js';
 import {
@@ -27,7 +27,7 @@ import {
   OPENLORE_CONFIG_REL_PATH,
   SOURCE_SCAN_MAX_FILE_BYTES,
 } from '../../constants.js';
-import { isOversizedForScan, SCANNED_SOURCE_EXTENSIONS } from '../../core/analyzer/bounded-file-scan.js';
+import { isOversizedForScan, isScannedByEnrichment } from '../../core/analyzer/bounded-file-scan.js';
 import { computeProjectFingerprint, isCacheFresh } from '../../core/services/mcp-handlers/utils.js';
 import type { AnalyzeOptions, OpenLoreConfig } from '../../types/index.js';
 import { readOpenLoreConfig } from '../../core/services/config-manager.js';
@@ -220,11 +220,12 @@ export async function runAnalysis(
   // Disclose files the extractors were too large to scan. The walker already stat'd every file,
   // so this is the same predicate the scan applies, evaluated for free — and saying nothing
   // would leave a component/route/env var that genuinely exists reading as genuinely absent.
-  // Scoped to extensions an extractor actually reads: `allFiles` also carries assets and data
-  // blobs, and reporting a 6 MB `.bin` as "excluded" is noise that teaches operators to ignore
-  // the line.
+  // Scoped by `isScannedByEnrichment` — the SAME predicate that describes what the scans open, so
+  // the two cannot drift. `allFiles` also carries assets and data blobs, and reporting a 6 MB
+  // `.bin` as "excluded" is noise that teaches operators to ignore the line; conversely an
+  // oversized `.env` must NOT slip through just because `extname('.env')` is empty.
   const oversized = repoMap.allFiles.filter(
-    f => isOversizedForScan(f.size) && SCANNED_SOURCE_EXTENSIONS.has(extname(f.path).toLowerCase()),
+    f => isOversizedForScan(f.size) && isScannedByEnrichment(f.path),
   );
   if (oversized.length > 0) {
     const worst = [...oversized].sort((a, b) => b.size - a.size || (a.path < b.path ? -1 : 1)).slice(0, 3);
@@ -232,7 +233,10 @@ export async function runAnalysis(
       `${oversized.length} file${oversized.length === 1 ? '' : 's'} exceeded the `
       + `${(SOURCE_SCAN_MAX_FILE_BYTES / 1024 / 1024).toFixed(0)} MB scan cap — components, schemas, `
       + `routes, middleware and env vars from them are a LOWER BOUND: `
-      + worst.map(f => `${f.path} (${(f.size / 1024 / 1024).toFixed(1)} MB)`).join('; '),
+      // `safe()`, not the raw path: the filename comes from the repository, and the logger's own
+      // sanitizer keeps newlines (correct for an OpenLore-authored template, wrong for a value
+      // interpolated into one) — so an unsanitized path could forge an extra output line.
+      + worst.map(f => `${safe(f.path)} (${(f.size / 1024 / 1024).toFixed(1)} MB)`).join('; '),
     );
   }
 

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -27,7 +27,12 @@ import {
   OPENLORE_CONFIG_REL_PATH,
   SOURCE_SCAN_MAX_FILE_BYTES,
 } from '../../constants.js';
-import { isOversizedForScan, isScannedByEnrichment } from '../../core/analyzer/bounded-file-scan.js';
+import {
+  isScannedByEnrichment,
+  mapFilesBounded,
+  readSourceCapped,
+  type OversizedFileObserver,
+} from '../../core/analyzer/bounded-file-scan.js';
 import { computeProjectFingerprint, isCacheFresh } from '../../core/services/mcp-handlers/utils.js';
 import type { AnalyzeOptions, OpenLoreConfig } from '../../types/index.js';
 import { readOpenLoreConfig } from '../../core/services/config-manager.js';
@@ -203,6 +208,11 @@ export async function runAnalysis(
   logger.analysis('Extracting UI components, schemas, routes, and env vars...');
 
   const allFilePaths = repoMap.allFiles.map(f => f.path);
+  const oversizedByPath = new Map<string, number>();
+  const observeOversized: OversizedFileObserver = (path, bytes) => {
+    if (!isScannedByEnrichment(path)) return;
+    oversizedByPath.set(path, Math.max(bytes, oversizedByPath.get(path) ?? 0));
+  };
 
   // SEQUENTIALLY, not `Promise.all` (change: fix-unbounded-file-scan-oom). Each extractor is
   // now an internally bounded scan, but running five of them together multiplies that bound by
@@ -211,22 +221,18 @@ export async function runAnalysis(
   //
   // This costs no extra I/O: the five always read the same files, so overlapping them shared
   // nothing beyond what the OS page cache already gives the later passes for free.
-  const uiComponents = await extractUIComponents(allFilePaths, rootPath);
-  const schemas = await extractSchemas(allFilePaths, rootPath);
-  const routeInventory = await buildRouteInventory(allFilePaths, rootPath);
-  const middleware = await extractMiddleware(allFilePaths, rootPath);
-  const envVars = await extractEnvVars(allFilePaths, rootPath);
+  const uiComponents = await extractUIComponents(allFilePaths, rootPath, observeOversized);
+  const schemas = await extractSchemas(allFilePaths, rootPath, observeOversized);
+  const routeInventory = await buildRouteInventory(allFilePaths, rootPath, observeOversized);
+  const middleware = await extractMiddleware(allFilePaths, rootPath, observeOversized);
+  const envVars = await extractEnvVars(allFilePaths, rootPath, observeOversized);
 
-  // Disclose files the extractors were too large to scan. The walker already stat'd every file,
-  // so this is the same predicate the scan applies, evaluated for free — and saying nothing
-  // would leave a component/route/env var that genuinely exists reading as genuinely absent.
-  // Scoped by `isScannedByEnrichment` — the SAME predicate that describes what the scans open, so
-  // the two cannot drift. `allFiles` also carries assets and data blobs, and reporting a 6 MB
-  // `.bin` as "excluded" is noise that teaches operators to ignore the line; conversely an
-  // oversized `.env` must NOT slip through just because `extname('.env')` is empty.
-  const oversized = repoMap.allFiles.filter(
-    f => isOversizedForScan(f.size) && isScannedByEnrichment(f.path),
-  );
+  // Disclose files the extractors ACTUALLY skipped. These observations come from the same
+  // open-handle stat that enforced the cap, rather than the walker's earlier size snapshot.
+  // A watcher or generator can rewrite a file between those phases; rebuilding the warning from
+  // stale metadata would silently omit a file that grew, or falsely report one that shrank.
+  const oversized = [...oversizedByPath]
+    .map(([path, size]) => ({ path, size }));
   if (oversized.length > 0) {
     const worst = [...oversized].sort((a, b) => b.size - a.size || (a.path < b.path ? -1 : 1)).slice(0, 3);
     logger.warning(
@@ -956,13 +962,18 @@ async function runEmbedStep(
       const hubIds = new Set(cg.hubFunctions.map(f => f.id));
       const entryIds = new Set(cg.entryPoints.map(f => f.id));
 
-      const fileContents = new Map<string, string>();
-      const uniquePaths = new Set(cg.nodes.map(n => n.filePath));
-      await Promise.all([...uniquePaths].map(async fp => {
+      const paths = [...new Set(cg.nodes.map(n => n.filePath))];
+      const contents = await mapFilesBounded(paths, async fp => {
         try {
-          fileContents.set(fp, await readFile(join(rootPath, fp), 'utf-8'));
-        } catch { /* skip unreadable files */ }
-      }));
+          return await readFile(join(rootPath, fp), 'utf-8');
+        } catch {
+          return null; // skip unreadable files
+        }
+      });
+      const fileContents = new Map<string, string>();
+      for (const [i, content] of contents.entries()) {
+        if (content !== null) fileContents.set(paths[i], content);
+      }
 
       // Build with the embedder when available; if a configured embedder fails
       // at runtime (endpoint unreachable), warn and fall back to a BM25 index
@@ -1027,20 +1038,13 @@ async function runTextLineIndexing(rootPath: string, outputPath: string): Promis
   try {
     const { FileWalker } = await import('../../core/analyzer/file-walker.js');
     const { TextLineIndex } = await import('../../core/analyzer/text-line-index.js');
-    const { readFile: read } = await import('node:fs/promises');
-
     const walk = await new FileWalker(rootPath).walk();
-    const files: { filePath: string; content: string }[] = [];
-    await Promise.all(
-      walk.files.map(async (f) => {
-        if (f.size > TEXT_INDEX_MAX_FILE_BYTES) return;
-        try {
-          files.push({ filePath: f.path, content: await read(f.absolutePath, 'utf-8') });
-        } catch {
-          /* skip unreadable files */
-        }
-      }),
-    );
+    const candidates = walk.files.filter(f => f.size <= TEXT_INDEX_MAX_FILE_BYTES);
+    const perFile = await mapFilesBounded(candidates.map(f => f.absolutePath), async (absolutePath, i) => {
+      const content = await readSourceCapped(absolutePath, TEXT_INDEX_MAX_FILE_BYTES);
+      return content === null ? null : { filePath: candidates[i].path, content };
+    });
+    const files = perFile.filter((f): f is { filePath: string; content: string } => f !== null);
 
     const { lines, files: indexedFiles } = await TextLineIndex.build(outputPath, files);
     console.log(`    ✓ Text line index built (${lines} lines across ${indexedFiles} files)`);

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -30,6 +30,7 @@ import {
 } from '../../constants.js';
 import { EdgeStore, SCHEMA_VERSION } from '../../core/services/edge-store.js';
 import { VectorIndex } from '../../core/analyzer/vector-index.js';
+import { mapFilesBounded } from '../../core/analyzer/bounded-file-scan.js';
 import { SpecVectorIndex } from '../../core/analyzer/spec-vector-index.js';
 import type { FileSignatureMap } from '../../core/analyzer/signature-extractor.js';
 import { reconcile } from '../../core/analyzer/index-attestation.js';
@@ -176,10 +177,18 @@ async function buildKeywordSearchIndex(rootPath: string, analysisDir: string): P
   const signatures = await readBundledSignatures(analysisDir);
   // Body-skeleton text needs the source (read, not parsed). It is present in the checkout we are
   // importing into; a missing file is skipped (that symbol is still indexed by name/signature/docstring).
+  const paths = [...new Set(nodes.map(n => n.filePath))];
+  const contents = await mapFilesBounded(paths, async fp => {
+    try {
+      return await readFile(join(rootPath, fp), 'utf-8');
+    } catch {
+      return null;
+    }
+  });
   const fileContents = new Map<string, string>();
-  await Promise.all([...new Set(nodes.map(n => n.filePath))].map(async fp => {
-    try { fileContents.set(fp, await readFile(join(rootPath, fp), 'utf-8')); } catch { /* skip unreadable */ }
-  }));
+  for (const [i, content] of contents.entries()) {
+    if (content !== null) fileContents.set(paths[i], content);
+  }
 
   await VectorIndex.build(analysisDir, nodes, signatures, hubIds, entryIds, null, fileContents);
   return true;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -832,3 +832,43 @@ export const SLOW_FILE_DISCLOSURE_MS = 5_000;
  * fix-analyze-native-abort-and-file-cost-budget).
  */
 export const MAX_HTML_INLINE_SCRIPT_CHARS = 1_000_000;
+
+/**
+ * How many files ONE repository-wide source scan may hold open at a time (change:
+ * fix-unbounded-file-scan-oom).
+ *
+ * The enrichment extractors used to fan out with `Promise.all(files.map(...))`, which issues
+ * every read simultaneously — so peak heap was a function of the REPOSITORY's size, not of any
+ * bound, and `analyze` ran five such scans at once. Past a few hundred megabytes of source that
+ * is a fatal OOM rather than a slowdown: V8 dies inside the read-completion path with no partial
+ * result and no diagnosis (issue #302).
+ *
+ * Small on purpose. File scanning is I/O plus regex over the decoded text, and eight concurrent
+ * reads already saturate a local disk; raising it buys no throughput and costs residency
+ * linearly. Bounding concurrency alone is not sufficient — see
+ * {@link SOURCE_SCAN_MAX_FILE_BYTES}, which bounds the other axis.
+ */
+export const SOURCE_SCAN_CONCURRENCY = 8;
+
+/**
+ * Largest file a repository-wide source scan will read (change: fix-unbounded-file-scan-oom).
+ *
+ * The companion bound to {@link SOURCE_SCAN_CONCURRENCY}: concurrency bounds how MANY files are
+ * resident, this bounds how large ONE may be. Both are required, because either alone still
+ * admits an OOM — a repository of many ordinary files exhausts the heap through fan-out, and a
+ * repository with one generated blob exhausts it through a single read.
+ *
+ * The multiplier is what makes this small. A scanned file is resident several times over at the
+ * peak: the decoded string, the length-preserving comment mask each parser builds beside it, and
+ * the `split('\n')` line array it measures offsets against. So the real ceiling is roughly
+ * `SOURCE_SCAN_CONCURRENCY × SOURCE_SCAN_MAX_FILE_BYTES × ~5`, and 4 MB keeps that inside a few
+ * hundred megabytes on the default heap.
+ *
+ * 4 MB of hand-written source is on the order of 100,000 lines; a file above it is generated,
+ * minified, or vendored in practice. This is deliberately BELOW the file-walker's 10 MB read cap,
+ * which gates cheap single-pass reads (line counting) rather than multi-copy text scanning. A file
+ * excluded here is disclosed by `analyze`, never silently dropped, and it is excluded only from
+ * the enrichment inventories (components, schemas, routes, middleware, env vars) — the call graph
+ * has its own bounds and is unaffected.
+ */
+export const SOURCE_SCAN_MAX_FILE_BYTES = 4 * 1024 * 1024;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -851,6 +851,17 @@ export const MAX_HTML_INLINE_SCRIPT_CHARS = 1_000_000;
 export const SOURCE_SCAN_CONCURRENCY = 8;
 
 /**
+ * Hard ceiling on a source scan's width, whatever a caller asks for (change:
+ * fix-unbounded-file-scan-oom).
+ *
+ * Without it the clamp is one-sided: `mapFilesBounded(paths, fn, 1_000_000)` would open a million
+ * files at once — the exact fan-out this module exists to prevent, from the function that is
+ * supposed to prevent it. A caller asking for more than this is asking for something the module
+ * does not offer, so it is clamped rather than honoured.
+ */
+export const SOURCE_SCAN_MAX_CONCURRENCY = 32;
+
+/**
  * Largest file a repository-wide source scan will read (change: fix-unbounded-file-scan-oom).
  *
  * The companion bound to {@link SOURCE_SCAN_CONCURRENCY}: concurrency bounds how MANY files are
@@ -866,9 +877,15 @@ export const SOURCE_SCAN_CONCURRENCY = 8;
  *
  * 4 MB of hand-written source is on the order of 100,000 lines; a file above it is generated,
  * minified, or vendored in practice. This is deliberately BELOW the file-walker's 10 MB read cap,
- * which gates cheap single-pass reads (line counting) rather than multi-copy text scanning. A file
- * excluded here is disclosed by `analyze`, never silently dropped, and it is excluded only from
- * the enrichment inventories (components, schemas, routes, middleware, env vars) — the call graph
- * has its own bounds and is unaffected.
+ * which gates cheap single-pass reads (line counting) rather than multi-copy text scanning.
+ *
+ * A file excluded here is disclosed by `analyze`, never silently dropped, and it is excluded only
+ * from the enrichment inventories (components, schemas, routes, middleware, env vars). The CALL
+ * GRAPH is unaffected — but not automatically, and it is worth saying how. Its route-handler
+ * synthesis calls the same route extractors, so it would have inherited this cap and lost the
+ * edges of every file above it, surfacing live handlers as dead code. It does not, because it
+ * passes those extractors the source it ALREADY holds in memory instead of having them re-read
+ * it: the cap exists to stop a scan allocating, and there is nothing to allocate for text that is
+ * already resident. `bounded-computation.test.ts` fails the build if that wiring is undone.
  */
 export const SOURCE_SCAN_MAX_FILE_BYTES = 4 * 1024 * 1024;

--- a/src/core/analyzer/artifact-output-determinism.test.ts
+++ b/src/core/analyzer/artifact-output-determinism.test.ts
@@ -21,20 +21,19 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Both fs entry points the bounded scan uses: it stats a file before reading it, so one
-// oversized file cannot materialize a string large enough to exhaust the heap.
+// The bounded scan sizes and reads through ONE open handle, so the size it checked and the
+// bytes it read cannot come from different files. The mock models that handle.
 vi.mock('node:fs/promises', () => ({
-  readFile: vi.fn(),
-  stat: vi.fn(),
+  open: vi.fn(),
 }));
 
-import { readFile, stat } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import { buildRouteInventory } from './http-route-parser.js';
 import { extractEnvVars } from './env-extractor.js';
 import { SOURCE_SCAN_CONCURRENCY } from '../../constants.js';
 
-const mockReadFile = readFile as ReturnType<typeof vi.fn>;
-const mockStat = stat as ReturnType<typeof vi.fn>;
+const mockOpen = open as ReturnType<typeof vi.fn>;
+const mockReadFile = vi.fn();
 
 /**
  * Resolve each path's content after a delay that DECREASES with input index, so
@@ -43,9 +42,12 @@ const mockStat = stat as ReturnType<typeof vi.fn>;
  */
 function withReversedCompletion(contentByPath: Map<string, string>, order: string[]): void {
   // The size gate must never be what decides the outcome here — every fixture is tiny, and
-  // the stat resolves immediately so all the adversarial latency stays on the read.
-  mockStat.mockImplementation((p: string) =>
-    Promise.resolve({ isFile: () => true, size: (contentByPath.get(p) ?? '').length }));
+  // stat resolves immediately, so all the adversarial latency stays on the read.
+  mockOpen.mockImplementation((p: string) => Promise.resolve({
+    stat: () => Promise.resolve({ isFile: () => true, size: (contentByPath.get(p) ?? '').length }),
+    readFile: () => mockReadFile(p),
+    close: () => Promise.resolve(),
+  }));
   mockReadFile.mockImplementation((p: string) => {
     const content = contentByPath.get(p) ?? '';
     const idx = order.indexOf(p);
@@ -55,7 +57,7 @@ function withReversedCompletion(contentByPath: Map<string, string>, order: strin
 }
 
 describe('buildRouteInventory — input-order aggregation', () => {
-  beforeEach(() => { mockReadFile.mockReset(); mockStat.mockReset(); });
+  beforeEach(() => { mockReadFile.mockReset(); mockOpen.mockReset(); });
 
   it('orders routes by file-list order under adversarial completion latency', async () => {
     // Three FastAPI files, each with one distinct route.
@@ -112,7 +114,7 @@ describe('buildRouteInventory — input-order aggregation', () => {
 });
 
 describe('extractEnvVars — input-order aggregation', () => {
-  beforeEach(() => { mockReadFile.mockReset(); mockStat.mockReset(); });
+  beforeEach(() => { mockReadFile.mockReset(); mockOpen.mockReset(); });
 
   it("orders a var's files[] by file-list order under adversarial latency", async () => {
     // Same var read in three source files, listed a → b → c.

--- a/src/core/analyzer/artifact-output-determinism.test.ts
+++ b/src/core/analyzer/artifact-output-determinism.test.ts
@@ -36,18 +36,36 @@ const mockOpen = open as ReturnType<typeof vi.fn>;
 const mockReadFile = vi.fn();
 
 /**
+ * A stand-in for the `FileHandle` the bounded scan opens. It models `read()` — NOT `readFile()` —
+ * because the scan reads exactly the number of bytes it stat'd, so that a file growing under it
+ * cannot be read past its checked size (change: fix-unbounded-file-scan-oom).
+ */
+function fakeHandle(content: string): {
+  stat: () => Promise<{ isFile: () => boolean; size: number }>;
+  read: (buf: Buffer, offset: number, length: number, position: number) => Promise<{ bytesRead: number }>;
+  close: () => Promise<void>;
+} {
+  const bytes = Buffer.from(content, 'utf-8');
+  return {
+    stat: () => Promise.resolve({ isFile: () => true, size: bytes.length }),
+    read: (buf, offset, length, position) => {
+      const copied = bytes.copy(buf, offset, position, Math.min(position + length, bytes.length));
+      return Promise.resolve({ bytesRead: copied });
+    },
+    close: () => Promise.resolve(),
+  };
+}
+
+
+/**
  * Resolve each path's content after a delay that DECREASES with input index, so
  * the last file in the list resolves first — completion order is the reverse of
  * input order. `index` is the file's position in the caller's `filePaths` array.
  */
 function withReversedCompletion(contentByPath: Map<string, string>, order: string[]): void {
-  // The size gate must never be what decides the outcome here — every fixture is tiny, and
-  // stat resolves immediately, so all the adversarial latency stays on the read.
-  mockOpen.mockImplementation((p: string) => Promise.resolve({
-    stat: () => Promise.resolve({ isFile: () => true, size: (contentByPath.get(p) ?? '').length }),
-    readFile: () => mockReadFile(p),
-    close: () => Promise.resolve(),
-  }));
+  // The size gate must never be what decides the outcome here — every fixture is tiny, so the
+  // handle always passes the cap and the adversarial latency is what orders completion.
+  mockOpen.mockImplementation(async (p: string) => fakeHandle(String(await mockReadFile(p) ?? '')));
   mockReadFile.mockImplementation((p: string) => {
     const content = contentByPath.get(p) ?? '';
     const idx = order.indexOf(p);

--- a/src/core/analyzer/artifact-output-determinism.test.ts
+++ b/src/core/analyzer/artifact-output-determinism.test.ts
@@ -7,20 +7,34 @@
  * the byte-determinism doctrine (decision c6d1ad07) is violated at the output
  * boundary. These tests stub readFile with ADVERSARIAL delays (later files resolve
  * FIRST) so a completion-order aggregator would produce reversed output; the fix's
- * `Promise.all(...).flat()` must still yield input order.
+ * `mapFilesBounded(...).flat()` must still yield input order.
+ *
+ * The scans are now also BOUNDED (change: fix-unbounded-file-scan-oom), which makes this
+ * property strictly harder to hold and strictly more important: under a concurrency limit,
+ * completion order additionally depends on which worker picks a file up and when a slot frees,
+ * so input-order aggregation is the only thing keeping the artifacts byte-stable. The cases
+ * below therefore include file lists LONGER than the concurrency bound — a list shorter than
+ * the bound never makes a worker wait for a slot, and so never exercises the bounded path at
+ * all. (`mapFilesBounded`'s own order-independence across widths is unit-tested directly in
+ * `bounded-file-scan.test.ts`.)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Both fs entry points the bounded scan uses: it stats a file before reading it, so one
+// oversized file cannot materialize a string large enough to exhaust the heap.
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
+  stat: vi.fn(),
 }));
 
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { buildRouteInventory } from './http-route-parser.js';
 import { extractEnvVars } from './env-extractor.js';
+import { SOURCE_SCAN_CONCURRENCY } from '../../constants.js';
 
 const mockReadFile = readFile as ReturnType<typeof vi.fn>;
+const mockStat = stat as ReturnType<typeof vi.fn>;
 
 /**
  * Resolve each path's content after a delay that DECREASES with input index, so
@@ -28,6 +42,10 @@ const mockReadFile = readFile as ReturnType<typeof vi.fn>;
  * input order. `index` is the file's position in the caller's `filePaths` array.
  */
 function withReversedCompletion(contentByPath: Map<string, string>, order: string[]): void {
+  // The size gate must never be what decides the outcome here — every fixture is tiny, and
+  // the stat resolves immediately so all the adversarial latency stays on the read.
+  mockStat.mockImplementation((p: string) =>
+    Promise.resolve({ isFile: () => true, size: (contentByPath.get(p) ?? '').length }));
   mockReadFile.mockImplementation((p: string) => {
     const content = contentByPath.get(p) ?? '';
     const idx = order.indexOf(p);
@@ -37,7 +55,7 @@ function withReversedCompletion(contentByPath: Map<string, string>, order: strin
 }
 
 describe('buildRouteInventory — input-order aggregation', () => {
-  beforeEach(() => mockReadFile.mockReset());
+  beforeEach(() => { mockReadFile.mockReset(); mockStat.mockReset(); });
 
   it('orders routes by file-list order under adversarial completion latency', async () => {
     // Three FastAPI files, each with one distinct route.
@@ -70,10 +88,31 @@ describe('buildRouteInventory — input-order aggregation', () => {
     expect(new Set(runs).size).toBe(1);
     expect(JSON.parse(runs[0])).toEqual(['POST /x1', 'GET /y1', 'PUT /z1']);
   });
+
+  it('holds input order across a file list LONGER than the concurrency bound', async () => {
+    // 3× the bound, so most files wait for a slot and are picked up by whichever worker
+    // frees first — the ordering hazard that only exists once the scan is bounded.
+    const n = SOURCE_SCAN_CONCURRENCY * 3;
+    const files = Array.from({ length: n }, (_, i) => `/root/r${String(i).padStart(3, '0')}.py`);
+    const contents = new Map(
+      files.map((f, i) => [f, `@app.get("/route-${String(i).padStart(3, '0')}")\ndef h${i}():\n    pass\n`]),
+    );
+
+    const runs: string[] = [];
+    for (let run = 0; run < 3; run++) {
+      withReversedCompletion(contents, files);
+      const inv = await buildRouteInventory(files, '/root');
+      runs.push(JSON.stringify(inv.routes.map(r => r.path)));
+    }
+    expect(new Set(runs).size, 'route order drifted between runs').toBe(1);
+    expect(JSON.parse(runs[0])).toEqual(
+      files.map((_, i) => `/route-${String(i).padStart(3, '0')}`),
+    );
+  });
 });
 
 describe('extractEnvVars — input-order aggregation', () => {
-  beforeEach(() => mockReadFile.mockReset());
+  beforeEach(() => { mockReadFile.mockReset(); mockStat.mockReset(); });
 
   it("orders a var's files[] by file-list order under adversarial latency", async () => {
     // Same var read in three source files, listed a → b → c.
@@ -104,5 +143,17 @@ describe('extractEnvVars — input-order aggregation', () => {
     const token = vars.find(v => v.name === 'TOKEN');
     expect(token?.description).toBe('description from example');
     expect(token?.files).toEqual(['.env.example', '.env.local']);
+  });
+
+  it("orders a var's files[] across a list LONGER than the concurrency bound", async () => {
+    const n = SOURCE_SCAN_CONCURRENCY * 3;
+    const files = Array.from({ length: n }, (_, i) => `/root/s${String(i).padStart(3, '0')}.ts`);
+    const contents = new Map(files.map(f => [f, 'const v = process.env.SHARED;\n']));
+    withReversedCompletion(contents, files);
+
+    const vars = await extractEnvVars(files, '/root');
+    expect(vars.find(v => v.name === 'SHARED')?.files).toEqual(
+      files.map(f => f.slice('/root/'.length)),
+    );
   });
 });

--- a/src/core/analyzer/bounded-computation.test.ts
+++ b/src/core/analyzer/bounded-computation.test.ts
@@ -283,13 +283,60 @@ describe('Bounded Computation — repository-wide scans stay bounded (issue #302
 
   it('analyze discloses files the scan was too large to read (no silent capping)', () => {
     const src = readFileSync(join(ANALYZER_DIR, '..', '..', 'cli', 'commands', 'analyze.ts'), 'utf-8');
-    expect(src).toMatch(/isOversizedForScan/);
+    expect(src).toMatch(/const observeOversized: OversizedFileObserver/);
+    expect(src).toMatch(/oversizedByPath\.set\(/);
+    for (const fn of [
+      'extractUIComponents',
+      'extractSchemas',
+      'buildRouteInventory',
+      'extractMiddleware',
+      'extractEnvVars',
+    ]) {
+      expect(src, `${fn} must report scan-time exclusions`).toMatch(
+        new RegExp(`${fn}\\([^\\n]+observeOversized\\)`),
+      );
+    }
     expect(src).toMatch(/LOWER BOUND/);
     // …and scopes the report to files an extractor would actually have opened, so a large
     // image or data blob does not train the operator to ignore the line.
     expect(src).toMatch(/isScannedByEnrichment\(/);
     // …and the repo-controlled path is sanitized before it reaches the terminal.
     expect(src).toMatch(/safe\(f\.path\)/);
+  });
+
+  it('the production function and text indexes do not reintroduce all-file fan-out', () => {
+    const analyze = codeOf(join('..', '..', 'cli', 'commands', 'analyze.ts'));
+    const liveData = readFileSync(
+      join(ANALYZER_DIR, '..', 'services', 'mcp-handlers', 'live-data', 'analyze-repo.ts'),
+      'utf-8',
+    );
+    const importCommand = readFileSync(
+      join(ANALYZER_DIR, '..', '..', 'cli', 'commands', 'import.ts'),
+      'utf-8',
+    );
+
+    // All three function-index entry points read every call-graph file. The CLI path was missed
+    // by the original fix even though it is the path `openlore install` actually runs.
+    for (const [name, src] of [
+      ['analyze.ts', analyze],
+      ['live-data/analyze-repo.ts', liveData],
+      ['import.ts', importCommand],
+    ] as const) {
+      expect(src, `${name} must use the shared bounded pool`).toMatch(/mapFilesBounded\(/);
+      expect(src, `${name} must not fan out reads with Promise.all`).not.toMatch(
+        /Promise\.all\([\s\S]{0,300}?readFile\(/,
+      );
+    }
+    for (const [name, src] of [
+      ['analyze.ts', analyze],
+      ['live-data/analyze-repo.ts', liveData],
+      ['import.ts', importCommand],
+    ] as const) {
+      expect(src, `${name} must route the function-index file list through the bounded pool`)
+        .toMatch(/const contents = await mapFilesBounded\(paths/);
+    }
+    expect(analyze, 'text-line indexing must use the shared bounded pool')
+      .toMatch(/const perFile = await mapFilesBounded\(candidates\.map\(/);
   });
 
   it('the disclosure covers every extension the scan modules read', async () => {

--- a/src/core/analyzer/bounded-computation.test.ts
+++ b/src/core/analyzer/bounded-computation.test.ts
@@ -147,3 +147,180 @@ describe('Bounded Computation — documented caps are present (regression guards
     expect(src).toMatch(/depth\s*=\s*Math\.max\(\s*1,\s*Math\.min\(\s*depth,\s*SUBGRAPH_MAX_DEPTH_LIMIT/);
   });
 });
+
+/**
+ * The regression guards for issue #302 (change: fix-unbounded-file-scan-oom).
+ *
+ * The OOM was not one bad line — it was a SHAPE that had been written independently in five
+ * extractors and three other places: `await Promise.all(files.map(async f => readFile(f)))`.
+ * It is the natural way to write a repository-wide scan and it is fatal at scale, so the fix is
+ * only durable if reintroducing the shape fails the build. These guards enforce that every
+ * repository-wide scan goes through `bounded-file-scan.ts`, whose two bounds are unit-tested in
+ * `bounded-file-scan.test.ts`.
+ */
+describe('Bounded Computation — repository-wide scans stay bounded (issue #302)', () => {
+  /** Every module that scans a whole repository's files. Add new ones here. */
+  const SCAN_MODULES = [
+    'ui-component-extractor.ts',
+    'schema-extractor.ts',
+    'http-route-parser.ts',
+    'middleware-extractor.ts',
+    'env-extractor.ts',
+  ];
+
+  /** `Promise.all(<expr>.map(` — the unbounded fan-out shape, across line breaks. */
+  const UNBOUNDED_FANOUT = /Promise\.all\(\s*[\w.]+\s*\.map\(/;
+
+  it.each(SCAN_MODULES)('%s reads through the bounded scan, never a raw readFile', file => {
+    const src = readFileSync(join(ANALYZER_DIR, file), 'utf-8');
+    // A raw `readFile` in a scan module is unbounded by construction — no size cap.
+    expect(src, `${file} must read via readSourceCapped, not readFile`).not.toMatch(/\breadFile\s*\(/);
+    expect(src).toMatch(/from '\.\/bounded-file-scan\.js'/);
+  });
+
+  it.each(SCAN_MODULES)('%s fans out through mapFilesBounded, not Promise.all', file => {
+    const src = readFileSync(join(ANALYZER_DIR, file), 'utf-8');
+    // Comments legitimately mention `Promise.all` when explaining why it is not used; strip
+    // them so prose cannot fail the guard and code cannot hide behind it.
+    const code = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    expect(code, `${file} must scan via mapFilesBounded`).not.toMatch(UNBOUNDED_FANOUT);
+    expect(code).toMatch(/mapFilesBounded\(/);
+  });
+
+  it('the call graph synthesizes route-handler edges through the bounded scan', () => {
+    const src = readFileSync(join(ANALYZER_DIR, 'call-graph.ts'), 'utf-8');
+    // This pass re-reads every file from disk to re-extract routes, so it carries the same
+    // hazard as the extractors even though it is handed the content already.
+    expect(src).toMatch(/const perFileRoutes = await mapFilesBounded\(/);
+  });
+
+  it('analyze runs the enrichment extractors sequentially, not five at once', () => {
+    const src = readFileSync(join(ANALYZER_DIR, '..', '..', 'cli', 'commands', 'analyze.ts'), 'utf-8');
+    // Each extractor is internally bounded; running the five together multiplied that bound by
+    // five, and the five together are what exhausted the heap.
+    expect(src).not.toMatch(/Promise\.all\(\[\s*\n?\s*extractUIComponents/);
+    for (const call of [
+      'const uiComponents = await extractUIComponents(',
+      'const schemas = await extractSchemas(',
+      'const routeInventory = await buildRouteInventory(',
+      'const middleware = await extractMiddleware(',
+      'const envVars = await extractEnvVars(',
+    ]) {
+      expect(src, `analyze.ts must await ${call}… sequentially`).toContain(call);
+    }
+  });
+
+  it('analyze discloses files the scan was too large to read (no silent capping)', () => {
+    const src = readFileSync(join(ANALYZER_DIR, '..', '..', 'cli', 'commands', 'analyze.ts'), 'utf-8');
+    expect(src).toMatch(/isOversizedForScan/);
+    expect(src).toMatch(/LOWER BOUND/);
+    // …and scopes the report to files an extractor would actually have opened, so a large
+    // image or data blob does not train the operator to ignore the line.
+    expect(src).toMatch(/SCANNED_SOURCE_EXTENSIONS\.has/);
+  });
+
+  it('the disclosure covers every extension the scan modules read', async () => {
+    const { SCANNED_SOURCE_EXTENSIONS } = await import('./bounded-file-scan.js');
+    // Harvest the extension literals each scan module tests against. An extension a module
+    // reads but the disclosure set omits would hide a genuinely dropped component/route/env
+    // var — the failure the disclosure exists to prevent — so the set must be a superset.
+    const missing: string[] = [];
+    for (const file of SCAN_MODULES) {
+      const src = readFileSync(join(ANALYZER_DIR, file), 'utf-8');
+      for (const m of src.matchAll(/'(\.[a-z0-9]{1,7})'/g)) {
+        const ext = m[1];
+        // Only extensions that appear in an accept-list position (a Set/array of extensions),
+        // which is how every one of these modules spells its filter.
+        if (!/^\.(ts|tsx|js|jsx|mjs|cjs|py|pyw|go|rb|java|vue|svelte|prisma|html|htm|env)$/.test(ext)) continue;
+        if (ext === '.html' || ext === '.htm' || ext === '.env') continue; // not enrichment-scanned
+        if (!SCANNED_SOURCE_EXTENSIONS.has(ext)) missing.push(`${file}: ${ext}`);
+      }
+    }
+    expect(missing, 'extensions read by a scan module but absent from the disclosure set').toEqual([]);
+  });
+
+  it('both bounds are defined, documented, and small enough to matter', async () => {
+    const { SOURCE_SCAN_CONCURRENCY, SOURCE_SCAN_MAX_FILE_BYTES } = await import('../../constants.js');
+    // A bound large enough to admit an ordinary repository wholesale is not a bound.
+    expect(SOURCE_SCAN_CONCURRENCY).toBeGreaterThan(0);
+    expect(SOURCE_SCAN_CONCURRENCY).toBeLessThanOrEqual(32);
+    expect(SOURCE_SCAN_MAX_FILE_BYTES).toBeGreaterThan(0);
+    expect(SOURCE_SCAN_MAX_FILE_BYTES).toBeLessThanOrEqual(16 * 1024 * 1024);
+  });
+});
+
+describe('Bounded Computation — an oversized file is skipped by every extractor (issue #302)', () => {
+  let repo: string | undefined;
+  afterEach(() => {
+    if (repo) rmSync(repo, { recursive: true, force: true });
+    repo = undefined;
+  });
+
+  it('excludes the oversized file and still extracts from its neighbours', async () => {
+    const { SOURCE_SCAN_MAX_FILE_BYTES } = await import('../../constants.js');
+    const { extractUIComponents } = await import('./ui-component-extractor.js');
+    const { extractSchemas } = await import('./schema-extractor.js');
+    const { buildRouteInventory } = await import('./http-route-parser.js');
+    const { extractMiddleware } = await import('./middleware-extractor.js');
+
+    repo = mkdtempSync(join(tmpdir(), 'ol-scan-oversize-'));
+    const big = join(repo, 'generated-client.tsx');
+    const small = join(repo, 'Widget.tsx');
+
+    // The oversized file carries content EVERY extractor would otherwise match, so a result
+    // naming it proves the cap was not applied — an empty result proves nothing on its own.
+    const marker =
+      'export const KEY = process.env.OVERSIZED_MARKER;\n'
+      + "app.get('/oversized-marker', (req, res) => res.send('x'));\n"
+      + "app.use(helmet());\n"
+      + "export const OversizedMarker = pgTable('oversized_marker', {});\n"
+      + 'export function OversizedWidget() { return <div />; }\n';
+    writeFileSync(big, marker + '// pad\n'.repeat(Math.ceil(SOURCE_SCAN_MAX_FILE_BYTES / 7)));
+    writeFileSync(
+      small,
+      "import express from 'express';\n"
+      + 'const app = express();\n'
+      + "app.get('/small', (req, res) => res.send('ok'));\n"
+      + 'export function SmallWidget() { return <div />; }\n',
+    );
+
+    const paths = [big, small];
+    const [ui, schemas, routes, middleware] = [
+      await extractUIComponents(paths, repo),
+      await extractSchemas(paths, repo),
+      await buildRouteInventory(paths, repo),
+      await extractMiddleware(paths, repo),
+    ];
+
+    const mentionsBig = (blob: unknown) => JSON.stringify(blob ?? null).includes('generated-client');
+    expect(mentionsBig(ui), 'UI components must skip the oversized file').toBe(false);
+    expect(mentionsBig(schemas), 'schemas must skip the oversized file').toBe(false);
+    expect(mentionsBig(routes), 'routes must skip the oversized file').toBe(false);
+    expect(mentionsBig(middleware), 'middleware must skip the oversized file').toBe(false);
+
+    // …and the cap did not simply disable the extractors: the neighbour is still extracted.
+    expect(JSON.stringify(ui)).toContain('SmallWidget');
+    expect(routes.routes.some(r => r.path === '/small')).toBe(true);
+  });
+
+  it('the env extractor skips the oversized file and still reads its neighbours', async () => {
+    const { SOURCE_SCAN_MAX_FILE_BYTES } = await import('../../constants.js');
+
+    repo = mkdtempSync(join(tmpdir(), 'ol-scan-oversize-env-'));
+    const big = join(repo, 'huge.ts');
+    const small = join(repo, 'config.ts');
+    writeFileSync(
+      big,
+      'const K = process.env.OVERSIZED_ONLY_VAR;\n'
+      + 'const PAD = 0;\n'.repeat(Math.ceil(SOURCE_SCAN_MAX_FILE_BYTES / 15)),
+    );
+    writeFileSync(small, 'export const url = process.env.SMALL_FILE_VAR;\n');
+
+    const vars = await extractEnvVars([big, small], repo);
+    const names = vars.map(v => v.name);
+    expect(names).toContain('SMALL_FILE_VAR');
+    expect(names).not.toContain('OVERSIZED_ONLY_VAR');
+  });
+});

--- a/src/core/analyzer/bounded-computation.test.ts
+++ b/src/core/analyzer/bounded-computation.test.ts
@@ -8,7 +8,7 @@
  * the actual parsers plus regression guards on the documented caps.
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import { readFileSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { readFileSync, statSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -159,6 +159,12 @@ describe('Bounded Computation — documented caps are present (regression guards
  * `bounded-file-scan.test.ts`.
  */
 describe('Bounded Computation — repository-wide scans stay bounded (issue #302)', () => {
+  let repo: string | undefined;
+  afterEach(() => {
+    if (repo) rmSync(repo, { recursive: true, force: true });
+    repo = undefined;
+  });
+
   /** Every module that scans a whole repository's files. Add new ones here. */
   const SCAN_MODULES = [
     'ui-component-extractor.ts',
@@ -168,32 +174,95 @@ describe('Bounded Computation — repository-wide scans stay bounded (issue #302
     'env-extractor.ts',
   ];
 
-  /** `Promise.all(<expr>.map(` — the unbounded fan-out shape, across line breaks. */
-  const UNBOUNDED_FANOUT = /Promise\.all\(\s*[\w.]+\s*\.map\(/;
+  /** Strip comments so prose explaining the rejected shape cannot fail the guard. */
+  const codeOf = (file: string): string =>
+    readFileSync(join(ANALYZER_DIR, file), 'utf-8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
 
-  it.each(SCAN_MODULES)('%s reads through the bounded scan, never a raw readFile', file => {
-    const src = readFileSync(join(ANALYZER_DIR, file), 'utf-8');
-    // A raw `readFile` in a scan module is unbounded by construction — no size cap.
-    expect(src, `${file} must read via readSourceCapped, not readFile`).not.toMatch(/\breadFile\s*\(/);
-    expect(src).toMatch(/from '\.\/bounded-file-scan\.js'/);
+  /**
+   * Any `Promise.all` whose argument reaches a `.map(` — the unbounded fan-out shape.
+   *
+   * Deliberately loose. An earlier version required a bare dotted identifier
+   * (`Promise\.all\(\s*[\w.]+\s*\.map\(`), which every natural way of reintroducing the bug
+   * walked straight past: `Promise.all(paths.filter(…).map(…))`, a line-broken chain, or the
+   * two-step `const jobs = paths.map(…); await Promise.all(jobs)`. A guard that only catches the
+   * one spelling nobody would write is not a guard. The two-step form is caught separately below,
+   * since no regex over one expression can see it.
+   */
+  const UNBOUNDED_FANOUT = /Promise\.all\([\s\S]{0,200}?\.map\(/;
+
+  /** Every way to spell "read a whole file" that is NOT the bounded reader. */
+  const RAW_READ = /\breadFile\s*\(|\breadFileSync\s*\(|\bcreateReadStream\s*\(/;
+
+  it.each(SCAN_MODULES)('%s reads through the bounded scan, never a raw read', file => {
+    const code = codeOf(file);
+    // A raw read in a scan module is unbounded by construction — no size cap. `readFileSync` is
+    // included because it is the single easiest way to reintroduce the defect while satisfying
+    // a naive `readFile(`-only guard.
+    expect(code, `${file} must read via readSourceCapped, not a raw read`).not.toMatch(RAW_READ);
+    // …and must not smuggle one in under an alias.
+    expect(code, `${file} must not alias an fs read`).not.toMatch(/from 'node:fs(\/promises)?'/);
+    expect(code).toMatch(/from '\.\/bounded-file-scan\.js'/);
   });
 
   it.each(SCAN_MODULES)('%s fans out through mapFilesBounded, not Promise.all', file => {
-    const src = readFileSync(join(ANALYZER_DIR, file), 'utf-8');
-    // Comments legitimately mention `Promise.all` when explaining why it is not used; strip
-    // them so prose cannot fail the guard and code cannot hide behind it.
-    const code = src
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    const code = codeOf(file);
     expect(code, `${file} must scan via mapFilesBounded`).not.toMatch(UNBOUNDED_FANOUT);
+    // The two-step form — `const jobs = xs.map(async …); await Promise.all(jobs)` — is invisible
+    // to any single-expression regex, so catch its ingredient: an async `.map(` callback that is
+    // not immediately consumed. In these modules every legitimate `.map(` is a synchronous
+    // projection over already-computed results.
+    expect(code, `${file} must not build an async .map() array to hand to Promise.all`)
+      .not.toMatch(/\.map\(\s*async\b/);
     expect(code).toMatch(/mapFilesBounded\(/);
   });
 
   it('the call graph synthesizes route-handler edges through the bounded scan', () => {
     const src = readFileSync(join(ANALYZER_DIR, 'call-graph.ts'), 'utf-8');
-    // This pass re-reads every file from disk to re-extract routes, so it carries the same
-    // hazard as the extractors even though it is handed the content already.
+    // This pass fans out over every file, so it carries the same fan-out hazard as the extractors.
     expect(src).toMatch(/const perFileRoutes = await mapFilesBounded\(/);
+  });
+
+  it('the call graph feeds route extraction its RESIDENT content, never a capped re-read', () => {
+    const src = readFileSync(join(ANALYZER_DIR, 'call-graph.ts'), 'utf-8');
+    // The enrichment size cap must not reach the graph. This pass already holds every file's
+    // text (`contentByPath`), so re-reading through the capped reader bought no memory back and
+    // silently dropped the route-handler edges of any file above the cap — turning live handlers
+    // into `find_dead_code` candidates.
+    expect(src).toMatch(/const resident = contentByPath\.get\(path\)/);
+    for (const fn of ['extractRouteDefinitions', 'extractTsRouteDefinitions', 'extractJavaRouteDefinitions']) {
+      expect(src, `${fn} must be handed the resident source`).toMatch(
+        new RegExp(`${fn}\\(path, resident\\)`),
+      );
+    }
+  });
+
+  it('an oversized file still yields routes when its source is already in memory', async () => {
+    // The behavioural half of the guard above: the cap applies to a re-read, never to text the
+    // caller already has. Without the `residentSource` path, a route in a 5 MB router silently
+    // disappears from the call graph.
+    const { extractTsRouteDefinitions } = await import('./http-route-parser.js');
+    const { SOURCE_SCAN_MAX_FILE_BYTES } = await import('../../constants.js');
+
+    repo = mkdtempSync(join(tmpdir(), 'ol-resident-'));
+    const big = join(repo, 'router.ts');
+    const head =
+      "import express from 'express';\n"
+      + 'const app = express();\n'
+      + "app.get('/oversized-route', (req, res) => res.send('ok'));\n";
+    // Pad past the cap by MEASURED length, not by an assumed line width — a fixture that
+    // silently lands under the cap would make this test assert nothing.
+    const padLine = `// ${'pad '.repeat(20)}\n`;
+    const body = head + padLine.repeat(Math.ceil((SOURCE_SCAN_MAX_FILE_BYTES + 1024) / padLine.length));
+    writeFileSync(big, body);
+    expect(statSync(big).size).toBeGreaterThan(SOURCE_SCAN_MAX_FILE_BYTES);
+
+    // Re-read through the cap: nothing (this is the capped path, and it is correct there).
+    expect(await extractTsRouteDefinitions(big)).toEqual([]);
+    // Handed the resident text: the route survives, which is what the graph gets.
+    const withResident = await extractTsRouteDefinitions(big, body);
+    expect(withResident.map(r => r.path)).toContain('/oversized-route');
   });
 
   it('analyze runs the enrichment extractors sequentially, not five at once', () => {
@@ -218,27 +287,41 @@ describe('Bounded Computation — repository-wide scans stay bounded (issue #302
     expect(src).toMatch(/LOWER BOUND/);
     // …and scopes the report to files an extractor would actually have opened, so a large
     // image or data blob does not train the operator to ignore the line.
-    expect(src).toMatch(/SCANNED_SOURCE_EXTENSIONS\.has/);
+    expect(src).toMatch(/isScannedByEnrichment\(/);
+    // …and the repo-controlled path is sanitized before it reaches the terminal.
+    expect(src).toMatch(/safe\(f\.path\)/);
   });
 
   it('the disclosure covers every extension the scan modules read', async () => {
-    const { SCANNED_SOURCE_EXTENSIONS } = await import('./bounded-file-scan.js');
-    // Harvest the extension literals each scan module tests against. An extension a module
-    // reads but the disclosure set omits would hide a genuinely dropped component/route/env
-    // var — the failure the disclosure exists to prevent — so the set must be a superset.
+    const { isScannedByEnrichment } = await import('./bounded-file-scan.js');
+    // Harvest EVERY extension literal each scan module mentions, with no allowlist.
+    //
+    // A previous version of this test filtered candidates through a hardcoded pattern that
+    // enumerated exactly the members of the disclosure set — so `missing` was provably always
+    // empty and the test could not fail. A guard that cannot fail is worse than no guard: it
+    // reads as coverage. Harvesting blind means adding `.kt` to any scan module fails this test
+    // until the disclosure predicate covers it, which is the whole point.
     const missing: string[] = [];
     for (const file of SCAN_MODULES) {
-      const src = readFileSync(join(ANALYZER_DIR, file), 'utf-8');
-      for (const m of src.matchAll(/'(\.[a-z0-9]{1,7})'/g)) {
-        const ext = m[1];
-        // Only extensions that appear in an accept-list position (a Set/array of extensions),
-        // which is how every one of these modules spells its filter.
-        if (!/^\.(ts|tsx|js|jsx|mjs|cjs|py|pyw|go|rb|java|vue|svelte|prisma|html|htm|env)$/.test(ext)) continue;
-        if (ext === '.html' || ext === '.htm' || ext === '.env') continue; // not enrichment-scanned
-        if (!SCANNED_SOURCE_EXTENSIONS.has(ext)) missing.push(`${file}: ${ext}`);
+      for (const m of codeOf(file).matchAll(/'(\.[A-Za-z0-9]{1,8})'/g)) {
+        if (!isScannedByEnrichment(`x${m[1]}`)) missing.push(`${file}: ${m[1]}`);
       }
     }
-    expect(missing, 'extensions read by a scan module but absent from the disclosure set').toEqual([]);
+    expect(missing, 'extensions read by a scan module but absent from the disclosure predicate').toEqual([]);
+  });
+
+  it('the disclosure predicate covers env declaration files, which have no usable extension', async () => {
+    const { isScannedByEnrichment, ENV_DECLARATION_FILES } = await import('./bounded-file-scan.js');
+    // `extname('.env')` is `''` and `extname('.env.production')` is `'.production'`, so an
+    // extension-only predicate drops an oversized `.env` with no disclosure at all — the exact
+    // silent loss the design forbids. Every file the env scan opens must be reportable.
+    for (const name of ENV_DECLARATION_FILES) {
+      expect(isScannedByEnrichment(`/repo/${name}`), `${name} must be disclosable`).toBe(true);
+    }
+    // …and it still excludes what no extractor opens, so the warning stays worth reading.
+    for (const noise of ['/repo/assets.bin', '/repo/data.json', '/repo/logo.png', '/repo/notes.md']) {
+      expect(isScannedByEnrichment(noise), `${noise} must not be reported`).toBe(false);
+    }
   });
 
   it('the size cap is measured on the same file handle it reads from (no TOCTOU)', () => {
@@ -253,9 +336,15 @@ describe('Bounded Computation — repository-wide scans stay bounded (issue #302
     // handle closes it by construction.
     expect(code).toMatch(/await open\(path, 'r'\)/);
     expect(code).toMatch(/handle\.stat\(\)/);
-    expect(code).toMatch(/handle\.readFile\(/);
     expect(code, 'must not re-resolve the path for the read').not.toMatch(/\breadFile\(path/);
     expect(code, 'must not stat the path separately from the read').not.toMatch(/[^.]\bstat\(path\)/);
+    // …and the read must be LENGTH-BOUNDED by the size just checked. `handle.readFile()` reads to
+    // CURRENT end-of-file, so one handle alone does not bound anything: a file appended to during
+    // the await window comes back in full, straight through the cap (measured: 1 KB -> 20 MB).
+    expect(code, 'the read must be bounded to the checked size, not readFile-to-EOF')
+      .not.toMatch(/handle\.readFile\(/);
+    expect(code).toMatch(/handle\.read\(buf/);
+    expect(code).toMatch(/Buffer\.allocUnsafe\(s\.size\)/);
     // The handle is always released, including on the oversized/unreadable paths.
     expect(code).toMatch(/finally\s*\{[\s\S]{0,200}handle\?\.close\(\)/);
   });

--- a/src/core/analyzer/bounded-computation.test.ts
+++ b/src/core/analyzer/bounded-computation.test.ts
@@ -241,6 +241,25 @@ describe('Bounded Computation — repository-wide scans stay bounded (issue #302
     expect(missing, 'extensions read by a scan module but absent from the disclosure set').toEqual([]);
   });
 
+  it('the size cap is measured on the same file handle it reads from (no TOCTOU)', () => {
+    // Comments stripped first: the module's own docblock explains the hazard by NAMING the
+    // rejected `stat(path)` / `readFile(path)` shape, and prose must not fail the guard.
+    const code = readFileSync(join(ANALYZER_DIR, 'bounded-file-scan.ts'), 'utf-8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    // A separate `stat(path)` then `readFile(path)` resolves the name twice, so a file that grew
+    // or was replaced in between is read at a size that was never checked — the cap can be
+    // stepped around by a repository being written to concurrently. Sizing and reading ONE open
+    // handle closes it by construction.
+    expect(code).toMatch(/await open\(path, 'r'\)/);
+    expect(code).toMatch(/handle\.stat\(\)/);
+    expect(code).toMatch(/handle\.readFile\(/);
+    expect(code, 'must not re-resolve the path for the read').not.toMatch(/\breadFile\(path/);
+    expect(code, 'must not stat the path separately from the read').not.toMatch(/[^.]\bstat\(path\)/);
+    // The handle is always released, including on the oversized/unreadable paths.
+    expect(code).toMatch(/finally\s*\{[\s\S]{0,200}handle\?\.close\(\)/);
+  });
+
   it('both bounds are defined, documented, and small enough to matter', async () => {
     const { SOURCE_SCAN_CONCURRENCY, SOURCE_SCAN_MAX_FILE_BYTES } = await import('../../constants.js');
     // A bound large enough to admit an ordinary repository wholesale is not a bound.

--- a/src/core/analyzer/bounded-file-scan.test.ts
+++ b/src/core/analyzer/bounded-file-scan.test.ts
@@ -10,7 +10,7 @@
  * the concurrency bound).
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, appendFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -126,6 +126,70 @@ describe('mapFilesBounded — results are in INPUT order', () => {
   });
 });
 
+describe('mapFilesBounded — a failed scan stops, it does not run on unobserved', () => {
+  it('starts no new work after the returned promise has rejected', async () => {
+    // `Promise.all(paths.map(fn))` cannot start work after a rejection — every call was issued
+    // before the first rejection could be observed. A worker pool can, and if it does, the
+    // caller's next scan runs alongside an abandoned one and the documented peak is breached.
+    const paths = Array.from({ length: 200 }, (_, i) => `f${i}.ts`);
+    let started = 0;
+    let rejected = false;
+    const startedAfterRejection: number[] = [];
+
+    await expect(
+      mapFilesBounded(paths, async (_p, i) => {
+        started++;
+        if (rejected) startedAfterRejection.push(i);
+        await tick(1);
+        if (i === 0) throw new Error('boom');
+        return i;
+      }, 4),
+    ).rejects.toThrow('boom');
+    rejected = true;
+
+    const startedAtRejection = started;
+    await tick(80); // plenty of time for an abandoned pool to drain the remaining 190+ paths
+
+    expect(startedAfterRejection, 'work was started after the caller gave up').toEqual([]);
+    expect(started, 'the pool kept draining the cursor after rejecting').toBe(startedAtRejection);
+    expect(started).toBeLessThan(paths.length);
+  });
+
+  it('an abandoned pool cannot keep scanning the repository behind the next one', async () => {
+    // This is the shape `analyze` actually runs: scans back to back, and MCP handlers that
+    // swallow the rejection. When scan A rejects, its already-awaiting workers necessarily
+    // finish their CURRENT file — `Promise.all` has that same straggler property — so a brief
+    // overlap bounded by the width is expected and fine. What must NOT happen is scan A's pool
+    // continuing to pull new files while scan B runs: that is unbounded in the repository's
+    // size, and it is what breaches the peak this module promises.
+    const WIDTH = 8;
+    const paths = Array.from({ length: 400 }, (_, i) => `f${i}.ts`);
+    let aStarted = 0;
+    let inFlight = 0;
+    let peak = 0;
+    const track = async <T,>(work: () => Promise<T>): Promise<T> => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      try { return await work(); } finally { inFlight--; }
+    };
+
+    await mapFilesBounded(paths, (_p, i) => track(async () => {
+      aStarted++;
+      await tick(1);
+      if (i === 0) throw new Error('scan A fails');
+      return i;
+    }), WIDTH).catch(() => { /* the caller swallows it, as MCP handlers do */ });
+
+    await mapFilesBounded(paths, () => track(async () => { await tick(1); return 1; }), WIDTH);
+
+    // Scan A touched roughly one wave, not the whole 400-file repository.
+    expect(aStarted, 'the abandoned pool kept scanning').toBeLessThanOrEqual(WIDTH * 2);
+    // Overlap is bounded by stragglers, never by the repository.
+    expect(peak, `peak ${peak} exceeds one width of stragglers plus a full scan`)
+      .toBeLessThanOrEqual(WIDTH * 2);
+  });
+});
+
 describe('mapFilesBounded — failure behaves like Promise.all', () => {
   it('rejects with the callback error and leaves no unhandled rejection', async () => {
     const paths = Array.from({ length: 20 }, (_, i) => `f${i}.ts`);
@@ -169,6 +233,46 @@ describe('readSourceCapped — one file cannot exhaust the heap', () => {
     expect(await readSourceCapped(big)).toBeNull();
     // The cap is a parameter, so a caller that can afford more can ask for more.
     expect(await readSourceCapped(big, Number.MAX_SAFE_INTEGER)).not.toBeNull();
+  });
+
+  it('reads no more than the size it checked, even if the file grows mid-read', async () => {
+    // THE cap's soundness property. `handle.readFile()` reads to CURRENT end-of-file, so sizing
+    // and reading one handle is NOT sufficient on its own: a file appended to during the await
+    // window comes back in full, straight through the cap. Measured before the fix: a 1 KB file
+    // that grew to 20 MB returned 20 MB. The read must be bounded to the size that was checked.
+    dir = mkdtempSync(join(tmpdir(), 'ol-scan-grow-'));
+    const p = join(dir, 'grows.ts');
+    const original = 'a'.repeat(1024);
+
+    // Race the append against the scan repeatedly. Whether it lands before the `stat` or between
+    // the `stat` and the read is timing-dependent, so BOTH correct outcomes are accepted — the
+    // file was already oversized when measured (`null`), or it was measured small and read at
+    // exactly that size. The buggy outcome — returning the GROWN contents through the cap — is
+    // excluded either way, so this cannot flake into a false pass or a false failure.
+    for (let attempt = 0; attempt < 25; attempt++) {
+      writeFileSync(p, original);
+      const pending = readSourceCapped(p);
+      appendFileSync(p, 'b'.repeat(8 * 1024 * 1024));
+      const out = await pending;
+
+      if (out !== null) {
+        expect(out, `attempt ${attempt}: read past the size it checked`).toBe(original);
+      }
+      expect(
+        out === null || out.length <= SOURCE_SCAN_MAX_FILE_BYTES,
+        `attempt ${attempt}: returned ${out?.length} bytes through a ${SOURCE_SCAN_MAX_FILE_BYTES}-byte cap`,
+      ).toBe(true);
+    }
+  });
+
+  it('returns the whole file for the ordinary case where nothing is writing', async () => {
+    // The bounded read must not truncate a file that is simply sitting there — including one
+    // whose byte length differs from its character length.
+    dir = mkdtempSync(join(tmpdir(), 'ol-scan-exact-'));
+    const p = join(dir, 'unicode.ts');
+    const body = `export const s = "${'héllo — wörld ✅'.repeat(500)}";\n`;
+    writeFileSync(p, body, 'utf-8');
+    expect(await readSourceCapped(p)).toBe(body);
   });
 
   it('returns null for a missing path and for a directory', async () => {

--- a/src/core/analyzer/bounded-file-scan.test.ts
+++ b/src/core/analyzer/bounded-file-scan.test.ts
@@ -235,6 +235,30 @@ describe('readSourceCapped — one file cannot exhaust the heap', () => {
     expect(await readSourceCapped(big, Number.MAX_SAFE_INTEGER)).not.toBeNull();
   });
 
+  it('reports the exact scan-time size that caused an exclusion', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'ol-scan-observe-'));
+    const p = join(dir, 'grows.ts');
+    writeFileSync(p, 'small');
+
+    // Model a file that was small during repository walking, then grew before the
+    // enrichment scan opened it. Disclosure must use this scan-time observation,
+    // not the walker's stale size.
+    writeFileSync(p, 'x'.repeat(SOURCE_SCAN_MAX_FILE_BYTES + 17));
+    const observed: Array<{ path: string; bytes: number }> = [];
+    expect(await readSourceCapped(p, SOURCE_SCAN_MAX_FILE_BYTES, (path, bytes) => {
+      observed.push({ path, bytes });
+    })).toBeNull();
+    expect(observed).toEqual([{ path: p, bytes: SOURCE_SCAN_MAX_FILE_BYTES + 17 }]);
+
+    // The inverse race must not produce a false warning.
+    writeFileSync(p, 'small again');
+    observed.length = 0;
+    expect(await readSourceCapped(p, SOURCE_SCAN_MAX_FILE_BYTES, (path, bytes) => {
+      observed.push({ path, bytes });
+    })).toBe('small again');
+    expect(observed).toEqual([]);
+  });
+
   it('reads no more than the size it checked, even if the file grows mid-read', async () => {
     // THE cap's soundness property. `handle.readFile()` reads to CURRENT end-of-file, so sizing
     // and reading one handle is NOT sufficient on its own: a file appended to during the await

--- a/src/core/analyzer/bounded-file-scan.test.ts
+++ b/src/core/analyzer/bounded-file-scan.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Bounded repository-wide file scanning (change: fix-unbounded-file-scan-oom).
+ *
+ * These cover the two properties the fix for issue #302 rests on:
+ *  - a scan's peak residency is a function of its CONCURRENCY BOUND, not of the file count, and
+ *  - a scan's peak residency is a function of its PER-FILE SIZE CAP, not of any one file's size.
+ *
+ * Plus the property the rest of the codebase silently depends on: results come back in INPUT
+ * order, so artifacts built from a scan stay byte-identical across runs (and across changes to
+ * the concurrency bound).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { mapFilesBounded, readSourceCapped, isOversizedForScan } from './bounded-file-scan.js';
+import { SOURCE_SCAN_MAX_FILE_BYTES, SOURCE_SCAN_CONCURRENCY } from '../../constants.js';
+
+let dir: string | undefined;
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = undefined;
+});
+
+const tick = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+describe('mapFilesBounded — concurrency is bounded', () => {
+  it('never runs more callbacks at once than the requested width', async () => {
+    const paths = Array.from({ length: 200 }, (_, i) => `f${i}.ts`);
+    let inFlight = 0;
+    let peak = 0;
+
+    await mapFilesBounded(paths, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await tick(1);
+      inFlight--;
+      return null;
+    }, 4);
+
+    expect(peak).toBeLessThanOrEqual(4);
+    // Sanity: the bound is real work-sharing, not accidental serialization.
+    expect(peak).toBeGreaterThan(1);
+  });
+
+  it('holds the bound even when one file is far slower than the rest', async () => {
+    // A worker stuck on a slow file must not let the others exceed the width, and must not
+    // stall them either — workers pull from a shared cursor rather than owning fixed slices.
+    const paths = Array.from({ length: 50 }, (_, i) => `f${i}.ts`);
+    let inFlight = 0;
+    let peak = 0;
+
+    const out = await mapFilesBounded(paths, async (_p, i) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await tick(i === 0 ? 60 : 1);
+      inFlight--;
+      return i;
+    }, 3);
+
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(out).toEqual(paths.map((_, i) => i));
+  });
+
+  it('visits every path exactly once', async () => {
+    const paths = Array.from({ length: 137 }, (_, i) => `f${i}.ts`);
+    const seen: string[] = [];
+    await mapFilesBounded(paths, async p => { seen.push(p); return null; }, 7);
+    expect(seen.slice().sort()).toEqual(paths.slice().sort());
+    expect(seen.length).toBe(paths.length);
+  });
+
+  it('clamps a nonsensical width instead of stalling or fanning out', async () => {
+    const paths = ['a.ts', 'b.ts', 'c.ts'];
+    for (const width of [0, -5, Number.NaN, 0.4]) {
+      const out = await mapFilesBounded(paths, async (_p, i) => i, width);
+      expect(out, `width ${String(width)}`).toEqual([0, 1, 2]);
+    }
+    // A width above the work available is harmless.
+    expect(await mapFilesBounded(paths, async (_p, i) => i, 1000)).toEqual([0, 1, 2]);
+  });
+
+  it('returns an empty result for an empty input without invoking the callback', async () => {
+    let called = 0;
+    expect(await mapFilesBounded([], async () => { called++; return 1; })).toEqual([]);
+    expect(called).toBe(0);
+  });
+
+  it('defaults to the documented repository-wide bound', async () => {
+    const paths = Array.from({ length: 100 }, (_, i) => `f${i}.ts`);
+    let peak = 0;
+    let inFlight = 0;
+    await mapFilesBounded(paths, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await tick(1);
+      inFlight--;
+      return null;
+    });
+    expect(peak).toBeLessThanOrEqual(SOURCE_SCAN_CONCURRENCY);
+  });
+});
+
+describe('mapFilesBounded — results are in INPUT order', () => {
+  it('orders by input even when callbacks complete in reverse', async () => {
+    // Completion order is deliberately the exact inverse of input order. A shared-array push
+    // (or any completion-ordered collection) would produce [9..0]; the artifacts built on top
+    // of these scans must not depend on I/O timing.
+    const paths = Array.from({ length: 10 }, (_, i) => `f${i}.ts`);
+    const out = await mapFilesBounded(paths, async (p, i) => {
+      await tick((paths.length - i) * 4);
+      return p;
+    }, paths.length);
+    expect(out).toEqual(paths);
+  });
+
+  it('produces the same order at every concurrency width', async () => {
+    const paths = Array.from({ length: 40 }, (_, i) => `f${i}.ts`);
+    const runs = await Promise.all(
+      [1, 2, 8, 64].map(w =>
+        mapFilesBounded(paths, async (p, i) => { await tick(i % 3); return p; }, w),
+      ),
+    );
+    for (const r of runs) expect(r).toEqual(paths);
+  });
+});
+
+describe('mapFilesBounded — failure behaves like Promise.all', () => {
+  it('rejects with the callback error and leaves no unhandled rejection', async () => {
+    const paths = Array.from({ length: 20 }, (_, i) => `f${i}.ts`);
+    const unhandled: unknown[] = [];
+    const onUnhandled = (e: unknown) => unhandled.push(e);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await expect(
+        mapFilesBounded(paths, async (_p, i) => {
+          await tick(1);
+          if (i % 5 === 0) throw new Error(`boom ${i}`);
+          return i;
+        }, 4),
+      ).rejects.toThrow(/boom/);
+      // Give any stray rejection a turn of the loop to surface.
+      await tick(20);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+    expect(unhandled).toEqual([]);
+  });
+});
+
+describe('isOversizedForScan — the threshold exists exactly once', () => {
+  it('admits a file exactly at the cap and rejects one byte over', () => {
+    expect(isOversizedForScan(SOURCE_SCAN_MAX_FILE_BYTES)).toBe(false);
+    expect(isOversizedForScan(SOURCE_SCAN_MAX_FILE_BYTES + 1)).toBe(true);
+    expect(isOversizedForScan(0)).toBe(false);
+  });
+});
+
+describe('readSourceCapped — one file cannot exhaust the heap', () => {
+  it('reads a normal file, and skips one over the cap without reading it', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'ol-scan-cap-'));
+    const small = join(dir, 'small.ts');
+    const big = join(dir, 'big.ts');
+    writeFileSync(small, 'export const a = 1;\n');
+    writeFileSync(big, 'x'.repeat(SOURCE_SCAN_MAX_FILE_BYTES + 1024));
+
+    expect(await readSourceCapped(small)).toBe('export const a = 1;\n');
+    expect(await readSourceCapped(big)).toBeNull();
+    // The cap is a parameter, so a caller that can afford more can ask for more.
+    expect(await readSourceCapped(big, Number.MAX_SAFE_INTEGER)).not.toBeNull();
+  });
+
+  it('returns null for a missing path and for a directory', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'ol-scan-miss-'));
+    mkdirSync(join(dir, 'subdir'));
+    expect(await readSourceCapped(join(dir, 'nope.ts'))).toBeNull();
+    expect(await readSourceCapped(join(dir, 'subdir'))).toBeNull();
+  });
+});

--- a/src/core/analyzer/bounded-file-scan.ts
+++ b/src/core/analyzer/bounded-file-scan.ts
@@ -1,0 +1,126 @@
+/**
+ * Bounded repository-wide file scanning (change: fix-unbounded-file-scan-oom).
+ *
+ * This is the one way this codebase fans out a read across every file in a repository.
+ *
+ * Every such scan used to be written `await Promise.all(files.map(async f => { const src =
+ * await readFile(f, 'utf-8'); ... }))`. That issues one read per file *simultaneously*, so at
+ * the peak the entire repository is resident in the heap — and `analyze` ran five of those
+ * scans concurrently. Past a few hundred megabytes of source it is a fatal OOM, not a
+ * slowdown: V8 aborts inside the read-completion path with no partial result, no artifact, and
+ * no indication of which phase died (issue #302).
+ *
+ * Two bounds, because they fail independently and either alone still admits the crash:
+ *
+ *  - {@link mapFilesBounded} caps how many files are in flight, so peak residency is a function
+ *    of the cap rather than of the repository's file count. This is the bound that fixes a
+ *    repository of many ordinary files.
+ *  - {@link readSourceCapped} caps how large a single file may be, so one generated or minified
+ *    blob cannot exhaust the heap however low the concurrency is.
+ *
+ * `mapFilesBounded` resolves results in INPUT order, exactly like `Promise.all`. That is
+ * load-bearing rather than cosmetic: several callers document that they depend on input
+ * ordering so the artifacts they build are byte-identical across runs of a fixed repository
+ * state (change: fix-artifact-output-determinism). Ordering by completion instead would make
+ * the serialized graph a function of I/O timing.
+ */
+import { readFile, stat } from 'node:fs/promises';
+
+import { SOURCE_SCAN_CONCURRENCY, SOURCE_SCAN_MAX_FILE_BYTES } from '../../constants.js';
+
+/**
+ * Run `fn` over every path with at most `concurrency` calls in flight, returning results in
+ * INPUT order — a drop-in replacement for `Promise.all(paths.map(fn))` that does not scale its
+ * peak memory with `paths.length`.
+ *
+ * Rejection behaves as `Promise.all` does: the returned promise rejects with the first error.
+ * Every caller in this codebase catches per file and returns an empty result instead, so a
+ * single unreadable file never aborts a scan.
+ */
+export async function mapFilesBounded<T>(
+  paths: readonly string[],
+  fn: (path: string, index: number) => Promise<T>,
+  concurrency: number = SOURCE_SCAN_CONCURRENCY,
+): Promise<T[]> {
+  const results = new Array<T>(paths.length);
+  if (paths.length === 0) return results;
+
+  // Clamp defensively: a caller-supplied 0, NaN, or negative width must still make progress,
+  // and a width above the work available just wastes idle workers.
+  const requested = Math.floor(concurrency);
+  const width = Math.min(
+    Number.isFinite(requested) && requested > 0 ? requested : 1,
+    paths.length,
+  );
+
+  // Workers pull from a shared cursor rather than being handed fixed slices, so one slow file
+  // cannot leave the remaining workers idle behind it.
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const i = cursor++;
+      if (i >= paths.length) return;
+      results[i] = await fn(paths[i], i);
+    }
+  };
+
+  await Promise.all(Array.from({ length: width }, () => worker()));
+  return results;
+}
+
+/**
+ * Is a file of this many bytes too large for a repository-wide source scan?
+ *
+ * Exported so the predicate exists exactly once: the scan applies it to a `stat` result, and
+ * `analyze` applies it to the sizes the walker already recorded in order to DISCLOSE the
+ * exclusions. Two spellings of the same threshold would let those two surfaces disagree about
+ * the same repository.
+ */
+export function isOversizedForScan(bytes: number, maxBytes = SOURCE_SCAN_MAX_FILE_BYTES): boolean {
+  return bytes > maxBytes;
+}
+
+/**
+ * The union of the file extensions the enrichment extractors read — UI components, schemas,
+ * routes, middleware, and environment variables.
+ *
+ * Used ONLY to scope the oversized-file disclosure. A repository can hold a 6 MB image or data
+ * blob that no extractor would ever have opened; reporting it as "excluded from the scan" is a
+ * true statement that tells the operator nothing and trains them to ignore the warning. So the
+ * disclosure is narrowed to files an extractor would actually have read.
+ *
+ * Errs WIDE on purpose. An extension listed here that some individual extractor ignores costs at
+ * most one over-reported file; an extension missing here would silently hide a genuinely dropped
+ * component, route, or environment variable — the exact failure the disclosure exists to prevent.
+ */
+export const SCANNED_SOURCE_EXTENSIONS: ReadonlySet<string> = new Set([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  '.py', '.pyw', '.go', '.rb', '.java',
+  '.vue', '.svelte', '.prisma',
+]);
+
+/**
+ * Read a source file as UTF-8, or return `null` if it is unreadable or exceeds the scan's
+ * per-file size cap.
+ *
+ * The size is checked with `stat` BEFORE the read, which is the whole point: reading first and
+ * measuring after would already have materialized the buffer and the string that the cap exists
+ * to prevent.
+ *
+ * `null` deliberately does not distinguish "too large" from "unreadable" — a scan callback can
+ * do nothing different about either. The user-facing distinction is made by `analyze`, which
+ * reports oversized files from the sizes the walker recorded, so the exclusion is disclosed
+ * rather than silent.
+ */
+export async function readSourceCapped(
+  path: string,
+  maxBytes = SOURCE_SCAN_MAX_FILE_BYTES,
+): Promise<string | null> {
+  try {
+    const s = await stat(path);
+    if (!s.isFile() || isOversizedForScan(s.size, maxBytes)) return null;
+    return await readFile(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}

--- a/src/core/analyzer/bounded-file-scan.ts
+++ b/src/core/analyzer/bounded-file-scan.ts
@@ -1,7 +1,7 @@
 /**
  * Bounded repository-wide file scanning (change: fix-unbounded-file-scan-oom).
  *
- * This is the one way this codebase fans out a read across every file in a repository.
+ * Shared primitive for analyzer and indexing paths that fan reads across repository files.
  *
  * Every such scan used to be written `await Promise.all(files.map(async f => { const src =
  * await readFile(f, 'utf-8'); ... }))`. That issues one read per file *simultaneously*, so at
@@ -29,6 +29,9 @@ import type { FileHandle } from 'node:fs/promises';
 import { basename, extname } from 'node:path';
 
 import { SOURCE_SCAN_CONCURRENCY, SOURCE_SCAN_MAX_CONCURRENCY, SOURCE_SCAN_MAX_FILE_BYTES } from '../../constants.js';
+
+/** Called from the exact scan-time stat that caused a file to be excluded. */
+export type OversizedFileObserver = (path: string, bytes: number) => void;
 
 /**
  * Run `fn` over every path with at most `concurrency` calls in flight, returning results in
@@ -172,19 +175,24 @@ export function isScannedByEnrichment(filePath: string): boolean {
  * is exact and no character can be split.
  *
  * `null` deliberately does not distinguish "too large" from "unreadable" — a scan callback can
- * do nothing different about either. The user-facing distinction is made by the caller, which
- * reports oversized files from the sizes the walker recorded, so the exclusion is disclosed
- * rather than silent.
+ * do nothing different about either. Callers that render user-facing disclosure pass
+ * `onOversized`; it fires from the exact open-handle stat that enforced the cap, so the warning
+ * does not depend on the repository walker's earlier size snapshot.
  */
 export async function readSourceCapped(
   path: string,
   maxBytes = SOURCE_SCAN_MAX_FILE_BYTES,
+  onOversized?: OversizedFileObserver,
 ): Promise<string | null> {
   let handle: FileHandle | undefined;
   try {
     handle = await open(path, 'r');
     const s = await handle.stat();
-    if (!s.isFile() || isOversizedForScan(s.size, maxBytes)) return null;
+    if (!s.isFile()) return null;
+    if (isOversizedForScan(s.size, maxBytes)) {
+      onOversized?.(path, s.size);
+      return null;
+    }
 
     // Read at most the bytes we just checked for. NOT `handle.readFile()`, which reads to EOF and
     // would hand back whatever the file has become since (see the docblock above).

--- a/src/core/analyzer/bounded-file-scan.ts
+++ b/src/core/analyzer/bounded-file-scan.ts
@@ -24,7 +24,8 @@
  * state (change: fix-artifact-output-determinism). Ordering by completion instead would make
  * the serialized graph a function of I/O timing.
  */
-import { readFile, stat } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
+import type { FileHandle } from 'node:fs/promises';
 
 import { SOURCE_SCAN_CONCURRENCY, SOURCE_SCAN_MAX_FILE_BYTES } from '../../constants.js';
 
@@ -103,9 +104,15 @@ export const SCANNED_SOURCE_EXTENSIONS: ReadonlySet<string> = new Set([
  * Read a source file as UTF-8, or return `null` if it is unreadable or exceeds the scan's
  * per-file size cap.
  *
- * The size is checked with `stat` BEFORE the read, which is the whole point: reading first and
- * measuring after would already have materialized the buffer and the string that the cap exists
- * to prevent.
+ * The size is measured BEFORE the read, which is the whole point: reading first and measuring
+ * after would already have materialized the buffer and the string that the cap exists to prevent.
+ *
+ * The measurement and the read go through ONE open file handle rather than a `stat(path)`
+ * followed by a `readFile(path)`. Those are two independent resolutions of the same name, so
+ * anything that grew, replaced, or symlinked the path in between would be read at a size that was
+ * never checked — the cap could be stepped around by a repository being written to concurrently,
+ * which for a tool that analyzes untrusted repositories is a real boundary rather than a
+ * theoretical one. Sizing and reading the same file description closes it by construction.
  *
  * `null` deliberately does not distinguish "too large" from "unreadable" — a scan callback can
  * do nothing different about either. The user-facing distinction is made by `analyze`, which
@@ -116,11 +123,15 @@ export async function readSourceCapped(
   path: string,
   maxBytes = SOURCE_SCAN_MAX_FILE_BYTES,
 ): Promise<string | null> {
+  let handle: FileHandle | undefined;
   try {
-    const s = await stat(path);
+    handle = await open(path, 'r');
+    const s = await handle.stat();
     if (!s.isFile() || isOversizedForScan(s.size, maxBytes)) return null;
-    return await readFile(path, 'utf-8');
+    return await handle.readFile('utf-8');
   } catch {
     return null;
+  } finally {
+    await handle?.close().catch(() => { /* closing a handle we are done with cannot fail usefully */ });
   }
 }

--- a/src/core/analyzer/bounded-file-scan.ts
+++ b/src/core/analyzer/bounded-file-scan.ts
@@ -26,8 +26,9 @@
  */
 import { open } from 'node:fs/promises';
 import type { FileHandle } from 'node:fs/promises';
+import { basename, extname } from 'node:path';
 
-import { SOURCE_SCAN_CONCURRENCY, SOURCE_SCAN_MAX_FILE_BYTES } from '../../constants.js';
+import { SOURCE_SCAN_CONCURRENCY, SOURCE_SCAN_MAX_CONCURRENCY, SOURCE_SCAN_MAX_FILE_BYTES } from '../../constants.js';
 
 /**
  * Run `fn` over every path with at most `concurrency` calls in flight, returning results in
@@ -46,22 +47,39 @@ export async function mapFilesBounded<T>(
   const results = new Array<T>(paths.length);
   if (paths.length === 0) return results;
 
-  // Clamp defensively: a caller-supplied 0, NaN, or negative width must still make progress,
-  // and a width above the work available just wastes idle workers.
+  // Clamp defensively, in BOTH directions. A caller-supplied 0, NaN, or negative width must
+  // still make progress; a width above the work available just wastes idle workers; and a width
+  // above the ceiling is the very fan-out this module exists to prevent, so it is clamped rather
+  // than honoured. `Infinity` is the natural way to spell "unbounded" for someone reaching for
+  // `Promise.all` semantics, and it clamps DOWN to the ceiling — never up, and never (as a bare
+  // `Number.isFinite` test would) down to a serial 1.
   const requested = Math.floor(concurrency);
-  const width = Math.min(
-    Number.isFinite(requested) && requested > 0 ? requested : 1,
-    paths.length,
-  );
+  const wanted = requested > 0 ? requested : 1; // covers 0, negatives, NaN (all comparisons false)
+  const width = Math.min(wanted, SOURCE_SCAN_MAX_CONCURRENCY, paths.length);
 
   // Workers pull from a shared cursor rather than being handed fixed slices, so one slow file
   // cannot leave the remaining workers idle behind it.
+  //
+  // `failed` is what makes this a faithful stand-in for `Promise.all` on the failure path.
+  // `Promise.all` cannot start work after a rejection — every call was already issued before the
+  // first rejection could be observed. A worker pool can: without this flag the surviving workers
+  // keep draining the cursor long after the caller has given up, opening files nobody will read.
+  // That is not just waste — a caller that CATCHES the rejection and starts the next scan (which
+  // is exactly what `analyze` does, five times in a row) would then have two live pools at once,
+  // and the peak this module promises would be breached by the abandoned one.
   let cursor = 0;
+  let failed = false;
   const worker = async (): Promise<void> => {
     for (;;) {
+      if (failed) return;
       const i = cursor++;
       if (i >= paths.length) return;
-      results[i] = await fn(paths[i], i);
+      try {
+        results[i] = await fn(paths[i], i);
+      } catch (err) {
+        failed = true;
+        throw err;
+      }
     }
   };
 
@@ -101,21 +119,60 @@ export const SCANNED_SOURCE_EXTENSIONS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Environment-declaration files the env scan reads. Lives here, beside the extension set, because
+ * these files are the reason an extension test alone is NOT a sufficient description of what the
+ * enrichment scans open: `extname('.env')` is `''`, `extname('.env.local')` is `'.local'`, and
+ * `extname('.env.production')` is `'.production'` — none of which is a source extension. A
+ * disclosure predicate built only from extensions therefore drops an oversized `.env` silently,
+ * which is precisely the failure this module claims to prevent.
+ */
+export const ENV_DECLARATION_FILES: ReadonlySet<string> = new Set([
+  '.env', '.env.example', '.env.local', '.env.test', '.env.production',
+]);
+
+/**
+ * Would an enrichment scan have opened this file at all?
+ *
+ * The single predicate behind the oversized-file disclosure. It exists so that "what the scans
+ * read" and "what we tell the operator we skipped" cannot drift apart: a file this returns `false`
+ * for was never going to contribute, so reporting it as excluded is noise; a file it returns
+ * `true` for and that exceeds the cap MUST be reported.
+ */
+export function isScannedByEnrichment(filePath: string): boolean {
+  const name = basename(filePath);
+  if (ENV_DECLARATION_FILES.has(name)) return true;
+  return SCANNED_SOURCE_EXTENSIONS.has(extname(filePath).toLowerCase());
+}
+
+/**
  * Read a source file as UTF-8, or return `null` if it is unreadable or exceeds the scan's
  * per-file size cap.
  *
  * The size is measured BEFORE the read, which is the whole point: reading first and measuring
  * after would already have materialized the buffer and the string that the cap exists to prevent.
  *
- * The measurement and the read go through ONE open file handle rather than a `stat(path)`
- * followed by a `readFile(path)`. Those are two independent resolutions of the same name, so
- * anything that grew, replaced, or symlinked the path in between would be read at a size that was
- * never checked — the cap could be stepped around by a repository being written to concurrently,
- * which for a tool that analyzes untrusted repositories is a real boundary rather than a
- * theoretical one. Sizing and reading the same file description closes it by construction.
+ * Two things are required to make that actually true, and it is worth being precise about which
+ * does what, because getting one of them is easy to mistake for getting both:
+ *
+ *  - The measurement and the read go through ONE open file handle, never a `stat(path)` followed
+ *    by a `readFile(path)`. Those are two independent resolutions of the same NAME, so a path
+ *    that was replaced or re-symlinked in between would be read at a size belonging to a
+ *    different file.
+ *  - The read is bounded to the size that was checked. This is the part a single handle does NOT
+ *    give you: `handle.readFile()` reads to CURRENT end-of-file, so a file appended to after the
+ *    `stat` is read in full — measured, a 1 KB file that grew to 20 MB during the await window
+ *    came back as 20 MB through a 4 MB cap. Reading exactly `size` bytes into a buffer allocated
+ *    at `size` bounds the allocation by construction, whatever the file does afterwards.
+ *
+ * For a tool that analyzes untrusted repositories — and that re-analyzes while a watcher is
+ * rewriting files — this is a real boundary, not a theoretical one.
+ *
+ * A file that GREW is therefore truncated to the prefix that was measured. That costs nothing in
+ * practice: for a file nobody is writing (every real scan) `size` IS the whole file, so the read
+ * is exact and no character can be split.
  *
  * `null` deliberately does not distinguish "too large" from "unreadable" — a scan callback can
- * do nothing different about either. The user-facing distinction is made by `analyze`, which
+ * do nothing different about either. The user-facing distinction is made by the caller, which
  * reports oversized files from the sizes the walker recorded, so the exclusion is disclosed
  * rather than silent.
  */
@@ -128,7 +185,17 @@ export async function readSourceCapped(
     handle = await open(path, 'r');
     const s = await handle.stat();
     if (!s.isFile() || isOversizedForScan(s.size, maxBytes)) return null;
-    return await handle.readFile('utf-8');
+
+    // Read at most the bytes we just checked for. NOT `handle.readFile()`, which reads to EOF and
+    // would hand back whatever the file has become since (see the docblock above).
+    const buf = Buffer.allocUnsafe(s.size);
+    let read = 0;
+    while (read < s.size) {
+      const { bytesRead } = await handle.read(buf, read, s.size - read, read);
+      if (bytesRead === 0) break; // the file shrank under us; keep the prefix we did get
+      read += bytesRead;
+    }
+    return buf.subarray(0, read).toString('utf-8');
   } catch {
     return null;
   } finally {

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -3711,13 +3711,20 @@ async function synthesizeRouteHandlerEdges(
   // completion, making the serialized graph bytes non-deterministic (decision c6d1ad07). The
   // bound matters here too: these extractors re-read each file from disk, so an unbounded
   // `Promise.all` made the whole repository resident at once (issue #302).
+  // The content is ALREADY resident here — `contentByPath` was just built from it — so each
+  // extractor is handed the text rather than re-reading it. That is not only cheaper (one fewer
+  // full pass over the repository); it is what keeps the enrichment scans' per-file SIZE CAP from
+  // reaching the graph. Re-reading through the capped reader silently dropped the route-handler
+  // edges of every file above the cap, which turns a live handler into a `find_dead_code`
+  // candidate — and it bought no memory back, because the content was resident either way.
   const perFileRoutes = await mapFilesBounded(
     files.map(f => f.path),
     async (path): Promise<RouteDefinition[]> => {
+      const resident = contentByPath.get(path);
       try {
-        if (/\.(py|pyw)$/.test(path)) return await extractRouteDefinitions(path);
-        if (/\.(ts|tsx|js|jsx|mjs)$/.test(path)) return await extractTsRouteDefinitions(path);
-        if (/\.java$/.test(path)) return await extractJavaRouteDefinitions(path);
+        if (/\.(py|pyw)$/.test(path)) return await extractRouteDefinitions(path, resident);
+        if (/\.(ts|tsx|js|jsx|mjs)$/.test(path)) return await extractTsRouteDefinitions(path, resident);
+        if (/\.java$/.test(path)) return await extractJavaRouteDefinitions(path, resident);
       } catch { /* best-effort per file */ }
       return [];
     },

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -25,6 +25,7 @@ import {
   extractJavaRouteDefinitions,
   type RouteDefinition,
 } from './http-route-parser.js';
+import { mapFilesBounded } from './bounded-file-scan.js';
 import { buildProjectedIac } from './iac/index.js';
 import { isIacLanguage } from './iac/types.js';
 import { isTestFile } from './test-file.js';
@@ -3704,18 +3705,23 @@ async function synthesizeRouteHandlerEdges(
   resolveHandler: HandlerResolver,
 ): Promise<CallEdge[]> {
   const contentByPath = new Map(files.map(f => [f.path, f.content]));
-  // Per-file-then-flatten: `Promise.all` resolves in INPUT (file-list) order, so the
-  // synthesized edge order is a pure function of the input — pushing into a shared
-  // `routes` array inside the callbacks would order routes by I/O completion, making
-  // the serialized graph bytes non-deterministic (decision c6d1ad07).
-  const perFileRoutes = await Promise.all(files.map(async (f): Promise<RouteDefinition[]> => {
-    try {
-      if (/\.(py|pyw)$/.test(f.path)) return await extractRouteDefinitions(f.path);
-      if (/\.(ts|tsx|js|jsx|mjs)$/.test(f.path)) return await extractTsRouteDefinitions(f.path);
-      if (/\.java$/.test(f.path)) return await extractJavaRouteDefinitions(f.path);
-    } catch { /* best-effort per file */ }
-    return [];
-  }));
+  // Per-file-then-flatten over a BOUNDED scan: `mapFilesBounded` resolves in INPUT (file-list)
+  // order regardless of its concurrency, so the synthesized edge order is a pure function of the
+  // input — pushing into a shared `routes` array inside the callbacks would order routes by I/O
+  // completion, making the serialized graph bytes non-deterministic (decision c6d1ad07). The
+  // bound matters here too: these extractors re-read each file from disk, so an unbounded
+  // `Promise.all` made the whole repository resident at once (issue #302).
+  const perFileRoutes = await mapFilesBounded(
+    files.map(f => f.path),
+    async (path): Promise<RouteDefinition[]> => {
+      try {
+        if (/\.(py|pyw)$/.test(path)) return await extractRouteDefinitions(path);
+        if (/\.(ts|tsx|js|jsx|mjs)$/.test(path)) return await extractTsRouteDefinitions(path);
+        if (/\.java$/.test(path)) return await extractJavaRouteDefinitions(path);
+      } catch { /* best-effort per file */ }
+      return [];
+    },
+  );
   const routes: RouteDefinition[] = perFileRoutes.flat();
   if (routes.length === 0) return [];
 

--- a/src/core/analyzer/env-extractor.test.ts
+++ b/src/core/analyzer/env-extractor.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { extractEnvVars, summarizeEnvVars, extractEnvReadSites } from './env-extractor.js';
 
+// The extractor stats a file before reading it, so a read cannot materialize a string larger
+// than the scan's per-file cap (change: fix-unbounded-file-scan-oom). The mock models both.
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
+  stat: vi.fn(),
 }));
 
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 
 const mockReadFile = readFile as ReturnType<typeof vi.fn>;
+const mockStat = stat as ReturnType<typeof vi.fn>;
 
 describe('extractEnvVars', () => {
   beforeEach(() => {
     mockReadFile.mockReset();
+    mockStat.mockReset();
+    mockStat.mockResolvedValue({ isFile: () => true, size: 1024 });
   });
 
   it('should return empty array when no files provided', async () => {

--- a/src/core/analyzer/env-extractor.test.ts
+++ b/src/core/analyzer/env-extractor.test.ts
@@ -1,23 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { extractEnvVars, summarizeEnvVars, extractEnvReadSites } from './env-extractor.js';
 
-// The extractor stats a file before reading it, so a read cannot materialize a string larger
-// than the scan's per-file cap (change: fix-unbounded-file-scan-oom). The mock models both.
+// The extractor sizes and reads a file through ONE open handle, so the cap cannot be raced
+// (change: fix-unbounded-file-scan-oom). The mock models that handle; `mockReadFile` still
+// stands in for the file's content so every case below reads as it did before.
 vi.mock('node:fs/promises', () => ({
-  readFile: vi.fn(),
-  stat: vi.fn(),
+  open: vi.fn(),
 }));
 
-import { readFile, stat } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 
-const mockReadFile = readFile as ReturnType<typeof vi.fn>;
-const mockStat = stat as ReturnType<typeof vi.fn>;
+const mockReadFile = vi.fn();
+const mockOpen = open as ReturnType<typeof vi.fn>;
 
 describe('extractEnvVars', () => {
   beforeEach(() => {
     mockReadFile.mockReset();
-    mockStat.mockReset();
-    mockStat.mockResolvedValue({ isFile: () => true, size: 1024 });
+    mockOpen.mockReset();
+    mockOpen.mockImplementation((p: string) => Promise.resolve({
+      stat: () => Promise.resolve({ isFile: () => true, size: 1024 }),
+      readFile: () => mockReadFile(p),
+      close: () => Promise.resolve(),
+    }));
   });
 
   it('should return empty array when no files provided', async () => {

--- a/src/core/analyzer/env-extractor.test.ts
+++ b/src/core/analyzer/env-extractor.test.ts
@@ -13,15 +13,32 @@ import { open } from 'node:fs/promises';
 const mockReadFile = vi.fn();
 const mockOpen = open as ReturnType<typeof vi.fn>;
 
+/**
+ * A stand-in for the `FileHandle` the bounded scan opens. It models `read()` — NOT `readFile()` —
+ * because the scan reads exactly the number of bytes it stat'd, so that a file growing under it
+ * cannot be read past its checked size (change: fix-unbounded-file-scan-oom).
+ */
+function fakeHandle(content: string): {
+  stat: () => Promise<{ isFile: () => boolean; size: number }>;
+  read: (buf: Buffer, offset: number, length: number, position: number) => Promise<{ bytesRead: number }>;
+  close: () => Promise<void>;
+} {
+  const bytes = Buffer.from(content, 'utf-8');
+  return {
+    stat: () => Promise.resolve({ isFile: () => true, size: bytes.length }),
+    read: (buf, offset, length, position) => {
+      const copied = bytes.copy(buf, offset, position, Math.min(position + length, bytes.length));
+      return Promise.resolve({ bytesRead: copied });
+    },
+    close: () => Promise.resolve(),
+  };
+}
+
 describe('extractEnvVars', () => {
   beforeEach(() => {
     mockReadFile.mockReset();
     mockOpen.mockReset();
-    mockOpen.mockImplementation((p: string) => Promise.resolve({
-      stat: () => Promise.resolve({ isFile: () => true, size: 1024 }),
-      readFile: () => mockReadFile(p),
-      close: () => Promise.resolve(),
-    }));
+    mockOpen.mockImplementation(async (p: string) => fakeHandle(String(await mockReadFile(p) ?? '')));
   });
 
   it('should return empty array when no files provided', async () => {

--- a/src/core/analyzer/env-extractor.ts
+++ b/src/core/analyzer/env-extractor.ts
@@ -13,7 +13,7 @@
 
 import { extname, relative, basename } from 'node:path';
 
-import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
+import { ENV_DECLARATION_FILES, mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
 
 // ============================================================================
 // TYPES
@@ -141,7 +141,8 @@ function extractFromSource(source: string, relPath: string, ext: string): Array<
 // PUBLIC API
 // ============================================================================
 
-const ENV_DECLARATION_FILES = new Set(['.env', '.env.example', '.env.local', '.env.test', '.env.production']);
+// ENV_DECLARATION_FILES is imported from bounded-file-scan: the disclosure predicate must be
+// built from the SAME list this scan reads, or an oversized `.env` is dropped without a word.
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.pyw', '.go', '.rb']);
 const SKIP_DIRS = ['/node_modules/', '/.openlore/', '/dist/', '/build/', '/coverage/'];
 

--- a/src/core/analyzer/env-extractor.ts
+++ b/src/core/analyzer/env-extractor.ts
@@ -13,7 +13,12 @@
 
 import { extname, relative, basename } from 'node:path';
 
-import { ENV_DECLARATION_FILES, mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
+import {
+  ENV_DECLARATION_FILES,
+  mapFilesBounded,
+  readSourceCapped,
+  type OversizedFileObserver,
+} from './bounded-file-scan.js';
 
 // ============================================================================
 // TYPES
@@ -151,7 +156,8 @@ const SKIP_DIRS = ['/node_modules/', '/.openlore/', '/dist/', '/build/', '/cover
  */
 export async function extractEnvVars(
   filePaths: string[],
-  rootDir: string
+  rootDir: string,
+  onOversized?: OversizedFileObserver,
 ): Promise<EnvVar[]> {
   const map = new Map<string, EnvVar>();
 
@@ -199,7 +205,7 @@ export async function extractEnvVars(
         if (fp.includes('.test.') || fp.includes('.spec.') || fp.includes('_test.') || fp.includes('_spec.')) return [];
       }
 
-      const source = await readSourceCapped(fp);
+      const source = await readSourceCapped(fp, undefined, onOversized);
       if (source === null) return [];
 
       // Env declaration files

--- a/src/core/analyzer/env-extractor.ts
+++ b/src/core/analyzer/env-extractor.ts
@@ -11,8 +11,9 @@
  * are marked required=true (no known default).
  */
 
-import { readFile } from 'node:fs/promises';
 import { extname, relative, basename } from 'node:path';
+
+import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
 
 // ============================================================================
 // TYPES
@@ -171,29 +172,37 @@ export async function extractEnvVars(
     }
   }
 
-  // Collect per-file upsert ops concurrently, then apply them sequentially in
-  // filePaths order. `Promise.all` resolves in INPUT order regardless of I/O
-  // completion, so a var's `files[]` order and its first-wins `description` are a
-  // pure function of the file list — upserting from inside the callbacks would make
-  // both depend on read-completion timing (decision c6d1ad07).
+  // Collect per-file upsert ops over a BOUNDED scan, then apply them sequentially in
+  // filePaths order. `mapFilesBounded` resolves in INPUT order regardless of I/O
+  // completion (and regardless of its concurrency), so a var's `files[]` order and its
+  // first-wins `description` are a pure function of the file list — upserting from inside
+  // the callbacks would make both depend on read-completion timing (decision c6d1ad07).
   type UpsertOp = { name: string; rel: string; patch: Partial<EnvVar> };
-  const perFileOps = await Promise.all(
-    filePaths.map(async (fp): Promise<UpsertOp[]> => {
+  const perFileOps = await mapFilesBounded(
+    filePaths,
+    async (fp): Promise<UpsertOp[]> => {
       if (SKIP_DIRS.some(d => fp.replace(/\\/g, '/').includes(d))) return [];
 
       const name = basename(fp);
       const ext = extname(fp).toLowerCase();
       const rel = relative(rootDir, fp);
 
-      let source: string;
-      try {
-        source = await readFile(fp, 'utf-8');
-      } catch {
-        return [];
+      const isDeclaration = ENV_DECLARATION_FILES.has(name);
+      // Decide whether this file can contribute BEFORE reading it. The read used to come
+      // first, so every file in the repository — images, archives, model weights — was
+      // decoded into a UTF-8 string only to be discarded one line later by the extension
+      // test. On a repository with large binary assets that alone could exhaust the heap.
+      if (!isDeclaration) {
+        if (!SOURCE_EXTENSIONS.has(ext)) return [];
+        // Skip test files
+        if (fp.includes('.test.') || fp.includes('.spec.') || fp.includes('_test.') || fp.includes('_spec.')) return [];
       }
 
+      const source = await readSourceCapped(fp);
+      if (source === null) return [];
+
       // Env declaration files
-      if (ENV_DECLARATION_FILES.has(name)) {
+      if (isDeclaration) {
         return parseEnvFile(source, rel).map(v => ({
           name: v.name,
           rel,
@@ -201,17 +210,12 @@ export async function extractEnvVars(
         }));
       }
 
-      // Source files
-      if (!SOURCE_EXTENSIONS.has(ext)) return [];
-      // Skip test files
-      if (fp.includes('.test.') || fp.includes('.spec.') || fp.includes('_test.') || fp.includes('_spec.')) return [];
-
       return extractFromSource(source, rel, ext).map(({ name: varName, required }) => ({
         name: varName,
         rel,
         patch: { required },
       }));
-    })
+    },
   );
 
   for (const op of perFileOps.flat()) {

--- a/src/core/analyzer/http-route-parser.ts
+++ b/src/core/analyzer/http-route-parser.ts
@@ -294,11 +294,19 @@ export async function extractHttpCalls(filePath: string): Promise<HttpCall[]> {
  * Extract all route definitions from a Python source file.
  * Supports FastAPI, Starlette, Flask, and Django (urls.py path/re_path).
  */
-export async function extractRouteDefinitions(filePath: string): Promise<RouteDefinition[]> {
+/**
+ * `residentSource` lets a caller that ALREADY holds the file's text pass it in instead of having
+ * it re-read and re-capped. The call-graph build is exactly that caller: it read every file into
+ * memory before Pass 1, so re-reading here bought nothing and the per-file size cap silently cost
+ * it the route-handler edges of any file above the cap — turning live handlers into `find_dead_code`
+ * candidates, the precise failure the length-preserving masking below exists to prevent
+ * (change: fix-unbounded-file-scan-oom).
+ */
+export async function extractRouteDefinitions(filePath: string, residentSource?: string): Promise<RouteDefinition[]> {
   const ext = extname(filePath).toLowerCase();
   if (!['.py', '.pyw'].includes(ext)) return [];
 
-  const content = await readSourceCapped(filePath);
+  const content = residentSource ?? await readSourceCapped(filePath);
   if (content === null) return [];
 
   const routes: RouteDefinition[] = [];
@@ -541,11 +549,11 @@ function extractNextJavaMethodName(lines: string[], annotationLine: number): str
  * Supports Spring MVC (@RestController / @Controller + @RequestMapping and the
  * shorthand @GetMapping / @PostMapping / …) and JAX-RS (@Path + @GET / @POST).
  */
-export async function extractJavaRouteDefinitions(filePath: string): Promise<RouteDefinition[]> {
+export async function extractJavaRouteDefinitions(filePath: string, residentSource?: string): Promise<RouteDefinition[]> {
   const ext = extname(filePath).toLowerCase();
   if (ext !== '.java') return [];
 
-  const content = await readSourceCapped(filePath);
+  const content = residentSource ?? await readSourceCapped(filePath);
   if (content === null) return [];
 
   const routes: RouteDefinition[] = [];
@@ -1051,8 +1059,8 @@ function detectTsFramework(source: string, filePath: string): string {
  * Extract HTTP route definitions from a TypeScript/JavaScript server file.
  * Handles Express-style, NestJS decorators, and Next.js App Router.
  */
-export async function extractTsRouteDefinitions(filePath: string): Promise<RouteDefinition[]> {
-  const raw = await readSourceCapped(filePath);
+export async function extractTsRouteDefinitions(filePath: string, residentSource?: string): Promise<RouteDefinition[]> {
+  const raw = residentSource ?? await readSourceCapped(filePath);
   if (raw === null) return [];
   // Mask comments LENGTH-PRESERVINGLY (blank to spaces, keep newlines) rather than
   // skeletonizing. The skeleton REMOVES pure-comment/log/blank lines and shrinks the
@@ -1063,9 +1071,20 @@ export async function extractTsRouteDefinitions(filePath: string): Promise<Route
   // with the original, so `route.line` is exact by construction while route pattern
   // strings inside comments still never match. Same length-preserving discipline as
   // extractHttpCalls (:193-195) and maskPythonNonCode (:906-908).
-  const source = raw
-    .replace(/\/\*[\s\S]*?\*\//g, blankKeepNewlines)
-    .replace(/(^|[\s,;()[\]{}])(\/\/.*)$/gm, (_m, prefix, comment) => prefix + ' '.repeat(comment.length));
+  //
+  // Masking stays INSIDE a guard. Before the bounded reader existed, this and the read shared one
+  // `try` and any failure here yielded `[]`; narrowing the guard to the read alone would let a
+  // throw from these regexes (a `RangeError` on a pathological string, say) propagate into
+  // `buildRouteInventory`, which does not catch per file. Today's per-file size cap makes that
+  // hard to reach — but the guard costs nothing and the cap is a tunable constant.
+  let source: string;
+  try {
+    source = raw
+      .replace(/\/\*[\s\S]*?\*\//g, blankKeepNewlines)
+      .replace(/(^|[\s,;()[\]{}])(\/\/.*)$/gm, (_m, prefix, comment) => prefix + ' '.repeat(comment.length));
+  } catch {
+    return [];
+  }
 
   const framework = detectTsFramework(source, filePath);
   const routes: RouteDefinition[] = [];

--- a/src/core/analyzer/http-route-parser.ts
+++ b/src/core/analyzer/http-route-parser.ts
@@ -28,7 +28,11 @@
 
 import { extname } from 'node:path';
 import { isTestFile } from './test-file.js';
-import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
+import {
+  mapFilesBounded,
+  readSourceCapped,
+  type OversizedFileObserver,
+} from './bounded-file-scan.js';
 
 // ============================================================================
 // TYPES
@@ -302,11 +306,15 @@ export async function extractHttpCalls(filePath: string): Promise<HttpCall[]> {
  * candidates, the precise failure the length-preserving masking below exists to prevent
  * (change: fix-unbounded-file-scan-oom).
  */
-export async function extractRouteDefinitions(filePath: string, residentSource?: string): Promise<RouteDefinition[]> {
+export async function extractRouteDefinitions(
+  filePath: string,
+  residentSource?: string,
+  onOversized?: OversizedFileObserver,
+): Promise<RouteDefinition[]> {
   const ext = extname(filePath).toLowerCase();
   if (!['.py', '.pyw'].includes(ext)) return [];
 
-  const content = residentSource ?? await readSourceCapped(filePath);
+  const content = residentSource ?? await readSourceCapped(filePath, undefined, onOversized);
   if (content === null) return [];
 
   const routes: RouteDefinition[] = [];
@@ -549,11 +557,15 @@ function extractNextJavaMethodName(lines: string[], annotationLine: number): str
  * Supports Spring MVC (@RestController / @Controller + @RequestMapping and the
  * shorthand @GetMapping / @PostMapping / …) and JAX-RS (@Path + @GET / @POST).
  */
-export async function extractJavaRouteDefinitions(filePath: string, residentSource?: string): Promise<RouteDefinition[]> {
+export async function extractJavaRouteDefinitions(
+  filePath: string,
+  residentSource?: string,
+  onOversized?: OversizedFileObserver,
+): Promise<RouteDefinition[]> {
   const ext = extname(filePath).toLowerCase();
   if (ext !== '.java') return [];
 
-  const content = residentSource ?? await readSourceCapped(filePath);
+  const content = residentSource ?? await readSourceCapped(filePath, undefined, onOversized);
   if (content === null) return [];
 
   const routes: RouteDefinition[] = [];
@@ -1059,8 +1071,12 @@ function detectTsFramework(source: string, filePath: string): string {
  * Extract HTTP route definitions from a TypeScript/JavaScript server file.
  * Handles Express-style, NestJS decorators, and Next.js App Router.
  */
-export async function extractTsRouteDefinitions(filePath: string, residentSource?: string): Promise<RouteDefinition[]> {
-  const raw = residentSource ?? await readSourceCapped(filePath);
+export async function extractTsRouteDefinitions(
+  filePath: string,
+  residentSource?: string,
+  onOversized?: OversizedFileObserver,
+): Promise<RouteDefinition[]> {
+  const raw = residentSource ?? await readSourceCapped(filePath, undefined, onOversized);
   if (raw === null) return [];
   // Mask comments LENGTH-PRESERVINGLY (blank to spaces, keep newlines) rather than
   // skeletonizing. The skeleton REMOVES pure-comment/log/blank lines and shrinks the
@@ -1254,7 +1270,8 @@ export interface RouteInventory {
  */
 export async function buildRouteInventory(
   filePaths: string[],
-  rootDir: string
+  rootDir: string,
+  onOversized?: OversizedFileObserver,
 ): Promise<RouteInventory> {
   const { relative } = await import('node:path');
 
@@ -1270,9 +1287,11 @@ export async function buildRouteInventory(
     // inventory doesn't report phantom endpoints.
     if (isTestFile(fp)) return [];
     const ext = extname(fp).toLowerCase();
-    if (['.py', '.pyw'].includes(ext)) return extractRouteDefinitions(fp);
-    if (['.ts', '.tsx', '.js', '.jsx', '.mjs'].includes(ext)) return extractTsRouteDefinitions(fp);
-    if (ext === '.java') return extractJavaRouteDefinitions(fp);
+    if (['.py', '.pyw'].includes(ext)) return extractRouteDefinitions(fp, undefined, onOversized);
+    if (['.ts', '.tsx', '.js', '.jsx', '.mjs'].includes(ext)) {
+      return extractTsRouteDefinitions(fp, undefined, onOversized);
+    }
+    if (ext === '.java') return extractJavaRouteDefinitions(fp, undefined, onOversized);
     return [];
   });
   const allRoutes: RouteDefinition[] = perFile.flat();

--- a/src/core/analyzer/http-route-parser.ts
+++ b/src/core/analyzer/http-route-parser.ts
@@ -26,9 +26,9 @@
  *   fuzzy   — normalised path matches after prefix stripping
  */
 
-import { readFile } from 'node:fs/promises';
 import { extname } from 'node:path';
 import { isTestFile } from './test-file.js';
+import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
 
 // ============================================================================
 // TYPES
@@ -171,12 +171,8 @@ export async function extractHttpCalls(filePath: string): Promise<HttpCall[]> {
   const ext = extname(filePath).toLowerCase();
   if (!['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'].includes(ext)) return [];
 
-  let content: string;
-  try {
-    content = await readFile(filePath, 'utf8');
-  } catch {
-    return [];
-  }
+  const content = await readSourceCapped(filePath);
+  if (content === null) return [];
 
   const calls: HttpCall[] = [];
 
@@ -302,12 +298,8 @@ export async function extractRouteDefinitions(filePath: string): Promise<RouteDe
   const ext = extname(filePath).toLowerCase();
   if (!['.py', '.pyw'].includes(ext)) return [];
 
-  let content: string;
-  try {
-    content = await readFile(filePath, 'utf8');
-  } catch {
-    return [];
-  }
+  const content = await readSourceCapped(filePath);
+  if (content === null) return [];
 
   const routes: RouteDefinition[] = [];
   const lines = content.split('\n');
@@ -553,12 +545,8 @@ export async function extractJavaRouteDefinitions(filePath: string): Promise<Rou
   const ext = extname(filePath).toLowerCase();
   if (ext !== '.java') return [];
 
-  let content: string;
-  try {
-    content = await readFile(filePath, 'utf8');
-  } catch {
-    return [];
-  }
+  const content = await readSourceCapped(filePath);
+  if (content === null) return [];
 
   const routes: RouteDefinition[] = [];
   const lines = content.split('\n');
@@ -838,14 +826,16 @@ export async function extractAllHttpEdges(filePaths: string[]): Promise<{
   routes: RouteDefinition[];
   edges: HttpEdge[];
 }> {
-  // Collect per-file results and flatten in filePaths order. `Promise.all` resolves
-  // in INPUT order regardless of completion order, so the aggregated calls/routes
-  // (and therefore the edges) are a deterministic function of the file list — NOT of
-  // filesystem I/O timing. Pushing into shared arrays inside the callbacks would
-  // append in completion order, a latent byte-determinism hazard the spec forbids
-  // (and the shareable-bundle digest relies on).
-  const perFile = await Promise.all(
-    filePaths.map(async (fp): Promise<{ calls: HttpCall[]; routes: RouteDefinition[] }> => {
+  // Collect per-file results over a BOUNDED scan and flatten in filePaths order.
+  // `mapFilesBounded` resolves in INPUT order regardless of completion order (and
+  // regardless of its concurrency), so the aggregated calls/routes (and therefore the
+  // edges) are a deterministic function of the file list — NOT of filesystem I/O timing.
+  // Pushing into shared arrays inside the callbacks would append in completion order, a
+  // latent byte-determinism hazard the spec forbids (and the shareable-bundle digest
+  // relies on).
+  const perFile = await mapFilesBounded(
+    filePaths,
+    async (fp): Promise<{ calls: HttpCall[]; routes: RouteDefinition[] }> => {
       const ext = extname(fp).toLowerCase();
       if (['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'].includes(ext)) {
         // A JS/TS file can be a client (fetch/axios calls), a server (route
@@ -853,10 +843,12 @@ export async function extractAllHttpEdges(filePaths: string[]): Promise<{
         // SAME-LANGUAGE client→server link (TS frontend → TS Express/NestJS/Next
         // backend) is matched — not only the cross-language JS/TS→Python/Java
         // case. Routes in .py/.java files are already extracted below.
-        const [calls, routes] = await Promise.all([
-          extractHttpCalls(fp),
-          extractTsRouteDefinitions(fp),
-        ]);
+        //
+        // Sequentially, not as a nested `Promise.all`: both passes read the SAME file, so
+        // running them together held two copies of it per scan slot and doubled the bound
+        // this scan exists to enforce.
+        const calls = await extractHttpCalls(fp);
+        const routes = await extractTsRouteDefinitions(fp);
         return { calls, routes };
       } else if (['.py', '.pyw'].includes(ext)) {
         return { calls: [], routes: await extractRouteDefinitions(fp) };
@@ -864,7 +856,7 @@ export async function extractAllHttpEdges(filePaths: string[]): Promise<{
         return { calls: [], routes: await extractJavaRouteDefinitions(fp) };
       }
       return { calls: [], routes: [] };
-    })
+    },
   );
   const allCalls: HttpCall[] = perFile.flatMap(r => r.calls);
   const allRoutes: RouteDefinition[] = perFile.flatMap(r => r.routes);
@@ -1060,24 +1052,20 @@ function detectTsFramework(source: string, filePath: string): string {
  * Handles Express-style, NestJS decorators, and Next.js App Router.
  */
 export async function extractTsRouteDefinitions(filePath: string): Promise<RouteDefinition[]> {
-  let source: string;
-  try {
-    const raw = await readFile(filePath, 'utf-8');
-    // Mask comments LENGTH-PRESERVINGLY (blank to spaces, keep newlines) rather than
-    // skeletonizing. The skeleton REMOVES pure-comment/log/blank lines and shrinks the
-    // text, so every `route.line` was computed in a coordinate system offset from the
-    // ORIGINAL file that synthesizeRouteHandlerEdges (call-graph.ts) and find_dead_code
-    // consume it against — silently dropping or mis-attributing route-handler edges and
-    // surfacing live handlers as false dead-code. Blanking keeps the string byte-aligned
-    // with the original, so `route.line` is exact by construction while route pattern
-    // strings inside comments still never match. Same length-preserving discipline as
-    // extractHttpCalls (:193-195) and maskPythonNonCode (:906-908).
-    source = raw
-      .replace(/\/\*[\s\S]*?\*\//g, blankKeepNewlines)
-      .replace(/(^|[\s,;()[\]{}])(\/\/.*)$/gm, (_m, prefix, comment) => prefix + ' '.repeat(comment.length));
-  } catch {
-    return [];
-  }
+  const raw = await readSourceCapped(filePath);
+  if (raw === null) return [];
+  // Mask comments LENGTH-PRESERVINGLY (blank to spaces, keep newlines) rather than
+  // skeletonizing. The skeleton REMOVES pure-comment/log/blank lines and shrinks the
+  // text, so every `route.line` was computed in a coordinate system offset from the
+  // ORIGINAL file that synthesizeRouteHandlerEdges (call-graph.ts) and find_dead_code
+  // consume it against — silently dropping or mis-attributing route-handler edges and
+  // surfacing live handlers as false dead-code. Blanking keeps the string byte-aligned
+  // with the original, so `route.line` is exact by construction while route pattern
+  // strings inside comments still never match. Same length-preserving discipline as
+  // extractHttpCalls (:193-195) and maskPythonNonCode (:906-908).
+  const source = raw
+    .replace(/\/\*[\s\S]*?\*\//g, blankKeepNewlines)
+    .replace(/(^|[\s,;()[\]{}])(\/\/.*)$/gm, (_m, prefix, comment) => prefix + ' '.repeat(comment.length));
 
   const framework = detectTsFramework(source, filePath);
   const routes: RouteDefinition[] = [];
@@ -1251,24 +1239,23 @@ export async function buildRouteInventory(
 ): Promise<RouteInventory> {
   const { relative } = await import('node:path');
 
-  // Collect per-file routes and flatten in filePaths order. `Promise.all` resolves
-  // in INPUT order regardless of completion order, so the inventory is a deterministic
-  // function of the file list — pushing into a shared array inside the callbacks would
-  // append in I/O-completion order (the byte-determinism hazard `extractAllHttpEdges`
-  // documents and fixes above).
-  const perFile = await Promise.all(
-    filePaths.map(async (fp): Promise<RouteDefinition[]> => {
-      // Routes declared inside test files (e.g. a `fastify.get('/error')` set up by a
-      // test harness) are fixtures, not the app's real API surface — exclude them so the
-      // inventory doesn't report phantom endpoints.
-      if (isTestFile(fp)) return [];
-      const ext = extname(fp).toLowerCase();
-      if (['.py', '.pyw'].includes(ext)) return extractRouteDefinitions(fp);
-      if (['.ts', '.tsx', '.js', '.jsx', '.mjs'].includes(ext)) return extractTsRouteDefinitions(fp);
-      if (ext === '.java') return extractJavaRouteDefinitions(fp);
-      return [];
-    })
-  );
+  // Collect per-file routes over a BOUNDED scan and flatten in filePaths order.
+  // `mapFilesBounded` resolves in INPUT order regardless of completion order (and
+  // regardless of its concurrency), so the inventory is a deterministic function of the
+  // file list — pushing into a shared array inside the callbacks would append in
+  // I/O-completion order (the byte-determinism hazard `extractAllHttpEdges` documents
+  // and fixes above).
+  const perFile = await mapFilesBounded(filePaths, async (fp): Promise<RouteDefinition[]> => {
+    // Routes declared inside test files (e.g. a `fastify.get('/error')` set up by a
+    // test harness) are fixtures, not the app's real API surface — exclude them so the
+    // inventory doesn't report phantom endpoints.
+    if (isTestFile(fp)) return [];
+    const ext = extname(fp).toLowerCase();
+    if (['.py', '.pyw'].includes(ext)) return extractRouteDefinitions(fp);
+    if (['.ts', '.tsx', '.js', '.jsx', '.mjs'].includes(ext)) return extractTsRouteDefinitions(fp);
+    if (ext === '.java') return extractJavaRouteDefinitions(fp);
+    return [];
+  });
   const allRoutes: RouteDefinition[] = perFile.flat();
 
   const byMethod: Record<string, number> = {};

--- a/src/core/analyzer/middleware-extractor.ts
+++ b/src/core/analyzer/middleware-extractor.ts
@@ -7,9 +7,9 @@
  * Detection is purely regex-based — no AST parsing required.
  */
 
-import { readFile } from 'node:fs/promises';
 import { extname, relative, basename } from 'node:path';
 import { isTestFile } from './test-file.js';
+import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
 import { blankCommentsPreservingLayout } from './comment-blanking.js';
 
 // ============================================================================
@@ -263,28 +263,23 @@ export async function extractMiddleware(
   filePaths: string[],
   rootDir: string
 ): Promise<MiddlewareEntry[]> {
-  const results: MiddlewareEntry[] = [];
+  // Per-file-then-flatten, over a BOUNDED scan. Flattening in `filePaths` order keeps the
+  // inventory a pure function of the file list; pushing into a shared array from inside the
+  // callbacks appended in I/O-completion order, which made the artifact's bytes depend on disk
+  // timing (change: fix-artifact-output-determinism) and would additionally have made the order
+  // depend on the scan's concurrency.
+  const perFile = await mapFilesBounded(filePaths, async (fp): Promise<MiddlewareEntry[]> => {
+    // Middleware/validation declared in test files are fixtures/assertions, not the
+    // app's real middleware surface — exclude them (they produced phantom entries).
+    if (isTestFile(fp)) return [];
+    const ext = extname(fp).toLowerCase();
+    if (!['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'].includes(ext)) return [];
 
-  await Promise.all(
-    filePaths.map(async fp => {
-      // Middleware/validation declared in test files are fixtures/assertions, not the
-      // app's real middleware surface — exclude them (they produced phantom entries).
-      if (isTestFile(fp)) return;
-      const ext = extname(fp).toLowerCase();
-      if (!['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'].includes(ext)) return;
+    const source = await readSourceCapped(fp);
+    if (source === null) return [];
 
-      let source: string;
-      try {
-        source = await readFile(fp, 'utf-8');
-      } catch {
-        return;
-      }
+    return extractFromSource(source, relative(rootDir, fp), fp);
+  });
 
-      const rel = relative(rootDir, fp);
-      const entries = extractFromSource(source, rel, fp);
-      results.push(...entries);
-    })
-  );
-
-  return results;
+  return perFile.flat();
 }

--- a/src/core/analyzer/middleware-extractor.ts
+++ b/src/core/analyzer/middleware-extractor.ts
@@ -9,7 +9,11 @@
 
 import { extname, relative, basename } from 'node:path';
 import { isTestFile } from './test-file.js';
-import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
+import {
+  mapFilesBounded,
+  readSourceCapped,
+  type OversizedFileObserver,
+} from './bounded-file-scan.js';
 import { blankCommentsPreservingLayout } from './comment-blanking.js';
 
 // ============================================================================
@@ -261,7 +265,8 @@ function extractFromSource(
  */
 export async function extractMiddleware(
   filePaths: string[],
-  rootDir: string
+  rootDir: string,
+  onOversized?: OversizedFileObserver,
 ): Promise<MiddlewareEntry[]> {
   // Per-file-then-flatten, over a BOUNDED scan. Flattening in `filePaths` order keeps the
   // inventory a pure function of the file list; pushing into a shared array from inside the
@@ -275,7 +280,7 @@ export async function extractMiddleware(
     const ext = extname(fp).toLowerCase();
     if (!['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'].includes(ext)) return [];
 
-    const source = await readSourceCapped(fp);
+    const source = await readSourceCapped(fp, undefined, onOversized);
     if (source === null) return [];
 
     return extractFromSource(source, relative(rootDir, fp), fp);

--- a/src/core/analyzer/schema-extractor.ts
+++ b/src/core/analyzer/schema-extractor.ts
@@ -12,7 +12,11 @@
 
 import { extname, relative } from 'node:path';
 import { getSkeletonContent } from './code-shaper.js';
-import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
+import {
+  mapFilesBounded,
+  readSourceCapped,
+  type OversizedFileObserver,
+} from './bounded-file-scan.js';
 
 // ============================================================================
 // TYPES
@@ -337,7 +341,8 @@ function parseJpaEntity(source: string, rel: string): SchemaTable[] {
  */
 export async function extractSchemas(
   filePaths: string[],
-  rootDir: string
+  rootDir: string,
+  onOversized?: OversizedFileObserver,
 ): Promise<SchemaTable[]> {
   // Per-file-then-flatten, over a BOUNDED scan. Returning each file's tables and flattening in
   // `filePaths` order keeps the inventory a pure function of the file list; pushing into a shared
@@ -348,7 +353,7 @@ export async function extractSchemas(
     const ext = extname(filePath).toLowerCase();
     const rel = relative(rootDir, filePath);
 
-    const raw = await readSourceCapped(filePath);
+    const raw = await readSourceCapped(filePath, undefined, onOversized);
     if (raw === null) return [];
 
     // Java entities are parsed from raw source — annotations and field

--- a/src/core/analyzer/schema-extractor.ts
+++ b/src/core/analyzer/schema-extractor.ts
@@ -10,9 +10,9 @@
  * Uses regex-based analysis without requiring tree-sitter.
  */
 
-import { readFile } from 'node:fs/promises';
 import { extname, relative } from 'node:path';
 import { getSkeletonContent } from './code-shaper.js';
+import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
 
 // ============================================================================
 // TYPES
@@ -339,46 +339,41 @@ export async function extractSchemas(
   filePaths: string[],
   rootDir: string
 ): Promise<SchemaTable[]> {
-  const results: SchemaTable[] = [];
+  // Per-file-then-flatten, over a BOUNDED scan. Returning each file's tables and flattening in
+  // `filePaths` order keeps the inventory a pure function of the file list; pushing into a shared
+  // array from inside the callbacks appended in I/O-completion order, which made the artifact's
+  // bytes depend on disk timing (change: fix-artifact-output-determinism) and would additionally
+  // have made the order depend on the scan's concurrency.
+  const perFile = await mapFilesBounded(filePaths, async (filePath): Promise<SchemaTable[]> => {
+    const ext = extname(filePath).toLowerCase();
+    const rel = relative(rootDir, filePath);
 
-  await Promise.all(
-    filePaths.map(async filePath => {
-      const ext = extname(filePath).toLowerCase();
-      const rel = relative(rootDir, filePath);
-      let raw: string;
+    const raw = await readSourceCapped(filePath);
+    if (raw === null) return [];
 
-      try {
-        raw = await readFile(filePath, 'utf-8');
-      } catch {
-        return;
+    // Java entities are parsed from raw source — annotations and field
+    // declarations must survive intact (the TS/Py skeletonizer would mangle them).
+    if (ext === '.java') {
+      return /@(?:Entity|MappedSuperclass)\b/.test(raw) ? parseJpaEntity(raw, rel) : [];
+    }
+
+    const source = getSkeletonContent(raw, ext === '.py' ? 'python' : 'typescript');
+
+    if (ext === '.prisma') {
+      return parsePrisma(source, rel);
+    } else if (ext === '.py' && (source.includes('Column(') || source.includes('mapped_column('))) {
+      return parseSqlAlchemy(source, rel);
+    } else if (ext === '.ts' || ext === '.tsx') {
+      if (source.includes('@Entity(') || source.includes('@Entity()')) {
+        return parseTypeOrm(source, rel);
+      } else if (/pgTable|mysqlTable|sqliteTable/.test(source)) {
+        return parseDrizzle(source, rel);
       }
+    }
+    return [];
+  });
 
-      // Java entities are parsed from raw source — annotations and field
-      // declarations must survive intact (the TS/Py skeletonizer would mangle them).
-      if (ext === '.java') {
-        if (/@(?:Entity|MappedSuperclass)\b/.test(raw)) {
-          results.push(...parseJpaEntity(raw, rel));
-        }
-        return;
-      }
-
-      const source = getSkeletonContent(raw, ext === '.py' ? 'python' : 'typescript');
-
-      if (ext === '.prisma') {
-        results.push(...parsePrisma(source, rel));
-      } else if (ext === '.py' && (source.includes('Column(') || source.includes('mapped_column('))) {
-        results.push(...parseSqlAlchemy(source, rel));
-      } else if (ext === '.ts' || ext === '.tsx') {
-        if (source.includes('@Entity(') || source.includes('@Entity()')) {
-          results.push(...parseTypeOrm(source, rel));
-        } else if (/pgTable|mysqlTable|sqliteTable/.test(source)) {
-          results.push(...parseDrizzle(source, rel));
-        }
-      }
-    })
-  );
-
-  return results;
+  return perFile.flat();
 }
 
 /**

--- a/src/core/analyzer/ui-component-extractor.ts
+++ b/src/core/analyzer/ui-component-extractor.ts
@@ -13,7 +13,11 @@
 
 import { basename, extname, relative } from 'node:path';
 
-import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
+import {
+  mapFilesBounded,
+  readSourceCapped,
+  type OversizedFileObserver,
+} from './bounded-file-scan.js';
 
 // ============================================================================
 // TYPES
@@ -147,10 +151,14 @@ function lineOfIndex(source: string, index: number): number {
 // PER-FILE EXTRACTOR
 // ============================================================================
 
-async function extractFromFile(filePath: string, rootDir: string): Promise<UIComponent[]> {
+async function extractFromFile(
+  filePath: string,
+  rootDir: string,
+  onOversized?: OversizedFileObserver,
+): Promise<UIComponent[]> {
   const ext = extname(filePath).toLowerCase();
   const rel = relative(rootDir, filePath);
-  const source = await readSourceCapped(filePath);
+  const source = await readSourceCapped(filePath, undefined, onOversized);
   if (source === null) return [];
 
   // ── Svelte ────────────────────────────────────────────────────────────────
@@ -277,13 +285,14 @@ async function extractFromFile(filePath: string, rootDir: string): Promise<UICom
  */
 export async function extractUIComponents(
   filePaths: string[],
-  rootDir: string
+  rootDir: string,
+  onOversized?: OversizedFileObserver,
 ): Promise<UIComponent[]> {
   const UI_EXTENSIONS = new Set(['.tsx', '.jsx', '.vue', '.svelte', '.ts', '.js']);
 
   const candidates = filePaths.filter(f => UI_EXTENSIONS.has(extname(f).toLowerCase()));
 
-  const results = await mapFilesBounded(candidates, f => extractFromFile(f, rootDir));
+  const results = await mapFilesBounded(candidates, f => extractFromFile(f, rootDir, onOversized));
 
   return results.flat();
 }

--- a/src/core/analyzer/ui-component-extractor.ts
+++ b/src/core/analyzer/ui-component-extractor.ts
@@ -11,8 +11,9 @@
  *   - Angular: @Component decorator
  */
 
-import { readFile } from 'node:fs/promises';
 import { basename, extname, relative } from 'node:path';
+
+import { mapFilesBounded, readSourceCapped } from './bounded-file-scan.js';
 
 // ============================================================================
 // TYPES
@@ -149,13 +150,8 @@ function lineOfIndex(source: string, index: number): number {
 async function extractFromFile(filePath: string, rootDir: string): Promise<UIComponent[]> {
   const ext = extname(filePath).toLowerCase();
   const rel = relative(rootDir, filePath);
-  let source: string;
-
-  try {
-    source = await readFile(filePath, 'utf-8');
-  } catch {
-    return [];
-  }
+  const source = await readSourceCapped(filePath);
+  if (source === null) return [];
 
   // ── Svelte ────────────────────────────────────────────────────────────────
   if (ext === '.svelte') {
@@ -287,9 +283,7 @@ export async function extractUIComponents(
 
   const candidates = filePaths.filter(f => UI_EXTENSIONS.has(extname(f).toLowerCase()));
 
-  const results = await Promise.all(
-    candidates.map(f => extractFromFile(f, rootDir))
-  );
+  const results = await mapFilesBounded(candidates, f => extractFromFile(f, rootDir));
 
   return results.flat();
 }

--- a/src/core/services/mcp-handlers/live-data/analyze-repo.ts
+++ b/src/core/services/mcp-handlers/live-data/analyze-repo.ts
@@ -12,6 +12,7 @@
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { mapFilesBounded } from '../../../analyzer/bounded-file-scan.js';
 import { openloreInit } from '../../../../api/init.js';
 import { openloreAnalyze } from '../../../../api/analyze.js';
 import { VectorIndex } from '../../../analyzer/vector-index.js';
@@ -69,16 +70,23 @@ async function buildKeywordIndex(
   const hubIds = new Set(cg.hubFunctions.map((f) => f.id));
   const entryIds = new Set(cg.entryPoints.map((f) => f.id));
 
+  // Bounded scan, not `Promise.all` over every path: issuing one read per file at once made the
+  // transient peak the whole repository's bytes ON TOP OF the map this retains — the fan-out OOM
+  // (issue #302). Only the fan-out is bounded here, deliberately: the scan's per-file SIZE cap is
+  // not applied, because dropping a large file would quietly remove it from the search index, and
+  // this path has nowhere to disclose that. Retention is therefore unchanged from before.
   const fileContents = new Map<string, string>();
-  await Promise.all(
-    [...new Set(cg.nodes.map((n) => n.filePath))].map(async (fp) => {
-      try {
-        fileContents.set(fp, await readFile(join(dir, fp), 'utf-8'));
-      } catch {
-        /* skip unreadable files */
-      }
-    }),
-  );
+  const paths = [...new Set(cg.nodes.map((n) => n.filePath))];
+  const contents = await mapFilesBounded(paths, async (fp) => {
+    try {
+      return await readFile(join(dir, fp), 'utf-8');
+    } catch {
+      return null; // skip unreadable files
+    }
+  });
+  for (const [i, content] of contents.entries()) {
+    if (content !== null) fileContents.set(paths[i], content);
+  }
 
   await VectorIndex.build(analysisDir, cg.nodes as Parameters<typeof VectorIndex.build>[1], sigs, hubIds, entryIds, null, fileContents, false);
 }

--- a/src/core/services/mcp-handlers/live-data/analyze-repo.ts
+++ b/src/core/services/mcp-handlers/live-data/analyze-repo.ts
@@ -70,11 +70,13 @@ async function buildKeywordIndex(
   const hubIds = new Set(cg.hubFunctions.map((f) => f.id));
   const entryIds = new Set(cg.entryPoints.map((f) => f.id));
 
-  // Bounded scan, not `Promise.all` over every path: issuing one read per file at once made the
-  // transient peak the whole repository's bytes ON TOP OF the map this retains — the fan-out OOM
-  // (issue #302). Only the fan-out is bounded here, deliberately: the scan's per-file SIZE cap is
-  // not applied, because dropping a large file would quietly remove it from the search index, and
-  // this path has nowhere to disclose that. Retention is therefore unchanged from before.
+  // Bounded scan, not `Promise.all` over every path: issuing one read per file at once put a
+  // second copy of the whole repository on the heap as a transient spike, on top of the map this
+  // builds (issue #302). Only the DECODE SPIKE is removed — be precise about that: this index
+  // retains every file's text by design, so peak residency here is still a function of repository
+  // size, and a single very large file is still read whole. The per-file SIZE cap is deliberately
+  // NOT applied, because dropping a large file would quietly remove it from the search index and
+  // this path has nowhere to disclose that.
   const fileContents = new Map<string, string>();
   const paths = [...new Set(cg.nodes.map((n) => n.filePath))];
   const contents = await mapFilesBounded(paths, async (fp) => {


### PR DESCRIPTION
**Status:** Ready for review. This addresses the phase-3 crash site in #302. Keep #302 open until the #304 follow-up makes the reporter's full `install` path complete.

## What was wrong

`openlore install` and `openlore analyze` crashed with `FATAL ERROR: ... JavaScript heap out of memory` while extracting UI components, schemas, routes, middleware, and environment variables.

Each enrichment extractor issued every repository read simultaneously, and all 5 extractors ran at once. The production function index, text-line index, MCP live-data index, and import rebuild contained the same all-file fan-out shape. Peak decoded-source memory therefore scaled with repository size rather than a concurrency bound.

## How it was fixed

- Repository-wide enrichment and indexing reads use one shared worker pool with at most 8 files in flight.
- Enrichment files are measured and read through one handle, and only the measured bytes are read. A 4 MB per-file cap prevents one generated source file from exhausting the heap.
- The 5 enrichment extractors run sequentially, so their bounds do not multiply.
- Results remain in input order, preserving deterministic artifacts.
- Oversized enrichment files are reported from the exact scan-time size observation that excluded them. Files changed after repository walking are not silently lost because of stale walker metadata.
- Route-handler synthesis uses source already resident in the call graph, preserving edges from files above the enrichment cap.

## Proof

| | 300 files / 439 MB | 6,000 files / 234 MB |
| --- | --- | --- |
| before (`main`) | **out of memory** | 3,112 MB peak |
| after | completes under a 512 MB heap | **405 MB peak** |

On a real 770-file codebase, all 5 inventories and `llm-context.json` are byte-identical to `main`.

Final local verification after merging current `main`:

- all required GitHub checks pass: unit tests, build, lint/type check, and CodeQL;
- local build, type check, and lint pass;
- 83 targeted bounded-scan, race, determinism, and integration tests pass;
- full suite: 6,524 passed, 2 skipped, with 1 existing serve cleanup-race failure that passed immediately in isolation.

## What adversarial review changed

Multiple independent reviews found and fixed:

- `handle.readFile()` read past the size checked if a file grew;
- a rejected worker pool could keep scanning behind the next phase;
- the enrichment cap could silently remove call-graph route edges;
- oversized `.env` files could be omitted without disclosure;
- repository-controlled filenames could forge terminal output;
- production CLI/install indexing still had an unbounded all-file read fan-out;
- oversized disclosure used a stale repository-walk size instead of the size that caused the scan to skip.

Regression guards cover all 5 enrichment modules plus production CLI/install, MCP live-data, import, call-graph route synthesis, and text indexing.

## Remaining blocker for #302

This fixes the reported phase-3 crash site, but a repository of the reporter's size still reaches a distinct phase-4 ceiling tracked in #304. On a 3,500-file / 205 MB repository at a 2 GB heap, the peak is 2,354 MB:

- file content: 194 MB;
- nodes and edges: 18 MB;
- CFG/def-use overlay: **1,574 MB**.

The overlay is transient but currently retained for every function at once. The #304 follow-up must land and the original `install` workflow must complete under the 2 GB heap before #302 is closed.
