### PR TITLE
fix(generator): confine spec-writer output to the project root (GHSA-5j8x-q7q6-58j5)

### DIFF
--- a/openspec/specs/mcp-security/spec.md
+++ b/openspec/specs/mcp-security/spec.md
@@ -356,6 +356,33 @@ outside the project root.
 - **THEN** it is confined to (or rejected against) the project's `.openlore/`/`openspec/`
   trees, and nothing outside the root is created or modified
 
+### Requirement: Spec-Generation Writer Confines LLM-Derived Paths
+
+The spec-generation writer (`openlore generate`, `OpenSpecFormatGenerator` +
+`OpenSpecWriter`) is the one write path that intentionally puts an LLM in the loop, and
+the LLM is fed **raw content from the analyzed repository**. The domain segment of every
+generated spec path derives from the Stage-3 `domain` field the model returns over that
+untrusted content. That value SHALL be normalized to a safe, single-segment directory name
+before it becomes a path, and every spec write SHALL be confined to the validated project
+root through the shared `safeJoin` guard — the same guard the MCP, `serve`, and `view`
+surfaces already route through. A spec path that resolves outside the root SHALL be refused
+(that spec skipped with a warning), never written. This closes the exact "repo content
+redirects a write outside the project root" gap on the generation surface that this spec
+already hardens elsewhere.
+
+#### Scenario: A traversal domain cannot escape the root
+- **GIVEN** a Stage-3 service whose `domain` is a path-traversal string (e.g.
+  `../../../../tmp/x`)
+- **WHEN** the generator builds the spec path and the writer writes it
+- **THEN** the domain is normalized to a plain in-root directory name and the spec lands
+  under `openspec/specs/`, never outside the project root
+
+#### Scenario: An escaping spec path is refused, not written
+- **GIVEN** a generated spec whose `path` resolves outside the project root
+- **WHEN** the writer attempts to write it
+- **THEN** `safeJoin` rejects it, the spec is skipped with a warning, and nothing is
+  created outside the root
+
 ### Requirement: Capability Declaration and Accepted-Risk Register
 
 The server SHALL ship a machine-readable declaration of its security-relevant capabilities

--- a/src/core/generator/openspec-format-generator.test.ts
+++ b/src/core/generator/openspec-format-generator.test.ts
@@ -214,6 +214,33 @@ describe('OpenSpecFormatGenerator', () => {
       expect(paths.some(p => p.includes('/user/'))).toBe(true);
     });
 
+    // Path-traversal confinement (GHSA-5j8x-q7q6-58j5). The Stage-3 `domain` field is
+    // returned verbatim by the LLM over untrusted repository content; a traversal
+    // value must not survive into the spec's output path.
+    it('normalizes a malicious service domain into a safe in-root path', () => {
+      const generator = new OpenSpecFormatGenerator();
+      const result = createMockPipelineResult();
+      // Only this service drives a domain, so the domain spec below is unambiguous.
+      result.entities = [];
+      result.endpoints = [];
+      result.services = [
+        { ...createMockServices()[0], domain: '../../../../../../tmp/openlore_traversal_proof' },
+      ];
+
+      const specs = generator.generateSpecs(result);
+      const domainSpecs = specs.filter(s => s.type === 'domain');
+
+      expect(domainSpecs.length).toBeGreaterThan(0);
+      for (const s of domainSpecs) {
+        // No traversal segment survives, and the path stays under openspec/specs/.
+        expect(s.path).not.toContain('..');
+        expect(s.path.startsWith('openspec/specs/')).toBe(true);
+        expect(s.path.endsWith('/spec.md')).toBe(true);
+        expect(s.domain).not.toContain('/');
+        expect(s.domain).not.toContain('..');
+      }
+    });
+
     it('should not generate API spec when no endpoints', () => {
       const generator = new OpenSpecFormatGenerator();
       const result = createMockPipelineResult();

--- a/src/core/generator/openspec-format-generator.ts
+++ b/src/core/generator/openspec-format-generator.ts
@@ -16,6 +16,7 @@ import type {
 } from './spec-pipeline.js';
 import type { DependencyGraphResult } from '../analyzer/dependency-graph.js';
 import type { MappingArtifact } from './mapping-generator.js';
+import { normalizeDomainName } from './openspec-compat.js';
 
 // ============================================================================
 // TYPES
@@ -559,10 +560,17 @@ export class OpenSpecFormatGenerator {
       lines.push(...depSection);
     }
 
+    // `domain.name` derives from the Stage-3 LLM `domain` field, which is fed raw
+    // repository content — an untrusted value. Route it through the same
+    // `normalizeDomainName` the writer already applies elsewhere (stale-dir cleanup,
+    // config metadata) so a traversal value like `../../../tmp/x` becomes a plain
+    // in-root directory segment and cannot redirect the write outside the project
+    // (GHSA-5j8x-q7q6-58j5). `.toLowerCase()` alone did not strip `/` or `..`.
+    const domainDir = normalizeDomainName(domain.name);
     return {
-      path: `openspec/specs/${domain.name.toLowerCase()}/spec.md`,
+      path: `openspec/specs/${domainDir}/spec.md`,
       content: lines.join('\n'),
-      domain: domain.name.toLowerCase(),
+      domain: domainDir,
       type: 'domain',
     };
   }

--- a/src/core/generator/openspec-writer.test.ts
+++ b/src/core/generator/openspec-writer.test.ts
@@ -576,6 +576,35 @@ describe('Edge Cases', () => {
     expect(await fileExists(join(tempDir, 'openspec/specs/user-profile/spec.md'))).toBe(true);
   });
 
+  // Path-traversal confinement (GHSA-5j8x-q7q6-58j5; mcp-security: Write Confinement).
+  // `spec.path`'s domain segment derives from the Stage-3 LLM `domain` field over
+  // untrusted repo content, so a traversal value must never escape the project root.
+  it('refuses to write a spec whose path escapes the project root', async () => {
+    // Escape one level above tempDir (still inside the OS temp dir, so a regression
+    // would land here and be caught — not scattered across the filesystem).
+    const escapeDirName = `openlore-escape-proof-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const escaping: GeneratedSpec[] = [
+      {
+        path: `openspec/specs/../../../${escapeDirName}/spec.md`,
+        content: '# Escaped\n\n## Purpose\n\nShould never be written.',
+        domain: 'evil',
+        type: 'domain',
+      },
+    ];
+
+    const writer = new OpenSpecWriter({ rootPath: tempDir, updateConfig: false });
+    const report = await writer.writeSpecs(escaping, createMockSurvey());
+
+    // The escaping spec is refused, not silently written out of root.
+    expect(report.filesWritten).toHaveLength(0);
+    expect(report.warnings.some(w => /traversal|escape|outside/i.test(w))).toBe(true);
+
+    // And nothing landed outside the project root.
+    const outside = join(tmpdir(), escapeDirName, 'spec.md');
+    expect(await fileExists(outside)).toBe(false);
+    await rm(join(tmpdir(), escapeDirName), { recursive: true, force: true });
+  });
+
   it('should handle deeply nested paths', async () => {
     const specs: GeneratedSpec[] = [
       {

--- a/src/core/generator/openspec-writer.test.ts
+++ b/src/core/generator/openspec-writer.test.ts
@@ -4,7 +4,9 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdir, rm, writeFile, readFile, readdir, access } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import {
   OpenSpecWriter,
@@ -117,6 +119,39 @@ Layered architecture.
 // ============================================================================
 // TESTS
 // ============================================================================
+
+// Structural guard (mcp-security: Spec-Generation Writer Confines LLM-Derived Paths;
+// GHSA-5j8x-q7q6-58j5). The spec-generation writer is the one LLM-in-the-loop write
+// surface, and it sits outside the MCP path-parameter coverage gate. This gate is its
+// equivalent: it fails if `writeSpec` ever stops confining the (LLM-derived) spec path
+// through `safeJoin`, or reverts to the vulnerable bare `join(this.rootPath, spec.path)`
+// — so a future edit cannot silently reopen the traversal.
+describe('Write confinement structural guard (mcp-security)', () => {
+  const writerSrc = readFileSync(
+    fileURLToPath(new URL('./openspec-writer.ts', import.meta.url)),
+    'utf-8',
+  );
+
+  it('imports the shared path-confinement guard', () => {
+    expect(writerSrc).toMatch(/import\s*\{[^}]*\bsafeJoin\b[^}]*\}\s*from\s*['"][^'"]*path-confinement/);
+  });
+
+  it('confines the spec write path through safeJoin', () => {
+    expect(
+      /safeJoin\(\s*this\.rootPath\s*,\s*spec\.path\s*\)/.test(writerSrc),
+      'writeSpec must resolve the spec path via safeJoin(this.rootPath, spec.path)',
+    ).toBe(true);
+  });
+
+  it('never resolves the untrusted spec path with a bare path.join (the pre-fix sink)', () => {
+    // `safeJoin(...)` carries a capital J, so this lowercase-j pattern matches only a
+    // reverted bare `join(this.rootPath, spec.path)`, not the confined call.
+    expect(
+      /\bjoin\(\s*this\.rootPath\s*,\s*spec\.path\s*\)/.test(writerSrc),
+      'writeSpec must not resolve the untrusted spec.path with an unconfined path.join',
+    ).toBe(false);
+  });
+});
 
 describe('OpenSpecWriter', () => {
   let tempDir: string;

--- a/src/core/generator/openspec-writer.ts
+++ b/src/core/generator/openspec-writer.ts
@@ -20,6 +20,7 @@ import {
   ARTIFACT_GENERATION_REPORT,
 } from '../../constants.js';
 import { fileExists } from '../../utils/command-helpers.js';
+import { safeJoin } from '../../utils/path-confinement.js';
 import {
   OpenSpecConfigManager,
   buildDetectedContext,
@@ -245,8 +246,26 @@ export class OpenSpecWriter {
    * Write a single spec file
    */
   private async writeSpec(spec: GeneratedSpec): Promise<WriteResult> {
-    const fullPath = join(this.rootPath, spec.path);
     const relativePath = spec.path;
+
+    // Confine every spec write to the project root through the shared, symlink-aware
+    // guard — the same one every other untrusted-path surface routes through
+    // (mcp-security: Symlink-Aware Path Confinement / Write Confinement). `spec.path`'s
+    // domain segment derives from the Stage-3 LLM `domain` field over untrusted repo
+    // content, so a traversal value must never escape the root (GHSA-5j8x-q7q6-58j5).
+    // Fail closed for this one spec and let the rest proceed.
+    let fullPath: string;
+    try {
+      fullPath = safeJoin(this.rootPath, spec.path);
+    } catch (error) {
+      logger.warning(`Refusing to write spec outside project root: ${relativePath}`);
+      return {
+        path: relativePath,
+        action: 'written',
+        success: false,
+        error: (error as Error).message,
+      };
+    }
 
     try {
       // Check if file exists


### PR DESCRIPTION
## Summary

Fixes a path-traversal weakness in the spec-generation writer (GHSA-5j8x-q7q6-58j5). When `openlore generate` runs against an untrusted repository, the LLM-derived `domain` field was used to build a spec's output path with no sanitization and no project-root confinement, so a crafted value could redirect a `writeFile` outside the project.

## Fix

Defense in depth, reusing existing project primitives (no new abstractions):

- **Sanitize at source** — normalize the domain into a single safe path segment before it becomes a path (`normalizeDomainName`, already used elsewhere in the writer).
- **Confine at sink** — route every spec write through the shared, symlink-aware `safeJoin` project-root guard the rest of the codebase uses. An out-of-root path is refused (skipped with a warning), never written.

## Validation

- Two regression tests (source + sink) that fail on the pre-fix code and pass after.
- A structural guard that fails if the writer ever stops confining the spec path through `safeJoin` (the generator sits outside the MCP path-parameter coverage gate, so nothing else enforced this).
- Generator + mcp-security + path-confinement + api-generate suites green.
- No behavior change for normal domains.

Scope: the two source files, their tests, and a documented invariant in `openspec/specs/mcp-security/spec.md`.