### PR TITLE
feat(decisions): give every draft a reasoned verdict

### DIFF
--- a/openspec/changes/explain-decision-rejection/.openspec.yaml
+++ b/openspec/changes/explain-decision-rejection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/explain-decision-rejection/proposal.md
+++ b/openspec/changes/explain-decision-rejection/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+An agent recorded three decisions during a session. One was dropped twice — including after being rewritten more tightly — with no reason given. The two that survived came back with `contentOrigin: llm-extracted` and `verificationEvidence: git-diff`: the consolidator had re-derived them from the diff and kept its own wording over the author's.
+
+The grounding is by design and worth keeping: a decision anchored to the diff is exactly the guarantee that no LLM fabricates architectural history. Two things around it are not defensible.
+
+First, `record_decision` writes a draft (`decisions.ts:180-208`) and a background consolidator decides its fate alone. A draft that is not promoted simply stops existing, with no verdict, no reason, and no way for the caller to find out. The author is left to guess whether the call failed, the wording was wrong, or the evidence was missing.
+
+Second, the tool's name promises more than it does. It does not record a decision; it proposes one. Renaming the tool would break an installed surface, but the description and the response can stop implying finality.
+
+## What Changes
+
+- Give every draft a terminal disposition at consolidation: `promoted`, `merged-into <id>`, or `rejected`, each with a stable reason code (for example `no-supporting-diff`, `duplicate-of`, `not-architectural`, `insufficient-rationale`). A draft can no longer vanish silently.
+- Make the verdict readable: `record_decision` returns the draft id and states how to read its outcome, `openlore decisions status <id>` reports the disposition and reason, and a repeat `record_decision` for an already-decided draft returns that verdict rather than a second silent draft.
+- Preserve the author's words. When consolidation re-derives content, the agent-recorded title and rationale are retained as `authorStatement` alongside the served content, and the response discloses that the served text is `llm-extracted`. Nothing the author wrote is discarded without trace.
+- Align the tool description with the behavior: `record_decision` records a *draft proposal* subject to diff-grounded consolidation. The tool name is unchanged; only the contract text and response wording change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `mcp-handlers`: `record_decision` discloses draft status, and every draft reaches a reasoned terminal verdict retrievable by id.
+- `cli`: `openlore decisions` exposes a draft's disposition and reason.
+
+## Impact
+
+- `src/core/decisions/consolidator.ts` (verdict emission), `store.ts` / `atomic-store.ts` (terminal disposition, append-only), `ledger.ts`.
+- `src/core/services/mcp-handlers/decisions.ts` response shape and tool description in `src/cli/commands/mcp.ts`.
+- `src/cli/commands/decisions.ts` status rendering.
+- Decision records gain additive fields; existing records without a disposition are read as `legacy-unknown`.

--- a/openspec/changes/explain-decision-rejection/specs/cli/spec.md
+++ b/openspec/changes/explain-decision-rejection/specs/cli/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: DecisionStatusReportsDispositionAndReason
+
+`openlore decisions` SHALL report, for a draft id, its terminal disposition and stable reason code, or an explicit pending state when consolidation has not yet run. A decided draft SHALL never render as absent or unknown.
+
+Where the disposition is `rejected`, the output SHALL name the reason and the concrete next action (for example: add the missing evidence, or record the decision with a narrower subject).
+
+#### Scenario: A rejected draft is explainable from the CLI
+
+- **GIVEN** a draft rejected with reason `no-supporting-diff`
+- **WHEN** the user asks for its status by id
+- **THEN** the output states `rejected`, the reason, and what to do next
+
+#### Scenario: Pending is distinguishable from decided
+
+- **GIVEN** a draft recorded while background consolidation has not completed
+- **WHEN** the user asks for its status
+- **THEN** the output states an explicit pending state, never a rejection

--- a/openspec/changes/explain-decision-rejection/specs/mcp-handlers/spec.md
+++ b/openspec/changes/explain-decision-rejection/specs/mcp-handlers/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: EveryDraftReachesAReasonedVerdict
+
+Consolidation SHALL assign every draft a terminal disposition — `promoted`, `merged-into` with the surviving decision id, or `rejected` — together with a stable reason code drawn from a source-declared registry. A draft SHALL NOT be removed, skipped, or left pending without a disposition.
+
+The disposition and its reason SHALL be persisted with the draft id, so the verdict outlives the background run that produced it.
+
+#### Scenario: A rejected draft carries its reason
+
+- **GIVEN** a draft whose subject matter no supporting diff evidence covers
+- **WHEN** consolidation runs
+- **THEN** the draft is recorded `rejected` with reason `no-supporting-diff`, retrievable by its id
+
+#### Scenario: A merged draft names its survivor
+
+- **GIVEN** two drafts describing the same decision
+- **WHEN** consolidation merges them
+- **THEN** the absorbed draft is recorded `merged-into` with the id of the surviving decision
+
+#### Scenario: No draft disappears
+
+- **GIVEN** any set of drafts
+- **WHEN** consolidation completes
+- **THEN** every input draft has a persisted disposition, and the count of dispositions equals the count of drafts
+
+### Requirement: RecordDecisionDisclosesDraftStatusAndVerdict
+
+`record_decision` SHALL state in its response that it records a draft subject to diff-grounded consolidation, return the draft id, and name the exact command that reads the verdict. Its tool description SHALL describe the same contract; it SHALL NOT imply that the decision is final on return.
+
+A `record_decision` call whose content and anchors match an already-decided draft SHALL return that draft's disposition and reason instead of silently creating a second draft.
+
+#### Scenario: The caller learns where to read the outcome
+
+- **WHEN** `record_decision` succeeds
+- **THEN** the response carries the draft id, the draft status, and the exact command that reports its disposition
+
+#### Scenario: Re-recording a rejected draft returns the verdict
+
+- **GIVEN** a draft already rejected with reason `not-architectural`
+- **WHEN** the same content and anchors are recorded again
+- **THEN** the response reports the existing disposition and reason rather than creating a new pending draft
+
+### Requirement: AuthorStatementSurvivesConsolidationRewrite
+
+When consolidation re-derives a decision's content from diff evidence, the agent-recorded title and rationale SHALL be retained as `authorStatement` on the resulting decision, and the response SHALL disclose that the served content is `llm-extracted` with `verificationEvidence: git-diff`. Recorded author text SHALL never be discarded or rewritten in place.
+
+#### Scenario: The author can see what replaced their wording
+
+- **GIVEN** a draft promoted with re-derived content
+- **WHEN** the decision is read
+- **THEN** the served content is disclosed as `llm-extracted` and the original author title and rationale are present as `authorStatement`

--- a/openspec/changes/explain-decision-rejection/tasks.md
+++ b/openspec/changes/explain-decision-rejection/tasks.md
@@ -1,0 +1,24 @@
+## 1. Terminal dispositions
+
+- [x] 1.1 Add an additive disposition (`promoted` | `merged-into` | `rejected` | `pending`) with a source-declared reason-code registry to the decision record types; read a record without one as `legacy-unknown`.
+- [x] 1.2 Emit a disposition for every input draft in `consolidator.ts`, including drafts the LLM pass does not return, and persist it through the CAS store.
+- [x] 1.3 Property test: for any draft set, the number of persisted dispositions equals the number of input drafts — no silent drop.
+- [x] 1.4 Tests for each reason code, including `merged-into` naming the surviving id.
+
+## 2. Readable verdicts
+
+- [x] 2.1 Return the draft id, draft status, and the exact verdict-reading command from `record_decision`.
+- [x] 2.2 Return the existing disposition and reason when a re-recorded draft matches a decided one (content plus anchors), instead of creating a second draft.
+- [x] 2.3 Add the disposition and reason to `openlore decisions` status output, with an explicit pending state and a concrete next action on rejection.
+- [x] 2.4 Update the `record_decision` tool description to state the draft-then-consolidation contract without implying finality.
+
+## 3. Author statement preservation
+
+- [x] 3.1 Retain the agent-recorded title and rationale as `authorStatement` when consolidation re-derives content.
+- [x] 3.2 Disclose `contentOrigin` and `verificationEvidence` in the decision read paths (`recall`, `openlore decisions`, MCP responses).
+- [x] 3.3 Tests: a promoted-with-rewrite decision exposes both the served content and the untouched author statement.
+
+## 4. Verification
+
+- [x] 4.1 Run the tests reaching the consolidator, decision store, decision handlers, and the CLI command.
+- [x] 4.2 Exercise the full loop on a scratch repository: record, consolidate, read verdict for a promoted draft and a rejected one.

--- a/src/api/decisions.test.ts
+++ b/src/api/decisions.test.ts
@@ -191,4 +191,87 @@ describe('openloreConsolidateDecisions — verification evidence', () => {
     expect(verifyDecisions).toHaveBeenCalledOnce();
     expect(mocks.saveLogs).toHaveBeenCalledOnce();
   });
+
+  it('settles absorbed drafts and preserves a draft recorded during consolidation', async () => {
+    const kept = makeDecision({ id: 'keep0001' });
+    const absorbed = makeDecision({ id: 'drop0002', title: 'Related draft' });
+    const concurrent = makeDecision({ id: 'later003', title: 'Recorded concurrently' });
+    const initial = makeStore([kept, absorbed]);
+    const fresh = makeStore([kept, absorbed, concurrent]);
+    vi.mocked(loadDecisionStore).mockResolvedValue(initial);
+    vi.mocked(updateDecisionStore).mockImplementation(async (_root, mutate) => mutate(fresh));
+    vi.mocked(isGitRepositoryRoot).mockResolvedValue(false);
+    vi.mocked(consolidateDrafts).mockResolvedValue({
+      decisions: [{ ...kept, status: 'consolidated' }],
+      supersededIds: [],
+      dispositions: [
+        { id: kept.id, disposition: 'promoted', reason: 'promoted-as-recorded' },
+        { id: absorbed.id, disposition: 'merged-into', reason: 'merged-into-consolidated', mergedIntoId: kept.id },
+      ],
+    });
+
+    const result = await openloreConsolidateDecisions({ rootPath: '/test/project', provider: 'anthropic' });
+
+    expect(result.store.decisions.find(d => d.id === kept.id)).toMatchObject({
+      status: 'verified', disposition: 'promoted', dispositionReason: 'promoted-as-recorded',
+    });
+    expect(result.store.decisions.find(d => d.id === absorbed.id)).toMatchObject({
+      status: 'rejected', disposition: 'merged-into',
+      dispositionReason: 'merged-into-consolidated', mergedIntoId: kept.id,
+    });
+    expect(result.store.decisions.find(d => d.id === concurrent.id)).toEqual(concurrent);
+  });
+
+  it('rejects every original draft when consolidation keeps nothing', async () => {
+    const first = makeDecision({ id: 'draft001' });
+    const second = makeDecision({ id: 'draft002', title: 'Non-architectural refactor' });
+    const initial = makeStore([first, second]);
+    vi.mocked(loadDecisionStore).mockResolvedValue(initial);
+    vi.mocked(updateDecisionStore).mockImplementation(async (_root, mutate) => mutate(initial));
+    vi.mocked(isGitRepositoryRoot).mockResolvedValue(false);
+    vi.mocked(consolidateDrafts).mockResolvedValue({
+      decisions: [],
+      supersededIds: [],
+      dispositions: [
+        { id: first.id, disposition: 'rejected', reason: 'not-in-consolidated-set' },
+        { id: second.id, disposition: 'rejected', reason: 'not-in-consolidated-set' },
+      ],
+    });
+
+    const result = await openloreConsolidateDecisions({ rootPath: '/test/project', provider: 'anthropic' });
+
+    expect(result.store.decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: first.id, status: 'rejected', disposition: 'rejected' }),
+      expect.objectContaining({ id: second.id, status: 'rejected', disposition: 'rejected' }),
+    ]));
+  });
+
+  it('rejects an absorbed draft instead of pointing it at a phantom survivor', async () => {
+    const survivor = makeDecision({ id: 'phantom1', affectedFiles: ['src/example.ts'] });
+    const absorbed = makeDecision({ id: 'merged02', affectedFiles: ['src/example.ts'] });
+    const initial = makeStore([survivor, absorbed]);
+    const phantom = { ...survivor, status: 'phantom' as const };
+    vi.mocked(loadDecisionStore).mockResolvedValue(initial);
+    vi.mocked(updateDecisionStore).mockImplementation(async (_root, mutate) => mutate(initial));
+    vi.mocked(consolidateDrafts).mockResolvedValue({
+      decisions: [{ ...survivor, status: 'consolidated' }],
+      supersededIds: [],
+      dispositions: [
+        { id: survivor.id, disposition: 'promoted', reason: 'promoted-as-recorded' },
+        { id: absorbed.id, disposition: 'merged-into', reason: 'merged-into-consolidated', mergedIntoId: survivor.id },
+      ],
+    });
+    vi.mocked(isGitRepositoryRoot).mockResolvedValue(true);
+    vi.mocked(verifyDecisions).mockResolvedValue({ verified: [], phantom: [phantom], missing: [] });
+
+    const result = await openloreConsolidateDecisions({ rootPath: '/test/project', provider: 'anthropic' });
+
+    expect(result.store.decisions.find(d => d.id === survivor.id)).toMatchObject({
+      status: 'phantom', disposition: 'rejected', dispositionReason: 'no-supporting-diff',
+    });
+    expect(result.store.decisions.find(d => d.id === absorbed.id)).toMatchObject({
+      status: 'rejected', disposition: 'rejected', dispositionReason: 'no-supporting-diff',
+    });
+    expect(result.store.decisions.find(d => d.id === absorbed.id)?.mergedIntoId).toBeUndefined();
+  });
 });

--- a/src/api/decisions.test.ts
+++ b/src/api/decisions.test.ts
@@ -164,7 +164,7 @@ describe('openloreConsolidateDecisions — verification evidence', () => {
     const store = makeStore([draft]);
     vi.mocked(loadDecisionStore).mockResolvedValue(store);
     vi.mocked(updateDecisionStore).mockResolvedValue(store);
-    vi.mocked(consolidateDrafts).mockResolvedValue({ decisions: [draft], supersededIds: [] });
+    vi.mocked(consolidateDrafts).mockResolvedValue({ decisions: [draft], supersededIds: [], dispositions: [{ id: draft.id, disposition: "promoted", reason: "promoted-as-recorded" }] });
 
     const result = await openloreConsolidateDecisions({ rootPath: '/test/project', provider: 'anthropic' });
 
@@ -179,7 +179,7 @@ describe('openloreConsolidateDecisions — verification evidence', () => {
     const store = makeStore([draft]);
     vi.mocked(loadDecisionStore).mockResolvedValue(store);
     vi.mocked(updateDecisionStore).mockResolvedValue(store);
-    vi.mocked(consolidateDrafts).mockResolvedValue({ decisions: [draft], supersededIds: [] });
+    vi.mocked(consolidateDrafts).mockResolvedValue({ decisions: [draft], supersededIds: [], dispositions: [{ id: draft.id, disposition: "promoted", reason: "promoted-as-recorded" }] });
     vi.mocked(isGitRepositoryRoot).mockResolvedValue(true);
     vi.mocked(verifyDecisions).mockImplementation(async () => {
       expect(mocks.saveLogs).not.toHaveBeenCalled();

--- a/src/api/decisions.ts
+++ b/src/api/decisions.ts
@@ -21,12 +21,11 @@ import {
   loadDecisionStore,
   updateDecisionStore,
   upsertDecisions,
-  applyConsolidationResult,
   makeDecisionId,
   illegalPromotionToApproved,
 } from '../core/decisions/store.js';
 import { consolidateDrafts } from '../core/decisions/consolidator.js';
-import { applyDispositions, withVerificationOutcome } from '../core/decisions/disposition.js';
+import { applyConsolidationOutcome, withVerificationOutcome } from '../core/decisions/disposition.js';
 import type { ProviderName } from '../utils/command-helpers.js';
 import { markVerificationEvidenceAbsent, verifyDecisions } from '../core/decisions/verifier.js';
 import { syncApprovedDecisions } from '../core/decisions/syncer.js';
@@ -156,6 +155,9 @@ export async function openloreConsolidateDecisions(
   });
 
   const store = await loadDecisionStore(rootPath);
+  const originalDraftIds = new Set(
+    store.decisions.filter((decision) => decision.status === 'draft').map((decision) => decision.id),
+  );
 
   const openspecPath = resolveOpenspecDir(rootPath, openloreConfig.openspecPath);
   const specMap = await buildSpecMap({ rootPath, openspecPath }).catch(() => undefined);
@@ -170,7 +172,13 @@ export async function openloreConsolidateDecisions(
     // draft that produced no decision must say so, not vanish
     // (change: explain-decision-rejection).
     const withVerdicts = dispositions.length
-      ? await updateDecisionStore(rootPath, (s) => applyDispositions(s, dispositions))
+      ? await updateDecisionStore(rootPath, (s) => applyConsolidationOutcome(s, {
+          originalDraftIds,
+          verified: [],
+          phantom: [],
+          supersededIds,
+          dispositions,
+        }))
       : store;
     return { verified: [], phantom: [], missing: [], store: withVerdicts };
   }
@@ -206,12 +214,18 @@ export async function openloreConsolidateDecisions(
   progress(onProgress, 'Verifying decisions', 'complete', `${verified.length} verified`);
 
   // CAS persist onto the freshest store so a concurrently-recorded draft is kept.
-  // replaceDecisions (via applyConsolidationResult), NOT upsert: consolidated decisions
+  // replaceDecisions (via applyConsolidationOutcome), NOT upsert: consolidated decisions
   // reuse their drafts' deterministic ids, so an upsert would silently drop the verified
   // status. Matches the CLI consolidation path.
   const finalDispositions = withVerificationOutcome(dispositions, new Set(phantom.map((d) => d.id)));
   const updatedStore = await updateDecisionStore(rootPath, (s) =>
-    applyDispositions(applyConsolidationResult(s, { verified, phantom, supersededIds }), finalDispositions),
+    applyConsolidationOutcome(s, {
+      originalDraftIds,
+      verified,
+      phantom,
+      supersededIds,
+      dispositions: finalDispositions,
+    }),
   );
 
   return { verified, phantom, missing, store: updatedStore };

--- a/src/api/decisions.ts
+++ b/src/api/decisions.ts
@@ -26,6 +26,7 @@ import {
   illegalPromotionToApproved,
 } from '../core/decisions/store.js';
 import { consolidateDrafts } from '../core/decisions/consolidator.js';
+import { applyDispositions, withVerificationOutcome } from '../core/decisions/disposition.js';
 import type { ProviderName } from '../utils/command-helpers.js';
 import { markVerificationEvidenceAbsent, verifyDecisions } from '../core/decisions/verifier.js';
 import { syncApprovedDecisions } from '../core/decisions/syncer.js';
@@ -160,12 +161,18 @@ export async function openloreConsolidateDecisions(
   const specMap = await buildSpecMap({ rootPath, openspecPath }).catch(() => undefined);
 
   progress(onProgress, 'Consolidating drafts', 'start');
-  const { decisions: consolidated, supersededIds } = await consolidateDrafts(store, llm, specMap);
+  const { decisions: consolidated, supersededIds, dispositions } = await consolidateDrafts(store, llm, specMap);
   progress(onProgress, 'Consolidating drafts', 'complete', `${consolidated.length} decisions`);
 
   if (consolidated.length === 0) {
     await llm.saveLogs().catch(() => {});
-    return { verified: [], phantom: [], missing: [], store };
+    // Consolidation kept nothing — but the drafts still get their verdicts. A
+    // draft that produced no decision must say so, not vanish
+    // (change: explain-decision-rejection).
+    const withVerdicts = dispositions.length
+      ? await updateDecisionStore(rootPath, (s) => applyDispositions(s, dispositions))
+      : store;
+    return { verified: [], phantom: [], missing: [], store: withVerdicts };
   }
 
   // Build combined diff + commit messages for verification
@@ -202,8 +209,9 @@ export async function openloreConsolidateDecisions(
   // replaceDecisions (via applyConsolidationResult), NOT upsert: consolidated decisions
   // reuse their drafts' deterministic ids, so an upsert would silently drop the verified
   // status. Matches the CLI consolidation path.
+  const finalDispositions = withVerificationOutcome(dispositions, new Set(phantom.map((d) => d.id)));
   const updatedStore = await updateDecisionStore(rootPath, (s) =>
-    applyConsolidationResult(s, { verified, phantom, supersededIds }),
+    applyDispositions(applyConsolidationResult(s, { verified, phantom, supersededIds }), finalDispositions),
   );
 
   return { verified, phantom, missing, store: updatedStore };

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -785,7 +785,9 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
           console.log('No architectural decisions found in drafts.');
           for (const d of dispositions) {
             const entry = DECISION_DISPOSITION_REASONS[d.reason];
-            console.log(`  ${d.id}: ${d.disposition} [${d.reason}] — ${entry.description}${entry.nextAction ? ` → ${entry.nextAction}` : ''}`);
+            // The id comes from the analyzed repository's decision store, so it is
+            // untrusted terminal input like any other repo-derived value.
+            console.log(`  ${safe(d.id)}: ${d.disposition} [${d.reason}] — ${entry.description}${entry.nextAction ? ` → ${entry.nextAction}` : ''}`);
           }
           if (dispositions.length > 0) console.log('  Read a verdict any time with: openlore decisions status <id>');
         } else {

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -28,7 +28,6 @@ import { isGitRepositoryRoot, getChangedFiles, getFileDiff, getCommitMessages, r
 import {
   loadDecisionStore,
   updateDecisionStore,
-  replaceDecisions,
   patchDecision,
   getDecisionsByStatus,
   INACTIVE_STATUSES,
@@ -39,7 +38,7 @@ import { rewriteSyncedDecisionStatus } from '../../core/decisions/syncer.js';
 import { consolidateDrafts } from '../../core/decisions/consolidator.js';
 import {
   DECISION_DISPOSITION_REASONS,
-  applyDispositions,
+  applyConsolidationOutcome,
   describeDisposition,
   readDisposition,
   withVerificationOutcome,
@@ -779,7 +778,13 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
         // can read WHY rather than watch the draft disappear
         // (change: explain-decision-rejection).
         if (dispositions.length > 0) {
-          await updateDecisionStore(rootPath, (s) => applyDispositions(s, dispositions), 'agent');
+          await updateDecisionStore(rootPath, (s) => applyConsolidationOutcome(s, {
+            originalDraftIds: new Set(drafts.map((draft) => draft.id)),
+            verified: [],
+            phantom: [],
+            supersededIds,
+            dispositions,
+          }), 'agent');
         }
         if (!options.json) {
           console.log('No architectural decisions found in drafts.');
@@ -848,13 +853,14 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
       // because consolidated decisions share IDs with their original drafts.
       const finalDispositions = withVerificationOutcome(dispositions, new Set(phantom.map((d) => d.id)));
       const updatedStore = await updateDecisionStore(rootPath, (s) => {
-        let next = s;
-        for (const id of [...originalDraftIds, ...supersededIds]) {
-          next = patchDecision(next, id, { status: 'rejected' });
-        }
-        next = replaceDecisions(next, withProvenance);
         // Every input draft's verdict, written alongside the status transition.
-        next = applyDispositions(next, finalDispositions);
+        const next = applyConsolidationOutcome(s, {
+          originalDraftIds,
+          verified: withProvenance.filter((decision) => decision.status === 'verified'),
+          phantom: withProvenance.filter((decision) => decision.status === 'phantom'),
+          supersededIds,
+          dispositions: finalDispositions,
+        });
         return { ...next, lastConsolidatedAt: new Date().toISOString() };
       });
 

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -37,6 +37,14 @@ import {
 import { readLedger } from '../../core/decisions/ledger.js';
 import { rewriteSyncedDecisionStatus } from '../../core/decisions/syncer.js';
 import { consolidateDrafts } from '../../core/decisions/consolidator.js';
+import {
+  DECISION_DISPOSITION_REASONS,
+  applyDispositions,
+  describeDisposition,
+  readDisposition,
+  withVerificationOutcome,
+  type DraftDisposition,
+} from '../../core/decisions/disposition.js';
 import { classifyGateState } from '../../core/decisions/gate-state.js';
 import { acquireDecisionsLock } from '../../core/decisions/lock.js';
 import { extractFromDiff } from '../../core/decisions/extractor.js';
@@ -753,11 +761,13 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
       const specMapResult = await buildSpecMap({ rootPath, openspecPath }).catch(() => undefined);
       let consolidated: PendingDecision[];
       let supersededIds: string[] = [];
+      let dispositions: DraftDisposition[] = [];
       if (hasDrafts) {
         if (!options.json) logger.discovery(`Consolidating ${drafts.length} draft decision(s) via ${resolved.provider}...`);
         const result = await consolidateDrafts(store, llm, specMapResult);
         consolidated = result.decisions;
         supersededIds = result.supersededIds;
+        dispositions = result.dispositions;
       } else {
         if (!options.json) logger.discovery(`No drafts found — extracting decisions from diff via ${resolved.provider}...`);
         const specMap = specMapResult ?? await buildSpecMap({ rootPath, openspecPath });
@@ -765,7 +775,22 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
         consolidated = await extractFromDiff({ rootPath, stagedOnly: true, specMap, sessionId: store.sessionId, llm });
       }
       if (consolidated.length === 0) {
-        if (!options.json) console.log('No architectural decisions found in drafts.');
+        // Nothing survived — but every draft still gets its verdict, so the author
+        // can read WHY rather than watch the draft disappear
+        // (change: explain-decision-rejection).
+        if (dispositions.length > 0) {
+          await updateDecisionStore(rootPath, (s) => applyDispositions(s, dispositions), 'agent');
+        }
+        if (!options.json) {
+          console.log('No architectural decisions found in drafts.');
+          for (const d of dispositions) {
+            const entry = DECISION_DISPOSITION_REASONS[d.reason];
+            console.log(`  ${d.id}: ${d.disposition} [${d.reason}] — ${entry.description}${entry.nextAction ? ` → ${entry.nextAction}` : ''}`);
+          }
+          if (dispositions.length > 0) console.log('  Read a verdict any time with: openlore decisions status <id>');
+        } else {
+          process.stdout.write(JSON.stringify({ verified: [], phantom: [], missing: [], dispositions }, null, 2) + '\n');
+        }
         if (options.gate) process.exitCode = 0;
         return;
       }
@@ -819,12 +844,15 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
       // record_decision/approve committed concurrently (different lock) is preserved
       // rather than clobbered by this stale snapshot. replaceDecisions (not upsert)
       // because consolidated decisions share IDs with their original drafts.
+      const finalDispositions = withVerificationOutcome(dispositions, new Set(phantom.map((d) => d.id)));
       const updatedStore = await updateDecisionStore(rootPath, (s) => {
         let next = s;
         for (const id of [...originalDraftIds, ...supersededIds]) {
           next = patchDecision(next, id, { status: 'rejected' });
         }
         next = replaceDecisions(next, withProvenance);
+        // Every input draft's verdict, written alongside the status transition.
+        next = applyDispositions(next, finalDispositions);
         return { ...next, lastConsolidatedAt: new Date().toISOString() };
       });
 
@@ -1252,6 +1280,70 @@ decisionsCommand
       console.log(`\nTotal: ${entries.length} transition(s)`);
     } catch (err) {
       logger.error(`decisions log failed: ${(err as Error).message}`);
+      process.exitCode = 1;
+    } finally {
+      restoreStdout?.();
+    }
+  });
+
+decisionsCommand
+  .command('status')
+  .argument('<id>', '8-char decision/draft id')
+  .description('Report a draft\'s terminal disposition and reason (pending, promoted, merged-into, rejected)')
+  .option('--json', 'Output as JSON', false)
+  .action(async (id: string, opts: { json: boolean }, cmd: Command) => {
+    const parentOpts = (cmd.parent?.opts() ?? {}) as { json?: boolean };
+    const json = Boolean(opts.json || parentOpts.json);
+    const restoreStdout = json ? redirectConsoleToStderr() : null;
+    try {
+      const rootPath = process.cwd();
+      const store = await loadDecisionStore(rootPath);
+      const decision = store.decisions.find((d) => d.id === id);
+      if (!decision) {
+        // An id the store has never held is "not found" — never a rejection.
+        if (json) {
+          process.stdout.write(JSON.stringify({ id, found: false, note: 'No decision or draft with this id — not found, NOT rejected.' }, null, 2) + '\n');
+        } else {
+          logger.warning(`No decision or draft with id ${safe(id)} — not found, NOT rejected.`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const { disposition, reason, mergedIntoId } = readDisposition(decision);
+      const entry = DECISION_DISPOSITION_REASONS[reason];
+      if (json) {
+        process.stdout.write(JSON.stringify({
+          id: decision.id,
+          found: true,
+          status: decision.status,
+          disposition,
+          reason,
+          reasonDescription: entry.description,
+          ...(entry.nextAction ? { nextAction: entry.nextAction } : {}),
+          ...(mergedIntoId ? { mergedIntoId } : {}),
+          ...(decision.dispositionAt ? { dispositionAt: decision.dispositionAt } : {}),
+          title: decision.title,
+          contentOrigin: decision.contentOrigin,
+          ...(decision.verificationEvidence ? { verificationEvidence: decision.verificationEvidence } : {}),
+          ...(decision.authorStatement ? { authorStatement: decision.authorStatement } : {}),
+        }, null, 2) + '\n');
+        return;
+      }
+
+      logger.section(`Decision ${safe(decision.id)}`);
+      console.log(`  title:       ${safe(decision.title)}`);
+      console.log(`  status:      ${safe(decision.status)}`);
+      console.log(`  disposition: ${describeDisposition(decision)}`);
+      // Provenance the author needs to interpret the served text.
+      console.log(`  content:     ${safe(decision.contentOrigin)}${decision.verificationEvidence ? ` (evidence: ${safe(decision.verificationEvidence)})` : ''}`);
+      if (decision.authorStatement) {
+        console.log('  authorStatement (your recorded wording, kept verbatim):');
+        console.log(`    title:     ${safe(decision.authorStatement.title)}`);
+        console.log(`    rationale: ${safe(decision.authorStatement.rationale)}`);
+      }
+    } catch (err) {
+      logger.error(`decisions status failed: ${(err as Error).message}`);
       process.exitCode = 1;
     } finally {
       restoreStdout?.();

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1929,15 +1929,12 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'record_decision',
     description:
-      'Record a DRAFT architectural decision for the current session — a proposal, not a final record. ' +
-      'Call this whenever you make a significant design choice: choosing a data structure, ' +
-      'picking a library, defining an API contract, selecting an auth strategy, etc. ' +
-      'The draft is then decided by diff-grounded consolidation, which promotes it (possibly ' +
-      'rewording it from the diff, keeping your text as authorStatement), merges it into another ' +
-      'decision, or rejects it — always with a stated reason. The response returns the draft id ' +
-      'and the command that reads its verdict (`openlore decisions status <id>`); re-recording an ' +
-      'already-decided draft returns that verdict instead of creating a second one. ' +
-      'Use the supersedes field when a later decision replaces an earlier one.',
+      'Record a DRAFT architectural decision — a proposal, not a final record. ' +
+      'Call this on a significant design choice: data structure, library, API contract, auth strategy. ' +
+      'Diff-grounded consolidation then promotes it (possibly rewording it, keeping your text as ' +
+      'authorStatement), merges it, or rejects it — always with a stated reason. The response returns ' +
+      'the draft id and the command that reads the verdict; re-recording a decided draft returns that ' +
+      'verdict instead of a second draft. Use supersedes when a later decision replaces an earlier one.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1929,10 +1929,14 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'record_decision',
     description:
-      'Record an architectural decision made during the current development session. ' +
+      'Record a DRAFT architectural decision for the current session — a proposal, not a final record. ' +
       'Call this whenever you make a significant design choice: choosing a data structure, ' +
       'picking a library, defining an API contract, selecting an auth strategy, etc. ' +
-      'Decisions are stored as drafts and consolidated before the next commit. ' +
+      'The draft is then decided by diff-grounded consolidation, which promotes it (possibly ' +
+      'rewording it from the diff, keeping your text as authorStatement), merges it into another ' +
+      'decision, or rejects it — always with a stated reason. The response returns the draft id ' +
+      'and the command that reads its verdict (`openlore decisions status <id>`); re-recording an ' +
+      'already-decided draft returns that verdict instead of creating a second one. ' +
       'Use the supersedes field when a later decision replaces an earlier one.',
     inputSchema: {
       type: 'object',

--- a/src/core/decisions/consolidator.test.ts
+++ b/src/core/decisions/consolidator.test.ts
@@ -378,3 +378,95 @@ describe('consolidateDrafts — ID reuse', () => {
       .rejects.toThrow(/invalid structured output/);
   });
 });
+
+// ============================================================================
+// Dispositions + author statement (change: explain-decision-rejection)
+// ============================================================================
+
+describe('consolidateDrafts — every draft reaches a reasoned verdict', () => {
+  it('emits one disposition per input draft, including drafts the LLM did not return', async () => {
+    // Two drafts in, one decision out (echoing draft0000's id): the second draft
+    // must still come back with a stated verdict, not vanish.
+    const response = JSON.stringify([{
+      id: 'draft0000',
+      title: 'Decision 0',
+      rationale: 'Some rationale',
+      consequences: 'c',
+      affectedDomains: ['api'],
+      affectedFiles: [],
+      proposedRequirement: null,
+    }]);
+    const result = await consolidateDrafts(
+      makeStore([{ title: 'Decision 0' }, { title: 'Decision 1' }]),
+      makeLLM(response),
+    );
+
+    expect(result.dispositions).toHaveLength(2);
+    expect(result.dispositions[0]).toEqual({
+      id: 'draft0000', disposition: 'promoted', reason: 'promoted-as-recorded',
+    });
+    // The absorbed draft names the survivor rather than disappearing.
+    expect(result.dispositions[1]).toEqual({
+      id: 'draft0001', disposition: 'merged-into', reason: 'merged-into-consolidated', mergedIntoId: 'draft0000',
+    });
+  });
+
+  it('gives every draft a verdict when the LLM keeps nothing at all', async () => {
+    const result = await consolidateDrafts(
+      makeStore([{ title: 'Decision 0' }, { title: 'Decision 1' }]),
+      makeLLM('[]'),
+    );
+    expect(result.decisions).toHaveLength(0);
+    expect(result.dispositions).toHaveLength(2);
+    for (const d of result.dispositions) {
+      expect(d.disposition).toBe('rejected');
+      expect(d.reason).toBe('not-in-consolidated-set');
+    }
+  });
+
+  it('preserves the author statement when consolidation re-derives the wording', async () => {
+    const response = JSON.stringify([{
+      id: 'draft0000',
+      title: 'Persist the call graph in SQLite rather than JSON',
+      rationale: 'Re-derived from the diff: the EdgeStore write path changed',
+      consequences: 'c',
+      affectedDomains: ['api'],
+      affectedFiles: [],
+      proposedRequirement: null,
+    }]);
+    const { decisions, dispositions } = await consolidateDrafts(
+      makeStore([{ title: 'Use SQLite', rationale: 'JSON artifact too big to reload' }]),
+      makeLLM(response),
+    );
+
+    const kept = decisions[0];
+    // The served content is the consolidator's, disclosed as such…
+    expect(kept.contentOrigin).toBe('llm-extracted');
+    expect(kept.title).toBe('Persist the call graph in SQLite rather than JSON');
+    // …and the author's own words survive untouched alongside it.
+    expect(kept.authorStatement).toEqual({
+      title: 'Use SQLite',
+      rationale: 'JSON artifact too big to reload',
+      recordedAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(dispositions[0].reason).toBe('promoted-with-rewrite');
+  });
+
+  it('does not attach an author statement when the wording was kept', async () => {
+    const response = JSON.stringify([{
+      id: 'draft0000',
+      title: 'Decision 0',
+      rationale: 'Some rationale',
+      consequences: 'c',
+      affectedDomains: ['api'],
+      affectedFiles: [],
+      proposedRequirement: null,
+    }]);
+    const { decisions, dispositions } = await consolidateDrafts(
+      makeStore([{ title: 'Decision 0' }]),
+      makeLLM(response),
+    );
+    expect(decisions[0].authorStatement).toBeUndefined();
+    expect(dispositions[0].reason).toBe('promoted-as-recorded');
+  });
+});

--- a/src/core/decisions/consolidator.ts
+++ b/src/core/decisions/consolidator.ts
@@ -12,6 +12,12 @@ import { logger } from '../../utils/logger.js';
 import type { LLMService } from '../services/llm-service.js';
 import type { PendingDecision, DecisionStore, SpecMap, DecisionScope } from '../../types/index.js';
 import { makeDecisionId } from './store.js';
+import {
+  authorStatementOf,
+  computeDraftDispositions,
+  contentWasRewritten,
+  type DraftDisposition,
+} from './disposition.js';
 import { parseJSON } from '../../utils/misc.js';
 import { matchFileToDomains } from '../drift/spec-mapper.js';
 import { createPromptBoundary } from '../../utils/prompt-boundary.js';
@@ -114,6 +120,12 @@ function isConsolidatedRaw(value: unknown): value is ConsolidatedRaw {
 export interface ConsolidateResult {
   decisions: PendingDecision[];
   supersededIds: string[];
+  /**
+   * One terminal verdict per INPUT draft (change: explain-decision-rejection).
+   * `dispositions.length === drafts.length` always — a draft can no longer leave
+   * consolidation without a reason the author can read.
+   */
+  dispositions: DraftDisposition[];
 }
 
 export async function consolidateDrafts(
@@ -122,7 +134,7 @@ export async function consolidateDrafts(
   specMap?: SpecMap,
 ): Promise<ConsolidateResult> {
   const drafts = store.decisions.filter((d) => d.status === 'draft');
-  if (drafts.length === 0) return { decisions: [], supersededIds: [] };
+  if (drafts.length === 0) return { decisions: [], supersededIds: [], dispositions: [] };
 
   // Non-draft decisions are context only. Their durable IDs may not be reused by
   // LLM output because replaceDecisions() overwrites matching records.
@@ -191,6 +203,8 @@ export async function consolidateDrafts(
     .flatMap((c) => c.supersededIds ?? [])
     .filter((id) => declaredSupersessionIds.has(id));
 
+  const draftById = new Map(drafts.map((d) => [d.id, d]));
+
   const decisions = consolidated.map((c): PendingDecision => {
     // Remap LLM-produced domain names to spec-map ground truth using affectedFiles.
     // Falls back to LLM names if specMap is absent or files yield no match.
@@ -202,6 +216,14 @@ export async function consolidateDrafts(
       c.id && draftIds.has(c.id)
         ? c.id
         : makeDecisionId(store.sessionId, domain, c.title);
+    // Preserve the author's words when the consolidator re-derived the wording.
+    // The served content stays `llm-extracted` — what changes is that the text
+    // the agent actually wrote is no longer discarded without trace.
+    const source = draftById.get(id);
+    const authorStatement = source && contentWasRewritten(source, {
+      ...source, title: c.title, rationale: c.rationale,
+    }) ? authorStatementOf(source) : undefined;
+
     return {
       id,
       status: 'consolidated',
@@ -218,10 +240,18 @@ export async function consolidateDrafts(
       recordedAt: now,
       consolidatedAt: now,
       syncedToSpecs: [],
+      ...(authorStatement ? { authorStatement } : {}),
     };
   });
 
-  return { decisions, supersededIds: allSupersededIds };
+  // One verdict per input draft — including the drafts the LLM did not return.
+  const dispositions = computeDraftDispositions({
+    drafts,
+    consolidated: decisions,
+    supersededIds: allSupersededIds,
+  });
+
+  return { decisions, supersededIds: allSupersededIds, dispositions };
 }
 
 /**

--- a/src/core/decisions/disposition.test.ts
+++ b/src/core/decisions/disposition.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   DECISION_DISPOSITION_REASONS,
+  applyConsolidationOutcome,
   applyDispositions,
   authorStatementOf,
   computeDraftDispositions,
@@ -16,6 +17,7 @@ import {
   describeDisposition,
   readDisposition,
   withVerificationOutcome,
+  type DraftDisposition,
 } from './disposition.js';
 import type { DecisionStore, PendingDecision } from '../../types/index.js';
 
@@ -163,6 +165,81 @@ describe('withVerificationOutcome', () => {
       consolidated: [decision({ id: 'a', status: 'consolidated' })],
     });
     expect(withVerificationOutcome(verdicts, new Set())).toEqual(verdicts);
+  });
+
+  it('rejects an absorbed draft when its supposed survivor is phantom', () => {
+    const verdicts: DraftDisposition[] = [
+      { id: 'a', disposition: 'promoted', reason: 'promoted-as-recorded' },
+      { id: 'b', disposition: 'merged-into', reason: 'merged-into-consolidated', mergedIntoId: 'a' },
+    ];
+
+    expect(withVerificationOutcome(verdicts, new Set(['a']))).toEqual([
+      { id: 'a', disposition: 'rejected', reason: 'no-supporting-diff' },
+      { id: 'b', disposition: 'rejected', reason: 'no-supporting-diff' },
+    ]);
+  });
+});
+
+describe('applyConsolidationOutcome', () => {
+  it('settles every original while leaving a concurrently recorded draft pending', () => {
+    const originalA = decision({ id: 'a' });
+    const originalB = decision({ id: 'b' });
+    const concurrent = decision({ id: 'later' });
+    const verified = decision({ id: 'a', status: 'verified' });
+
+    const next = applyConsolidationOutcome(store([originalA, originalB, concurrent]), {
+      originalDraftIds: new Set(['a', 'b']),
+      verified: [verified],
+      phantom: [],
+      supersededIds: [],
+      dispositions: [
+        { id: 'a', disposition: 'promoted', reason: 'promoted-as-recorded' },
+        { id: 'b', disposition: 'merged-into', reason: 'merged-into-consolidated', mergedIntoId: 'a' },
+      ],
+    });
+
+    expect(next.decisions.find(d => d.id === 'a')).toMatchObject({
+      status: 'verified', disposition: 'promoted', dispositionReason: 'promoted-as-recorded',
+    });
+    expect(next.decisions.find(d => d.id === 'b')).toMatchObject({
+      status: 'rejected', disposition: 'merged-into',
+      dispositionReason: 'merged-into-consolidated', mergedIntoId: 'a',
+    });
+    expect(next.decisions.find(d => d.id === 'later')).toEqual(concurrent);
+  });
+
+  it('turns every discarded draft into a rejected record when consolidation keeps nothing', () => {
+    const dispositions: DraftDisposition[] = [
+      { id: 'a', disposition: 'rejected', reason: 'not-in-consolidated-set' },
+      { id: 'b', disposition: 'rejected', reason: 'superseded-by-later-draft' },
+    ];
+    const next = applyConsolidationOutcome(store([decision({ id: 'a' }), decision({ id: 'b' })]), {
+      originalDraftIds: new Set(['a', 'b']),
+      verified: [],
+      phantom: [],
+      supersededIds: ['b'],
+      dispositions,
+    });
+
+    expect(next.decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'a', status: 'rejected', disposition: 'rejected' }),
+      expect.objectContaining({ id: 'b', status: 'rejected', disposition: 'rejected' }),
+    ]));
+  });
+
+  it('keeps phantom status while recording the no-supporting-diff verdict', () => {
+    const phantom = decision({ id: 'a', status: 'phantom' });
+    const next = applyConsolidationOutcome(store([decision({ id: 'a' })]), {
+      originalDraftIds: new Set(['a']),
+      verified: [],
+      phantom: [phantom],
+      supersededIds: [],
+      dispositions: [{ id: 'a', disposition: 'rejected', reason: 'no-supporting-diff' }],
+    });
+
+    expect(next.decisions[0]).toMatchObject({
+      status: 'phantom', disposition: 'rejected', dispositionReason: 'no-supporting-diff',
+    });
   });
 });
 

--- a/src/core/decisions/disposition.test.ts
+++ b/src/core/decisions/disposition.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Terminal dispositions for decision drafts (change: explain-decision-rejection).
+ *
+ * The invariant under test: consolidation assigns EVERY input draft a verdict
+ * with a stated reason. A draft can no longer stop existing silently — and where
+ * attribution is ambiguous, the tool says "did not survive" rather than inventing
+ * a merge target.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  DECISION_DISPOSITION_REASONS,
+  applyDispositions,
+  authorStatementOf,
+  computeDraftDispositions,
+  contentWasRewritten,
+  describeDisposition,
+  readDisposition,
+  withVerificationOutcome,
+} from './disposition.js';
+import type { DecisionStore, PendingDecision } from '../../types/index.js';
+
+function decision(over: Partial<PendingDecision> & { id: string }): PendingDecision {
+  return {
+    status: 'draft',
+    title: `title ${over.id}`,
+    rationale: `rationale ${over.id}`,
+    consequences: '',
+    proposedRequirement: null,
+    affectedDomains: [],
+    affectedFiles: [],
+    sessionId: 's',
+    recordedAt: '2026-01-01T00:00:00Z',
+    contentOrigin: 'agent-recorded',
+    confidence: 'medium',
+    scope: 'component',
+    syncedToSpecs: [],
+    ...over,
+  } as PendingDecision;
+}
+
+function store(decisions: PendingDecision[]): DecisionStore {
+  return { version: '1', sessionId: 's', updatedAt: '', decisions } as DecisionStore;
+}
+
+describe('computeDraftDispositions', () => {
+  it('promotes a draft whose id survives consolidation, noting a rewrite', () => {
+    const draft = decision({ id: 'd1' });
+    const kept = decision({ id: 'd1', status: 'consolidated' });
+    const reworded = decision({ id: 'd1', status: 'consolidated', title: 'entirely different wording' });
+
+    expect(computeDraftDispositions({ drafts: [draft], consolidated: [kept] })).toEqual([
+      { id: 'd1', disposition: 'promoted', reason: 'promoted-as-recorded' },
+    ]);
+    expect(computeDraftDispositions({ drafts: [draft], consolidated: [reworded] })).toEqual([
+      { id: 'd1', disposition: 'promoted', reason: 'promoted-with-rewrite' },
+    ]);
+  });
+
+  it('treats whitespace-only differences as the same wording, not a rewrite', () => {
+    const draft = decision({ id: 'd1', title: 'Use JWTs  for auth' });
+    const kept = decision({ id: 'd1', status: 'consolidated', title: 'use jwts for auth' });
+    expect(contentWasRewritten(draft, kept)).toBe(false);
+  });
+
+  it('rejects an explicitly superseded draft, naming supersession as the reason', () => {
+    const [verdict] = computeDraftDispositions({
+      drafts: [decision({ id: 'old' })],
+      consolidated: [decision({ id: 'new', status: 'consolidated' })],
+      supersededIds: ['old'],
+    });
+    expect(verdict).toEqual({ id: 'old', disposition: 'rejected', reason: 'superseded-by-later-draft' });
+  });
+
+  it('names the survivor when a draft was absorbed into the single consolidated decision', () => {
+    const verdicts = computeDraftDispositions({
+      drafts: [decision({ id: 'a' }), decision({ id: 'b' })],
+      consolidated: [decision({ id: 'a', status: 'consolidated' })],
+    });
+    expect(verdicts[1]).toEqual({
+      id: 'b', disposition: 'merged-into', reason: 'merged-into-consolidated', mergedIntoId: 'a',
+    });
+  });
+
+  it('names the survivor when exactly one consolidated decision shares a file', () => {
+    const verdicts = computeDraftDispositions({
+      drafts: [decision({ id: 'b', affectedFiles: ['src/auth.ts'] })],
+      consolidated: [
+        decision({ id: 'x', status: 'consolidated', affectedFiles: ['src/auth.ts'] }),
+        decision({ id: 'y', status: 'consolidated', affectedFiles: ['src/db.ts'] }),
+      ],
+    });
+    expect(verdicts[0].disposition).toBe('merged-into');
+    expect(verdicts[0].mergedIntoId).toBe('x');
+  });
+
+  it('refuses to invent a merge target when attribution is ambiguous', () => {
+    const verdicts = computeDraftDispositions({
+      drafts: [decision({ id: 'b', affectedFiles: ['src/auth.ts'] })],
+      consolidated: [
+        decision({ id: 'x', status: 'consolidated', affectedFiles: ['src/auth.ts'] }),
+        decision({ id: 'y', status: 'consolidated', affectedFiles: ['src/auth.ts'] }),
+      ],
+    });
+    expect(verdicts[0]).toEqual({ id: 'b', disposition: 'rejected', reason: 'not-in-consolidated-set' });
+    expect(verdicts[0].mergedIntoId).toBeUndefined();
+  });
+
+  it('rejects every draft with a reason when consolidation keeps nothing', () => {
+    const verdicts = computeDraftDispositions({
+      drafts: [decision({ id: 'a' }), decision({ id: 'b' })],
+      consolidated: [],
+    });
+    expect(verdicts.map(v => v.reason)).toEqual(['not-in-consolidated-set', 'not-in-consolidated-set']);
+  });
+
+  it('property: one persisted verdict per input draft, for any draft set — no silent drop', () => {
+    // Deterministic pseudo-random shapes: draft counts, which ids survive, which
+    // are superseded. Every case must satisfy dispositions.length === drafts.length.
+    let seed = 7;
+    const rand = (n: number) => (seed = (seed * 1103515245 + 12345) % 2147483648) % n;
+
+    for (let trial = 0; trial < 120; trial++) {
+      const draftCount = 1 + rand(6);
+      const drafts = Array.from({ length: draftCount }, (_, i) =>
+        decision({ id: `d${trial}-${i}`, affectedFiles: rand(2) ? [`src/f${rand(3)}.ts`] : [] }));
+      const consolidated = drafts
+        .filter(() => rand(3) === 0)
+        .map(d => decision({ id: d.id, status: 'consolidated' }));
+      const supersededIds = drafts.filter(() => rand(4) === 0).map(d => d.id);
+
+      const verdicts = computeDraftDispositions({ drafts, consolidated, supersededIds });
+      expect(verdicts).toHaveLength(drafts.length);
+      expect(new Set(verdicts.map(v => v.id))).toEqual(new Set(drafts.map(d => d.id)));
+      for (const v of verdicts) {
+        // Every emitted reason is registry-declared, and its declared disposition matches.
+        expect(DECISION_DISPOSITION_REASONS[v.reason]).toBeDefined();
+        expect(DECISION_DISPOSITION_REASONS[v.reason].disposition).toBe(v.disposition);
+        expect(v.disposition).not.toBe('pending');
+      }
+
+      // And the verdicts persist: every draft in the store carries one.
+      const persisted = applyDispositions(store(drafts), verdicts);
+      expect(persisted.decisions.filter(d => d.disposition && d.disposition !== 'pending'))
+        .toHaveLength(drafts.length);
+    }
+  });
+});
+
+describe('withVerificationOutcome', () => {
+  it('overrides a promotion with no-supporting-diff when verification found the decision phantom', () => {
+    const verdicts = computeDraftDispositions({
+      drafts: [decision({ id: 'a' }), decision({ id: 'b' })],
+      consolidated: [decision({ id: 'a', status: 'consolidated' }), decision({ id: 'b', status: 'consolidated' })],
+    });
+    const final = withVerificationOutcome(verdicts, new Set(['b']));
+    expect(final[0].disposition).toBe('promoted');
+    expect(final[1]).toEqual({ id: 'b', disposition: 'rejected', reason: 'no-supporting-diff' });
+  });
+
+  it('is a no-op when nothing was phantom', () => {
+    const verdicts = computeDraftDispositions({
+      drafts: [decision({ id: 'a' })],
+      consolidated: [decision({ id: 'a', status: 'consolidated' })],
+    });
+    expect(withVerificationOutcome(verdicts, new Set())).toEqual(verdicts);
+  });
+});
+
+describe('applyDispositions / readDisposition', () => {
+  it('does not re-stamp a record that already reached a terminal verdict', () => {
+    const decided = decision({
+      id: 'a', status: 'rejected', disposition: 'rejected',
+      dispositionReason: 'no-supporting-diff', dispositionAt: '2026-01-01T00:00:00Z',
+    });
+    const next = applyDispositions(store([decided]), [
+      { id: 'a', disposition: 'promoted', reason: 'promoted-as-recorded' },
+    ], '2026-02-02T00:00:00Z');
+    expect(next.decisions[0].dispositionReason).toBe('no-supporting-diff');
+    expect(next.decisions[0].dispositionAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('reads an undecided draft as pending, never as a rejection', () => {
+    expect(readDisposition(decision({ id: 'a' }))).toEqual({
+      disposition: 'pending', reason: 'awaiting-consolidation',
+    });
+  });
+
+  it('reads a pre-existing record without a disposition as legacy-unknown, never as a rejection', () => {
+    const legacy = decision({ id: 'a', status: 'synced' });
+    const v = readDisposition(legacy);
+    expect(v).toEqual({ disposition: 'pending', reason: 'legacy-unknown' });
+    expect(DECISION_DISPOSITION_REASONS[v.reason].description).toMatch(/NOT a rejection/);
+  });
+
+  it('describes a rejection with its reason and a concrete next action', () => {
+    const rejected = decision({
+      id: 'a', status: 'rejected', disposition: 'rejected', dispositionReason: 'no-supporting-diff',
+    });
+    const line = describeDisposition(rejected);
+    expect(line).toMatch(/^rejected/);
+    expect(line).toContain('no-supporting-diff');
+    expect(line).toMatch(/→ .*staged/);
+  });
+
+  it('describes a merge by naming the surviving decision', () => {
+    const merged = decision({
+      id: 'a', status: 'rejected', disposition: 'merged-into',
+      dispositionReason: 'merged-into-consolidated', mergedIntoId: 'zz99',
+    });
+    expect(describeDisposition(merged)).toContain('survivor: zz99');
+  });
+});
+
+describe('authorStatement', () => {
+  it('captures the author’s recorded wording verbatim', () => {
+    const draft = decision({ id: 'a', title: 'Use JWTs', rationale: 'Avoids a session store' });
+    expect(authorStatementOf(draft)).toEqual({
+      title: 'Use JWTs',
+      rationale: 'Avoids a session store',
+      recordedAt: '2026-01-01T00:00:00Z',
+    });
+  });
+});

--- a/src/core/decisions/disposition.ts
+++ b/src/core/decisions/disposition.ts
@@ -1,0 +1,241 @@
+/**
+ * Terminal dispositions for decision drafts (change: explain-decision-rejection).
+ *
+ * `record_decision` writes a draft and a background consolidator decides its
+ * fate. Before this module a draft that was not promoted simply stopped
+ * existing: no verdict, no reason, nothing the author could read. Guessing
+ * whether the call failed, the wording was wrong, or the evidence was missing is
+ * not a reasonable thing to ask of a caller.
+ *
+ * Every input draft now reaches one of four states, each with a stable reason
+ * code from the registry below:
+ *   pending      — consolidation has not run yet (an honest "not decided",
+ *                  never a rejection by omission)
+ *   promoted     — it survived, as recorded or with re-derived wording
+ *   merged-into  — it was absorbed, and the surviving decision is named
+ *   rejected     — it did not survive, and the reason says why
+ *
+ * The mapping is DERIVED, deterministic, and computed with no LLM: it reads the
+ * consolidation output against the input drafts. Where attribution is genuinely
+ * ambiguous — a draft absent from a multi-decision consolidated set with no
+ * unique overlap — it reports `rejected / not-in-consolidated-set` rather than
+ * inventing a merge target. An honest "it did not survive" beats a fabricated
+ * lineage.
+ */
+
+import type {
+  AuthorStatement,
+  DecisionDisposition,
+  DecisionDispositionReason,
+  DecisionStore,
+  PendingDecision,
+} from '../../types/index.js';
+import { patchDecision } from './store.js';
+
+/**
+ * Source-declared reason registry. A code that is not here cannot be emitted;
+ * the description is what a human reads, and `nextAction` is what they do about
+ * it. Same discipline as the governance FINDING_CODE_REGISTRY.
+ */
+export const DECISION_DISPOSITION_REASONS: Record<
+  DecisionDispositionReason,
+  { disposition: DecisionDisposition; description: string; nextAction?: string }
+> = {
+  'promoted-as-recorded': {
+    disposition: 'promoted',
+    description: 'Consolidation kept this decision with the wording you recorded.',
+  },
+  'promoted-with-rewrite': {
+    disposition: 'promoted',
+    description:
+      'Consolidation kept this decision but re-derived its wording from the diff; your original text is preserved as authorStatement.',
+  },
+  'merged-into-consolidated': {
+    disposition: 'merged-into',
+    description: 'This draft was absorbed into another consolidated decision.',
+    nextAction: 'Read the surviving decision named in mergedIntoId.',
+  },
+  'superseded-by-later-draft': {
+    disposition: 'rejected',
+    description: 'A later draft explicitly superseded this one.',
+    nextAction: 'Read the superseding decision; re-record only if the reversal was wrong.',
+  },
+  'not-in-consolidated-set': {
+    disposition: 'rejected',
+    description:
+      'Consolidation did not carry this draft into the final set, and no single surviving decision could be identified as its target.',
+    nextAction:
+      'Re-record it with a narrower subject and a rationale that names the constraint it introduces, or accept that it was not architectural.',
+  },
+  'no-supporting-diff': {
+    disposition: 'rejected',
+    description:
+      'Verification found no change in the diff supporting this decision (recorded as phantom).',
+    nextAction:
+      'Record it again once the supporting code change is staged, so the decision is anchored to real evidence.',
+  },
+  'awaiting-consolidation': {
+    disposition: 'pending',
+    description: 'Recorded as a draft; background consolidation has not decided it yet.',
+    nextAction: 'Run `openlore decisions --consolidate` to decide it now.',
+  },
+  'legacy-unknown': {
+    disposition: 'pending',
+    description:
+      'Recorded before dispositions existed — its outcome was never captured. This is an unknown, NOT a rejection.',
+  },
+};
+
+/** One draft's verdict. */
+export interface DraftDisposition {
+  id: string;
+  disposition: DecisionDisposition;
+  reason: DecisionDispositionReason;
+  /** Set exactly when `disposition` is `merged-into`. */
+  mergedIntoId?: string;
+}
+
+/** Normalize whitespace so a formatting-only difference is not read as a rewrite. */
+function normalize(text: string): string {
+  return (text ?? '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/** True when consolidation re-derived the wording rather than keeping the author's. */
+export function contentWasRewritten(draft: PendingDecision, consolidated: PendingDecision): boolean {
+  return normalize(draft.title) !== normalize(consolidated.title)
+    || normalize(draft.rationale) !== normalize(consolidated.rationale);
+}
+
+/** The author's words, kept verbatim for a decision whose content was re-derived. */
+export function authorStatementOf(draft: PendingDecision): AuthorStatement {
+  return { title: draft.title, rationale: draft.rationale, recordedAt: draft.recordedAt };
+}
+
+/**
+ * Derive one verdict per input draft. Total by construction: the returned array
+ * has exactly one entry per draft, in input order.
+ *
+ * Attribution rules, in order:
+ *   1. The draft's id appears in the consolidated set  → promoted (rewrite noted).
+ *   2. The draft was explicitly superseded             → rejected/superseded.
+ *   3. Exactly one consolidated decision exists, or exactly one shares a file
+ *      with the draft                                  → merged-into that id.
+ *   4. Otherwise                                       → rejected/not-in-set.
+ */
+export function computeDraftDispositions(input: {
+  drafts: readonly PendingDecision[];
+  consolidated: readonly PendingDecision[];
+  supersededIds?: readonly string[];
+}): DraftDisposition[] {
+  const consolidatedById = new Map(input.consolidated.map(d => [d.id, d]));
+  const superseded = new Set(input.supersededIds ?? []);
+
+  return input.drafts.map((draft): DraftDisposition => {
+    const survivor = consolidatedById.get(draft.id);
+    if (survivor) {
+      return {
+        id: draft.id,
+        disposition: 'promoted',
+        reason: contentWasRewritten(draft, survivor) ? 'promoted-with-rewrite' : 'promoted-as-recorded',
+      };
+    }
+    if (superseded.has(draft.id)) {
+      return { id: draft.id, disposition: 'rejected', reason: 'superseded-by-later-draft' };
+    }
+
+    // Absorbed? Only when the target is UNAMBIGUOUS — a lone consolidated
+    // decision, or exactly one sharing a file with this draft. Anything else is
+    // reported as "did not survive", never as an invented merge.
+    const target = uniqueMergeTarget(draft, input.consolidated);
+    if (target) {
+      return { id: draft.id, disposition: 'merged-into', reason: 'merged-into-consolidated', mergedIntoId: target };
+    }
+    return { id: draft.id, disposition: 'rejected', reason: 'not-in-consolidated-set' };
+  });
+}
+
+function uniqueMergeTarget(
+  draft: PendingDecision,
+  consolidated: readonly PendingDecision[],
+): string | undefined {
+  if (consolidated.length === 0) return undefined;
+  if (consolidated.length === 1) return consolidated[0].id;
+  const draftFiles = new Set(draft.affectedFiles ?? []);
+  if (draftFiles.size === 0) return undefined;
+  const overlapping = consolidated.filter(c => (c.affectedFiles ?? []).some(f => draftFiles.has(f)));
+  return overlapping.length === 1 ? overlapping[0].id : undefined;
+}
+
+/**
+ * Fold the verification outcome into the verdicts: a decision the verifier could
+ * not tie to a change in the diff (phantom) is rejected with `no-supporting-diff`,
+ * even if consolidation had promoted it. Verification is the later, stronger
+ * signal — and "no evidence in the diff" is precisely the reason an author most
+ * needs to be told.
+ */
+export function withVerificationOutcome(
+  dispositions: readonly DraftDisposition[],
+  phantomIds: ReadonlySet<string>,
+): DraftDisposition[] {
+  if (phantomIds.size === 0) return [...dispositions];
+  return dispositions.map(d =>
+    phantomIds.has(d.id)
+      ? { id: d.id, disposition: 'rejected' as const, reason: 'no-supporting-diff' as const }
+      : d);
+}
+
+/**
+ * Write the verdicts onto the store. Pure — the caller persists through the CAS
+ * path. A decision that already carries a terminal disposition is not re-stamped;
+ * a `pending` one is.
+ */
+export function applyDispositions(
+  store: DecisionStore,
+  dispositions: readonly DraftDisposition[],
+  at: string = new Date().toISOString(),
+): DecisionStore {
+  let next = store;
+  for (const d of dispositions) {
+    const current = next.decisions.find(x => x.id === d.id);
+    if (current && current.disposition && current.disposition !== 'pending') continue;
+    next = patchDecision(next, d.id, {
+      disposition: d.disposition,
+      dispositionReason: d.reason,
+      dispositionAt: at,
+      ...(d.mergedIntoId ? { mergedIntoId: d.mergedIntoId } : {}),
+    });
+  }
+  return next;
+}
+
+/**
+ * The disposition of a stored record, filling in the honest defaults: a draft
+ * with no disposition is awaiting consolidation; any other status with no
+ * disposition predates this field and reads `legacy-unknown` — an unknown
+ * outcome, explicitly not a rejection.
+ */
+export function readDisposition(d: PendingDecision): {
+  disposition: DecisionDisposition;
+  reason: DecisionDispositionReason;
+  mergedIntoId?: string;
+} {
+  if (d.disposition && d.dispositionReason) {
+    return {
+      disposition: d.disposition,
+      reason: d.dispositionReason,
+      ...(d.mergedIntoId ? { mergedIntoId: d.mergedIntoId } : {}),
+    };
+  }
+  return d.status === 'draft'
+    ? { disposition: 'pending', reason: 'awaiting-consolidation' }
+    : { disposition: 'pending', reason: 'legacy-unknown' };
+}
+
+/** One human-readable line: the verdict, why, and what to do next. */
+export function describeDisposition(d: PendingDecision): string {
+  const { disposition, reason, mergedIntoId } = readDisposition(d);
+  const entry = DECISION_DISPOSITION_REASONS[reason];
+  const target = mergedIntoId ? ` (survivor: ${mergedIntoId})` : '';
+  const next = entry.nextAction ? ` → ${entry.nextAction}` : '';
+  return `${disposition}${target} [${reason}]: ${entry.description}${next}`;
+}

--- a/src/core/decisions/disposition.ts
+++ b/src/core/decisions/disposition.ts
@@ -30,7 +30,7 @@ import type {
   DecisionStore,
   PendingDecision,
 } from '../../types/index.js';
-import { patchDecision } from './store.js';
+import { patchDecision, replaceDecisions } from './store.js';
 
 /**
  * Source-declared reason registry. A code that is not here cannot be emitted;
@@ -179,9 +179,36 @@ export function withVerificationOutcome(
 ): DraftDisposition[] {
   if (phantomIds.size === 0) return [...dispositions];
   return dispositions.map(d =>
-    phantomIds.has(d.id)
+    phantomIds.has(d.id) || (d.mergedIntoId !== undefined && phantomIds.has(d.mergedIntoId))
       ? { id: d.id, disposition: 'rejected' as const, reason: 'no-supporting-diff' as const }
       : d);
+}
+
+/**
+ * Atomically apply every state transition produced by one consolidation run.
+ * `originalDraftIds` is captured before the LLM call, so drafts recorded while
+ * consolidation is in flight remain untouched in the fresh CAS snapshot.
+ *
+ * Rejected originals stay in the store as an audit trail; verified/phantom
+ * survivors replace source drafts with the same deterministic id. Dispositions
+ * are applied last so both survivors and absorbed originals carry their verdict.
+ */
+export function applyConsolidationOutcome(
+  store: DecisionStore,
+  result: {
+    originalDraftIds: ReadonlySet<string>;
+    verified: readonly PendingDecision[];
+    phantom: readonly PendingDecision[];
+    supersededIds: readonly string[];
+    dispositions: readonly DraftDisposition[];
+  },
+): DecisionStore {
+  let next = store;
+  for (const id of new Set([...result.originalDraftIds, ...result.supersededIds])) {
+    next = patchDecision(next, id, { status: 'rejected' });
+  }
+  next = replaceDecisions(next, [...result.verified, ...result.phantom]);
+  return applyDispositions(next, result.dispositions);
 }
 
 /**

--- a/src/core/services/mcp-handlers/decisions.test.ts
+++ b/src/core/services/mcp-handlers/decisions.test.ts
@@ -154,6 +154,49 @@ describe('handleRecordDecision', () => {
     expect(result.message).toContain('Use SQLite');
   });
 
+  it('returns the draft status and the exact command that reads the verdict', async () => {
+    // The tool proposes a decision; it does not finalize one. The response must say
+    // so and point at where the outcome will be readable
+    // (change: explain-decision-rejection).
+    const r = await handleRecordDecision(tmpDir, 'Use SQLite', 'JSON too big') as {
+      id: string; status: string; disposition: string; reason: string;
+      readVerdictWith: string; message: string;
+    };
+    expect(r.status).toBe('draft');
+    expect(r.disposition).toBe('pending');
+    expect(r.reason).toBe('awaiting-consolidation');
+    expect(r.readVerdictWith).toBe(`openlore decisions status ${r.id}`);
+    expect(r.message).toMatch(/draft/i);
+    expect(r.message).toContain(r.readVerdictWith);
+  });
+
+  it('returns the existing verdict when a decided draft is recorded again', async () => {
+    const first = await handleRecordDecision(tmpDir, 'Use SQLite', 'JSON too big') as { id: string };
+
+    // Simulate consolidation having rejected it with a stated reason.
+    const store = await readStore(tmpDir);
+    store.decisions = store.decisions.map(d => d.id === first.id
+      ? { ...d, status: 'rejected', disposition: 'rejected', dispositionReason: 'not-in-consolidated-set' }
+      : d);
+    await writeStore(tmpDir, store);
+
+    const again = await handleRecordDecision(tmpDir, 'Use SQLite', 'JSON too big') as {
+      id: string; alreadyDecided: boolean; disposition: string; reason: string;
+      nextAction?: string; message: string;
+    };
+    expect(again.alreadyDecided).toBe(true);
+    expect(again.id).toBe(first.id);
+    expect(again.disposition).toBe('rejected');
+    expect(again.reason).toBe('not-in-consolidated-set');
+    expect(again.nextAction).toMatch(/narrower subject|not architectural/i);
+    expect(again.message).toMatch(/No new draft was created/);
+
+    // …and no second draft was written.
+    const after = await readStore(tmpDir);
+    expect(after.decisions).toHaveLength(1);
+    expect(after.decisions[0].status).toBe('rejected');
+  });
+
   it('persists the decision with draft status to disk', async () => {
     await handleRecordDecision(tmpDir, 'Use SQLite', 'JSON too big');
     const store = await readStore(tmpDir);

--- a/src/core/services/mcp-handlers/decisions.ts
+++ b/src/core/services/mcp-handlers/decisions.ts
@@ -27,6 +27,11 @@ import { readOpenLoreConfig } from '../config-manager.js';
 import { join } from 'node:path';
 import type { PendingDecision, DecisionScope } from '../../../types/index.js';
 import { decisionContentProvenance } from '../served-content.js';
+import {
+  DECISION_DISPOSITION_REASONS,
+  describeDisposition,
+  readDisposition,
+} from '../../decisions/disposition.js';
 
 type ConsolidateSpawnOutcome =
   | { outcome: 'started' }
@@ -133,6 +138,32 @@ export async function handleRecordDecision(
 
     const id = makeDecisionId(store.sessionId, primaryDomain, title.trim());
 
+    // Re-recording something already decided must return that verdict, not open a
+    // second draft the author will watch disappear the same way
+    // (change: explain-decision-rejection). Match on the deterministic id (content
+    // + session + domain) — the same identity the store already dedupes on.
+    const existing = store.decisions.find((d) => d.id === id);
+    if (existing) {
+      const verdict = readDisposition(existing);
+      if (verdict.disposition !== 'pending') {
+        const entry = DECISION_DISPOSITION_REASONS[verdict.reason];
+        return {
+          id: existing.id,
+          alreadyDecided: true,
+          status: existing.status,
+          disposition: verdict.disposition,
+          reason: verdict.reason,
+          reasonDescription: entry.description,
+          ...(entry.nextAction ? { nextAction: entry.nextAction } : {}),
+          ...(verdict.mergedIntoId ? { mergedIntoId: verdict.mergedIntoId } : {}),
+          readVerdictWith: `openlore decisions status ${existing.id}`,
+          message:
+            `This decision was already recorded and decided: ${describeDisposition(existing)} ` +
+            'No new draft was created.',
+        };
+      }
+    }
+
     // Resolve scope: explicit caller value wins; otherwise auto-promote via deterministic signals.
     // Two independent triggers, either is sufficient:
     //   1. Structural: files span 2+ distinct top-level source dirs (file-topology, no LLM)
@@ -211,16 +242,24 @@ export async function handleRecordDecision(
     // already committed (CAS upsert above), independent of the spawn's outcome —
     // report that outcome honestly rather than an unconditional "running".
     const spawnOutcome = await spawnConsolidateBackground(rootPath);
+    // The response says DRAFT, not "recorded", and names where the verdict is read.
+    // The tool proposes a decision; diff-grounded consolidation decides it
+    // (change: explain-decision-rejection).
+    const readVerdictWith = `openlore decisions status ${recordedId}`;
     const message =
       spawnOutcome.outcome === 'failed'
-        ? `Decision recorded: "${title}". Consolidation could NOT be started (${spawnOutcome.detail}) — run \`openlore decisions --consolidate\` to consolidate it now.`
+        ? `Draft decision recorded: "${title}". Consolidation could NOT be started (${spawnOutcome.detail}) — run \`openlore decisions --consolidate\` to decide it now, then read the verdict with \`${readVerdictWith}\`.`
         : spawnOutcome.outcome === 'coalesced'
-          ? `Decision recorded: "${title}". Consolidation already running — this draft will be picked up by the in-flight run.`
-          : `Decision recorded: "${title}". Consolidation running in background.`;
+          ? `Draft decision recorded: "${title}". Consolidation already running — this draft will be picked up by the in-flight run. Read its verdict with \`${readVerdictWith}\`.`
+          : `Draft decision recorded: "${title}". Diff-grounded consolidation is running in background and will promote, merge, or reject it with a stated reason. Read the verdict with \`${readVerdictWith}\`.`;
 
     return {
       id: recordedId,
+      status: 'draft' as const,
+      disposition: 'pending' as const,
+      reason: 'awaiting-consolidation' as const,
       consolidation: spawnOutcome.outcome,
+      readVerdictWith,
       message,
     };
   } catch (err) {
@@ -262,6 +301,19 @@ export async function handleListDecisions(
         syncedToSpecs: d.syncedToSpecs,
         verificationEvidence: d.verificationEvidence,
         contentOrigin: d.contentOrigin,
+        // The verdict travels with the record: a caller reading the list can tell a
+        // promoted decision from one still awaiting consolidation, and the author's
+        // own wording survives a consolidator rewrite
+        // (change: explain-decision-rejection).
+        ...(() => {
+          const v = readDisposition(d);
+          return {
+            disposition: v.disposition,
+            dispositionReason: v.reason,
+            ...(v.mergedIntoId ? { mergedIntoId: v.mergedIntoId } : {}),
+          };
+        })(),
+        ...(d.authorStatement ? { authorStatement: d.authorStatement } : {}),
         // Provenance is always disclosed: an autopilot-accepted decision is
         // authoritative but never presented as human-reviewed. (add-decision-autopilot)
         ...(d.approvedBy ? { approvedBy: d.approvedBy } : {}),

--- a/src/core/services/mcp-handlers/memory.ts
+++ b/src/core/services/mcp-handlers/memory.ts
@@ -42,6 +42,7 @@ import {
   type PendingDecision,
   type AnchorVerdict,
   type GroundingCertificate,
+  type AuthorStatement,
 } from '../../../types/index.js';
 
 /** Normalize a caller-supplied type to the closed set; unknown/absent ⇒ `note`. No inference. */
@@ -214,6 +215,15 @@ interface RecalledMemory {
    * so it is NOT presented as cleanly fresh. (add-finding-enforcement-policy)
    */
   staleDecisionRef?: StaleRef[];
+  /**
+   * Provenance of a decision's served text (decisions only): `llm-extracted`
+   * content was re-derived by consolidation from the diff, with the author's
+   * recorded wording preserved in `authorStatement`
+   * (change: explain-decision-rejection).
+   */
+  contentOrigin?: PendingDecision['contentOrigin'];
+  verificationEvidence?: PendingDecision['verificationEvidence'];
+  authorStatement?: AuthorStatement;
   score: number;
 }
 
@@ -361,6 +371,12 @@ export async function handleRecall(
             recordedAt: d.recordedAt,
             match: hasQuery ? { fields: r.matched, anchorBoost: r.anchorBoost } : undefined,
             ...certify(f.freshness, anchors),
+            // Disclose how the served text came to be: `llm-extracted` content is
+            // the consolidator's wording, and the author's own is kept alongside it
+            // (change: explain-decision-rejection).
+            contentOrigin: d.contentOrigin,
+            ...(d.verificationEvidence ? { verificationEvidence: d.verificationEvidence } : {}),
+            ...(d.authorStatement ? { authorStatement: d.authorStatement } : {}),
             score: r.score,
           });
           contradictionItems.push({ id: d.id, anchors, freshness: f.freshness });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -620,6 +620,41 @@ export type DecisionScope =
   | 'cross-domain' // touches multiple spec domains or service contracts
   | 'system';      // global constraint (auth, data model, infra, API protocol)
 
+/**
+ * Terminal verdict a draft receives from consolidation
+ * (change: explain-decision-rejection). A draft may no longer simply stop
+ * existing: every input draft carries one of these, and `pending` is the honest
+ * state of a draft consolidation has not reached yet — never a silent rejection.
+ */
+export type DecisionDisposition = 'pending' | 'promoted' | 'merged-into' | 'rejected';
+
+/**
+ * Stable reason codes for a disposition. Source-declared (see
+ * `DECISION_DISPOSITION_REASONS` in `src/core/decisions/disposition.ts`) so a
+ * caller can branch on the code and a human can read the description.
+ */
+export type DecisionDispositionReason =
+  | 'promoted-as-recorded'
+  | 'promoted-with-rewrite'
+  | 'merged-into-consolidated'
+  | 'superseded-by-later-draft'
+  | 'not-in-consolidated-set'
+  | 'no-supporting-diff'
+  | 'awaiting-consolidation'
+  | 'legacy-unknown';
+
+/**
+ * The author's own words, kept verbatim when consolidation re-derives a
+ * decision's content from the diff (change: explain-decision-rejection).
+ * Recorded text is never rewritten in place — the served content and what the
+ * author actually wrote are both readable.
+ */
+export interface AuthorStatement {
+  title: string;
+  rationale: string;
+  recordedAt: string;
+}
+
 export type DecisionStatus =
   | 'draft'         // recorded by agent during dev session
   | 'consolidated'  // LLM has merged/resolved drafts
@@ -656,6 +691,23 @@ export interface PendingDecision {
 
   /** ID of a prior decision this one supersedes (agent signals a reversal) */
   supersedes?: string;
+
+  /**
+   * Terminal verdict from consolidation and its stable reason
+   * (change: explain-decision-rejection). Additive: a record written before this
+   * existed reads as `legacy-unknown`, never as a rejection.
+   */
+  disposition?: DecisionDisposition;
+  dispositionReason?: DecisionDispositionReason;
+  /** Set exactly when `disposition` is `merged-into`: the surviving decision's id. */
+  mergedIntoId?: string;
+  /** When the disposition was assigned (ISO). */
+  dispositionAt?: string;
+  /**
+   * The agent-recorded title/rationale, retained verbatim when consolidation
+   * re-derived the served content. Present only when the two differ.
+   */
+  authorStatement?: AuthorStatement;
 
   // Provenance
   sessionId: string;


### PR DESCRIPTION
Implements OpenSpec change `explain-decision-rejection`.

## Why
An agent recorded three decisions in a session. One was dropped twice — including after being rewritten more tightly — with no reason given. The two that survived came back reworded, with the author's text gone. `record_decision` writes a draft and a background consolidator decides its fate; a draft that was not promoted simply stopped existing. The author was left to guess whether the call failed, the wording was wrong, or the evidence was missing.

The diff-grounding is by design and stays. What changes is everything around it.

## What changed
- **Every input draft reaches a terminal disposition** — `promoted` / `merged-into` / `rejected`, or an explicit `pending` — with a stable reason code from a source-declared registry that also carries the next action. Derived deterministically from the consolidation output, no LLM. Where attribution is genuinely ambiguous the verdict is "did not survive", never an invented merge target.
- **Verification folds in**: a phantom decision is rejected with `no-supporting-diff` — the reason an author most needs to hear.
- **The verdict is readable**: `openlore decisions status <id>`, the disposition on `list_decisions`, and a `record_decision` response that returns the draft id, says DRAFT, and names the exact command. Re-recording an already-decided draft returns that verdict instead of opening a second one.
- **The author's words survive**: when consolidation re-derives content from the diff, the recorded title and rationale are kept verbatim as `authorStatement`, with `contentOrigin: llm-extracted` disclosed in the read paths (recall, list_decisions, CLI).
- **The tool description** states the draft-then-consolidation contract instead of implying finality. The tool name is unchanged (no installed surface breaks).

Existing records with no disposition read as `legacy-unknown` — an unknown outcome, explicitly **not** a rejection.

## Verification
- New `disposition.test.ts` (16), incl. a 120-case property test: `dispositions.length === drafts.length` for any draft set, every emitted reason registry-declared, every draft persisted with a verdict.
- Consolidator (29) and decision-handler (41) suites extended and green; decisions + api + render + autopilot + memory suites: 379 passing. `tsc --noEmit` clean.
- End-to-end on a scratch repo: rejected / promoted-with-rewrite (author statement shown) / pending / unknown-id all render distinctly, with an unknown id reported as "not found, NOT rejected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)