### PR TITLE
fix(security): stabilize reviewed CodeQL egress sinks

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -15,10 +15,11 @@ queries:
 # shipped program, so a dataflow SOURCE inside it describes a scenario that cannot
 # occur in the artifact users run.
 #
-# Findings are NOT suppressed by rule. When a query fires on real shipped code and
-# the behaviour is intended, that alert is dismissed individually in the Security
-# tab with a stated reason — so the rule keeps guarding new code instead of going
-# quiet everywhere.
+# Findings are NOT suppressed by rule. A stable, reviewed sink whose behavior is
+# essential may carry a query-specific inline suppression with its reason next to
+# it. All other accepted findings are dismissed individually in the Security tab
+# with a stated reason. Both approaches keep the rule guarding new code instead of
+# going quiet everywhere.
 # ---------------------------------------------------------------------------
 paths-ignore:
   # ---- test code -----------------------------------------------------------

--- a/src/core/analyzer/embedding-service.ts
+++ b/src/core/analyzer/embedding-service.ts
@@ -174,7 +174,11 @@ export class EmbeddingService implements Embedder {
 
     const response = await withRelaxedTls(() => fetch(url, {
       method: 'POST',
+      // INTENTIONAL EGRESS: the operator-selected endpoint needs its configured credential.
+      // codeql[js/file-access-to-http]
       headers,
+      // INTENTIONAL EGRESS: embedding repository text is this configured feature's purpose.
+      // codeql[js/file-access-to-http]
       body: JSON.stringify({ input: truncated, model: this.model }),
     }), this.relaxTls);
 

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -900,6 +900,8 @@ export class OpenAIProvider implements LLMProvider {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
+      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
     }), this.relaxTls);
 
@@ -1085,6 +1087,8 @@ export class OpenAICompatibleProvider implements LLMProvider {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
+      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
     }), this.relaxTls);
 
@@ -1215,6 +1219,8 @@ export class CopilotProvider implements LLMProvider {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
+      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
     }), this.relaxTls);
 
@@ -1553,6 +1559,8 @@ export class GeminiProvider implements LLMProvider {
     const response = await withRelaxedTls(() => fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
     }), this.relaxTls);
 

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -74,6 +74,16 @@ const ALL_ACTION_FILES = [...workflowFiles.map(f => join(WORKFLOW_DIR, f)), ...C
 
 const rel = (abs: string) => abs.slice(REPO_ROOT.length + 1);
 
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    return entry.name.endsWith('.ts') && !entry.name.includes('.test.') && !entry.name.includes('.spec.')
+      ? [full]
+      : [];
+  });
+}
+
 /**
  * The only expressions allowed to be interpolated directly into a `run:` script.
  * `needs.<job>.result` is a closed enum produced by Actions itself
@@ -318,5 +328,34 @@ describe('workflow security: supply-chain automation is wired', () => {
     expect(Object.keys(triggers), 'CodeQL needs both a PR trigger and a schedule').toEqual(
       expect.arrayContaining(['pull_request', 'schedule'])
     );
+  });
+});
+
+describe('workflow security: CodeQL suppressions stay narrow and auditable', () => {
+  it('allows only the six reviewed file-to-HTTP egress sinks', () => {
+    const suppressions: Record<string, number> = {};
+    const unexplained: string[] = [];
+
+    for (const file of sourceFiles(join(REPO_ROOT, 'src'))) {
+      const lines = read(file).split('\n');
+      lines.forEach((line, index) => {
+        if (!line.includes('codeql[')) return;
+        const location = `${rel(file)}:${index + 1}`;
+        if (line.trim() !== '// codeql[js/file-access-to-http]' ||
+            lines[index - 1]?.trim().startsWith('// INTENTIONAL EGRESS:') !== true) {
+          unexplained.push(location);
+        }
+        suppressions[rel(file)] = (suppressions[rel(file)] ?? 0) + 1;
+      });
+    }
+
+    expect(
+      unexplained,
+      'Every CodeQL suppression must name one query and have an immediately preceding rationale.'
+    ).toEqual([]);
+    expect(suppressions, 'Changing the reviewed suppression set requires explicit security review.').toEqual({
+      'src/core/analyzer/embedding-service.ts': 2,
+      'src/core/services/llm-service.ts': 4,
+    });
   });
 });


### PR DESCRIPTION
**Status:** LGTM

**What was wrong:**
Six previously reviewed `js/file-access-to-http` findings reopened after routine source movement gave the same intentional LLM and embedding egress paths new alert identities. Repeated dashboard dismissal was fragile and left the repository showing six medium-severity CodeQL alerts even though sending repository-derived text to the operator-selected model endpoint is the feature itself.

**How it was fixed:**
Added query-specific inline suppressions at only the six reviewed properties that carry credentials or repository text to the configured endpoint. Each suppression has an adjacent intentional-egress rationale. The CodeQL policy now documents this narrow mechanism, and a source-tree regression test rejects broad, unexplained, or newly added suppressions unless the reviewed inventory is updated explicitly. The `js/file-access-to-http` query remains active everywhere else.

**Replication / proof:**
- GitHub main showed open CodeQL alerts #495 through #500, all duplicates of previously dismissed findings at these same sinks.
- `npm test -- --run src/workflow-security.test.ts src/core/analyzer/embedding-service.test.ts src/core/services/llm-service.test.ts`: 151 passed, 2 skipped.
- `npm run test:run`: 7,245 passed, 2 skipped.
- `npm run lint`, `npm run typecheck`, and `npm run build`: passed.
- `npm run audit:gate`: passed with no unallowed high/critical advisories.
- `npm run audit:packlist`: passed.
- The PR CodeQL check is the authoritative proof that alerts #495-#500 no longer recur.

**Notes / nits:**
`openlore drift` was invoked, but this repository has no local OpenLore configuration, so it reports that no configuration was found. No product behavior or network destination changed.