### PR TITLE
fix(security): resolve open dependency advisories and harden file-walker property write

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6602,9 +6602,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7500,9 +7500,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -7990,9 +7990,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -209,12 +209,14 @@
       "protobufjs": "^7.6.5"
     },
     "ws": "^8.21.0",
-    "undici": "^8.5.0",
+    "undici": "^8.9.0",
     "js-yaml": "^4.3.0",
-    "hono": "^4.12.32",
+    "hono": "^4.12.34",
     "@hono/node-server": "^2.0.5",
     "sharp": "^0.35.0",
     "adm-zip": "^0.6.0",
+    "fast-uri": "^3.1.5",
+    "brace-expansion": "^5.0.9",
     "onnxruntime-web": {
       "protobufjs": "^7.6.5"
     },
@@ -223,7 +225,7 @@
         "protobufjs": "^7.6.5"
       },
       "ws": "^8.21.0",
-      "undici": "^8.5.0"
+      "undici": "^8.9.0"
     }
   },
   "devDependencies": {

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -32,6 +32,33 @@ const ALLOWLIST = {
     clearsWhen:
       'pi-coding-agent bumps brace-expansion in its shrinkwrap, or drops the shrinkwrap.',
   },
+  'GHSA-rgw5-rvv9-x895': {
+    package: 'brace-expansion',
+    reason:
+      'Affects <5.0.9, patched in 5.0.9 (a follow-up to CVE-2026-14257). Our own tree is ' +
+      'already on 5.0.9 via a top-level `overrides` pin; this survives ONLY under the same ' +
+      'shrinkwrapped @earendil-works/pi-coding-agent -> minimatch -> brace-expansion@5.0.7 ' +
+      'subtree as GHSA-mh99-v99m-4gvg — `overrides` cannot rewrite a dependency\'s ' +
+      'npm-shrinkwrap.json (same verification as that entry). Dev-only (pi-coding-agent is a ' +
+      'devDependency, absent from the published `files` list) and reached only by ' +
+      'developer-authored glob input.',
+    clearsWhen:
+      'pi-coding-agent bumps brace-expansion in its shrinkwrap, or drops the shrinkwrap.',
+  },
+  'GHSA-4cwx-7wf7-3272': {
+    package: 'undici',
+    reason:
+      'Affects <8.9.0, patched in 8.9.0. undici appears in the tree ONLY as a nested ' +
+      'dependency of @earendil-works/pi-coding-agent (8.5.0), locked by that package\'s ' +
+      'npm-shrinkwrap.json — a top-level and a nested `overrides` undici pin both left it at ' +
+      '8.5.0, so `overrides` cannot rewrite it (same mechanism as the brace-expansion ' +
+      'entries). Dev-only (pi-coding-agent is a devDependency, absent from the published ' +
+      '`files` list); undici is not reachable from any shipped code path. The four remaining ' +
+      'undici advisories on the same 8.5.0 copy are moderate and below this gate\'s ' +
+      'high/critical threshold.',
+    clearsWhen:
+      'pi-coding-agent bumps undici to >=8.9.0 in its shrinkwrap, or drops the shrinkwrap.',
+  },
 };
 
 const GATED = new Set(['high', 'critical']);

--- a/src/core/analyzer/file-walker.test.ts
+++ b/src/core/analyzer/file-walker.test.ts
@@ -415,6 +415,22 @@ describe('FileWalker', () => {
       expect(result.summary.byDirectory['(root)']).toBe(1);
     });
 
+    it('counts a directory named __proto__ as an ordinary key without polluting Object.prototype', async () => {
+      // The directory/extension counters are keyed by repository-derived names. A directory
+      // literally named `__proto__` (or `constructor`) must be counted as a plain key and must
+      // never reach `Object.prototype` — the counters are Maps materialized to plain objects.
+      await mkdir(join(testDir, '__proto__'));
+      await writeFile(join(testDir, '__proto__', 'a.ts'), '');
+      await writeFile(join(testDir, '__proto__', 'b.ts'), '');
+
+      const result = await walkDirectory(testDir);
+
+      expect(result.summary.byDirectory['__proto__']).toBe(2);
+      // No global prototype pollution occurred.
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(Object.prototype).not.toHaveProperty('a.ts');
+    });
+
     it('should track skipped files', async () => {
       await mkdir(join(testDir, 'node_modules'));
       await writeFile(join(testDir, 'node_modules', 'pkg.js'), '');

--- a/src/core/analyzer/file-walker.ts
+++ b/src/core/analyzer/file-walker.ts
@@ -479,14 +479,14 @@ export class FileWalker {
   private skippedCount = 0;
   private skippedReasons: Record<string, number> = {};
   private directoriesScanned = 0;
-  private extensionCounts: Record<string, number> = {};
   /**
-   * Keyed by directory path, which comes from the scanned repository — so a directory
-   * literally named `__proto__` would otherwise read and write `Object.prototype`
-   * instead of this table. `Object.create(null)` has no prototype to reach, and still
-   * serializes as a plain object for `byDirectory`.
+   * Counters keyed by file extension and by directory path. Both keys come from the
+   * scanned repository, so a file whose extension or directory is literally `__proto__`
+   * (or `constructor`) must never reach `Object.prototype`. A `Map` has no such sink;
+   * it is materialized to a plain object for the public summary at the walk boundary.
    */
-  private directoryCounts: Record<string, number> = Object.create(null) as Record<string, number>;
+  private extensionCounts = new Map<string, number>();
+  private directoryCounts = new Map<string, number>();
 
   constructor(rootPath: string, options: FileWalkerOptions = {}) {
     this.rootPath = rootPath;
@@ -910,10 +910,10 @@ export class FileWalker {
 
       // Update counts
       const ext = extension || '(no extension)';
-      this.extensionCounts[ext] = (this.extensionCounts[ext] ?? 0) + 1;
+      this.extensionCounts.set(ext, (this.extensionCounts.get(ext) ?? 0) + 1);
 
       const dir = directory === '' || directory === '.' ? '(root)' : directory;
-      this.directoryCounts[dir] = (this.directoryCounts[dir] ?? 0) + 1;
+      this.directoryCounts.set(dir, (this.directoryCounts.get(dir) ?? 0) + 1);
       return true;
     } catch (e) {
       this.recordSkip(directorySkipReason(e));
@@ -936,8 +936,8 @@ export class FileWalker {
     this.skippedCount = 0;
     this.skippedReasons = {};
     this.directoriesScanned = 0;
-    this.extensionCounts = {};
-    this.directoryCounts = Object.create(null) as Record<string, number>;
+    this.extensionCounts = new Map();
+    this.directoryCounts = new Map();
     this.stopWalk = false;
     this.truncatedAtPath = null;
     this.postCapEntriesExamined = 0;
@@ -1000,8 +1000,8 @@ export class FileWalker {
       summary: {
         totalFiles: this.files.length,
         totalDirectories: this.directoriesScanned,
-        byExtension: this.extensionCounts,
-        byDirectory: this.directoryCounts,
+        byExtension: Object.fromEntries(this.extensionCounts),
+        byDirectory: Object.fromEntries(this.directoryCounts),
         skippedCount: this.skippedCount,
         skippedReasons: this.skippedReasons,
         // Followed symlinks entered the corpus (a symlinked `src/`, a vendored file). The spec


### PR DESCRIPTION
**Status:** LGTM — all local gates green (audit-gate, lint, typecheck, build, packlist, 6863 tests pass). Resolves every open security alert we can act on; documents the ones blocked upstream.

## What was wrong
Eight open Dependabot advisories and one actionable CodeQL alert:

| Source | Alert | Severity |
|---|---|---|
| Dependabot | `fast-uri` < 3.1.5 — host confusion | high |
| Dependabot | `brace-expansion` < 5.0.9 — DoS (bypasses CVE-2026-14257 mitigation) | high |
| Dependabot | `undici` < 8.9.0 — 5 advisories (desync, cache disclosure, CRLF, cookie inject) | high + moderate |
| Dependabot | `hono` < 4.12.34 — CORS ReDoS | medium |
| CodeQL | `js/remote-property-injection` — `file-walker.ts:916` | high |

## How it was fixed

**Dependencies** (`package.json` overrides + regenerated lock):
- `fast-uri` 3.1.4 → **3.1.5**
- `hono` 4.12.32 → **4.13.0**
- `brace-expansion` 5.0.8 → **5.0.9** (top level)

`undici` and a second `brace-expansion` copy survive **only** nested under the dev-only `@earendil-works/pi-coding-agent`, which ships its own `npm-shrinkwrap.json`. npm honors a dependency's shrinkwrap, so `overrides` provably cannot rewrite that subtree (verified: top-level, nested, and depth-targeted pins all leave it unchanged). That subtree is a **devDependency**, absent from the published `files` allowlist, so it never reaches consumers. The two new **high** advisories there (`GHSA-rgw5-rvv9-x895`, `GHSA-4cwx-7wf7-3272`) are added to the **self-expiring** `scripts/audit-gate.mjs` allowlist with reasons + clearing conditions, matching the existing exception. The gate FAILS if any allowlisted advisory leaves the tree, so no exception can outlive its cause.

**CodeQL `js/remote-property-injection`:** the extension/directory counters are keyed by repository-derived names. `directoryCounts` was already `Object.create(null)`, but CodeQL doesn't treat that as a sanitizer. Both counters now use a `Map` (no `Object.prototype` sink) and materialize to a plain object at the walk boundary — this removes the entire injection class rather than suppressing the alert.

## Proof it works
- `node scripts/audit-gate.mjs` → **OK**, no unallowed high/critical advisories.
- New regression test: a directory literally named `__proto__` is counted as an ordinary key and does not pollute `Object.prototype`.
- Full suite: **357 files, 6863 passed, 2 skipped**; lint / typecheck / build / packlist all green; lockfile in sync with `package.json` (`npm ci` will pass).

## Notes
- The 5 moderate `undici` advisories on the same shrinkwrapped 8.5.0 copy are below the gate's high/critical threshold; they clear when pi-coding-agent bumps undici upstream.
- Remaining open **code-scanning** alerts are OpenSSF Scorecard governance findings (branch protection, code-review, best-practices badge) — repo-policy settings, open by design, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)