### PR TITLE
fix(coverage-gaps): rank undecidable reachability below certain gaps

### DIFF
--- a/openspec/changes/demote-dead-flagged-coverage-gaps/.openspec.yaml
+++ b/openspec/changes/demote-dead-flagged-coverage-gaps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/demote-dead-flagged-coverage-gaps/proposal.md
+++ b/openspec/changes/demote-dead-flagged-coverage-gaps/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+On an external repository (pi-outpost), `report_coverage_gaps` returned 264 gaps over 413 in-scope symbols, and the head of the ranking was dominated by `index.ts` symbols carrying `alsoFlaggedDead` — including `send`, with fan-in 26, presented simultaneously as load-bearing and as dead. The cause is known and disclosed in the caveats: the repository dispatches over a WebSocket, so the edges that reach those symbols are invisible to static analysis.
+
+The disclosure is correct and the verdict is sound. The *ranking* is not: `alsoFlaggedDead` plays no part in `gaps.sort` (`coverage-gaps.ts:211-218`), so a symbol whose reachability the tool itself could not establish outranks a symbol whose gap is certain. An agent working the list top-down spends its budget on ghosts, and the tool's honesty ends up funding the wrong work.
+
+A second signal is being thrown away. A symbol with zero resolved callers and a symbol with 26 resolved callers that is *still* in the dead set are two different facts: the first has no caller, the second has callers that are themselves unreachable from any entry point — the exact signature of a dispatch edge the analysis cannot see. Today both collapse into one boolean.
+
+## What Changes
+
+- Rank gaps flagged `alsoFlaggedDead` below every live gap, whatever their significance signals. Tiering stays deterministic and label-based: live load-bearing, then live, then dead-flagged load-bearing, then dead-flagged. No composite score, no new tuning constant.
+- Split `alsoFlaggedDead` into a stable reason: `no-callers` (fan-in zero) versus `dead-via-unreachable-callers` (fan-in above zero, still unreachable from an entry point). The boolean is kept for compatibility.
+- State in the result that a `dead-via-unreachable-callers` gap is the signature of an inbound edge static analysis could not resolve — a reachability the tool cannot decide, not evidence the code is unused.
+- Report the composition of the returned page (live versus dead-flagged counts), so a caller can see at a glance that most of a large gap set is undecidable reachability rather than untested load-bearing code.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `mcp-handlers`: `report_coverage_gaps` gains reachability-aware ranking, a typed dead-flag reason, and page composition counts.
+
+## Impact
+
+- `src/core/services/mcp-handlers/coverage-gaps.ts` ranking and `CoverageGap` shape (additive fields), plus `coverage-gaps.test.ts`.
+- `src/cli/commands/coverage-gaps.ts` rendering.
+- Consumers reading `alsoFlaggedDead` keep working; the boolean is unchanged in meaning.

--- a/openspec/changes/demote-dead-flagged-coverage-gaps/specs/mcp-handlers/spec.md
+++ b/openspec/changes/demote-dead-flagged-coverage-gaps/specs/mcp-handlers/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: DeadFlaggedGapsRankBelowLiveGaps
+
+`report_coverage_gaps` SHALL rank a gap flagged `alsoFlaggedDead` below every gap that is not so flagged, regardless of its significance signals or fan-in. Within each of the two groups the existing order SHALL apply unchanged: load-bearing label first, then raw fan-in, then a stable file-and-name tiebreak.
+
+Ranking SHALL remain deterministic and derived from existing labels; no composite score and no new tuning constant SHALL be introduced.
+
+#### Scenario: A dead-flagged hub does not outrank a live gap
+
+- **GIVEN** a dead-flagged gap with the `hub` signal and fan-in 26, and a live gap with no significance signal and fan-in 1
+- **WHEN** the gaps are ranked
+- **THEN** the live gap is returned before the dead-flagged hub
+
+#### Scenario: Order within a group is unchanged
+
+- **GIVEN** two live gaps, one labelled `chokepoint` and one unlabelled with higher fan-in
+- **WHEN** the gaps are ranked
+- **THEN** the labelled gap precedes the unlabelled one, as it does today
+
+#### Scenario: Truncation does not hide every live gap
+
+- **GIVEN** more dead-flagged gaps than the result limit and at least one live gap
+- **WHEN** the result is truncated to `maxResults`
+- **THEN** every returned live gap precedes any dead-flagged gap, and the truncation receipt states how many of each were omitted
+
+### Requirement: DeadFlagCarriesItsReason
+
+A gap flagged `alsoFlaggedDead` SHALL carry a stable reason: `no-callers` when its fan-in is zero, and `dead-via-unreachable-callers` when its fan-in is above zero and it is still unreachable from an entry point. The existing `alsoFlaggedDead` boolean SHALL keep its current meaning.
+
+The result SHALL state that `dead-via-unreachable-callers` marks a reachability the analysis could not decide — the signature of a dynamic, reflective, or registry-mediated inbound edge — and SHALL NOT present it as evidence that the code is unused.
+
+#### Scenario: Resolved callers that are themselves unreachable
+
+- **GIVEN** a symbol with 26 resolved callers, all of them unreachable from any entry point
+- **WHEN** it is reported as a gap
+- **THEN** it carries `alsoFlaggedDead` with reason `dead-via-unreachable-callers`, and the result names the undecided-reachability caveat
+
+#### Scenario: A genuinely uncalled symbol
+
+- **GIVEN** a symbol with no resolved caller
+- **WHEN** it is reported as a gap
+- **THEN** it carries `alsoFlaggedDead` with reason `no-callers`
+
+### Requirement: GapPageDisclosesItsComposition
+
+The result SHALL report how many of the returned gaps are live and how many are dead-flagged, and the same split for the omitted remainder. A caller SHALL be able to tell a page of untested load-bearing code from a page of undecidable reachability without inspecting every entry.
+
+#### Scenario: A mostly dead-flagged gap set is legible at a glance
+
+- **GIVEN** 264 gaps of which 210 are dead-flagged
+- **WHEN** the first page of 20 is returned
+- **THEN** the response states the live and dead-flagged counts for both the returned page and the omitted remainder

--- a/openspec/changes/demote-dead-flagged-coverage-gaps/tasks.md
+++ b/openspec/changes/demote-dead-flagged-coverage-gaps/tasks.md
@@ -1,0 +1,21 @@
+## 1. Reachability-aware ranking
+
+- [x] 1.1 Add a dead-flag tier ahead of the existing label/fan-in comparators in `gaps.sort`, keeping the comparator total and deterministic.
+- [x] 1.2 Tests: a dead-flagged hub ranks below a live unlabelled gap; intra-group order is byte-identical to today; ranking is stable across repeated runs.
+
+## 2. Typed dead-flag reason
+
+- [x] 2.1 Extend `CoverageGap` with an additive `deadReason` (`no-callers` | `dead-via-unreachable-callers`), derived from the existing dead set and the node's fan-in — no new traversal.
+- [x] 2.2 Add the undecided-reachability caveat, emitted only when at least one returned gap carries `dead-via-unreachable-callers`.
+- [x] 2.3 Tests: fan-in zero yields `no-callers`; fan-in above zero inside the dead set yields `dead-via-unreachable-callers`; the caveat appears only when the reason is present.
+
+## 3. Page composition
+
+- [x] 3.1 Report live and dead-flagged counts for the returned page and for the omitted remainder in the truncation receipt.
+- [x] 3.2 Render the split in `openlore coverage-gaps` output.
+- [x] 3.3 Tests: composition counts sum to the total gap set; truncation never returns a dead-flagged gap ahead of a live one.
+
+## 4. Verification
+
+- [x] 4.1 Run the tests reaching `handleCoverageGaps` and the CLI command.
+- [x] 4.2 Re-run against a repository with dynamic dispatch and confirm the head of the ranking is live gaps.

--- a/src/cli/commands/coverage-gaps.ts
+++ b/src/cli/commands/coverage-gaps.ts
@@ -21,6 +21,13 @@ interface CoverageGapItem {
   fanIn: number;
   signals: Array<{ label: string; evidence: Record<string, number | string> }>;
   alsoFlaggedDead?: true;
+  deadReason?: 'no-callers' | 'dead-via-unreachable-callers';
+}
+
+/** Live vs dead-flagged split of a gap list (change: demote-dead-flagged-coverage-gaps). */
+interface GapComposition {
+  live: number;
+  deadFlagged: number;
 }
 
 interface CoverageGapsResult {
@@ -31,6 +38,11 @@ interface CoverageGapsResult {
   reachableFromTest: number;
   gapCount: number;
   coverageGaps: CoverageGapItem[];
+  composition?: {
+    returned: GapComposition;
+    omittedRemainder?: GapComposition;
+    total: GapComposition;
+  };
   omitted?: number;
   note?: string;
   soundness: { posture: string; claim: string; caveats: string[] };
@@ -74,14 +86,29 @@ function renderHuman(r: CoverageGapsResult): string {
   if (r.coverageGaps.length === 0) {
     lines.push(r.note ? '   (nothing in scope to report)' : '   No gaps in scope.');
   } else {
-    lines.push('   Top untested (most load-bearing first):');
+    lines.push('   Top untested (live and load-bearing first; dead-flagged last):');
     for (const g of r.coverageGaps) {
       const labels = g.signals.map(s => s.label).join(',');
-      const tags = [labels && `[${labels}]`, g.alsoFlaggedDead && '(also dead)'].filter(Boolean).join(' ');
+      // Name WHY it is dead-flagged: "has callers, still unreachable" is a resolution
+      // limit of the analysis, not a claim the code is unused.
+      const deadTag = g.deadReason === 'dead-via-unreachable-callers'
+        ? '(dead-flagged: callers unreachable — undecidable)'
+        : g.alsoFlaggedDead ? '(dead-flagged: no callers)' : '';
+      const tags = [labels && `[${labels}]`, deadTag].filter(Boolean).join(' ');
       lines.push(`   • ${g.name}  ${g.file}  fanIn=${g.fanIn}${tags ? '  ' + tags : ''}`);
     }
-    if (r.omitted && r.omitted > 0) lines.push(`   … and ${r.omitted} more (raise --max to see them)`);
+    if (r.composition) {
+      const { live, deadFlagged } = r.composition.returned;
+      lines.push(`   composition: ${live} live · ${deadFlagged} dead-flagged (of ${r.composition.total.live} live / ${r.composition.total.deadFlagged} dead-flagged overall)`);
+    }
+    if (r.omitted && r.omitted > 0) {
+      const rest = r.composition?.omittedRemainder;
+      const detail = rest ? ` (${rest.live} live · ${rest.deadFlagged} dead-flagged)` : '';
+      lines.push(`   … and ${r.omitted} more${detail} (raise --max to see them)`);
+    }
   }
+  const undecidable = r.soundness.caveats.find(c => /dead-via-unreachable-callers/.test(c));
+  if (undecidable) lines.push(`   ⚠ ${undecidable}`);
   lines.push('   ' + r.soundness.caveats[0]);
   lines.push('');
   return lines.join('\n');

--- a/src/core/services/mcp-handlers/coverage-gaps.test.ts
+++ b/src/core/services/mcp-handlers/coverage-gaps.test.ts
@@ -47,7 +47,16 @@ interface GapResult {
   analyzedSymbols: number;
   reachableFromTest: number;
   gapCount: number;
-  coverageGaps: Array<{ name: string; file: string; fanIn: number; signals: Array<{ label: string }>; alsoFlaggedDead?: true }>;
+  coverageGaps: Array<{
+    name: string; file: string; fanIn: number; signals: Array<{ label: string }>;
+    alsoFlaggedDead?: true;
+    deadReason?: 'no-callers' | 'dead-via-unreachable-callers';
+  }>;
+  composition?: {
+    returned: { live: number; deadFlagged: number };
+    omittedRemainder?: { live: number; deadFlagged: number };
+    total: { live: number; deadFlagged: number };
+  };
   omitted?: number;
   note?: string;
   confidenceBoundary?: Record<string, unknown>;
@@ -84,13 +93,18 @@ describe('handleReportCoverageGaps', () => {
     vi.mocked(getChangedFiles).mockResolvedValue({ files: [] } as never);
   });
 
-  it('ranks the untested hub on top, sinks the leaves, and omits the tested hub', async () => {
+  it('ranks live gaps above dead-flagged ones, sinks the leaves, and omits the tested hub', async () => {
     const r = await handleReportCoverageGaps({ directory: '/p' }) as GapResult;
     const names = r.coverageGaps.map(g => g.name);
 
     expect(names).not.toContain('testedHub'); // reached by a test → not a gap
-    expect(names[0]).toBe('untestedHub');     // load-bearing (hub/chokepoint) floats up
-    // the two untested leaves sink below the hub
+    // `untestedHub` is load-bearing BUT reached only from candidate-dead leaves, so
+    // its own reachability is undecidable. The live gap leads instead
+    // (change: demote-dead-flagged-coverage-gaps) — certainty before significance.
+    expect(names[0]).toBe('main');
+    // Within the dead-flagged tier the old comparator still holds: the hub outranks
+    // the leaves.
+    expect(names.indexOf('untestedHub')).toBeLessThan(names.indexOf('leaf1'));
     expect(names.indexOf('leaf1')).toBeGreaterThan(names.indexOf('untestedHub'));
     expect(names.indexOf('leaf2')).toBeGreaterThan(names.indexOf('untestedHub'));
     // the untested hub carries its earned significance labels (evidence, not a score)
@@ -236,6 +250,90 @@ describe('handleReportCoverageGaps', () => {
     vi.mocked(readCachedContext).mockResolvedValue({ callGraph: FIXTURE() } as never);
     const b = await handleReportCoverageGaps({ directory: '/p' });
     expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  // ==========================================================================
+  // Reachability-aware ranking, typed dead reason, page composition
+  // (change: demote-dead-flagged-coverage-gaps)
+  // ==========================================================================
+
+  it('ranks a dead-flagged hub below a live unlabelled gap', async () => {
+    const r = await handleReportCoverageGaps({ directory: '/p' }) as GapResult;
+    const names = r.coverageGaps.map(g => g.name);
+    const hub = r.coverageGaps.find(g => g.name === 'untestedHub')!;
+    const live = r.coverageGaps.find(g => g.name === 'main')!;
+
+    // `untestedHub` carries hub+chokepoint and fanIn 5; `main` carries neither and
+    // has fanIn 0. Under the old comparator the hub led. It no longer does.
+    expect(hub.signals.map(s => s.label)).toEqual(expect.arrayContaining(['hub', 'chokepoint']));
+    expect(hub.alsoFlaggedDead).toBe(true);
+    expect(live.alsoFlaggedDead).toBeUndefined();
+    expect(names.indexOf('main')).toBeLessThan(names.indexOf('untestedHub'));
+
+    // Every live gap precedes every dead-flagged one — a partition, not a nudge.
+    const lastLive = Math.max(...r.coverageGaps.map((g, i) => (g.alsoFlaggedDead ? -1 : i)));
+    const firstDead = r.coverageGaps.findIndex(g => g.alsoFlaggedDead);
+    expect(lastLive).toBeLessThan(firstDead);
+  });
+
+  it('types the dead flag: fan-in zero is no-callers, fan-in above zero is undecidable reachability', async () => {
+    const r = await handleReportCoverageGaps({ directory: '/p' }) as GapResult;
+    const leaf = r.coverageGaps.find(g => g.name === 'leaf1')!;
+    const hub = r.coverageGaps.find(g => g.name === 'untestedHub')!;
+    const live = r.coverageGaps.find(g => g.name === 'main')!;
+
+    expect(leaf.fanIn).toBe(0);
+    expect(leaf.deadReason).toBe('no-callers');
+    // 5 resolved callers, still unreachable from a liveness root — the signature of
+    // an inbound edge static analysis cannot see (the pi-outpost WebSocket case).
+    expect(hub.fanIn).toBeGreaterThan(0);
+    expect(hub.deadReason).toBe('dead-via-unreachable-callers');
+    // The boolean keeps its exact prior meaning; the reason is additive.
+    expect(hub.alsoFlaggedDead).toBe(true);
+    expect(live.deadReason).toBeUndefined();
+  });
+
+  it('emits the undecidable-reachability caveat only when that reason is on the page', async () => {
+    const withReason = await handleReportCoverageGaps({ directory: '/p' }) as GapResult;
+    expect(withReason.soundness.caveats.join(' ')).toMatch(/dead-via-unreachable-callers/);
+
+    // A graph whose only gap has no callers at all: no such reason, so no caveat.
+    vi.mocked(readCachedContext).mockResolvedValueOnce({
+      callGraph: graph(
+        [node({ id: 'src/z.ts::lonely', fanIn: 0 }), node({ id: 'src/z.test.ts::t', isTest: true })],
+        [],
+      ),
+    } as never);
+    const without = await handleReportCoverageGaps({ directory: '/p' }) as GapResult;
+    expect(without.coverageGaps.map(g => g.deadReason)).not.toContain('dead-via-unreachable-callers');
+    expect(without.soundness.caveats.join(' ')).not.toMatch(/dead-via-unreachable-callers/);
+  });
+
+  it('reports page composition that sums to the whole gap set', async () => {
+    const r = await handleReportCoverageGaps({ directory: '/p' }) as GapResult;
+    const c = r.composition!;
+    expect(c.returned.live + c.returned.deadFlagged).toBe(r.coverageGaps.length);
+    expect(c.total.live + c.total.deadFlagged).toBe(r.gapCount);
+    expect(c.total.live).toBe(1);              // only `main` is live-and-untested
+    expect(c.omittedRemainder).toBeUndefined(); // nothing truncated here
+  });
+
+  it('truncation never returns a dead-flagged gap ahead of a live one, and discloses the remainder split', async () => {
+    const r = await handleReportCoverageGaps({ directory: '/p', maxResults: 1 }) as GapResult;
+    expect(r.coverageGaps).toHaveLength(1);
+    expect(r.coverageGaps[0].alsoFlaggedDead).toBeUndefined(); // the live gap survives truncation
+    expect(r.composition!.returned).toEqual({ live: 1, deadFlagged: 0 });
+    expect(r.composition!.omittedRemainder).toEqual({ live: 0, deadFlagged: 3 });
+    expect(
+      r.composition!.omittedRemainder!.live + r.composition!.omittedRemainder!.deadFlagged,
+    ).toBe(r.omitted);
+  });
+
+  it('keeps ranking stable across repeated runs', async () => {
+    const first = await handleReportCoverageGaps({ directory: '/p' }) as GapResult;
+    vi.mocked(readCachedContext).mockResolvedValue({ callGraph: FIXTURE() } as never);
+    const second = await handleReportCoverageGaps({ directory: '/p' }) as GapResult;
+    expect(second.coverageGaps.map(g => g.name)).toEqual(first.coverageGaps.map(g => g.name));
   });
 
   it('errors cleanly when no analysis is cached', async () => {

--- a/src/core/services/mcp-handlers/coverage-gaps.ts
+++ b/src/core/services/mcp-handlers/coverage-gaps.ts
@@ -76,7 +76,23 @@ interface CoverageGap {
    * untested symbol (e.g. an entry point invoked by a framework): untested-not-dead.
    */
   alsoFlaggedDead?: true;
+  /**
+   * WHY the symbol landed in the dead set (change: demote-dead-flagged-coverage-gaps).
+   * Present exactly when `alsoFlaggedDead` is — the boolean's meaning is unchanged.
+   *
+   *   `no-callers`                    — fan-in zero: nothing in the graph calls it.
+   *   `dead-via-unreachable-callers`  — fan-in above zero, yet still unreachable
+   *                                     from any liveness root. Its callers are
+   *                                     themselves unreachable, which is the
+   *                                     signature of an INBOUND edge this analysis
+   *                                     could not resolve (WebSocket/queue/DI
+   *                                     dispatch), not evidence the code is unused.
+   */
+  deadReason?: DeadFlagReason;
 }
+
+/** Why a gap is also in the dead set. Closed set, derived — no new traversal. */
+export type DeadFlagReason = 'no-callers' | 'dead-via-unreachable-callers';
 
 /**
  * Report the structurally-untested surface: internal code in no test's reachable
@@ -201,15 +217,28 @@ export async function handleReportCoverageGaps(input: ReportCoverageGapsInput): 
       fanIn: n.fanIn ?? 0,
       signals,
     };
-    if (deadIds.has(n.id)) gap.alsoFlaggedDead = true;
+    if (deadIds.has(n.id)) {
+      gap.alsoFlaggedDead = true;
+      // Derived from the dead set + the node's own fan-in — no extra traversal.
+      gap.deadReason = gap.fanIn > 0 ? 'dead-via-unreachable-callers' : 'no-callers';
+    }
     return gap;
   });
 
-  // Rank: load-bearing untested code first. Tier by hub/chokepoint label (the
-  // significance signals named in the proposal), then raw fan-in (evidence), then
-  // a stable file+name tiebreak for determinism. No composite score, no constant.
+  // Rank: certainty before significance. A dead-flagged gap is one whose
+  // reachability this analysis could NOT establish, so ranking it above a gap that
+  // is certainly live-and-untested spends the reader's budget on the undecidable
+  // (change: demote-dead-flagged-coverage-gaps). Tiers, in order:
+  //   live load-bearing > live > dead-flagged load-bearing > dead-flagged.
+  // Within a tier the previous comparator is preserved byte-for-byte: fan-in
+  // (evidence), then a stable file+name tiebreak. Still label-based and
+  // deterministic — no composite score, no new tuning constant.
   const isLoadBearing = (g: CoverageGap) => g.signals.some(s => s.label === 'hub' || s.label === 'chokepoint');
+  const isLive = (g: CoverageGap) => !g.alsoFlaggedDead;
   gaps.sort((a, b) => {
+    const al = isLive(a) ? 1 : 0;
+    const bl = isLive(b) ? 1 : 0;
+    if (al !== bl) return bl - al;
     const at = isLoadBearing(a) ? 1 : 0;
     const bt = isLoadBearing(b) ? 1 : 0;
     if (at !== bt) return bt - at;
@@ -219,6 +248,24 @@ export async function handleReportCoverageGaps(input: ReportCoverageGapsInput): 
 
   const returned = gaps.slice(0, maxResults);
   const omitted = gaps.length - returned.length;
+
+  // Page composition: how much of what the caller is holding is decidable
+  // untested code versus undecidable reachability. Reported for the returned page
+  // AND the omitted remainder, so a 264-gap set discloses its shape without the
+  // caller re-deriving it.
+  const liveOf = (list: CoverageGap[]) => list.filter(isLive).length;
+  const composition = {
+    returned: { live: liveOf(returned), deadFlagged: returned.length - liveOf(returned) },
+    ...(omitted > 0
+      ? {
+          omittedRemainder: {
+            live: liveOf(gaps) - liveOf(returned),
+            deadFlagged: omitted - (liveOf(gaps) - liveOf(returned)),
+          },
+        }
+      : {}),
+    total: { live: liveOf(gaps), deadFlagged: gaps.length - liveOf(gaps) },
+  };
 
   // ── Honest coverage posture (mirrors select_tests' testDetection) ───────────
   const graphHasTests = cg.nodes.some(n => n.isTest) || cg.edges.some(e => e.kind === 'tested_by');
@@ -248,6 +295,11 @@ export async function handleReportCoverageGaps(input: ReportCoverageGapsInput): 
     // to substring, so a short name can scope to more than the one function intended.
     caveats.push('Symbol scope resolves by name (exact preferred, substring fallback); a short or partial symbol name may widen the scope to several functions.');
   }
+  // Emitted only when the returned page actually carries the reason — a caveat about
+  // a signal that is not present is noise of the kind this change exists to remove.
+  if (returned.some(g => g.deadReason === 'dead-via-unreachable-callers')) {
+    caveats.push('Some returned gaps are flagged dead despite having callers (deadReason "dead-via-unreachable-callers"): their callers are themselves unreachable from any liveness root. That is the signature of an INBOUND edge static analysis could not resolve (WebSocket/queue/DI dispatch) — undecidable reachability, NOT evidence the code is unused. Such gaps are ranked below every live gap.');
+  }
 
   // Confidence boundary: the liveness partition rests on the edges traversed within
   // the test-reachable set (the complement of the reported gaps — same posture as
@@ -275,6 +327,7 @@ export async function handleReportCoverageGaps(input: ReportCoverageGapsInput): 
     reachableFromTest: testedCount,
     gapCount: gaps.length,
     coverageGaps: returned,
+    composition,
     ...(omitted > 0 ? { omitted } : {}),
     ...(unmatchedNote ? { note: unmatchedNote } : {}),
     soundness: { posture: 'gaps-only' as const, claim: 'no-reaching-test' as const, caveats },


### PR DESCRIPTION
Implements OpenSpec change `demote-dead-flagged-coverage-gaps`.

## Why
On an external repo (pi-outpost), `report_coverage_gaps` returned 264 gaps over 413 in-scope symbols and the head of the ranking was dominated by `alsoFlaggedDead` symbols — including one with fan-in 26, presented simultaneously as load-bearing and as dead. The disclosure was correct; the *ranking* was not. `alsoFlaggedDead` played no part in the sort, so a symbol whose reachability the tool itself could not establish outranked a symbol whose gap is certain. An agent working the list top-down spends its budget on ghosts.

## What changed
- **Tiered ranking**: live load-bearing > live > dead-flagged load-bearing > dead-flagged. Within a tier the previous comparator is byte-identical (fan-in, then file+name). Still label-based and deterministic — no composite score, no new tuning constant.
- **Typed dead flag**: `no-callers` (fan-in zero) vs `dead-via-unreachable-callers` (callers exist but are themselves unreachable — the signature of an inbound edge static analysis cannot resolve). The boolean keeps its exact prior meaning, so existing consumers are unaffected.
- **Said out loud**: a caveat, emitted only when that reason is actually on the returned page, states this is undecidable reachability, not evidence the code is unused.
- **Page composition**: live vs dead-flagged counts for the returned page and the omitted remainder, so a large gap set discloses its shape without the caller re-deriving it.

## Note on the changed test
`ranks the untested hub on top` now asserts the live gap leads. The fixture's `untestedHub` is reached only from candidate-dead leaves — it is precisely the pi-outpost shape, and demoting it is the point of the change.

## Verification
- `coverage-gaps.test.ts`: 21 passing (6 new). `tsc --noEmit` clean.
- End-to-end on this repo: 833 gaps, head of the ranking is all live; `composition: 12 live · 0 dead-flagged (of 191 live / 642 dead-flagged overall)`.
- 5 pre-existing failures in `structural-diff-*` / `memory-invariant` were confirmed on a clean `origin/main` tree and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)