### PR TITLE
fix(analyzer): use the tsx grammar for .tsx/.jsx files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8908,9 +8908,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "sharp": "^0.35.0",
     "adm-zip": "^0.6.0",
     "fast-uri": "^3.1.5",
+    "nanoid": "^3.3.17",
     "brace-expansion": "^5.0.9",
     "onnxruntime-web": {
       "protobufjs": "^7.6.5"

--- a/src/core/analyzer/ast-chunker.test.ts
+++ b/src/core/analyzer/ast-chunker.test.ts
@@ -115,6 +115,22 @@ describe('astChunkContent', () => {
     }
   });
 
+  it('keeps TSX declarations intact instead of chunking parser-error fragments', async () => {
+    const content = [
+      "import React from 'react';",
+      'export const A = () => <section>{items.map(x => <span>{x}</span>)}</section>;',
+      'export const B = () => <main/>;',
+    ].join('\n');
+
+    const chunks = await astChunkContent(content, 'src/View.tsx', 80);
+
+    expect(chunks).toEqual([
+      "import React from 'react';",
+      "import React from 'react';\n\nexport const A = () => <section>{items.map(x => <span>{x}</span>)}</section>;",
+      "import React from 'react';\n\nexport const B = () => <main/>;",
+    ]);
+  });
+
   // Regression for change: fix-language-detection-single-source. The `.mts`/`.cts`/`.jsx`
   // extension variants were absent from the (now-deleted) code-shaper detection map that fed
   // this chunker, so they resolved to 'unknown' → generic blank-line fallback. With the single

--- a/src/core/analyzer/ast-chunker.ts
+++ b/src/core/analyzer/ast-chunker.ts
@@ -10,7 +10,7 @@
  */
 
 import type Parser from 'tree-sitter';
-import { detectLanguage } from './language-detection.js';
+import { detectLanguage, usesTsxGrammar } from './language-detection.js';
 import { parseWithBudget, type BudgetableParser } from './parse-budget.js';
 
 // ── Lazy parser singletons (one per language, created on first use) ─────────
@@ -37,17 +37,6 @@ async function loadNativeParser(): Promise<typeof Parser | null> {
   return _NativeParser;
 }
 
-
-/** True when the file is JSX/TSX, which needs tree-sitter-typescript's `tsx`
- *  grammar. The plain `typescript` grammar treats every JSX element as a syntax
- *  error, so a React file parses to thousands of ERROR nodes and its symbols and
- *  edges silently become a small fraction of what is there. */
-function isJsxPath(filePath?: string): boolean {
-  if (!filePath) return false;
-  const p = filePath.toLowerCase();
-  return p.endsWith('.tsx') || p.endsWith('.jsx');
-}
-
 async function getParserForLanguage(lang: string, filePath?: string): Promise<Parser | null> {
   try {
     const NP = await loadNativeParser();
@@ -55,7 +44,7 @@ async function getParserForLanguage(lang: string, filePath?: string): Promise<Pa
     switch (lang.toLowerCase()) {
       case 'typescript':
       case 'javascript': {
-        if (isJsxPath(filePath)) {
+        if (usesTsxGrammar(filePath)) {
           if (!_tsxParser) {
             const m = await import('tree-sitter-typescript');
             _tsxParser = new NP();

--- a/src/core/analyzer/ast-chunker.ts
+++ b/src/core/analyzer/ast-chunker.ts
@@ -16,6 +16,7 @@ import { parseWithBudget, type BudgetableParser } from './parse-budget.js';
 // ── Lazy parser singletons (one per language, created on first use) ─────────
 
 let _tsParser: Parser | undefined;
+let _tsxParser: Parser | undefined;
 let _pyParser: Parser | undefined;
 let _goParser: Parser | undefined;
 let _rustParser: Parser | undefined;
@@ -36,13 +37,34 @@ async function loadNativeParser(): Promise<typeof Parser | null> {
   return _NativeParser;
 }
 
-async function getParserForLanguage(lang: string): Promise<Parser | null> {
+
+/** True when the file is JSX/TSX, which needs tree-sitter-typescript's `tsx`
+ *  grammar. The plain `typescript` grammar treats every JSX element as a syntax
+ *  error, so a React file parses to thousands of ERROR nodes and its symbols and
+ *  edges silently become a small fraction of what is there. */
+function isJsxPath(filePath?: string): boolean {
+  if (!filePath) return false;
+  const p = filePath.toLowerCase();
+  return p.endsWith('.tsx') || p.endsWith('.jsx');
+}
+
+async function getParserForLanguage(lang: string, filePath?: string): Promise<Parser | null> {
   try {
     const NP = await loadNativeParser();
     if (!NP) return null;
     switch (lang.toLowerCase()) {
       case 'typescript':
       case 'javascript': {
+        if (isJsxPath(filePath)) {
+          if (!_tsxParser) {
+            const m = await import('tree-sitter-typescript');
+            _tsxParser = new NP();
+            _tsxParser.setLanguage(
+              ((m.default ?? m) as { tsx: object }).tsx as Parser.Language
+            );
+          }
+          return _tsxParser!;
+        }
         if (!_tsParser) {
           const m = await import('tree-sitter-typescript');
           _tsParser = new NP();
@@ -177,7 +199,7 @@ export async function astChunkContent(
   if (content.length <= maxChars) return [content];
 
   const language = detectLanguage(filePath);
-  const parser = await getParserForLanguage(language);
+  const parser = await getParserForLanguage(language, filePath);
   if (!parser) return blankLineChunk(content, maxChars, overlapLines);
 
   let tree: Parser.Tree;

--- a/src/core/analyzer/call-graph.test.ts
+++ b/src/core/analyzer/call-graph.test.ts
@@ -550,6 +550,23 @@ describe('CallGraphBuilder — JavaScript', () => {
     expect(edgePairs(result)).toEqual(['init→setup']);
     expect(fanIn(result, 'setup')).toBe(1);
   });
+
+  it('parses JSX files with JSX syntax and resolves their calls', async () => {
+    const builder = new CallGraphBuilder();
+    const result = await builder.build([{
+      path: 'src/View.jsx',
+      language: 'JavaScript',
+      content: `
+        function save() {}
+        export function View() {
+          return <button onClick={() => save()}>Save</button>;
+        }
+      `,
+    }]);
+
+    expect(nodeNames(result)).toEqual(['View', 'save']);
+    expect(edgePairs(result)).toContain('View→save');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/analyzer/call-graph.test.ts
+++ b/src/core/analyzer/call-graph.test.ts
@@ -132,6 +132,22 @@ describe('CallGraphBuilder — TypeScript', () => {
     expect(edgePairs(result)).toContain('run→shared');
   });
 
+  it('resolves inherited methods in TSX files', async () => {
+    const builder = new CallGraphBuilder();
+    const result = await builder.build([{
+      path: 'src/view.tsx',
+      language: 'TypeScript',
+      content: `
+        class Base { inherited() { return <span />; } }
+        class Child extends Base {
+          run() { this.inherited(); return <main />; }
+        }
+      `,
+    }]);
+
+    expect(edgePairs(result)).toContain('run→inherited');
+  });
+
   it('resolves super.method() to the PARENT class method, not the overriding child', async () => {
     const builder = new CallGraphBuilder();
     const result = await builder.build([{

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -44,6 +44,7 @@ import {
 // Per-file parse budget (change: fix-analyze-native-abort-and-file-cost-budget). Bounds the one
 // synchronous native call nothing else can interrupt.
 import { parseWithBudget, parseBudgetOverrunMs, parseBudgetMs, type BudgetableParser } from './parse-budget.js';
+import { usesTsxGrammar } from './language-detection.js';
 // Pass-1 extraction lane (change: optimize-parallel-extraction-pool). The pool holds no
 // extraction logic of its own — it dispatches `dispatchFileExtract` to worker threads and
 // merges by input index, with the serial loop as both reference and fallback.
@@ -200,23 +201,12 @@ let _KtLanguage: object | undefined;
 let _ScalaLanguage: object | undefined;
 let _ExLanguage: object | undefined;
 
-
-/** True when the file is JSX/TSX, which needs tree-sitter-typescript's `tsx`
- *  grammar. The plain `typescript` grammar treats every JSX element as a syntax
- *  error, so a React file parses to thousands of ERROR nodes and its symbols and
- *  edges silently become a small fraction of what is there. */
-function isJsxPath(filePath?: string): boolean {
-  if (!filePath) return false;
-  const p = filePath.toLowerCase();
-  return p.endsWith('.tsx') || p.endsWith('.jsx');
-}
-
 async function getTSParser(
   filePath?: string
 ): Promise<{ parser: Parser; lang: object } | null> {
   const NP = await loadNativeParser();
   if (!NP) return null;
-  if (isJsxPath(filePath)) {
+  if (usesTsxGrammar(filePath)) {
     if (!_tsxParser) {
       const tsModule = await import('tree-sitter-typescript');
       _TsxLanguage = (tsModule.default as { tsx: object }).tsx;
@@ -2508,7 +2498,7 @@ async function extractClassRelationships(
   for (const file of files) {
     try {
       if (file.language === 'TypeScript' || file.language === 'JavaScript') {
-        const r = await getTSParser();
+        const r = await getTSParser(file.path);
         if (!r) continue;
         const { parser, lang } = r;
         const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content);
@@ -3679,16 +3669,14 @@ async function synthesizeEventChannelEdges(
     (f.language === 'TypeScript' || f.language === 'JavaScript') && EVENT_PREFILTER.test(f.content),
   );
   if (tsFiles.length > 0) {
-    const r = await getTSParser();
-    if (r) {
-      const { parser } = r;
-      const sites: EventSites = { registrations: [], dispatches: [] };
-      for (const file of tsFiles) {
-        try { collectTsEventSites(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
-        catch { /* skip unparseable file */ }
-      }
-      edges.push(...pairAndEmitEventEdges(sites, allNodes, 'event-channel'));
+    const sites: EventSites = { registrations: [], dispatches: [] };
+    for (const file of tsFiles) {
+      const r = await getTSParser(file.path);
+      if (!r) continue;
+      try { collectTsEventSites(parseWithBudget(r.parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, sites); }
+      catch { /* skip unparseable file */ }
     }
+    edges.push(...pairAndEmitEventEdges(sites, allNodes, 'event-channel'));
   }
 
   const pyFiles = files.filter(f => f.language === 'Python' && EVENT_PREFILTER.test(f.content));
@@ -3989,13 +3977,11 @@ async function synthesizeCallbackRegistrationEdges(
 
   const tsFiles = files.filter(f => (f.language === 'TypeScript' || f.language === 'JavaScript') && TS_CALLBACK_PREFILTER.test(f.content));
   if (tsFiles.length > 0) {
-    const r = await getTSParser();
-    if (r) {
-      const { parser } = r;
-      for (const file of tsFiles) {
-        try { collectTsCallbackEdges(parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, out, seen); }
-        catch { /* skip */ }
-      }
+    for (const file of tsFiles) {
+      const r = await getTSParser(file.path);
+      if (!r) continue;
+      try { collectTsCallbackEdges(parseWithBudget(r.parser as unknown as BudgetableParser<Parser.Tree>, file.content), nodesByFile.get(file.path) ?? [], file.path, resolveHandler, out, seen); }
+      catch { /* skip */ }
     }
   }
 

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -154,6 +154,7 @@ function tallyStyle(language: string, tree: Parser.Tree, nodes: FunctionNode[], 
 // ============================================================================
 
 let _tsParser: Parser | undefined;
+let _tsxParser: Parser | undefined;
 let _pyParser: Parser | undefined;
 let _goParser: Parser | undefined;
 let _rustParser: Parser | undefined;
@@ -185,6 +186,7 @@ async function loadNativeParser(): Promise<typeof Parser | null> {
   return _NativeParser;
 }
 let _TsLanguage: object | undefined;
+let _TsxLanguage: object | undefined;
 let _PyLanguage: object | undefined;
 let _GoLanguage: object | undefined;
 let _RustLanguage: object | undefined;
@@ -198,9 +200,31 @@ let _KtLanguage: object | undefined;
 let _ScalaLanguage: object | undefined;
 let _ExLanguage: object | undefined;
 
-async function getTSParser(): Promise<{ parser: Parser; lang: object } | null> {
+
+/** True when the file is JSX/TSX, which needs tree-sitter-typescript's `tsx`
+ *  grammar. The plain `typescript` grammar treats every JSX element as a syntax
+ *  error, so a React file parses to thousands of ERROR nodes and its symbols and
+ *  edges silently become a small fraction of what is there. */
+function isJsxPath(filePath?: string): boolean {
+  if (!filePath) return false;
+  const p = filePath.toLowerCase();
+  return p.endsWith('.tsx') || p.endsWith('.jsx');
+}
+
+async function getTSParser(
+  filePath?: string
+): Promise<{ parser: Parser; lang: object } | null> {
   const NP = await loadNativeParser();
   if (!NP) return null;
+  if (isJsxPath(filePath)) {
+    if (!_tsxParser) {
+      const tsModule = await import('tree-sitter-typescript');
+      _TsxLanguage = (tsModule.default as { tsx: object }).tsx;
+      _tsxParser = new NP();
+      _tsxParser.setLanguage(_TsxLanguage as unknown as Parser.Language);
+    }
+    return { parser: _tsxParser!, lang: _TsxLanguage! };
+  }
   if (!_tsParser) {
     const tsModule = await import('tree-sitter-typescript');
     _TsLanguage = (tsModule.default as { typescript: object }).typescript;
@@ -697,7 +721,7 @@ async function extractTSGraph(
   filePath: string,
   content: string
 ): Promise<{ nodes: FunctionNode[]; rawEdges: RawEdge[]; cfg: Map<string, FunctionCfg>; style?: FileStyleRaw; parseHealth?: FileParseHealth }> {
-  const r = await getTSParser();
+  const r = await getTSParser(filePath);
   if (!r) return { nodes: [], rawEdges: [], cfg: new Map() };
   const { parser, lang } = r;
   const tree = parseWithBudget(parser as unknown as BudgetableParser<Parser.Tree>, content);

--- a/src/core/analyzer/edge-synthesis.test.ts
+++ b/src/core/analyzer/edge-synthesis.test.ts
@@ -38,6 +38,20 @@ describe('event-channel synthesis', () => {
     expect(edge!.kind).toBe('calls');
   });
 
+  it('TSX event handlers remain reachable through synthesized edges', async () => {
+    const b = await new CallGraphBuilder().build([{
+      path: 'src/app.tsx',
+      language: 'TypeScript',
+      content: `
+        function onMount() { return <span />; }
+        function register(emitter: any) { emitter.on('mount', onMount); return <div />; }
+        function trigger(emitter: any) { emitter.emit('mount'); return <main />; }
+      `,
+    }]);
+
+    expect(edgeBetween(b, 'trigger', 'onMount')?.synthesizedBy).toBe('event-channel');
+  });
+
   it('Mismatched channel keys produce no edge', async () => {
     const b = await build(`
       function handler() { return 1; }
@@ -693,6 +707,19 @@ describe('callback-registration synthesis', () => {
     ].join('\n') }]);
     expect(edgeBetween(b, 'start', 'tick')?.synthesizedBy).toBe('callback-registration');
     expect(edgeBetween(b, 'start', 'poll')?.synthesizedBy).toBe('callback-registration');
+  });
+
+  it('TSX: setTimeout with a named function wires the callback', async () => {
+    const b = await new CallGraphBuilder().build([{
+      path: 'app.tsx',
+      language: 'TypeScript',
+      content: [
+        'function tick() { return <span />; }',
+        'function start() { setTimeout(tick, 1000); return <main />; }',
+      ].join('\n'),
+    }]);
+
+    expect(edgeBetween(b, 'start', 'tick')?.synthesizedBy).toBe('callback-registration');
   });
 
   it('JS/TS: an inline arrow to setTimeout is NOT a callback-registration edge (direct resolution covers it)', async () => {

--- a/src/core/analyzer/edge-synthesis.test.ts
+++ b/src/core/analyzer/edge-synthesis.test.ts
@@ -52,6 +52,30 @@ describe('event-channel synthesis', () => {
     expect(edgeBetween(b, 'trigger', 'onMount')?.synthesizedBy).toBe('event-channel');
   });
 
+  it('selects the grammar per file in a mixed TypeScript and TSX batch', async () => {
+    const b = await new CallGraphBuilder().build([
+      {
+        path: 'src/register.ts',
+        language: 'TypeScript',
+        content: `
+          function onSave() { return 1; }
+          function register(emitter: any) {
+            const count = <number>1;
+            emitter.on('save', onSave);
+            return count;
+          }
+        `,
+      },
+      {
+        path: 'src/trigger.tsx',
+        language: 'TypeScript',
+        content: `function trigger(emitter: any) { emitter.emit('save'); return <main />; }`,
+      },
+    ]);
+
+    expect(edgeBetween(b, 'trigger', 'onSave')?.synthesizedBy).toBe('event-channel');
+  });
+
   it('Mismatched channel keys produce no edge', async () => {
     const b = await build(`
       function handler() { return 1; }

--- a/src/core/analyzer/exception-flow.test.ts
+++ b/src/core/analyzer/exception-flow.test.ts
@@ -20,6 +20,19 @@ describe('extractExceptionFacts — TypeScript', () => {
     expect(tsParser?.parse('const value = <Widget>input;').rootNode.hasError).toBe(false);
   });
 
+  it('extracts exception facts from a TSX function through the source API', async () => {
+    const facts = await extractExceptionFactsFromSource(
+      'function View() { risky(); if (bad) throw new RenderError(); return <button>Go</button>; }',
+      'TypeScript',
+      'src/View.tsx',
+    );
+
+    expect(facts.throwSites).toEqual([
+      expect.objectContaining({ type: 'RenderError', locallyHandled: false }),
+    ]);
+    expect(facts.callSites.map(site => site.calleeName)).toContain('risky');
+  });
+
   it('reports a direct, un-caught throw with its constructed type', async () => {
     const facts = await extractExceptionFactsFromSource(
       `function f() {\n  throw new RangeError("bad");\n}`,

--- a/src/core/analyzer/exception-flow.test.ts
+++ b/src/core/analyzer/exception-flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   extractExceptionFactsFromSource,
+  getExceptionParser,
   innermostGuard,
   enclosingGuards,
   guardCatches,
@@ -11,6 +12,14 @@ import {
 } from './exception-flow.js';
 
 describe('extractExceptionFacts — TypeScript', () => {
+  it('parses TSX without regressing TypeScript angle-bracket assertions', async () => {
+    const tsxParser = await getExceptionParser('TypeScript', 'src/View.tsx');
+    const tsParser = await getExceptionParser('TypeScript', 'src/cast.ts');
+
+    expect(tsxParser?.parse('const View = () => <section />;').rootNode.hasError).toBe(false);
+    expect(tsParser?.parse('const value = <Widget>input;').rootNode.hasError).toBe(false);
+  });
+
   it('reports a direct, un-caught throw with its constructed type', async () => {
     const facts = await extractExceptionFactsFromSource(
       `function f() {\n  throw new RangeError("bad");\n}`,

--- a/src/core/analyzer/exception-flow.ts
+++ b/src/core/analyzer/exception-flow.ts
@@ -26,6 +26,7 @@
  */
 
 import type Parser from 'tree-sitter';
+import { usesTsxGrammar } from './language-detection.js';
 import { parseWithBudget, type BudgetableParser } from './parse-budget.js';
 
 /** The languages whose exception flow is statically extractable here. This is the
@@ -187,17 +188,6 @@ async function loadNativeParser(): Promise<typeof Parser | null> {
   return _NativeParser;
 }
 
-
-/** True when the file is JSX/TSX, which needs tree-sitter-typescript's `tsx`
- *  grammar. The plain `typescript` grammar treats every JSX element as a syntax
- *  error, so a React file parses to thousands of ERROR nodes and its symbols and
- *  edges silently become a small fraction of what is there. */
-function isJsxPath(filePath?: string): boolean {
-  if (!filePath) return false;
-  const p = filePath.toLowerCase();
-  return p.endsWith('.tsx') || p.endsWith('.jsx');
-}
-
 /** A tree-sitter parser for a supported language, or null if unavailable.
  *  `filePath` is optional and only used to select the JSX grammar. */
 export async function getExceptionParser(
@@ -210,7 +200,7 @@ export async function getExceptionParser(
     switch (language) {
       case 'TypeScript':
       case 'JavaScript': {
-        if (isJsxPath(filePath)) {
+        if (usesTsxGrammar(filePath)) {
           if (!_tsxParser) {
             const m = await import('tree-sitter-typescript');
             _tsxParser = new NP();

--- a/src/core/analyzer/exception-flow.ts
+++ b/src/core/analyzer/exception-flow.ts
@@ -172,6 +172,7 @@ function specFor(language: string): LangSpec | null {
 // ── Lazy tree-sitter parsers (scoped to the supported languages) ─────────────
 
 let _tsParser: Parser | undefined;
+let _tsxParser: Parser | undefined;
 let _pyParser: Parser | undefined;
 let _NativeParser: typeof Parser | null | undefined;
 
@@ -186,14 +187,39 @@ async function loadNativeParser(): Promise<typeof Parser | null> {
   return _NativeParser;
 }
 
-/** A tree-sitter parser for a supported language, or null if unavailable. */
-export async function getExceptionParser(language: string): Promise<Parser | null> {
+
+/** True when the file is JSX/TSX, which needs tree-sitter-typescript's `tsx`
+ *  grammar. The plain `typescript` grammar treats every JSX element as a syntax
+ *  error, so a React file parses to thousands of ERROR nodes and its symbols and
+ *  edges silently become a small fraction of what is there. */
+function isJsxPath(filePath?: string): boolean {
+  if (!filePath) return false;
+  const p = filePath.toLowerCase();
+  return p.endsWith('.tsx') || p.endsWith('.jsx');
+}
+
+/** A tree-sitter parser for a supported language, or null if unavailable.
+ *  `filePath` is optional and only used to select the JSX grammar. */
+export async function getExceptionParser(
+  language: string,
+  filePath?: string
+): Promise<Parser | null> {
   try {
     const NP = await loadNativeParser();
     if (!NP) return null;
     switch (language) {
       case 'TypeScript':
       case 'JavaScript': {
+        if (isJsxPath(filePath)) {
+          if (!_tsxParser) {
+            const m = await import('tree-sitter-typescript');
+            _tsxParser = new NP();
+            _tsxParser.setLanguage(
+              ((m.default ?? m) as { tsx: object }).tsx as Parser.Language,
+            );
+          }
+          return _tsxParser!;
+        }
         if (!_tsParser) {
           const m = await import('tree-sitter-typescript');
           _tsParser = new NP();
@@ -532,11 +558,12 @@ export function extractExceptionFacts(
 export async function extractExceptionFactsFromSource(
   source: string,
   language: string,
+  filePath?: string,
 ): Promise<FunctionExceptionFacts> {
   if (!ERROR_PROPAGATION_LANGUAGES.has(language)) {
     return { language, supported: false, throwSites: [], tryGuards: [], callSites: [], dynamicThrowCount: 0 };
   }
-  const parser = await getExceptionParser(language);
+  const parser = await getExceptionParser(language, filePath);
   if (!parser) {
     return { language, supported: false, throwSites: [], tryGuards: [], callSites: [], dynamicThrowCount: 0 };
   }

--- a/src/core/analyzer/extraction-pool-threads.test.ts
+++ b/src/core/analyzer/extraction-pool-threads.test.ts
@@ -155,6 +155,30 @@ describe('extraction pool — real worker threads', () => {
     expect(JSON.stringify(serializeCallGraph(result))).toBe(serial);
   }, 120_000);
 
+  it('matches the serial lane for TSX and JSX files', async () => {
+    if (!resolveWorkerEntry()) return;
+    const files: ExtractionFile[] = [
+      {
+        path: 'src/View.tsx',
+        language: 'TypeScript',
+        content: 'function save() {}\nexport function View() { return <button onClick={() => save()}>Save</button>; }',
+      },
+      {
+        path: 'src/Panel.jsx',
+        language: 'JavaScript',
+        content: 'function close() {}\nexport function Panel() { return <button onClick={() => close()}>Close</button>; }',
+      },
+    ];
+
+    process.env.OPENLORE_NO_WORKERS = '1';
+    const serial = await buildJson(files);
+    delete process.env.OPENLORE_NO_WORKERS;
+
+    expect(await buildJson(files, POOL_SIZE)).toBe(serial);
+    const names = JSON.parse(serial).nodes.map((node: { name: string }) => node.name);
+    expect(names).toEqual(expect.arrayContaining(['View', 'save', 'Panel', 'close']));
+  }, 120_000);
+
   it('loads the per-thread WASM grammars (Lua, Dart) without cross-contaminating them', async () => {
     if (!resolveWorkerEntry()) return;
     const lua = fixtureFile('lua/app.lua', 'Lua');

--- a/src/core/analyzer/language-detection.ts
+++ b/src/core/analyzer/language-detection.ts
@@ -65,3 +65,13 @@ export function detectLanguage(filePath: string): string {
   const ext = lower.split('.').pop() ?? '';
   return EXTENSION_TO_LANGUAGE[ext] ?? 'unknown';
 }
+
+/**
+ * Whether a JavaScript/TypeScript-family file needs tree-sitter-typescript's TSX grammar.
+ * Keep this path decision beside the canonical extension map so parser consumers cannot drift.
+ */
+export function usesTsxGrammar(filePath?: string): boolean {
+  if (!filePath) return false;
+  const lower = filePath.toLowerCase();
+  return lower.endsWith('.tsx') || lower.endsWith('.jsx');
+}

--- a/src/core/analyzer/language-support.test.ts
+++ b/src/core/analyzer/language-support.test.ts
@@ -28,6 +28,7 @@ import {
   ERROR_PROPAGATION_LANGUAGES as ERRP,
   extractExceptionFactsFromSource,
 } from './exception-flow.js';
+import { usesTsxGrammar } from './language-detection.js';
 import {
   CROSS_SERVICE_HTTP_LANGUAGES as XSVC,
   extractHttpCalls,
@@ -479,6 +480,13 @@ describe('single-source language detection', () => {
 
   it.each(FORMERLY_MISSED)('formerly-missed %s resolves to %s (not unknown)', (path, lang) => {
     expect(detectLanguage(path)).toBe(lang);
+  });
+
+  it('selects the TSX grammar only for .tsx/.jsx paths', () => {
+    expect(usesTsxGrammar('src/View.tsx')).toBe(true);
+    expect(usesTsxGrammar('src/View.JSX')).toBe(true);
+    expect(usesTsxGrammar('src/cast.ts')).toBe(false);
+    expect(usesTsxGrammar()).toBe(false);
   });
 
   it('an unknown extension degrades honestly to "unknown", never a guess', () => {

--- a/src/core/services/mcp-handlers/error-propagation.ts
+++ b/src/core/services/mcp-handlers/error-propagation.ts
@@ -214,7 +214,7 @@ export async function handleAnalyzeErrorPropagation(
     if (tree === undefined) {
       try {
         const content = await readFile(join(absDir, n.filePath), 'utf-8');
-        const parser = await getExceptionParser(n.language);
+        const parser = await getExceptionParser(n.language, n.filePath);
         // Bounded (change: fix-analyze-native-abort-and-file-cost-budget): this parse runs inside
         // the long-lived daemon, so one pathological file must not be able to wedge it. On the
         // budget the file becomes a disclosed boundary below, never a silent "no exceptions".


### PR DESCRIPTION
## The problem

`tree-sitter-typescript` ships two grammars — `typescript` and `tsx` — and openlore binds `.typescript` for every TypeScript/JavaScript file, in three analyzers:

- `src/core/analyzer/call-graph.ts` — `getTSParser()`
- `src/core/analyzer/exception-flow.ts` — `getExceptionParser()`
- `src/core/analyzer/ast-chunker.ts` — `getParserForLanguage()`

`language-detection.ts` maps `tsx: 'TypeScript'`, so the extension is discarded before any parser sees it.

Under the non-JSX grammar, every JSX element is a syntax error. React files parse to thousands of `ERROR` nodes. Crucially **`parseFailures` stays 0** — nothing throws, `doctor` reports only "symbols/edges there are a lower bound", and the file still yields a plausible-looking result. So `orient` / `search_code` return a *partial* caller list for components, which is harder to notice than an empty one.

## Measurement

One React-heavy repo, 3,312 files / 18,879 functions, from `.openlore/analysis/parse-health.json`:

| | degraded files | error regions |
|---|---|---|
| before | 490 | **39,135** |
| after | 80 | **167** |

437 of the 490 were `.tsx`; that drops to 17.

Two individual files, counting `ERROR` + missing nodes directly with each grammar:

| file | `typescript` | `tsx` |
|---|---|---|
| `ContentPanel.tsx` | 650 | **2** |
| `DrillsTable.tsx` | 574 | **0** |

## The fix

**Per-extension, not a blanket swap.** `.tsx`/`.jsx` get the `tsx` grammar; everything else keeps `typescript`. A blanket swap would regress plain `.ts` files using the angle-bracket cast form (`<T>value`), which the `tsx` grammar cannot parse — I tried that first and it moves the problem rather than fixing it. Each analyzer caches the two parsers separately.

`filePath` was already in scope at every call site, so this threads it through as an **optional** argument:

```
getTSParser(filePath?)
getParserForLanguage(lang, filePath?)
getExceptionParser(language, filePath?)
extractExceptionFactsFromSource(source, language, filePath?)
```

Every existing caller keeps working unchanged — omitting the path selects exactly the current behaviour. Only `error-propagation.ts` needed updating, and it already had `n.filePath` to hand.

## Verification

- `npm run typecheck` — clean
- `npx vitest run` — **357 files, 6,863 tests passing**, 2 skipped
- Built and re-ran `analyze` against the repo above to produce the table

Happy to add a regression test if you'd like one — a small fixture asserting a `.tsx` file yields zero `ERROR` regions would pin this. Wasn't sure where you'd want it to live.