### PR TITLE
chore(release): stage v2.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to OpenLore are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [2.1.8] - 2026-08-02
+
+**The release where `analyze` stopped caring how big your repo is.**
+
+Last time `analyze` stopped dying on one hostile *file*. This time it stops dying on
+the whole *repository*, however large. Plus we closed a security advisory, and the MCP
+server finally leaves when you do. Everything is additive and backward-compatible.
+
+### Security: a spec write that could escape the project root (GHSA-5j8x-q7q6-58j5)
+
+`openlore generate` built each spec's output path from an LLM-derived `domain` field.
+Against a repository you don't trust, a crafted value could steer that write *outside*
+your project root. Now the domain is normalized to a single safe path segment and every
+spec write goes through the same symlink-aware root guard the rest of the codebase uses —
+an out-of-root path is refused, not written. Regression tests on both the source and the
+sink, plus a structural guard so a future edit can't quietly reopen the door.
+
+### `analyze` scales to any repo size
+
+- **No more out-of-memory on large repositories.** Repo-wide enrichment scans are bounded,
+  five superlinear scans are gone, and the background index no longer grows forever.
+- **The CFG overlay stays in memory and only spills to disk when it's actually big** — the
+  common case never touches the filesystem.
+- **Adaptive heap + graceful degradation.** `analyze` sizes its own heap to the machine
+  (cgroup-aware) and, when a repo is too big for a full pass, steps down a level instead of
+  falling over. Any repo finishes with *some* answer, never a crash.
+- **Deep import chains no longer overflow the stack** — cycle detection is iterative now.
+
+### The MCP server leaves when you do
+
+The zombie-process known issue from 2.1.7 is fixed: the stdio server's lifetime is now
+bound to its transport, so when your agent closes stdin, the process (and its file watcher)
+exits. No more stray `openlore mcp` holding caches after the session ends.
+
+### Honesty, still the house style
+
+- **The walker no longer hands back a silently smaller graph.** If it can't cover the whole
+  corpus it says so — with a truncation receipt — instead of quietly analyzing less.
+- **Git-derived signals tell the truth** about their own window: churn is measured over a
+  real pre-change window, federation claims reflect the current tree, and change detection is
+  work-tree-aware.
+- **`generate` preserves your existing specs** instead of clobbering them on regeneration.
+
+### Under the hood
+
+- Property-based fuzzing now runs against the untrusted-input surface.
+- Dependency bumps: commander 15, chalk 6, ora 9, transformers 4.
+
+### Known issues
+
+- **A config missing its `analysis` section still crashes `analyze`** with an internal
+  `TypeError` (and `doctor` still calls that config healthy). Not a regression — carried over
+  from 2.1.7. If you hand-edit `.openlore/config.json`, keep the `analysis` block, or re-run
+  `openlore init`.
+
+---
+
+**Upgrade:** `npm i -g openlore@2.1.8` — or `openlore update`.
+
+**Full Changelog**: https://github.com/clay-good/OpenLore/compare/v2.1.7...v2.1.8
+
 ## [2.1.7] - 2026-07-26
 
 **The release where `analyze` stopped dying and started explaining itself.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Persistent architectural memory and structural cognition for AI coding agents.",
   "type": "module",
   "main": "dist/api/index.js",


### PR DESCRIPTION
## Status

**LGTM — ready to cut v2.1.8.** All release gates pass locally against `main` (already in sync at #322). This PR only stages the release: version bump + CHANGELOG. No source changes.

## What this does

Bumps `package.json` + `package-lock.json` to **2.1.8** and adds the CHANGELOG section for the 23 commits merged since v2.1.7. Headlines:

- **Security advisory GHSA-5j8x-q7q6-58j5 closed** (#311) — the spec-writer confined the output path from an LLM-derived `domain` without sanitizing it; a crafted value in an untrusted repo could write outside the project root. Now normalized to a safe segment and routed through the symlink-aware root guard, with source+sink regression tests and a structural guard.
- **`analyze` scales to any repo size** (#294, #303, #305, #306/#310, #309, #312, #313/#314) — bounded enrichment scans, five superlinear scans removed, in-memory CFG overlay that spills only when large, adaptive (cgroup-aware) heap sizing + a graceful-degradation ladder, and iterative cycle detection so deep import chains no longer overflow the stack.
- **No more zombie MCP servers** (#320) — stdio server lifetime bound to its transport; closing stdin exits the process and its watcher. (Resolves a v2.1.7 known issue.)
- **Honesty surface hardened** — walker no longer returns a silently smaller graph (#322), git-derived signals are truthful about their window (#318), `generate` preserves existing specs (#315).
- **Property-based fuzzing** on the untrusted-input surface (#319); dep bumps (commander 15, chalk 6, ora 9, transformers 4).

## Proof it works — release gates (local, mirrors `release.yml` validate)

| Gate | Result |
|------|--------|
| `npm run lint` | ✅ clean |
| `npm run typecheck` | ✅ clean |
| `npm run test:run` | ✅ 357 files, **6862 passed**, 2 skipped |
| `npm run build` | ✅ clean |
| `npm run audit:packlist` | ✅ 1563 files, nothing forbidden, all entrypoints present |
| `npm run fuzz` | ✅ 35 passed |
| `npm run test:e2e` (integration) | ✅ **178 passed**, 1 stale golden (see notes) |
| `openlore analyze` (dogfood) | ✅ exit 0, 15s, ~1.4 GB peak RSS, 0 parse failures |
| `npm audit --omit=dev` | ✅ **0 vulnerabilities** in production deps |

## Notes / nits

- **One e2e non-blocker:** the `live-data` integration test's golden for the external `ts-commander` repo is stale (`totalFiles` 203→206, `criticalHubs` 0→3). Last refreshed 2026-06-21; the delta is deterministic across re-runs and fully explained by intended analyzer improvements since (notably #322, "no silently smaller graph"). This test clones external repos, is **not run in CI**, and is **not a release gate**. Refreshing all 7 repo goldens belongs in a full-clone environment (a blanket `-u` here would delete the 6 goldens for repos not cloned locally), so it is intentionally left for a separate change.
- **Carried-forward known issue:** a config missing its `analysis` section still crashes `analyze` with a `TypeError` (pre-existing, documented in 2.1.7, not a regression). Noted in the CHANGELOG.
- The high-severity `brace-expansion` npm-audit finding is **dev-only** (via the `pi-coding-agent` devDependency) and does not ship in the tarball.

## Cutting the release

After merge to `main`: tag `v2.1.8` at the merge commit and push it. `release.yml` runs validate → create GitHub Release (from this CHANGELOG section) → publish to npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)