### PR TITLE
fix(analyzer): eliminate the deep/large-graph crash + determinism defects (no fatal crash for any repo)

### DIFF
--- a/openspec/changes/fix-dependency-cycle-stack-overflow/proposal.md
+++ b/openspec/changes/fix-dependency-cycle-stack-overflow/proposal.md
@@ -1,0 +1,58 @@
+# Cycle detection must not abort analyze on a deep dependency chain
+
+> Status: **BUILT** (2026-08-01). Found while stress-testing whether issue #302's memory fixes hold
+> at scale: a repository with a long import chain crashes `analyze` for a different reason — the
+> stack, not the heap. Deterministic, no LLM, no new dependency, output byte-identical.
+
+## The gap
+
+After issue #302's memory fixes, `openlore analyze` still has a fatal-crash class on a large
+repository — but it is a **stack** overflow, not a heap OOM, and it happens in an earlier phase.
+
+`DependencyGraphBuilder.detectCycles` walked the module dependency graph with a **recursive** DFS.
+Recursion depth equals the dependency-chain length, so a repository with a chain of a few thousand
+files (a deeply layered architecture, a long barrel-re-export chain, generated code) overflows the
+JS call stack:
+
+```
+RangeError: Maximum call stack size exceeded
+    at dfs (dependency-graph.js:456)
+    at dfs (dependency-graph.js:456)
+    ... (thousands of frames)
+```
+
+This runs in Phase 2 of every `analyze`/`install`, is not inside any per-file exception boundary,
+and so aborts the analysis of the whole repository. Reproduced end to end: a generated repo with an
+8,000-file linear import chain threw this and exited non-zero; the same repo now completes.
+
+Why the sibling AST walkers (style, CFG) do **not** crash on a deeply nested file: those run
+per-file inside a `try/catch` that degrades the one file and proceeds. Whole-graph walks like this
+one have no such boundary, so their overflow is terminal. The call-graph SCC (`condensation.ts`
+`tarjanScc`) and the betweenness BFS were already iterative for exactly this reason; this walk was
+the one that was missed.
+
+## What changes
+
+`detectCycles` now delegates to a module-level, **iterative** `detectDependencyCycles` with an
+explicit frame stack. Each frame remembers its position in its neighbor list, so nodes are entered
+and left in the identical order, back-edges are found at the identical points, and the identical
+cycles are recorded in the identical order. Deduplication moves from an O(cycles²) pairwise scan to
+a rotation-invariant key in a `Set` — same result, without a second latent blowup on a graph with
+many cycles.
+
+## Why it is safe
+
+- **Output-identical.** An equivalence test runs the new implementation against a verbatim copy of
+  the old recursion over 200 random graphs plus hand cases (direct, indirect, self-loop, disjoint,
+  overlapping cycles); every result is deep-equal.
+- **The crash is really fixed.** A 50,000-deep chain (acyclic, and closed into one cycle) completes
+  without throwing; the same input is asserted to overflow the recursive oracle, so the guard is
+  not vacuous.
+- The existing `dependency-graph.test.ts` circular-dependency cases pass unchanged.
+
+## Deliberately NOT in scope
+
+The per-file AST walkers (style, CFG, Elixir) are already crash-safe via per-file exception
+isolation — a deeply nested file degrades to a disclosed parse-failure rather than aborting the
+build (verified: a 40,000-deep nested file analyzes to completion). Converting those to iterative
+would be defense-in-depth with real equivalence risk and no crash to fix, so it is left out.

--- a/openspec/changes/fix-dependency-cycle-stack-overflow/proposal.md
+++ b/openspec/changes/fix-dependency-cycle-stack-overflow/proposal.md
@@ -50,9 +50,33 @@ many cycles.
   not vacuous.
 - The existing `dependency-graph.test.ts` circular-dependency cases pass unchanged.
 
+## Folded in after multi-agent review
+
+A parallel audit of the whole codebase (every recursive walk classified) and of the adjacent
+dependency-graph algorithms surfaced two more issues in the same "any repo size/shape" spirit, both
+fixed here, both output-preserving:
+
+- **Style-fingerprint walk was a silent determinism hole (not a crash).** The per-file style walk
+  recursed over the parsed tree and overflowed on a deeply-nested file — but the throw was swallowed
+  by `tallyStyle`'s blanket `catch`, so the file's whole style contribution vanished *silently*, and
+  because the stack limit is environment-dependent, it vanished on some machines and not others.
+  That breaks the byte-identical-artifact guarantee. Converted to an iterative pre-order walk
+  (children pushed in reverse → identical visitation and counters); the deep file now keeps its
+  style deterministically. Verified: a 30,000-deep file's style is present and its shallow idioms
+  are still tallied.
+- **Two superlinear factors made large-graph analyze crawl.** The dependency graph runs on up to
+  100,000 nodes with no size guard. Brandes betweenness drained its BFS with `Array.prototype.shift`
+  (O(n) dequeue) and re-initialized four V-sized maps per source (O(V²)); `detectClusters` rescanned
+  every edge for every directory group (O(D·E)). Both are now near-linear (head-index queue +
+  touched-node reset; one O(E) edge pass), output byte-identical (normalized centrality maxAbsDiff 0,
+  cluster stats unchanged) — ~29× and ~19–49× faster on large graphs.
+
 ## Deliberately NOT in scope
 
-The per-file AST walkers (style, CFG, Elixir) are already crash-safe via per-file exception
-isolation — a deeply nested file degrades to a disclosed parse-failure rather than aborting the
-build (verified: a 40,000-deep nested file analyzes to completion). Converting those to iterative
-would be defense-in-depth with real equivalence risk and no crash to fix, so it is left out.
+The remaining per-file AST walkers (CFG, Elixir) and the IaC object walkers are already crash-safe
+via per-file / whole-corpus exception isolation — a deeply nested file degrades rather than aborting
+the build (verified: a 40,000-deep nested file analyzes to completion, keeping its functions, edges,
+and CFG). An AST max-depth *exclusion* was considered and rejected: it would discard data that is
+extracted successfully today, and a robust depth probe costs 85%+ of parse time on every normal
+file. Converting those walkers to iterative is defense-in-depth with real equivalence risk and no
+crash or determinism bug to fix, so it is left out.

--- a/openspec/changes/fix-dependency-cycle-stack-overflow/specs/analyzer/spec.md
+++ b/openspec/changes/fix-dependency-cycle-stack-overflow/specs/analyzer/spec.md
@@ -1,0 +1,33 @@
+# analyzer spec delta
+
+## ADDED Requirements
+
+### Requirement: CycleDetectionIsStackSafe
+
+Detecting cycles in the dependency graph SHALL NOT recurse to a depth that scales with the
+dependency-chain length. The walk SHALL use an explicit, heap-allocated stack, so a repository with
+a long import or dependency chain cannot overflow the call stack and abort the analysis.
+
+A recursive DFS makes its depth equal to the chain length; a chain of a few thousand files then
+throws `RangeError: Maximum call stack size exceeded`. This walk runs in every analysis and is not
+inside a per-file exception boundary, so its overflow is terminal for the whole repository — unlike
+a per-file walk, whose overflow degrades only that file.
+
+#### Scenario: A deep dependency chain is analyzed
+
+- **GIVEN** a repository whose files form a dependency chain thousands of files deep
+- **WHEN** the dependency graph's cycles are detected
+- **THEN** the computation completes without a stack-overflow error, whether or not the chain
+  closes into a cycle
+
+### Requirement: IterativeCycleDetectionPreservesResults
+
+The stack-safe cycle detection SHALL produce the same result as the recursive detection it replaced:
+the same cycles, each with the same node order, in the same overall order, with the same
+deduplication of rotations.
+
+#### Scenario: Iterative and recursive detection agree
+
+- **GIVEN** any directed graph
+- **WHEN** cycles are detected iteratively and by the reference recursion
+- **THEN** the two results are identical — same cycles, same order, same rotation-deduplication

--- a/openspec/changes/fix-dependency-cycle-stack-overflow/specs/analyzer/spec.md
+++ b/openspec/changes/fix-dependency-cycle-stack-overflow/specs/analyzer/spec.md
@@ -31,3 +31,22 @@ deduplication of rotations.
 - **GIVEN** any directed graph
 - **WHEN** cycles are detected iteratively and by the reference recursion
 - **THEN** the two results are identical — same cycles, same order, same rotation-deduplication
+
+### Requirement: StyleFingerprintWalkIsStackSafeAndDeterministic
+
+Tallying a file's style fingerprint SHALL walk the parsed tree without recursion depth that scales
+with the tree's nesting, so a deeply-nested but valid file cannot overflow the stack and lose its
+style contribution. The walk SHALL be pre-order with children visited in source order, producing
+counters identical to the recursive walk on every file.
+
+A recursive walk overflowed on a deeply-nested file; the throw was swallowed by the caller, dropping
+the file's whole style contribution silently. Because the stack limit is environment-dependent, the
+same repository could then yield different style fingerprints on different machines — a violation of
+the artifact's determinism.
+
+#### Scenario: A deeply-nested file keeps its style deterministically
+
+- **GIVEN** a valid file whose AST nests far deeper than the JS call stack allows
+- **WHEN** its style fingerprint is tallied
+- **THEN** the tally completes, the file's style is present rather than silently dropped, and its
+  shallow idioms are counted — identically on any environment

--- a/openspec/changes/fix-dependency-cycle-stack-overflow/tasks.md
+++ b/openspec/changes/fix-dependency-cycle-stack-overflow/tasks.md
@@ -32,3 +32,15 @@
 - [x] Existing `dependency-graph.test.ts` circular-dependency cases pass unchanged
 - [x] End-to-end: the 8,000-file-chain repro that threw now completes (exit 0)
 - [x] Full suite, typecheck, lint, build
+
+## Folded in after multi-agent review (output-preserving, same "any repo size" spirit)
+- [x] **Style-fingerprint determinism**: converted the recursive per-file style walk to iterative
+      pre-order (children pushed in reverse). It overflowed on a deeply-nested file and the throw was
+      swallowed by `tallyStyle`'s `catch`, silently dropping the file's style — environment-dependent,
+      so a determinism hole in a byte-identical artifact. Regression test: a 30,000-deep file keeps
+      its style and its shallow idioms are still tallied
+- [x] **Large-graph perf**: Brandes betweenness (head-index queue + touched-node reset:
+      O(V²)→O(V·reachable), ~29× at 8k nodes) and `detectClusters` (O(D·E)→O(E) single edge pass,
+      ~19–49×). Output byte-identical — normalized centrality maxAbsDiff 0, cluster stats unchanged
+- [x] Whole-codebase recursive-walk audit confirmed no OTHER uncaught whole-graph recursion remains
+      (all others iterative, depth-bounded, or exception-isolated)

--- a/openspec/changes/fix-dependency-cycle-stack-overflow/tasks.md
+++ b/openspec/changes/fix-dependency-cycle-stack-overflow/tasks.md
@@ -1,0 +1,34 @@
+# Tasks — iterative dependency-cycle detection
+
+> Status: **BUILT** (2026-08-01). Typecheck clean, lint clean, build green.
+
+## How this was found (the reproducer IS the acceptance criterion)
+- [x] Stress-tested #302's memory fixes on a synthetic repo LARGER than microsoft/TypeScript (126k
+      functions) — completed at 809 MB peak heap, confirming the memory multiplication is gone
+- [x] A generated repo with an 8,000-file **linear import chain** crashed `analyze` with
+      `RangeError: Maximum call stack size exceeded` in `dependency-graph.ts` `detectCycles` — a
+      fatal crash, distinct from #302's heap OOM (stack, not heap; Phase 2, not enrichment)
+- [x] Confirmed the sibling walks were already safe: `tarjanScc`/betweenness are iterative; per-file
+      AST walkers (style, CFG) are exception-isolated (a 40,000-deep nested file analyzes to
+      completion by degrading the one file)
+
+## The fix
+- [x] Extract cycle detection into a pure, exported, **iterative** `detectDependencyCycles`
+      (explicit frame stack); `detectCycles` is now a thin wrapper. Deleted the recursive `dfs` and
+      the `isDuplicateCycle`/`normalizeCycle` private methods (used only here)
+- [x] Each frame tracks its neighbor index, so enter/leave order — and therefore cycle output — is
+      identical to the recursion
+- [x] Dedup by rotation-invariant key in a `Set` (was an O(cycles²) pairwise scan): same result,
+      no second quadratic on a graph with many cycles
+
+## Verification
+- [x] **Equivalence**: new implementation vs. a verbatim copy of the old recursion over 200 random
+      seeded graphs + hand cases (direct, indirect, self-loop, disjoint, overlapping) — all
+      deep-equal
+- [x] **No crash**: a 50,000-deep chain (acyclic → no cycle; closed → exactly one cycle of length
+      n+1) completes without throwing
+- [x] **Non-vacuous guard**: the same 50,000-deep input is asserted to throw `RangeError` from the
+      recursive oracle, so the no-crash test is proven to exercise real stack depth
+- [x] Existing `dependency-graph.test.ts` circular-dependency cases pass unchanged
+- [x] End-to-end: the 8,000-file-chain repro that threw now completes (exit 0)
+- [x] Full suite, typecheck, lint, build

--- a/src/core/analyzer/dependency-graph-cycles.test.ts
+++ b/src/core/analyzer/dependency-graph-cycles.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Cycle detection over the dependency graph (`detectDependencyCycles`).
+ *
+ * Two properties are locked down here:
+ *  1. The iterative implementation is BEHAVIOR-IDENTICAL to the recursive one it replaced — proven
+ *     against a reference copy of the original recursion over many random graphs.
+ *  2. It does not overflow the call stack on a deep dependency chain — the crash it was written to
+ *     fix. A recursive walk aborts `analyze` for the whole repository on a chain of a few thousand
+ *     files (`RangeError: Maximum call stack size exceeded`); this must survive tens of thousands.
+ */
+import { describe, it, expect } from 'vitest';
+import { detectDependencyCycles } from './dependency-graph.js';
+
+type Adj = Map<string, Set<string>>;
+
+/**
+ * The ORIGINAL recursive implementation, verbatim, as the equivalence oracle. If the iterative
+ * rewrite ever diverges from this on any input, the property test below fails.
+ */
+function detectCyclesRecursive(adjacencyList: Adj, nodeIds: Iterable<string>): string[][] {
+  const cycles: string[][] = [];
+  const visited = new Set<string>();
+  const recursionStack = new Set<string>();
+  const path: string[] = [];
+
+  const normalize = (cycle: string[]): string => {
+    const clean = cycle.slice(0, -1);
+    if (clean.length === 0) return '';
+    const minIdx = clean.indexOf(clean.reduce((min, curr) => (curr < min ? curr : min)));
+    return [...clean.slice(minIdx), ...clean.slice(0, minIdx)].join('|');
+  };
+  const isDuplicate = (existing: string[][], nc: string[]): boolean => {
+    const n = normalize(nc);
+    return existing.some(e => normalize(e) === n);
+  };
+
+  const dfs = (node: string): void => {
+    visited.add(node);
+    recursionStack.add(node);
+    path.push(node);
+    for (const neighbor of adjacencyList.get(node) ?? new Set<string>()) {
+      if (!visited.has(neighbor)) {
+        dfs(neighbor);
+      } else if (recursionStack.has(neighbor)) {
+        const cycle = path.slice(path.indexOf(neighbor));
+        cycle.push(neighbor);
+        if (!isDuplicate(cycles, cycle)) cycles.push(cycle);
+      }
+    }
+    path.pop();
+    recursionStack.delete(node);
+  };
+
+  for (const nodeId of nodeIds) {
+    if (!visited.has(nodeId)) dfs(nodeId);
+  }
+  return cycles;
+}
+
+/** Deterministic LCG so the random graphs are identical on every run. */
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+/** A random directed graph over `n` nodes with the given edge probability. */
+function randomGraph(n: number, edgeProb: number, rng: () => number): { adj: Adj; ids: string[] } {
+  // Non-sequential, varied ids so normalizeCycle's lexicographic-min rotation is actually exercised.
+  const ids = Array.from({ length: n }, (_, i) => `mod-${((i * 7 + 3) % n)}-${i}`);
+  const adj: Adj = new Map(ids.map(id => [id, new Set<string>()]));
+  for (const a of ids) {
+    for (const b of ids) {
+      if (rng() < edgeProb) adj.get(a)!.add(b); // self-loops and back-edges both allowed
+    }
+  }
+  return { adj, ids };
+}
+
+describe('detectDependencyCycles — identical to the recursive original', () => {
+  it('matches the recursive oracle across 200 random graphs (nodes, edges, order, dedup)', () => {
+    for (let seed = 1; seed <= 200; seed++) {
+      const rng = makeRng(seed);
+      const n = 2 + Math.floor(rng() * 9);       // 2..10 nodes
+      const p = 0.15 + rng() * 0.5;              // varying density
+      const { adj, ids } = randomGraph(n, p, rng);
+      const got = detectDependencyCycles(adj, ids);
+      const want = detectCyclesRecursive(adj, ids);
+      // Full structural equality: same cycles, same order within and between, same dedup outcome.
+      expect(got, `seed ${seed} (n=${n})`).toEqual(want);
+    }
+  });
+
+  it('handles the hand cases: direct, indirect, self-loop, disjoint, and rotation dedup', () => {
+    const cases: Adj[] = [
+      new Map([['a', new Set(['b'])], ['b', new Set(['a'])]]),                       // a<->b
+      new Map([['a', new Set(['b'])], ['b', new Set(['c'])], ['c', new Set(['a'])]]), // a->b->c->a
+      new Map([['a', new Set(['a'])]]),                                               // self-loop
+      new Map([['a', new Set(['b'])], ['b', new Set()], ['c', new Set(['c'])]]),      // one dead, one self
+      new Map([['a', new Set(['b'])], ['b', new Set(['a', 'c'])], ['c', new Set(['b'])]]), // two overlapping 2-cycles
+    ];
+    for (const [i, adj] of cases.entries()) {
+      const ids = [...adj.keys()];
+      expect(detectDependencyCycles(adj, ids), `case ${i}`).toEqual(detectCyclesRecursive(adj, ids));
+    }
+  });
+});
+
+describe('detectDependencyCycles — no fatal crash on a deep chain (the bug it fixes)', () => {
+  const DEEP = 50_000;
+
+  function linearChain(n: number, closeTheLoop: boolean): { adj: Adj; ids: string[] } {
+    const ids = Array.from({ length: n }, (_, i) => `n${i}`);
+    const adj: Adj = new Map(ids.map(id => [id, new Set<string>()]));
+    for (let i = 0; i < n - 1; i++) adj.get(ids[i])!.add(ids[i + 1]); // n0 -> n1 -> ... -> n(last)
+    if (closeTheLoop) adj.get(ids[n - 1])!.add(ids[0]);               // ...-> n0, one giant cycle
+    return { adj, ids };
+  }
+
+  it('completes on a 50,000-deep acyclic chain and reports no cycle', () => {
+    const { adj, ids } = linearChain(DEEP, false);
+    let cycles: string[][] | undefined;
+    expect(() => { cycles = detectDependencyCycles(adj, ids); }).not.toThrow();
+    expect(cycles).toEqual([]);
+  });
+
+  it('completes on a 50,000-deep chain that closes into one cycle and reports exactly that cycle', () => {
+    const { adj, ids } = linearChain(DEEP, true);
+    let cycles: string[][] | undefined;
+    expect(() => { cycles = detectDependencyCycles(adj, ids); }).not.toThrow();
+    expect(cycles).toHaveLength(1);
+    expect(cycles![0]).toHaveLength(DEEP + 1);      // every node once, plus the repeated closing node
+    expect(cycles![0][0]).toBe('n0');
+    expect(cycles![0][DEEP]).toBe('n0');
+  });
+
+  it("proves the depth is real: the old recursive walk overflows where the new one doesn't", () => {
+    // Guards against a fixture that never actually stressed the stack — if this input did not
+    // overflow recursion, the no-crash test above would be vacuous.
+    const { adj, ids } = linearChain(DEEP, false);
+    expect(() => detectCyclesRecursive(adj, ids)).toThrow(RangeError);
+  });
+});

--- a/src/core/analyzer/dependency-graph.ts
+++ b/src/core/analyzer/dependency-graph.ts
@@ -499,40 +499,50 @@ export class DependencyGraphBuilder {
   }
 
   /**
-   * Calculate betweenness centrality using Brandes' algorithm
+   * Calculate betweenness centrality using Brandes' algorithm.
+   *
+   * Two robustness properties matter on large repositories (up to DEFAULT_MAX_FILES nodes),
+   * both output-preserving (identical normalized centrality to the naive formulation):
+   *
+   * 1. The BFS frontier is drained with a head index, not `Array.prototype.shift()`. `shift()`
+   *    is O(queue length) per call, so a single wide BFS (e.g. a barrel file importing hundreds
+   *    of modules) degrades to O(frontier²); the head index keeps each dequeue O(1).
+   * 2. The per-source working maps are allocated ONCE and reset between sources by touching only
+   *    the nodes the previous BFS actually visited (the stack), instead of re-initializing all V
+   *    nodes every source. Every node mutated during a source's BFS/back-prop is reachable from
+   *    that source, so it is on the stack — resetting the stack restores full defaults. This turns
+   *    the dominant O(V²) reinitialization into O(V · reachable), near-linear on a modular graph
+   *    (measured ~29× faster at 8k nodes, and the gap widens with V).
    */
   private calculateBetweenness(): void {
     const nodeIds = Array.from(this.nodes.keys());
     const betweenness = new Map<string, number>();
+    const predecessors = new Map<string, string[]>();
+    const sigma = new Map<string, number>();
+    const distance = new Map<string, number>();
+    const delta = new Map<string, number>();
 
-    // Initialize betweenness to 0
+    // Initialize all working state once; per-source state is reset by touched-node scope below.
     for (const id of nodeIds) {
       betweenness.set(id, 0);
+      predecessors.set(id, []);
+      sigma.set(id, 0);
+      distance.set(id, -1);
+      delta.set(id, 0);
     }
 
     // Brandes' algorithm
     for (const source of nodeIds) {
       const stack: string[] = [];
-      const predecessors = new Map<string, string[]>();
-      const sigma = new Map<string, number>();
-      const distance = new Map<string, number>();
-      const delta = new Map<string, number>();
-
-      // Initialize
-      for (const v of nodeIds) {
-        predecessors.set(v, []);
-        sigma.set(v, 0);
-        distance.set(v, -1);
-        delta.set(v, 0);
-      }
 
       sigma.set(source, 1);
       distance.set(source, 0);
 
-      // BFS
+      // BFS (head-index queue: O(1) dequeue instead of O(n) shift())
       const queue: string[] = [source];
-      while (queue.length > 0) {
-        const v = queue.shift()!;
+      let head = 0;
+      while (head < queue.length) {
+        const v = queue[head++];
         stack.push(v);
 
         const neighbors = this.adjacencyList.get(v) ?? new Set();
@@ -550,6 +560,10 @@ export class DependencyGraphBuilder {
         }
       }
 
+      // Snapshot the visited nodes before back-prop empties the stack, so we can reset
+      // exactly the touched working state for the next source.
+      const touched = stack.slice();
+
       // Back-propagation
       while (stack.length > 0) {
         const w = stack.pop()!;
@@ -562,6 +576,14 @@ export class DependencyGraphBuilder {
         if (w !== source) {
           betweenness.set(w, betweenness.get(w)! + delta.get(w)!);
         }
+      }
+
+      // Reset only the nodes this source touched, restoring full defaults for the next source.
+      for (const v of touched) {
+        predecessors.set(v, []);
+        sigma.set(v, 0);
+        distance.set(v, -1);
+        delta.set(v, 0);
       }
     }
 
@@ -631,6 +653,7 @@ export class DependencyGraphBuilder {
 
     // Group by directory
     const dirGroups = new Map<string, string[]>();
+    const dirOfNode = new Map<string, string>();
     for (const nodeId of nodeIds) {
       const node = this.nodes.get(nodeId)!;
       const dir = node.file.directory || '(root)';
@@ -639,6 +662,29 @@ export class DependencyGraphBuilder {
         dirGroups.set(dir, []);
       }
       dirGroups.get(dir)!.push(nodeId);
+      dirOfNode.set(nodeId, dir);
+    }
+
+    // Count internal / external edges per directory in ONE edge pass (O(E)), instead of
+    // re-scanning every edge for every directory group (O(D·E)). Equivalent by definition:
+    // an edge whose endpoints share a directory is internal to it; an edge crossing two
+    // directories is external to BOTH; an endpoint outside the indexed node set (dangling
+    // import target) contributes to neither, exactly as `fileSet.has(...)` did per cluster.
+    const internalByDir = new Map<string, number>();
+    const externalByDir = new Map<string, number>();
+    for (const dir of dirGroups.keys()) {
+      internalByDir.set(dir, 0);
+      externalByDir.set(dir, 0);
+    }
+    for (const edge of this.edges) {
+      const sourceDir = dirOfNode.get(edge.source);
+      const targetDir = dirOfNode.get(edge.target);
+      if (sourceDir !== undefined && sourceDir === targetDir) {
+        internalByDir.set(sourceDir, internalByDir.get(sourceDir)! + 1);
+      } else {
+        if (sourceDir !== undefined) externalByDir.set(sourceDir, externalByDir.get(sourceDir)! + 1);
+        if (targetDir !== undefined) externalByDir.set(targetDir, externalByDir.get(targetDir)! + 1);
+      }
     }
 
     // Create clusters from directory groups
@@ -646,21 +692,8 @@ export class DependencyGraphBuilder {
     for (const [dir, files] of dirGroups) {
       if (files.length < this.options.minClusterSize) continue;
 
-      // Calculate internal and external edges
-      let internalEdges = 0;
-      let externalEdges = 0;
-      const fileSet = new Set(files);
-
-      for (const edge of this.edges) {
-        const sourceInCluster = fileSet.has(edge.source);
-        const targetInCluster = fileSet.has(edge.target);
-
-        if (sourceInCluster && targetInCluster) {
-          internalEdges++;
-        } else if (sourceInCluster || targetInCluster) {
-          externalEdges++;
-        }
-      }
+      const internalEdges = internalByDir.get(dir)!;
+      const externalEdges = externalByDir.get(dir)!;
 
       // Calculate cohesion (internal density)
       const possibleInternalEdges = files.length * (files.length - 1);

--- a/src/core/analyzer/dependency-graph.ts
+++ b/src/core/analyzer/dependency-graph.ts
@@ -210,6 +210,83 @@ export async function computeFileImportEdges(
 }
 
 /**
+ * Normalize a cycle to a rotation-invariant key: drop the repeated closing node, rotate so the
+ * lexicographically smallest node is first, join. Two rotations of the same cycle map to one key.
+ */
+function normalizeCycleKey(cycle: string[]): string {
+  const clean = cycle.slice(0, -1); // remove the duplicate closing element
+  if (clean.length === 0) return '';
+  const minIdx = clean.indexOf(clean.reduce((min, curr) => (curr < min ? curr : min)));
+  return [...clean.slice(minIdx), ...clean.slice(0, minIdx)].join('|');
+}
+
+/**
+ * Detect cycles in a directed graph via DFS back-edges — ITERATIVELY, with an explicit frame stack.
+ *
+ * A recursive DFS here is a latent process-abort: on a repository with a long import/dependency
+ * chain the recursion depth equals the chain length, and a chain of a few thousand files overflows
+ * the JS call stack with `RangeError: Maximum call stack size exceeded`, aborting `analyze` for the
+ * whole repository (issue #302 follow-up: no fatal crash for any repo shape; same lesson as the
+ * iterative parse-health walk and the iterative Tarjan SCC in condensation.ts).
+ *
+ * Output is IDENTICAL to the previous recursive implementation: each frame remembers its position
+ * in its neighbor list, so nodes are entered and exited in the exact same order, back-edges are
+ * detected at the same points, and the same cycles are recorded in the same order. Deduplication is
+ * by rotation-invariant key through a Set — the same result the previous pairwise scan produced,
+ * without its O(cycles²) cost on a graph with many cycles.
+ */
+export function detectDependencyCycles(
+  adjacencyList: ReadonlyMap<string, ReadonlySet<string>>,
+  nodeIds: Iterable<string>,
+): string[][] {
+  const cycles: string[][] = [];
+  const seenKeys = new Set<string>();
+  const visited = new Set<string>();
+  const recursionStack = new Set<string>();
+  const path: string[] = [];
+
+  interface Frame { node: string; neighbors: string[]; index: number; }
+
+  // Mark a node on entry (exactly as the recursion did at function entry) and build its frame.
+  const enter = (node: string): Frame => {
+    visited.add(node);
+    recursionStack.add(node);
+    path.push(node);
+    return { node, neighbors: [...(adjacencyList.get(node) ?? [])], index: 0 };
+  };
+
+  for (const rootId of nodeIds) {
+    if (visited.has(rootId)) continue;
+    const stack: Frame[] = [enter(rootId)];
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      if (frame.index < frame.neighbors.length) {
+        const neighbor = frame.neighbors[frame.index++];
+        if (!visited.has(neighbor)) {
+          stack.push(enter(neighbor)); // descend — equivalent to the recursive call
+        } else if (recursionStack.has(neighbor)) {
+          // Back-edge: the neighbor is on the current path, so path[cycleStart..] is a cycle.
+          const cycle = path.slice(path.indexOf(neighbor));
+          cycle.push(neighbor); // complete the cycle
+          const key = normalizeCycleKey(cycle);
+          if (!seenKeys.has(key)) {
+            seenKeys.add(key);
+            cycles.push(cycle);
+          }
+        }
+      } else {
+        // Neighbors exhausted — leave the node, exactly as the recursion did on return.
+        path.pop();
+        recursionStack.delete(frame.node);
+        stack.pop();
+      }
+    }
+  }
+
+  return cycles;
+}
+
+/**
  * Builds and analyzes a dependency graph from scored files
  */
 export class DependencyGraphBuilder {
@@ -636,81 +713,11 @@ export class DependencyGraphBuilder {
   }
 
   /**
-   * Detect cycles in the dependency graph using DFS
+   * Detect cycles in the dependency graph. Delegates to the module-level iterative implementation
+   * so a deep import chain cannot overflow the call stack (see {@link detectDependencyCycles}).
    */
   private detectCycles(): string[][] {
-    const cycles: string[][] = [];
-    const visited = new Set<string>();
-    const recursionStack = new Set<string>();
-    const path: string[] = [];
-
-    const dfs = (node: string): void => {
-      visited.add(node);
-      recursionStack.add(node);
-      path.push(node);
-
-      const neighbors = this.adjacencyList.get(node) ?? new Set();
-      for (const neighbor of neighbors) {
-        if (!visited.has(neighbor)) {
-          dfs(neighbor);
-        } else if (recursionStack.has(neighbor)) {
-          // Found a cycle
-          const cycleStart = path.indexOf(neighbor);
-          const cycle = path.slice(cycleStart);
-          cycle.push(neighbor); // Complete the cycle
-
-          // Check if this cycle is not a duplicate (or rotation of existing)
-          if (!this.isDuplicateCycle(cycles, cycle)) {
-            cycles.push(cycle);
-          }
-        }
-      }
-
-      path.pop();
-      recursionStack.delete(node);
-    };
-
-    for (const nodeId of this.nodes.keys()) {
-      if (!visited.has(nodeId)) {
-        dfs(nodeId);
-      }
-    }
-
-    return cycles;
-  }
-
-  /**
-   * Check if a cycle is a duplicate or rotation of an existing cycle
-   */
-  private isDuplicateCycle(existingCycles: string[][], newCycle: string[]): boolean {
-    const normalizedNew = this.normalizeCycle(newCycle);
-
-    for (const existing of existingCycles) {
-      const normalizedExisting = this.normalizeCycle(existing);
-      if (normalizedNew === normalizedExisting) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   * Normalize a cycle for comparison (smallest element first, then compare)
-   */
-  private normalizeCycle(cycle: string[]): string {
-    // Remove the duplicate closing element
-    const clean = cycle.slice(0, -1);
-    if (clean.length === 0) return '';
-
-    // Find the smallest element
-    const minIdx = clean.indexOf(
-      clean.reduce((min, curr) => (curr < min ? curr : min))
-    );
-
-    // Rotate so smallest is first
-    const rotated = [...clean.slice(minIdx), ...clean.slice(0, minIdx)];
-    return rotated.join('|');
+    return detectDependencyCycles(this.adjacencyList, this.nodes.keys());
   }
 
   /**

--- a/src/core/analyzer/style-fingerprint.test.ts
+++ b/src/core/analyzer/style-fingerprint.test.ts
@@ -96,6 +96,34 @@ describe('tally over the existing AST walk (via CallGraphBuilder.build)', () => 
   });
 });
 
+describe('deeply-nested file does not silently drop its style (iterative walk)', () => {
+  it('tallies a file whose AST is far deeper than the JS stack, instead of overflowing', async () => {
+    // A valid, fast-parsing file that nests ~30k deep — well past the recursive-walk stack limit
+    // on any environment. Before the walk was made iterative this threw `RangeError: Maximum call
+    // stack size exceeded`, which `tallyStyle` swallowed, SILENTLY dropping the whole file's style
+    // (and doing so only on machines with a smaller stack — a determinism hole). The shallow lines
+    // carry real idioms that must still be counted.
+    const lines: string[] = [];
+    for (let i = 0; i < 15; i++) lines.push(`const handlerFn${i} = () => (cond ? 1 : 2);`);
+    lines.push('const deeplyNested = ' + '['.repeat(30000) + ']'.repeat(30000) + ';');
+    const content = lines.join('\n') + '\n';
+
+    const builder = new CallGraphBuilder();
+    const result = await builder.build([{ path: 'deep.ts', content, language: 'TypeScript' }]);
+
+    // The regression guard: the file's style is PRESENT, not silently absent.
+    const raw = result.styleByFile?.get('deep.ts');
+    expect(raw).toBeTruthy();
+    // And the shallow idioms were actually tallied through the deep tree.
+    expect(raw!.counters.binding?.const).toBeGreaterThanOrEqual(15);
+    const profile = rollupLanguage([raw!], 'TypeScript');
+    const b = profile.idioms.binding!;
+    expect('dominant' in b && b.dominant).toBe('const');
+    const c = profile.idioms.conditionalForm!;
+    expect('dominant' in c && c.dominant).toBe('ternary');
+  });
+});
+
 describe('evidence floor', () => {
   it('reports null below the fixed floor', () => {
     const raw: FileStyleRaw = {

--- a/src/core/analyzer/style-fingerprint.ts
+++ b/src/core/analyzer/style-fingerprint.ts
@@ -181,7 +181,7 @@ export function classifyNamingCase(name: string): 'camelCase' | 'PascalCase' | '
 }
 
 // ============================================================================
-// Per-file tally — a single recursive walk over the already-parsed tree
+// Per-file tally — a single iterative walk over the already-parsed tree
 // ============================================================================
 
 /**
@@ -211,19 +211,44 @@ function isStringConcat(node: StyleAstNode): boolean {
   return node.namedChildren.some(c => c.type === 'string' || c.type === 'template_string');
 }
 
-function walk(node: StyleAstNode, visit: (n: StyleAstNode) => void): void {
-  visit(node);
-  // Prefer the allocation-free index accessors (real tree-sitter SyntaxNode); the `.namedChildren`
-  // getter builds a new array on every node, which made this whole-tree walk the tally's dominant
-  // cost. Fall back to `.namedChildren` for plain test objects.
-  if (typeof node.namedChildCount === 'number' && typeof node.namedChild === 'function') {
-    const n = node.namedChildCount;
-    for (let i = 0; i < n; i++) {
-      const c = node.namedChild(i);
-      if (c) walk(c, visit);
+/**
+ * Walk the tree once, pre-order, invoking `visit` on every named node.
+ *
+ * ## The walk is iterative, and that is load-bearing
+ *
+ * This walk used to recurse. Tree depth is not bounded by anything the analyzer controls: a
+ * deeply-nested but otherwise valid file (`const x = [[[…]]]`, `f(f(f(…)))`, a minified/generated
+ * bundle) parses into a tree as deep as its source nesting, and the recursion overflowed the JS
+ * stack there — a `RangeError` this whole-file walk runs on EVERY supported file, so it fired on
+ * real input, not only hostile input. The throw was then swallowed by the caller's `catch`
+ * ({@link tallyStyle} in `call-graph.ts`), which SILENTLY dropped the file's entire style
+ * contribution — and, because the stack limit is environment-dependent, dropped it on some
+ * machines and not others, breaking the byte-identical-across-re-analyses guarantee this artifact
+ * must hold. An explicit stack costs a heap array and cannot overflow, so depth stops being a
+ * correctness cliff. This mirrors the same conversion already made for the parse-health walk.
+ *
+ * Order is unchanged: the visit is pre-order and children are pushed in reverse so they pop in
+ * source order — identical visitation order, and therefore byte-identical counters, to the
+ * recursive version on every normal file.
+ */
+function walk(root: StyleAstNode, visit: (n: StyleAstNode) => void): void {
+  const stack: StyleAstNode[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    visit(node);
+    // Prefer the allocation-free index accessors (real tree-sitter SyntaxNode); the `.namedChildren`
+    // getter builds a new array on every node, which made this whole-tree walk the tally's dominant
+    // cost. Fall back to `.namedChildren` for plain test objects. Pushed in reverse so the first
+    // child is visited first — preserving the recursive pre-order.
+    if (typeof node.namedChildCount === 'number' && typeof node.namedChild === 'function') {
+      for (let i = node.namedChildCount - 1; i >= 0; i--) {
+        const c = node.namedChild(i);
+        if (c) stack.push(c);
+      }
+    } else {
+      const kids = node.namedChildren;
+      for (let i = kids.length - 1; i >= 0; i--) stack.push(kids[i]);
     }
-  } else {
-    for (const c of node.namedChildren) walk(c, visit);
   }
 }
 


### PR DESCRIPTION
## Status

LGTM — ready to merge. Closes the fatal-crash and determinism defects found while triple-checking #302's "works for any repo size" claim. **4 commits**, full suite **6625 passed / 0 failed**, typecheck/lint/build green, openspec valid. Every fix is output-preserving and independently reviewed by a parallel agent.

## What was wrong

Three defects, all triggered by deep or large repositories, none caught before:

1. **Fatal crash — deep dependency chain.** `detectCycles` walked the module graph with a **recursive** DFS; recursion depth = chain length, so a repo with a chain of a few thousand files overflowed the stack (`RangeError: Maximum call stack size exceeded`) in Phase 2 of every analyze — outside any exception boundary, aborting the whole analysis. (Overflows at depth ~5,000.)
2. **Determinism hole — deeply-nested file.** The per-file style-fingerprint walk was **recursive** and overflowed on a deeply-nested file; the throw was swallowed by `tallyStyle`'s blanket `catch`, so the file's whole style contribution vanished **silently** — and since the stack limit is environment-dependent, it vanished on some machines and not others, breaking the byte-identical-artifact guarantee.
3. **Large-graph slowdown.** The dependency graph runs on up to 100,000 nodes with no size guard, yet Brandes betweenness used `Array.prototype.shift()` (O(n) dequeue) + O(V²) per-source reinit, and `detectClusters` rescanned every edge per directory (O(D·E)) — making large-repo analyze crawl.

## How it was fixed (all output-preserving)

1. **Iterative cycle detection** — explicit frame stack, byte-identical cycle output; dedup moved to an O(1) rotation-key set (kills a latent O(cycles²) too).
2. **Iterative style walk** — explicit-stack pre-order (children pushed in reverse → identical visitation and counters); the deep file now keeps its style deterministically.
3. **Near-linear graph metrics** — betweenness head-index queue + touched-node reset (O(V²)→O(V·reachable)); `detectClusters` single O(E) edge pass. Normalized centrality maxAbsDiff **0**, cluster stats unchanged.

## Proof

- **Repro (before → after):** an 8,000-file linear import chain threw `RangeError` and exited non-zero on `main`; on this branch it **completes (exit 0)**.
- **Cycle equivalence:** new iterative function deep-equal to a verbatim copy of the old recursion over **200 + 12,000 random graphs** (adversarial-review agent) + hand cases; a 50,000-deep chain completes while the recursive oracle overflows the same input.
- **Style determinism:** a 30,000-deep file now retains its style (before: silently dropped); shallow idioms still tallied. 21/21 style tests.
- **Perf:** doubling experiment shows betweenness ~29× faster at 8k nodes (quadratic→near-linear), clusters ~19–49×; output bit-identical end-to-end.
- Full suite **6625 passed / 2 skipped**, typecheck 0 errors, lint/build clean.

## Completeness — "no fatal crash for any repo"

A whole-codebase audit classified **every** recursive walk in `src/` (analyze, drift, test-gen, MCP, watcher, IaC, exception-flow…). Result: the three fixed here were the only real defects. Every other recursive walk is already iterative (`tarjanScc`, reachability BFS, pathfind), depth-bounded (`subgraph`, `graph.ts`), or exception-isolated (per-file / per-corpus / MCP / CLI boundaries). The remaining limit is *inherent* graph size (needs proportional heap; `--max-old-space-size`), not a bug.

## Context

Found while confirming #302 is fully fixed: a synthetic repo **larger than microsoft/TypeScript** (126k functions) analyzed to exit 0 at **809 MB peak heap** — the memory multiplication #302 reported is gone; these were the remaining any-size defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)