### PR TITLE
test(analyzer): tell a missing optional grammar apart from a broken extractor

### DIFF
--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -1906,6 +1906,27 @@ async function loadWasmGrammarSoft(
   }
 }
 
+/**
+ * Did a grammar load attempt for this language already FAIL in this process?
+ *
+ * Every soft loader records `null` in the handle cache when a grammar cannot be loaded — an
+ * optional dependency that was not installed, a native binding that will not build, a WASM file
+ * that is absent. This reports that, so a caller can tell "the grammar is not here" apart from
+ * "the grammar is here and produced nothing", which are the same empty result but very different
+ * facts. `false` also means "not attempted yet"; drive an extraction first.
+ *
+ * Exists because the two are indistinguishable at the assertion site: when `tree-sitter-kotlin`
+ * failed to install in CI, nine tests failed with messages like `expected [] to include 'main'`,
+ * which reads exactly like a broken extractor and cost real time to diagnose as an install
+ * problem. The grammars are `optionalDependencies` BY DESIGN (`loadGrammarSoft`, restricted
+ * environments) — so a suite that cannot distinguish absence from breakage will keep going red
+ * for reasons that are not defects.
+ */
+export function grammarLoadFailed(language: string): boolean {
+  return _grammarHandleCache.get(language) === null
+    || _grammarHandleCache.get(`wasm:${language}`) === null;
+}
+
 /** Reset loader caches — test-only hook for the graceful-degradation test. */
 export function __resetGrammarCacheForTests(): void {
   _grammarHandleCache.clear();

--- a/src/core/analyzer/language-capability-conformance.test.ts
+++ b/src/core/analyzer/language-capability-conformance.test.ts
@@ -22,7 +22,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { CallGraphBuilder } from './call-graph.js';
-import { CALLGRAPH_LANGUAGES } from './call-graph.js';
+import { CALLGRAPH_LANGUAGES, grammarLoadFailed } from './call-graph.js';
 import { ERROR_PROPAGATION_LANGUAGES, extractExceptionFactsFromSource } from './exception-flow.js';
 import { cfgSupportsLanguage, isStructurallyValid } from './cfg.js';
 import { inferTypesFromSource, TYPE_INFERENCE_LANGUAGES } from './type-inference-engine.js';
@@ -68,6 +68,33 @@ const BASIC: Basic[] = [
   { language: 'Elixir', path: 'm.ex', caller: 'main', callee: 'helper', content: `defmodule M do\n  def helper(), do: 1\n  def main(), do: helper()\nend\n` },
   { language: 'Bash', path: 'm.sh', caller: 'main', callee: 'helper', content: `helper() { echo hi; }\nmain() { helper; }\n` },
 ];
+
+/**
+ * Runs FIRST, so that when a grammar is missing this is the failure an engineer reads rather than
+ * a dozen `expected [] to include 'main'` assertions further down.
+ *
+ * The grammars are `optionalDependencies` loaded through `loadGrammarSoft` — by design, so
+ * `npm install` still succeeds in restricted environments. That means an install can legitimately
+ * come up short, and when `tree-sitter-kotlin` did exactly that in CI, nine tests failed with
+ * messages indistinguishable from a broken extractor. The absence and the breakage produce the
+ * same empty result; only the loader knows which happened, and this asks it.
+ */
+describe('language conformance — grammar availability (diagnostic, runs first)', () => {
+  it('reports which claimed call-graph grammars failed to LOAD, separately from what they extract', async () => {
+    const unavailable: string[] = [];
+    for (const f of BASIC) {
+      await build([{ path: f.path, language: f.language, content: f.content }]);
+      if (grammarLoadFailed(f.language)) unavailable.push(f.language);
+    }
+
+    expect(
+      unavailable,
+      `these grammars did not LOAD, so every capability assertion for them below is about a missing `
+      + `optional dependency rather than a code defect: ${unavailable.join(', ')}. `
+      + `Reinstall (npm ci) and re-run before investigating the extractor.`,
+    ).toEqual([]);
+  });
+});
 
 describe('language conformance — basic call graph (every claimed callGraph language)', () => {
   // Guard: if the registry adds a callGraph language, this sweep must cover it.


### PR DESCRIPTION
**Status:** Ready for review. Closes the CI fragility that turned main red after #305 merged. See the last section — it also documents why #306 was closed as invalid rather than fixed.

## What was wrong

CI on main went red with nine failures, all Kotlin, reading:

```
AssertionError: Kotlin functions: expected [] to include 'main'
```

That reads exactly like a call-graph regression. It wasn't — a plain re-run with **no code change** went green. `tree-sitter-kotlin` had simply not installed that time.

The grammars are `optionalDependencies` loaded through `loadGrammarSoft()`, deliberately, so `npm install` still succeeds in restricted environments. The consequence nobody had closed: **an absent grammar and a broken extractor produce the identical empty result** at every assertion site. Only the loader knows which happened, and nothing was asking it.

## The fix

`grammarLoadFailed(language)` reports it. The soft loaders already record `null` in the handle cache when a grammar cannot be loaded — that signal existed and was simply unread.

A diagnostic case placed **first** in the conformance sweep now fails with the grammar named and the remedy stated, so that is what an engineer reads instead of a dozen misleading assertions further down.

## Proof

Hiding `tree-sitter-kotlin` and re-running reproduces the CI failure exactly, and the diagnostic is now the first failure reported:

```
× reports which claimed call-graph grammars failed to LOAD, separately from what they extract
  AssertionError: these grammars did not LOAD, so every capability assertion for them below is
  about a missing optional dependency rather than a code defect: Kotlin. Reinstall (npm ci) and
  re-run before investigating the extractor.
```

Full suite green: 6,547 passed, 337/337.

## Why #306 is closed as invalid, not fixed

I filed #306 claiming #305 cost 14% of `analyze`'s wall clock. **I never checked the exit codes.** The baseline was crashing:

| | e2e2, 3,500 files |
| --- | --- |
| pre-#305 (`3d75a35`) | **exit 134**, 239s, `FATAL ERROR: heap out of memory` |
| post-#305 | **exit 0**, 260s, completes |

The "baseline" was time-to-OOM, not time-to-complete. The post-#305 run does strictly more work — finishes the call graph, builds a 31,501-function keyword index and a 3,955,003-line text index — and succeeds where the baseline died. The same error invalidates the 5× figure I recorded there for a prototype.

I also built the memory-first spill that issue proposed, then isolated its cost by disabling spilling entirely (threshold `MAX_SAFE_INTEGER`): **263s/263s/260s with it, 283s/256s without.** No difference — the spill is not measurably part of the wall clock either. That work is reverted; this PR contains none of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)