### PR TITLE
chore(release): stage v2.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to OpenLore are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [2.1.9] - 2026-08-09
+
+**The release where OpenLore stopped trusting the vibes.**
+
+- Import resolution got smarter, including the deeply suspicious `.tsx` and `.jsx` twins.
+- Stale analysis now says it is stale instead of confidently wearing last week's nametag.
+- Repository secrets, hostile prompts, and wandering viewer file reads all meet firmer boundaries.
+- First-run guidance and empty results now tell you what actually happened.
+
+Everything is backward-compatible: no commands, options, exports, or config keys were removed.
+
+**Upgrade:** `npm i -g openlore@2.1.9` — or `openlore update`.
+
+**Full Changelog**: https://github.com/clay-good/OpenLore/compare/v2.1.8...v2.1.9
+
 ## [2.1.8] - 2026-08-02
 
 **The release where `analyze` stopped caring how big your repo is.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Persistent architectural memory and structural cognition for AI coding agents.",
   "type": "module",
   "main": "dist/api/index.js",


### PR DESCRIPTION
Status: LGTM.

## What was missing / motivation

Main contains 18 merged PRs since v2.1.8 and is ready for a patch release.

## What it does

- Bumps package.json and package-lock.json to 2.1.9.
- Adds short user-facing release notes covering analyzer correctness, freshness disclosure, and security hardening.
- Records that the audited changes remove no commands, options, exports, or config keys.

## Proof it works

- 7,129 tests passed; 2 skipped.
- Lint, typecheck, and build passed.
- Dependency audit gate passed; its 3 allowed advisories are dev-only shrinkwrapped copies absent from the published package.
- Publish packlist passed: 1,601 files, all entrypoints present, nothing forbidden.
- Every merged PR since v2.1.8 had green CI and CodeQL.

## Notes / nits

Tag v2.1.9 after merge; the tag workflow creates the GitHub release from CHANGELOG.md and publishes to npm with provenance.