### PR TITLE
docs(openspec): make analyze scale to any repo size with no user attention (spec only)

### DIFF
--- a/openspec/changes/make-analyze-scale-to-any-repo/proposal.md
+++ b/openspec/changes/make-analyze-scale-to-any-repo/proposal.md
@@ -1,0 +1,67 @@
+# Analyze should just work at any repo size, without the user thinking about memory
+
+> Status: **PROPOSED** (2026-08-01). Spec only — no code in this change. Follows the memory-hardening
+> that made analyze *bounded and crash-free* (#302/#304/#306/#312); this makes it *effortless* at
+> scale, so a large repository needs no flags and no attention.
+
+## The gap
+
+OpenLore is now memory-bounded and does not crash on any realistic repository. But the CLI still
+runs at Node's conservative default heap. On a very large repository the call graph itself (its
+nodes and edges) can exceed that default, and the user's only recourse is to know to pass
+`--max-old-space-size` by hand. "It works if you set a Node flag" is not "it just works" — it asks
+for exactly the attention we want to eliminate.
+
+## The promise, stated honestly
+
+OpenLore SHALL analyze any repository that fits the machine, with no flags and no attention. When a
+repository genuinely exceeds the machine, it SHALL degrade gracefully and disclose what it reduced,
+in one line — never abort with a raw V8 fatal. "Any size" is bounded by your RAM; we make the common
+case fully automatic and the over-capacity case survivable, instead of asking anyone to tune a heap.
+
+## What changes — four pillars
+
+1. **Adaptive heap sizing.** The CLI sizes its own heap to the machine: a generous fraction of
+   *available* memory — the container/cgroup limit when one is present, not merely `os.totalmem()` —
+   by re-executing itself once with the right `--max-old-space-size`. It is idempotent (never loops),
+   honors an explicit override and any `NODE_OPTIONS` the user already set, is transparent to the
+   stdio MCP server, and logs the chosen size once so the behavior is observable, not magic.
+
+2. **A cheap pre-flight capacity signal.** Before the heavy passes, estimate the graph's memory from
+   the repository's own size (file count and bytes — already produced by the repository mapper). Use
+   it to pick the heap tier and, when the repository is near the machine's ceiling, choose the
+   reduced-fidelity path *up front* rather than discover the ceiling by crashing partway through.
+
+3. **A graceful-degradation ladder, disclosed.** When even the largest sane heap will not hold
+   full-fidelity analysis, shed the most expensive, least-essential work first, in a defined order
+   (CFG/def-use overlay → deep-analysis breadth → …), so the user still gets a working index. What
+   was reduced is disclosed in the artifact through the existing parse-health / exclusion machinery
+   and in one CLI line, so a downstream conclusion never reads reduced coverage as genuine absence.
+
+4. **Determinism preserved.** Memory management SHALL NOT change the produced artifact. Heap size and
+   buffer-vs-spill choices are already byte-identical (the CFG spill proved this). Only the explicit
+   degradation path may reduce content, and it does so as a function of *declared* constraints
+   (available memory, repository size) — disclosed and reproducible — never a silent,
+   machine-dependent difference between two "full" runs of the same repository.
+
+## Why this shape
+
+- Auto-heap-sizing removes essentially every real-world OOM with a small, safe change and zero user
+  attention — the 80/20 of "just works."
+- The honest degradation ladder keeps the crash-free guarantee from #302/#312 true even past the
+  machine's capacity, without a raw fatal and without silently dropping data undisclosed.
+- Keeping memory management artifact-neutral protects OpenLore's core determinism promise; making
+  degradation explicit, ordered, and disclosed is what lets us scale without lying about coverage.
+
+## Deliberately NOT in scope
+
+- **Out-of-core / streaming graph** — persisting the node/edge graph to SQLite and never holding it
+  whole. That is the only thing that makes a graph *larger than RAM* analyzable, but it is a large
+  architectural bet, and adaptive heap plus graceful degradation cover the practical need. If a real
+  user hits the RAM ceiling at normal function density, that earns its own proposal — this change
+  deliberately does not pre-commit to it.
+- **The embeddable in-process API** cannot re-execute the process; its heap is the host's. This
+  change is the CLI happy path. The API path documents that the host owns the heap and that the
+  degradation ladder still applies within whatever heap the host provides.
+- **A perpetual heap-growth loop.** Re-execution happens at most once per invocation; the pre-flight
+  estimate, not repeated failures, chooses the size.

--- a/openspec/changes/make-analyze-scale-to-any-repo/specs/analyzer/spec.md
+++ b/openspec/changes/make-analyze-scale-to-any-repo/specs/analyzer/spec.md
@@ -1,0 +1,79 @@
+# analyzer spec delta
+
+## ADDED Requirements
+
+### Requirement: PreflightCapacityEstimate
+
+Before the heavy analysis passes, the analyzer SHALL derive a cheap estimate of the memory the
+analysis will need from the repository's own size (file count and total bytes, already produced by
+the repository mapper). The estimate SHALL be used to choose the memory strategy up front — full
+fidelity when it fits, the degradation ladder when it does not — rather than discovering the ceiling
+by failing partway through.
+
+The estimate SHALL be conservative and deterministic given the repository: the same repository
+yields the same estimate, so the strategy chosen is reproducible for a given memory budget.
+
+#### Scenario: A repository that fits runs at full fidelity
+
+- **GIVEN** a repository whose estimated need is within the available heap
+- **WHEN** analysis starts
+- **THEN** the full-fidelity path runs and nothing is degraded or disclosed
+
+#### Scenario: An over-capacity repository is detected before the heavy passes
+
+- **GIVEN** a repository whose estimated need exceeds the available heap
+- **WHEN** analysis starts
+- **THEN** the reduced-fidelity path is chosen up front, not reached by a crash
+
+### Requirement: GracefulMemoryDegradationLadder
+
+When full-fidelity analysis will not fit the available heap, the analyzer SHALL shed work in a
+defined, documented order — most expensive and least essential first (the CFG/def-use overlay, then
+deep-analysis breadth, then further tiers as defined) — and still produce a usable index, rather than
+abort. A raw out-of-memory fatal SHALL NOT be the user-visible outcome of an over-capacity repository
+on a machine that can hold the reduced tier.
+
+Whatever the ladder reduces SHALL be disclosed: recorded in the artifact through the existing
+parse-health / exclusion disclosure machinery, and surfaced in one CLI line. The disclosure SHALL be
+specific enough that a downstream conclusion treats the reduced content as reduced, never as a
+genuine structural absence.
+
+#### Scenario: An over-capacity repository still produces a usable index
+
+- **GIVEN** a repository too large for full fidelity but within the reduced tier
+- **WHEN** it is analyzed
+- **THEN** a working index is produced (call graph and search intact), the overlay/deep-analysis
+  tiers are shed in the defined order, and the reduction is disclosed in the artifact and in one line
+
+#### Scenario: Reduced coverage is never read as genuine absence
+
+- **GIVEN** an analysis that shed a tier under memory pressure
+- **WHEN** a conclusion is served over the resulting index
+- **THEN** the disclosure lets the conclusion distinguish "reduced under memory pressure" from
+  "structurally absent", the same way an excluded-file boundary does today
+
+### Requirement: MemoryManagementIsArtifactNeutral
+
+Memory-management decisions that are NOT degradation — the chosen heap size, and any buffer-versus-
+spill choice such as the CFG overlay's in-memory-then-overflow behavior — SHALL NOT change the
+produced artifact. Two full-fidelity runs of the same repository SHALL yield byte-identical
+artifacts regardless of how much memory each machine had.
+
+Only the degradation ladder may reduce content, and only as a function of *declared* constraints
+(available memory and repository size). A reduction under the same declared constraints SHALL be
+reproducible; there SHALL be no silent, machine-dependent difference between two runs that both ran
+at full fidelity.
+
+#### Scenario: Same repository, different machines, identical full-fidelity artifact
+
+- **GIVEN** two machines with different amounts of RAM, both able to analyze a repository at full
+  fidelity
+- **WHEN** each analyzes the same repository at the same revision
+- **THEN** the produced artifacts are byte-identical — heap size and spill decisions did not leak
+  into the output
+
+#### Scenario: Degradation is a function of declared constraints, not chance
+
+- **GIVEN** two runs of the same repository under the same declared memory budget
+- **WHEN** both must degrade
+- **THEN** they shed the same tiers and disclose the same reduction

--- a/openspec/changes/make-analyze-scale-to-any-repo/specs/cli/spec.md
+++ b/openspec/changes/make-analyze-scale-to-any-repo/specs/cli/spec.md
@@ -1,0 +1,58 @@
+# cli spec delta
+
+## ADDED Requirements
+
+### Requirement: AdaptiveHeapSizing
+
+The `openlore` CLI SHALL size its own V8 heap to the machine so that a large repository analyzes
+without the user setting any Node flag. When the default heap is smaller than a generous fraction of
+the memory available to the process, the CLI SHALL re-execute itself once with
+`--max-old-space-size` set to that fraction, then continue normally.
+
+"Available memory" SHALL be the container/cgroup memory limit when the process runs under one, and
+`os.totalmem()` otherwise — so a CI or container job sizes to its own limit rather than the host's,
+and is not OOM-killed for over-allocating.
+
+Re-execution SHALL be safe and quiet: it happens at most once (a marker prevents any loop), it is
+skipped when the user has already set the heap (via `--max-old-space-size`, `NODE_OPTIONS`, or the
+opt-out below), it preserves argv, environment, exit code, and the stdio streams unchanged (so the
+stdio MCP server and any piped output are unaffected), and it emits a single line naming the chosen
+heap so the behavior is observable rather than hidden.
+
+#### Scenario: A large repository analyzes with no flag
+
+- **GIVEN** a repository whose graph needs more heap than Node's default
+- **AND** the user runs `openlore analyze` (or `install`) with no memory flag
+- **WHEN** the CLI starts
+- **THEN** it re-executes once with a heap sized to the available memory, the analysis completes, and
+  a single line discloses the heap it chose
+
+#### Scenario: The user's own heap choice is respected
+
+- **GIVEN** the user has set `--max-old-space-size` or `NODE_OPTIONS`, or set the opt-out variable
+- **WHEN** the CLI starts
+- **THEN** it does not re-execute and does not override the user's choice
+
+#### Scenario: Re-execution never loops
+
+- **GIVEN** any invocation that re-executes to raise the heap
+- **WHEN** the re-executed process starts
+- **THEN** it sees the marker and does not re-execute again, regardless of outcome
+
+#### Scenario: Container memory limit is honored
+
+- **GIVEN** the process runs under a cgroup/container memory limit smaller than host RAM
+- **WHEN** the CLI sizes its heap
+- **THEN** it sizes to the container limit, not host RAM, so the container does not OOM-kill it
+
+### Requirement: MemoryScalingIsObservableAndOverridable
+
+The CLI SHALL expose a single documented escape hatch to disable adaptive heap sizing, and SHALL make
+the active choice observable. Disabling it SHALL fall back to the current behavior (Node's default or
+whatever the user set), unchanged.
+
+#### Scenario: Adaptive sizing can be turned off
+
+- **GIVEN** the documented opt-out is set
+- **WHEN** the CLI runs
+- **THEN** it does not re-execute or resize, and behaves exactly as it does today

--- a/openspec/changes/make-analyze-scale-to-any-repo/tasks.md
+++ b/openspec/changes/make-analyze-scale-to-any-repo/tasks.md
@@ -1,0 +1,49 @@
+# Tasks — make analyze scale to any repo size
+
+> Status: **PROPOSED** (spec only). No code in this change. Tasks below are the implementation plan
+> for when it is built; all unchecked by design.
+
+## Adaptive heap sizing (CLI)
+- [ ] At CLI entry (`src/cli/index.ts`), before command dispatch: detect the memory budget — read the
+      cgroup/container limit when present (`/sys/fs/cgroup/.../memory.max` etc.), else `os.totalmem()`
+- [ ] If the current `--max-old-space-size` is below the target fraction of the budget AND the user
+      has not set a heap (`--max-old-space-size`, `NODE_OPTIONS`) AND the opt-out is unset AND the
+      re-exec marker is unset: re-exec `process.execPath` with the computed `--max-old-space-size`,
+      passing argv/env through, setting the marker
+- [ ] Marker (e.g. an internal env var) makes re-exec at-most-once; verify no loop under any outcome
+- [ ] Transparent to stdio: the re-exec must not touch the JSON-RPC stream used by `openlore mcp`
+      (inherit stdio; no banner on stdout — the one-line heap disclosure goes to stderr)
+- [ ] One-line disclosure of the chosen heap (stderr); documented opt-out env var
+- [ ] Add the opt-out + the sizing fraction to config/docs; add `OPENLORE_*` knobs consistent with
+      the existing set (e.g. an opt-out and an explicit-budget override)
+
+## Pre-flight capacity estimate (analyzer)
+- [ ] Derive a conservative memory estimate from `repoMap.summary` (file count, bytes) before Phase 3
+- [ ] Map the estimate + available heap to a strategy: full fidelity vs. a degradation tier
+- [ ] Estimate is deterministic for a given repository (no wall-clock/RAM inputs into the number
+      itself — only into the strategy choice)
+
+## Graceful-degradation ladder (analyzer)
+- [ ] Define the tier order (overlay → deep-analysis breadth → …) and the trigger thresholds
+- [ ] Wire each shed tier to a disclosure via the existing parse-health / `FileExclusionReason` /
+      boundary machinery (add a memory-pressure reason/among the existing disclosure surfaces)
+- [ ] Surface one CLI line summarizing what was reduced and why
+- [ ] Guarantee a usable index (call graph + search) is always produced within the reduced tier
+- [ ] Never let a raw V8 fatal be the outcome when the reduced tier fits
+
+## Determinism guardrails (tests)
+- [ ] Test: two heap sizes / two spill thresholds → byte-identical artifact on a fixed repo (extend
+      the existing analyze-twice byte-diff e2e)
+- [ ] Test: degradation is a pure function of declared constraints (same budget + repo → same shed
+      tiers + same disclosure)
+- [ ] Test: over-capacity repo produces a usable, disclosed, reduced index instead of a fatal
+- [ ] Test (CLI): re-exec is at-most-once, respects user heap / `NODE_OPTIONS` / opt-out, and is
+      transparent to stdio (mcp JSON-RPC unaffected)
+
+## Docs
+- [ ] README / docs: state the honest promise — "works to your machine's capacity, degrades
+      gracefully and transparently beyond it, never crashes" — and the opt-out
+- [ ] Note the embeddable API path: host owns the heap; the degradation ladder still applies within it
+
+## Explicitly deferred
+- [ ] Out-of-core / streaming graph (graph larger than RAM) — its own proposal if ever needed


### PR DESCRIPTION
## Status

Spec only — **no code**. A design proposal for review, following the memory-hardening that already made analyze bounded and crash-free (#302 / #304 / #306 / #312). This makes it *effortless* at scale: a large repo needs no flags and no attention.

## What was missing / the motivation

OpenLore no longer crashes or leaks on large repos, but the CLI still runs at Node's conservative default heap. On a very large repository the call graph itself can exceed that default, and the user's only recourse is to know to pass `--max-old-space-size` by hand. "Works if you set a Node flag" is not "just works."

## What it proposes — four pillars

1. **Adaptive heap sizing.** The CLI sizes its own heap to the machine — a generous fraction of *available* memory (container/cgroup limit when present, not just `os.totalmem()`) — by re-executing once with the right `--max-old-space-size`. At-most-once (no loop), respects a user-set heap / `NODE_OPTIONS` / an opt-out, transparent to the stdio MCP server, logged once.
2. **Pre-flight capacity estimate.** Estimate memory need from the repo's own size (file count/bytes, already computed) and pick full-fidelity vs. reduced *up front*, instead of hitting the ceiling by crashing.
3. **Graceful-degradation ladder, disclosed.** Past the machine's capacity, shed the most expensive/least-essential work first (overlay → deep-analysis breadth → …), still produce a usable index, and **disclose** what was reduced via the existing parse-health/exclusion machinery — never a raw fatal, never silent.
4. **Determinism preserved.** Memory management (heap size, buffer-vs-spill) must **not** change the artifact; only the explicit degradation path reduces content, and only as a function of declared constraints — so two machines produce byte-identical full-fidelity artifacts.

## The honest promise

> Works to your machine's capacity with zero attention; beyond it, degrades gracefully and transparently — never crashes.

"Any size" is bounded by RAM; we make the common case automatic and the over-capacity case survivable and disclosed, rather than asking anyone to tune a heap.

## Deliberately out of scope

- **Out-of-core / streaming graph** (graph larger than RAM) — the only thing that makes a graph bigger than RAM analyzable, but a large architectural bet; earns its own proposal if a real user hits the ceiling at normal function density.
- **The embeddable in-process API** can't re-exec — host owns the heap; the degradation ladder still applies within it.

## Files

`openspec/changes/make-analyze-scale-to-any-repo/` — `proposal.md`, `tasks.md`, and spec deltas for `cli` (adaptive heap sizing, observable/overridable) and `analyzer` (pre-flight estimate, degradation ladder, artifact-neutral memory management). `openspec validate --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)