### PR TITLE
fix(security): attach CodeQL suppressions to egress calls

### DIFF
--- a/src/core/analyzer/embedding-service.ts
+++ b/src/core/analyzer/embedding-service.ts
@@ -172,13 +172,11 @@ export class EmbeddingService implements Embedder {
       headers['Authorization'] = `Bearer ${this.apiKey}`;
     }
 
+    // INTENTIONAL EGRESS: this feature sends repository text to the operator-selected endpoint.
+    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(url, {
       method: 'POST',
-      // INTENTIONAL EGRESS: the operator-selected endpoint needs its configured credential.
-      // codeql[js/file-access-to-http]
       headers,
-      // INTENTIONAL EGRESS: embedding repository text is this configured feature's purpose.
-      // codeql[js/file-access-to-http]
       body: JSON.stringify({ input: truncated, model: this.model }),
     }), this.relaxTls);
 

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -894,14 +894,14 @@ export class OpenAIProvider implements LLMProvider {
       body.response_format = { type: 'json_object' };
     }
 
+    // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
-      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
-      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
     }), this.relaxTls);
 
@@ -1081,14 +1081,14 @@ export class OpenAICompatibleProvider implements LLMProvider {
       }
     }
 
+    // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
-      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
-      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
     }), this.relaxTls);
 
@@ -1213,14 +1213,14 @@ export class CopilotProvider implements LLMProvider {
       body.response_format = { type: 'json_object' };
     }
 
+    // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
-      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
-      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
     }), this.relaxTls);
 
@@ -1556,11 +1556,11 @@ export class GeminiProvider implements LLMProvider {
     };
 
     const url = `${this.baseUrl}/${this.model}:generateContent?key=${this.apiKey}`;
+    // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
-      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
     }), this.relaxTls);
 

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -332,7 +332,7 @@ describe('workflow security: supply-chain automation is wired', () => {
 });
 
 describe('workflow security: CodeQL suppressions stay narrow and auditable', () => {
-  it('allows only the six reviewed file-to-HTTP egress sinks', () => {
+  it('allows only the five reviewed file-to-HTTP egress sinks', () => {
     const suppressions: Record<string, number> = {};
     const unexplained: string[] = [];
 
@@ -354,7 +354,7 @@ describe('workflow security: CodeQL suppressions stay narrow and auditable', () 
       'Every CodeQL suppression must name one query and have an immediately preceding rationale.'
     ).toEqual([]);
     expect(suppressions, 'Changing the reviewed suppression set requires explicit security review.').toEqual({
-      'src/core/analyzer/embedding-service.ts': 2,
+      'src/core/analyzer/embedding-service.ts': 1,
       'src/core/services/llm-service.ts': 4,
     });
   });


### PR DESCRIPTION
**Status:** LGTM

**What was wrong:**
PR #357 placed query-specific suppressions on object properties inside five outbound request statements. The PR scan had no open findings, but the authoritative post-merge `main` scan proved CodeQL associates suppression with the enclosing statement: only one old alert closed, six old alerts remained, and two new embedding alert identities appeared.

**How it was fixed:**
Moved each `js/file-access-to-http` suppression to the line immediately before its complete outbound request statement, which is the placement CodeQL documents and evaluates. One statement-level marker now covers both reviewed embedding flows, so the guarded inventory is five sinks rather than six property locations.

**Replication / proof:**
- Post-merge CodeQL run 31897434113 reproduced 7 open findings on `main`.
- `npm test -- --run src/workflow-security.test.ts src/core/analyzer/embedding-service.test.ts src/core/services/llm-service.test.ts`: 151 passed, 2 skipped.
- `npm run lint` and `npm run typecheck`: passed.
- PR and post-merge CodeQL scans are required before this is considered resolved.

**Notes / nits:**
This is a corrective follow-up to #357. There is no product behavior change; only suppression attachment and its reviewed-inventory assertion change.