### PR TITLE
test: make load-sensitive suites deterministic

### DIFF
--- a/src/cli/commands/viewer-freshness.test.ts
+++ b/src/cli/commands/viewer-freshness.test.ts
@@ -154,6 +154,13 @@ describe('viewer freshness', () => {
       .toMatchObject({ status: 'stale' });
 
     const second = (await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: root })).stdout.trim();
+    // Re-analysis rewrites the ARTIFACT as well as the fingerprint. Advancing only
+    // the fingerprint leaves an artifact older than the commit it claims to have
+    // analyzed — which `artifactPredatesAnalyzedCommit` correctly calls stale. Git
+    // commit times have one-second granularity, so the old fixture read `current`
+    // only when the whole test finished inside a single second, and failed under a
+    // loaded parallel run. Rewrite the artifact, as a real re-analysis does.
+    await writeFile(artifactPath, '{}');
     await writeFile(join(analysisDir, 'fingerprint.json'), JSON.stringify({ commit: second }));
     await expect(readViewerFreshness(root, analysisDir, artifactPath)).resolves
       .toMatchObject({ analyzedCommit: second, status: 'current', filesChangedSince: 0 });

--- a/src/core/analyzer/call-graph-enclosing.test.ts
+++ b/src/core/analyzer/call-graph-enclosing.test.ts
@@ -155,9 +155,23 @@ describe('computeEnclosing — identical to the brute-force definition', () => {
       return Number(process.hrtime.bigint() - t) / 1e6;
     };
 
+    // BEST of several runs, not a single sample. A sub-millisecond baseline measured
+    // once on a loaded machine is noise, not signal: one GC pause or scheduler
+    // preemption during the large run inflated the ratio past the bound and this
+    // test failed under a full parallel suite while passing in isolation. Noise only
+    // ever ADDS time, so the minimum is the honest estimate of the intrinsic cost —
+    // and it leaves the quadratic detector intact (a quadratic implementation is
+    // ~64× at its best run too).
+    const best = (n: number, runs = 5): number => {
+      const nodes = build(n);
+      let fastest = Infinity;
+      for (let i = 0; i < runs; i++) fastest = Math.min(fastest, time(nodes));
+      return Math.max(fastest, 0.01);
+    };
+
     time(build(1000)); // warm
-    const small = Math.max(time(build(2000)), 0.01);
-    const large = Math.max(time(build(16000)), 0.01);
+    const small = best(2000);
+    const large = best(16000);
 
     // 8× the nodes. Linear-with-a-sort is ~8-10×; quadratic is ~64×. The bound is loose enough to
     // survive CI noise and still fails by a wide margin if the scan returns.

--- a/src/core/analyzer/extractor-redos.test.ts
+++ b/src/core/analyzer/extractor-redos.test.ts
@@ -101,7 +101,14 @@ async function measure(
  * asserted only where it can mean something — the cases slow enough (the middleware
  * and Vue extractors, ~0.5-1.5s) that a doubling is visible above the noise.
  */
-const RATIO_FLOOR_MS = 50;
+const RATIO_FLOOR_MS = 250;
+// Raised from 50ms to match the rationale above rather than undercut it. At 50ms the
+// ratio was still being asserted on tens-of-milliseconds cases — the Java route
+// extractor measured 3.18 against a 3.0 bound on CI while measuring ~50ms, which is
+// the scheduler talking, not the parser. The cases the ratio is actually for (the
+// middleware and Vue extractors) run in seconds and clear this floor by an order of
+// magnitude; everything below it stays guarded by MAX_ABSOLUTE_MS, which separates
+// fixed from unfixed by three orders of magnitude (5ms vs 10,866ms).
 
 /**
  * Assert the absolute cost always, and the growth ratio when it is measurable.

--- a/src/core/analyzer/parse-budget.test.ts
+++ b/src/core/analyzer/parse-budget.test.ts
@@ -224,7 +224,7 @@ describe('reproducer: a pathological file is abandoned rather than stalling the 
     // abandoned file through the SAME singleton parser, and without a reset it produced nothing.
     expect([...result.nodes.values()].some(n => n.name === 'a')).toBe(true);
     expect(result.parseHealthByFile?.has('src/ok.ts')).toBe(false);
-  }, 60_000);
+  }, 180_000);
 
   it('records the same thing twice — a budget-exceeded file must not make the artifact non-deterministic', async () => {
     // `parse-health.json` is persisted and must be byte-identical across re-analyses of a fixed
@@ -237,13 +237,19 @@ describe('reproducer: a pathological file is abandoned rather than stalling the 
     expect(JSON.stringify([...once.parseHealthByFile!]))
       .toBe(JSON.stringify([...twice.parseHealthByFile!]));
     expect(once.parseHealthByFile!.get('src/hostile.ts')?.budgetMs).toBe(600);
-    // 120s, not the 60s its siblings use: this is the only case here that builds the graph TWICE
+    // 240s, not the 180s its siblings use: this is the only case here that builds the graph TWICE
     // over the 300 KB pathological payload, and abandoning that parse is expensive on both runs.
     // It takes ~17s on a developer machine but ~61s on a 2-core CI runner, so at 60s it had no
     // headroom at all and failed on load it did not cause. Measured on this branch and on `main`
     // uncontended it is unchanged (17.0/17.4s vs 17.6/18.0s), so the budget — not the code — is
     // what was wrong.
-  }, 120_000);
+    //
+    // Bumped again (60→180 / 120→240 across this file) after the same failure recurred under a
+    // FULL parallel suite: measured at ~187s for the file on a box at load 5, against per-test
+    // bounds of 60/120s. These tests abandon a deliberately pathological parse, so their cost is
+    // real work that contention multiplies — headroom is the only correct lever. No assertion is
+    // weakened by this; a genuine hang still fails, three minutes later.
+  }, 240_000);
 
   it('CONTROL: an ordinary large file is NOT recorded, and the graph matches a run with the budget disabled', async () => {
     // ~1.4 MB of well-formed generated-client-shaped source — far larger than anything in this
@@ -262,7 +268,7 @@ describe('reproducer: a pathological file is abandoned rather than stalling the 
 
     expect(withBudget.parseHealthByFile?.get('src/generated-client.ts')).toBeUndefined();
     expect(JSON.stringify(serializeCallGraph(withBudget))).toBe(JSON.stringify(withoutBudget));
-  }, 120_000);
+  }, 240_000);
 });
 
 // ---------------------------------------------------------------------------
@@ -363,5 +369,5 @@ describe('an abandoned file must not cost OTHER files their edges', () => {
     expect(edge!.calleeId).toBe('src/impl.ts::realThing');
     // And the healthy files carry no parse-health record — they were never degraded.
     expect(result.parseHealthByFile?.has('src/consumer.ts')).toBe(false);
-  }, 60_000);
+  }, 180_000);
 });

--- a/src/core/services/mcp-handlers/memory-invariant.test.ts
+++ b/src/core/services/mcp-handlers/memory-invariant.test.ts
@@ -80,7 +80,6 @@ const fnSrc = (k: number, body: string) => `export function ${fnName(k)}() {\n  
 // that actually failed.
 let root: string;
 const analysisDirOf = (dir: string) => join(dir, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
-const ANALYSIS = () => analysisDirOf(root);
 
 function nodeFor(k: number, src: string): FunctionNode {
   return {

--- a/src/core/services/mcp-handlers/memory-invariant.test.ts
+++ b/src/core/services/mcp-handlers/memory-invariant.test.ts
@@ -34,6 +34,17 @@ vi.mock('../../analyzer/embedding-service.js', () => ({
 vi.mock('../../analyzer/spec-vector-index.js', () => ({
   SpecVectorIndex: { exists: vi.fn(() => false), search: vi.fn(async () => []) },
 }));
+// The bitemporal valid-time marker is orthogonal to the freshness invariant under
+// test, but `handleRemember` reads it by spawning `git rev-parse HEAD` — 600 of
+// them across these 120-trial properties, which on a machine with slow process
+// spawn is ~90s of pure subprocess overhead and the sole reason this file timed
+// out. The fixtures are throwaway temp dirs with no git repo, so HEAD is
+// `undefined` here anyway; return it directly and keep the property intact.
+vi.mock('../../decisions/git-time.js', () => ({
+  getHeadCommit: vi.fn(async () => undefined),
+  resolveCommitSha: vi.fn(async () => undefined),
+  isAncestor: vi.fn(async () => false),
+}));
 
 import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -61,8 +72,15 @@ const fnName = (k: number) => `fn${k}`;
 const fnFile = (k: number) => `src/m${k}.ts`;
 const fnSrc = (k: number, body: string) => `export function ${fnName(k)}() {\n  ${body}\n}\n`;
 
+// The fixture root is module-scoped for the helpers below, but each test also
+// binds it to a LOCAL const and uses that. A timed-out test's loop keeps running
+// (a JS promise cannot be cancelled); reading the shared `root` it would delete
+// the NEXT test's fixture mid-run, turning one timeout into a cascade of
+// unrelated ENOENT failures. The local binding contains the damage to the test
+// that actually failed.
 let root: string;
-const ANALYSIS = () => join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+const analysisDirOf = (dir: string) => join(dir, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+const ANALYSIS = () => analysisDirOf(root);
 
 function nodeFor(k: number, src: string): FunctionNode {
   return {
@@ -78,9 +96,10 @@ function nodeFor(k: number, src: string): FunctionNode {
   };
 }
 
-async function buildStore(nodes: FunctionNode[]): Promise<void> {
-  await mkdir(ANALYSIS(), { recursive: true });
-  const store = EdgeStore.open(EdgeStore.dbPath(ANALYSIS()));
+async function buildStore(nodes: FunctionNode[], dir: string = root): Promise<void> {
+  const analysis = analysisDirOf(dir);
+  await mkdir(analysis, { recursive: true });
+  const store = EdgeStore.open(EdgeStore.dbPath(analysis));
   store.clearAll();
   store.insertNodes(nodes);
   store.close();
@@ -90,7 +109,7 @@ async function buildStore(nodes: FunctionNode[]): Promise<void> {
     hubFunctions: [], entryPoints: [], layerViolations: [],
     stats: { totalNodes: nodes.length, totalEdges: 0, avgFanIn: 0, avgFanOut: 0 },
   };
-  await writeFile(join(ANALYSIS(), ARTIFACT_LLM_CONTEXT), JSON.stringify({ callGraph }), 'utf-8');
+  await writeFile(join(analysis, ARTIFACT_LLM_CONTEXT), JSON.stringify({ callGraph }), 'utf-8');
 }
 
 beforeEach(async () => {
@@ -123,19 +142,20 @@ function assertRecallInvariant(r: {
 
 describe('AuthoritativeRecallInvariant — recall, property-based over generated mutations', () => {
   it('the authoritative set never contains an orphaned or unlabeled-drifted memory (120 generated cases)', async () => {
+    const dir = root;   // see the note on `root`: never touch the next test's fixture
     for (let trial = 0; trial < 120; trial++) {
       const rand = rng(0x1000 + trial);
 
       // Fresh baseline: every function present and unmodified.
       const baseSrc = Array.from({ length: FN_COUNT }, (_, k) => fnSrc(k, `return ${k};`));
-      for (let k = 0; k < FN_COUNT; k++) await writeFile(join(root, fnFile(k)), baseSrc[k], 'utf-8');
-      await buildStore(baseSrc.map((s, k) => nodeFor(k, s)));
+      for (let k = 0; k < FN_COUNT; k++) await writeFile(join(dir, fnFile(k)), baseSrc[k], 'utf-8');
+      await buildStore(baseSrc.map((s, k) => nodeFor(k, s)), dir);
 
       // Anchor one memory per function (plus an occasional unanchored note).
       for (let k = 0; k < FN_COUNT; k++) {
-        await handleRemember(root, `memory about ${fnName(k)} number ${trial}`, [{ symbol: fnName(k), file: fnFile(k) }]);
+        await handleRemember(dir, `memory about ${fnName(k)} number ${trial}`, [{ symbol: fnName(k), file: fnFile(k) }]);
       }
-      if (rand() < 0.5) await handleRemember(root, `free-floating note ${trial}`);
+      if (rand() < 0.5) await handleRemember(dir, `free-floating note ${trial}`);
 
       // Apply an arbitrary mutation plan: keep / edit-body (→drift) / delete (→orphan).
       const survivors: FunctionNode[] = [];
@@ -147,19 +167,19 @@ describe('AuthoritativeRecallInvariant — recall, property-based over generated
         } else if (roll < 0.67) {
           // edit body in place → span hash differs → drifted (node stays in store)
           const edited = fnSrc(k, `return ${k * 100 + trial};`);
-          await writeFile(join(root, fnFile(k)), edited, 'utf-8');
+          await writeFile(join(dir, fnFile(k)), edited, 'utf-8');
           survivors.push(nodeFor(k, baseSrc[k])); // stale offsets/hash on purpose
         } else if (roll < 0.84) {
           // delete the node from the graph → orphaned
           // (file may or may not remain; symbol-level anchor still orphans)
         } else {
           // delete the whole file too → orphaned
-          await rm(join(root, fnFile(k)), { force: true });
+          await rm(join(dir, fnFile(k)), { force: true });
         }
       }
-      await buildStore(survivors);
+      await buildStore(survivors, dir);
 
-      const r = (await handleRecall(root, undefined, 50)) as {
+      const r = (await handleRecall(dir, undefined, 50)) as {
         authoritative: RecalledItem[]; needsReanchoring: RecalledItem[];
       };
       assertRecallInvariant(r, `recall trial ${trial}`);
@@ -167,9 +187,9 @@ describe('AuthoritativeRecallInvariant — recall, property-based over generated
       // Reset for the next trial: clear the source tree and the notes store. The
       // edge store is reset by buildStore's clearAll, so we avoid rm-ing the
       // .openlore dir (which races with the SQLite file handle on some platforms).
-      await rm(join(root, 'src'), { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
-      await rm(join(memoryDir(root), MEMORY_NOTES_FILE), { force: true });
-      await mkdir(join(root, 'src'), { recursive: true });
+      await rm(join(dir, 'src'), { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+      await rm(join(memoryDir(dir), MEMORY_NOTES_FILE), { force: true });
+      await mkdir(join(dir, 'src'), { recursive: true });
     }
   }, 60_000);
 });
@@ -177,8 +197,8 @@ describe('AuthoritativeRecallInvariant — recall, property-based over generated
 // orient surfaces decisions (not notes); the property mirrors recall over the
 // decision store. Decisions are anchored to files via affectedFiles, so a deleted
 // file orphans, a changed-symbol anchor drifts, an untouched file stays fresh.
-async function writeDecisions(decisions: Array<Record<string, unknown>>): Promise<void> {
-  const dir = join(root, OPENLORE_DIR, 'decisions');
+async function writeDecisions(decisions: Array<Record<string, unknown>>, rootDir: string = root): Promise<void> {
+  const dir = join(rootDir, OPENLORE_DIR, 'decisions');
   await mkdir(dir, { recursive: true });
   const full = decisions.map((d) => ({
     status: 'approved', title: 'untitled', rationale: '', consequences: '', proposedRequirement: null,
@@ -190,12 +210,13 @@ async function writeDecisions(decisions: Array<Record<string, unknown>>): Promis
 
 describe('AuthoritativeRecallInvariant — orient decision section, property-based', () => {
   it('pendingDecisions never lists an orphaned decision; staleDecisions holds only orphaned (120 cases)', async () => {
+    const dir = root;   // see the note on `root`
     for (let trial = 0; trial < 120; trial++) {
       const rand = rng(0x2000 + trial);
 
       const baseSrc = Array.from({ length: FN_COUNT }, (_, k) => fnSrc(k, `return ${k};`));
-      for (let k = 0; k < FN_COUNT; k++) await writeFile(join(root, fnFile(k)), baseSrc[k], 'utf-8');
-      await buildStore(baseSrc.map((s, k) => nodeFor(k, s)));
+      for (let k = 0; k < FN_COUNT; k++) await writeFile(join(dir, fnFile(k)), baseSrc[k], 'utf-8');
+      await buildStore(baseSrc.map((s, k) => nodeFor(k, s)), dir);
 
       // One approved decision per function, symbol-anchored to it.
       const decisions = Array.from({ length: FN_COUNT }, (_, k) => ({
@@ -221,13 +242,13 @@ describe('AuthoritativeRecallInvariant — orient decision section, property-bas
           survivors.push(nodeFor(k, edited));
         } else {
           // delete the node (and sometimes the file) → orphan
-          if (roll > 0.84) await rm(join(root, fnFile(k)), { force: true });
+          if (roll > 0.84) await rm(join(dir, fnFile(k)), { force: true });
         }
       }
-      await buildStore(survivors);
-      await writeDecisions(decisions);
+      await buildStore(survivors, dir);
+      await writeDecisions(decisions, dir);
 
-      const r = (await handleOrient(root, `work on ${fnName(0)} ${fnName(1)} ${fnName(2)} ${fnName(3)} ${fnName(4)}`)) as {
+      const r = (await handleOrient(dir, `work on ${fnName(0)} ${fnName(1)} ${fnName(2)} ${fnName(3)} ${fnName(4)}`)) as {
         error?: string;
         pendingDecisions?: Array<{ id: string; freshness?: string; verify?: boolean }>;
         staleDecisions?: Array<{ id: string; freshness?: string }>;
@@ -246,8 +267,8 @@ describe('AuthoritativeRecallInvariant — orient decision section, property-bas
 
       // Reset the source tree only; buildStore.clearAll resets the edge store and
       // writeDecisions overwrites pending.json next trial.
-      await rm(join(root, 'src'), { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
-      await mkdir(join(root, 'src'), { recursive: true });
+      await rm(join(dir, 'src'), { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+      await mkdir(join(dir, 'src'), { recursive: true });
     }
   }, 60_000);
 });

--- a/src/core/services/mcp-handlers/structural-diff-escape.test.ts
+++ b/src/core/services/mcp-handlers/structural-diff-escape.test.ts
@@ -18,8 +18,19 @@ vi.mock('./utils.js', async (orig) => {
 
 import { handleStructuralDiff } from './structural-diff.js';
 
+// Identity and signing come from the environment rather than three extra
+// `git config` invocations per fixture. Process spawn dominates the cost of
+// these git-backed fixtures, so every avoided call is real wall time.
+const GIT_FIXTURE_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+  GIT_AUTHOR_NAME: 'T', GIT_AUTHOR_EMAIL: 't@e.com',
+  GIT_COMMITTER_NAME: 'T', GIT_COMMITTER_EMAIL: 't@e.com',
+};
+
 function git(cwd: string, args: string[]): void {
-  execFileSync('git', args, { cwd, stdio: 'ignore', env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' } });
+  execFileSync('git', args, { cwd, stdio: 'ignore', env: GIT_FIXTURE_ENV });
 }
 function write(cwd: string, rel: string, content: string): void {
   const p = join(cwd, rel); mkdirSync(dirname(p), { recursive: true }); writeFileSync(p, content);
@@ -78,8 +89,6 @@ describe('structural_diff footprint escape detection', () => {
   beforeEach(() => {
     repo = mkdtempSync(join(tmpdir(), 'escape-'));
     git(repo, ['init', '-q', '-b', 'main']);
-    git(repo, ['config', 'user.name', 'T']); git(repo, ['config', 'user.email', 't@e.com']);
-    git(repo, ['config', 'commit.gpgsign', 'false']);
     write(repo, 'src/core.ts', BASE);
     git(repo, ['add', '.']); git(repo, ['commit', '-q', '-m', 'base', '--no-gpg-sign']);
   });
@@ -208,8 +217,6 @@ describe('structural_diff escape detection — adversarial regressions', () => {
   const init = () => {
     repo = mkdtempSync(join(tmpdir(), 'escape-adv-'));
     git(repo, ['init', '-q', '-b', 'main']);
-    git(repo, ['config', 'user.name', 'T']); git(repo, ['config', 'user.email', 't@e.com']);
-    git(repo, ['config', 'commit.gpgsign', 'false']);
   };
   const commit = (msg: string) => { git(repo, ['add', '.']); git(repo, ['commit', '-q', '-m', msg, '--no-gpg-sign']); };
   beforeEach(init);

--- a/src/core/services/mcp-handlers/structural-diff-mergebase.test.ts
+++ b/src/core/services/mcp-handlers/structural-diff-mergebase.test.ts
@@ -42,8 +42,19 @@ vi.mock('../../analyzer/call-graph.js', async (orig) => {
 
 import { handleStructuralDiff } from './structural-diff.js';
 
+// Identity and signing come from the environment rather than three extra
+// `git config` invocations per fixture. Process spawn dominates the cost of
+// these git-backed fixtures, so every avoided call is real wall time.
+const GIT_FIXTURE_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+  GIT_AUTHOR_NAME: 'T', GIT_AUTHOR_EMAIL: 't@e.com',
+  GIT_COMMITTER_NAME: 'T', GIT_COMMITTER_EMAIL: 't@e.com',
+};
+
 function git(cwd: string, args: string[]): void {
-  execFileSync('git', args, { cwd, stdio: 'ignore', env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' } });
+  execFileSync('git', args, { cwd, stdio: 'ignore', env: GIT_FIXTURE_ENV });
 }
 function write(cwd: string, rel: string, content: string): void {
   const p = join(cwd, rel); mkdirSync(dirname(p), { recursive: true }); writeFileSync(p, content);
@@ -77,8 +88,6 @@ interface DiffResult {
 function buildAdvancedBaseRepo(checkout: 'feature' | 'main'): string {
   const repo = mkdtempSync(join(tmpdir(), 'struct-mb-'));
   git(repo, ['init', '-q', '-b', 'main']);
-  git(repo, ['config', 'user.name', 'T']); git(repo, ['config', 'user.email', 't@e.com']);
-  git(repo, ['config', 'commit.gpgsign', 'false']);
   // C0 — the branch point.
   write(repo, 'src/mod.ts', C0);
   git(repo, ['add', '.']); git(repo, ['commit', '-q', '-m', 'c0', '--no-gpg-sign']);
@@ -145,8 +154,6 @@ describe('structural_diff — merge-base old-content discipline', () => {
     // from the same SHA the pre-fix code used, so behavior is unchanged.
     repo = mkdtempSync(join(tmpdir(), 'struct-mb-nodrift-'));
     git(repo, ['init', '-q', '-b', 'main']);
-    git(repo, ['config', 'user.name', 'T']); git(repo, ['config', 'user.email', 't@e.com']);
-    git(repo, ['config', 'commit.gpgsign', 'false']);
     write(repo, 'src/mod.ts', C0);
     git(repo, ['add', '.']); git(repo, ['commit', '-q', '-m', 'c0', '--no-gpg-sign']);
     write(repo, 'src/mod.ts', FEATURE); // working-tree change only, no divergence
@@ -169,8 +176,6 @@ describe('structural_diff — snapshot build failure is a disclosed boundary', (
   it('names the failed snapshot instead of a silent empty comparison', async () => {
     repo = mkdtempSync(join(tmpdir(), 'struct-mb-crash-'));
     git(repo, ['init', '-q', '-b', 'main']);
-    git(repo, ['config', 'user.name', 'T']); git(repo, ['config', 'user.email', 't@e.com']);
-    git(repo, ['config', 'commit.gpgsign', 'false']);
     // Old version carries the parse-crash marker → its snapshot build throws.
     write(repo, 'src/mod.ts', `// __PARSE_CRASH__\nexport function keep(): void {}\n`);
     git(repo, ['add', '.']); git(repo, ['commit', '-q', '-m', 'c0', '--no-gpg-sign']);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,17 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts', 'test/**/*.test.ts', 'examples/**/*.test.ts'],
     exclude: ['**/*.integration.test.ts', 'node_modules/**'],
+    // A meaningful part of this suite builds REAL fixtures — git repositories,
+    // SQLite edge stores, tree-sitter parses — because that is exactly what the
+    // code under test reads. Process spawn alone costs ~150ms per `git` call on
+    // some machines (macOS with the Xcode CLT shim), so a fixture that creates a
+    // repo with three commits and two branches spends seconds before the first
+    // assertion. Vitest's 5s default was tuned for pure unit tests and made those
+    // suites pass only on fast hardware; under a full parallel run they timed out
+    // and read as logic failures. 30s is chosen to be comfortably above the real
+    // work while still catching a genuine hang.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     env: {
       // Keep the suite on the serial Pass-1 extraction lane by default
       // (change: optimize-parallel-extraction-pool): spawning real worker threads under


### PR DESCRIPTION
Five tests failed under a full parallel run while passing in isolation. **None was a logic defect** — every one measured the machine rather than the code.

## Timeouts: git subprocess cost vs. a 5s default
`git` costs ~150ms per spawn on some machines (macOS with the Xcode CLT shim), which the 5s default never accounted for.

- **`memory-invariant`** spent ~90s in `git rev-parse HEAD` alone: 600 spawns across two 120-trial properties. The bitemporal HEAD marker is orthogonal to the freshness invariant under test, and the fixtures are throwaway temp dirs with no git repo, so `git-time` is mocked. **80s → 28s**, trial count and property strength unchanged.
- **`structural-diff-*`** fixtures build real repos — that *is* what is under test, so git cannot be mocked away. Identity and signing move to the environment (three fewer spawns per fixture), and the global `testTimeout` goes to 30s. A suite that legitimately builds git repositories, SQLite edge stores and tree-sitter parses should not be governed by a default tuned for pure unit tests.

## Timing-ratio assertions measuring the scheduler
- **`call-graph-enclosing`** compared single samples with a sub-millisecond baseline; one GC pause in the large window blew the ratio past the bound. Now takes the best of five — noise only ever *adds* time, so the minimum is the honest estimate of intrinsic cost. The quadratic detector is intact: a quadratic implementation is ~64× at its best run too.
- **`extractor-redos`** asserted its growth ratio from 50ms up, while its own comment explains the ratio is only meaningful on the second-scale cases (middleware, Vue). The Java extractor measured 3.18 against a 3.0 bound at ~50ms — the scheduler talking. Floor raised to 250ms to match the stated rationale; `MAX_ABSOLUTE_MS` still separates fixed from unfixed by three orders of magnitude (5ms vs 10,866ms).

## Order-dependent fixture state
- **`viewer-freshness`** advanced the fingerprint without rewriting the artifact, so `artifactPredatesAnalyzedCommit` read `current` only when the test finished inside a single git-second (commit times have 1s granularity). The artifact is now rewritten, as a real re-analysis does.
- **`memory-invariant`**'s timed-out property kept running after the timeout (a JS promise cannot be cancelled) and deleted the *next* test's fixture through the shared module-level `root` — turning one timeout into a cascade of unrelated ENOENT failures. The fixture is now bound per test, containing the damage to the test that actually failed.

## Verification
Full suite: **2041/2041 files, 7129 tests green** (was 6 files / 5 tests failing). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)