### PR TITLE
fix(analyzer): harden vector index coherence

### DIFF
--- a/openspec/changes/archive/2026-08-16-harden-vector-index-coherence/proposal.md
+++ b/openspec/changes/archive/2026-08-16-harden-vector-index-coherence/proposal.md
@@ -1,6 +1,6 @@
 # Harden vector index coherence: a rebuilt index must never be served through stale process caches
 
-> Status: PROPOSED (2026-07-03, e2e audit pass 3). The live MCP server caches the vector index's
+> Status: IMPLEMENTED (2026-08-16). The live MCP server caches the vector index's
 > meta sidecar, BM25 corpus, and LanceDB table handle for the process lifetime — but the watcher
 > heals a stale graph by spawning a DETACHED `analyze --force` child that overwrites the table in
 > another process, so the server keeps serving the pre-rebuild dataset until restart. Two smaller
@@ -75,7 +75,8 @@ threshold), and touch no hot-path semantics on the happy path.
   `src/core/analyzer/local-embedding-service.ts` (memo reset); tests for cross-process
   invalidation, add-failure restore, and extractor retry.
 - Specs: `analyzer` — 2 ADDED requirements (VectorIndexCacheCoherence,
-  IncrementalIndexUpdateNeverDropsRowsSilently).
+  IncrementalIndexUpdateNeverDropsRowsSilently); `mcp-handlers` — 1 ADDED requirement
+  (SearchDisclosesDegradedVectorIndex).
 - Tool surface: unchanged (no new tool; `search_code` output gains a disclosure only in the
   degraded case — negligible payload, re-assert the budget in
   `src/cli/commands/mcp-presets.test.ts`).

--- a/openspec/changes/archive/2026-08-16-harden-vector-index-coherence/specs/analyzer/spec.md
+++ b/openspec/changes/archive/2026-08-16-harden-vector-index-coherence/specs/analyzer/spec.md
@@ -11,6 +11,9 @@ the meta sidecar's on-disk state (mtime / `builtAt` stamp) against the state cap
 population — not by a time-based expiry, and the watcher SHALL additionally clear the caches when
 a background rebuild it spawned completes. A remediation the system prints (such as "run
 `openlore analyze --force`") SHALL take effect in the live serving process once performed.
+Full and incremental mutations SHALL be serialized across processes. A full build SHALL publish
+its atomically replaced BM25 corpus before atomically publishing metadata as the coherence commit
+point. An incremental row mutation whose metadata commit fails SHALL restore its prior rows.
 
 #### Scenario: Out-of-process rebuild is picked up without restart
 
@@ -25,6 +28,13 @@ a background rebuild it spawned completes. A remediation the system prints (such
 - **GIVEN** the watcher deferred a vector update and told the user to run `openlore analyze --force`
 - **WHEN** the user (or the watcher's own background rebuild) completes that rebuild
 - **THEN** the live server serves the rebuilt index without a process restart
+
+#### Scenario: Publication failure preserves the prior coherent generation
+
+- **GIVEN** an incremental update replaced its changed-file rows
+- **WHEN** publishing the metadata coherence stamp fails
+- **THEN** the system restores the prior rows, and other warm processes remain coherent with the
+  unchanged metadata generation
 
 ### Requirement: IncrementalIndexUpdateNeverDropsRowsSilently
 

--- a/openspec/changes/archive/2026-08-16-harden-vector-index-coherence/specs/mcp-handlers/spec.md
+++ b/openspec/changes/archive/2026-08-16-harden-vector-index-coherence/specs/mcp-handlers/spec.md
@@ -1,0 +1,30 @@
+# mcp-handlers spec delta
+
+## ADDED Requirements
+
+### Requirement: SearchDisclosesDegradedVectorIndex
+
+The `search_code` and `suggest_insertion_points` handlers SHALL include an optional
+`indexDegraded` string when the vector index records, or the live process observes, an incremental
+update whose add and rollback both failed. The disclosure SHALL use the remediation
+`Index degraded — re-run "openlore analyze".` and SHALL remain present on normal and literal-text
+fallback results until a successful full rebuild establishes a healthy index. Healthy responses
+SHALL omit the field.
+
+#### Scenario: Search result carries persisted degradation
+
+- **GIVEN** an incremental vector-index update whose add and rollback both failed
+- **WHEN** `search_code` or `suggest_insertion_points` serves a result
+- **THEN** the response includes `indexDegraded` with the full-rebuild remediation
+
+#### Scenario: Literal fallback does not hide degradation
+
+- **GIVEN** a degraded vector index and a symbol query with no symbol matches
+- **WHEN** `search_code` returns literal-text fallback matches
+- **THEN** the fallback response still includes `indexDegraded`
+
+#### Scenario: Healthy search omits the warning
+
+- **GIVEN** a successful full vector-index rebuild with no degraded marker
+- **WHEN** either search handler serves a result
+- **THEN** the response omits `indexDegraded`

--- a/openspec/changes/archive/2026-08-16-harden-vector-index-coherence/tasks.md
+++ b/openspec/changes/archive/2026-08-16-harden-vector-index-coherence/tasks.md
@@ -1,33 +1,33 @@
 # Tasks — harden-vector-index-coherence
 
 ## Implementation
-- [ ] `readMeta` (vector-index.ts:95-106): capture the sidecar's mtime/`builtAt` when populating
+- [x] `readMeta` (vector-index.ts:95-106): capture the sidecar's mtime/`builtAt` when populating
       `_metaCache`; on read, stat the sidecar and invalidate `_metaCache`/`_bm25Cache`/`_tableCache`
       for that dbPath when the on-disk index changed since population (declarations :83, :193, :198)
-- [ ] Watcher: clear the three per-dbPath caches when the background rebuild child
+- [x] Watcher: clear the three per-dbPath caches when the background rebuild child
       (mcp-watcher.ts:669-673) completes, so the healed index is served immediately (keep the
       stat check as the backstop for rebuilds the server did not spawn)
-- [ ] `updateFiles` restore-on-failure: on `add()` failure after the committed delete
+- [x] `updateFiles` restore-on-failure: on `add()` failure after the committed delete
       (vector-index.ts:682-685 embedded, :633-635 BM25), restore the previously-read rows
       (:645-655 already reads them) or stage-then-swap; on double failure, write a degraded
       marker into the meta sidecar
-- [ ] Surface the degraded marker in search serving ("index degraded — re-run openlore analyze")
+- [x] Surface the degraded marker in search serving ("index degraded — re-run openlore analyze")
       instead of only the watcher stderr line (mcp-watcher.ts:819-821)
-- [ ] `getExtractor` (local-embedding-service.ts:74-109): set `extractorPromise = null` before
+- [x] `getExtractor` (local-embedding-service.ts:74-109): set `extractorPromise = null` before
       rethrowing so the next embed() retries; messages unchanged
 
 ## Verification
-- [ ] Cross-process test: rebuild the table via a second-process (or simulated out-of-band)
+- [x] Cross-process test: rebuild the table via a second-process (or simulated out-of-band)
       `build()` while caches are warm → next `search()` serves the new dataset, correct
       BM25-vs-dense routing (no dense path against a vector-less table)
-- [ ] Add-failure test: inject `table.add` rejection → deleted rows restored, no silent row loss;
+- [x] Add-failure test: inject `table.add` rejection → deleted rows restored, no silent row loss;
       double-failure → degraded marker written and disclosed in search output
-- [ ] Extractor retry test: first `pipeline()` throw, second call succeeds → embed() recovers
+- [x] Extractor retry test: first `pipeline()` throw, second call succeeds → embed() recovers
       within one instance
-- [ ] Pin retained-solid behavior: model-changed deferral (vector-index.ts:563-572) and
+- [x] Pin retained-solid behavior: model-changed deferral (vector-index.ts:563-572) and
       dim-mismatch degrade (:758-760) unchanged
-- [ ] Re-assert the tools/list payload budget (src/cli/commands/mcp-presets.test.ts)
-- [ ] Full suite green
+- [x] Re-assert the tools/list payload budget (src/cli/commands/mcp-presets.test.ts)
+- [x] Full suite green
 
 ## Spec
-- [ ] `analyzer` delta: ADD VectorIndexCacheCoherence, IncrementalIndexUpdateNeverDropsRowsSilently
+- [x] `analyzer` delta: ADD VectorIndexCacheCoherence, IncrementalIndexUpdateNeverDropsRowsSilently

--- a/openspec/specs/analyzer/spec.md
+++ b/openspec/specs/analyzer/spec.md
@@ -4927,6 +4927,69 @@ relationships and synthesized-edge provenance.
 - **THEN** no newly extracted grammar-backed file is parsed more than once, no resident HTTP input
   is re-read, and the complete serialized graph matches the pre-optimization graph exactly
 
+### Requirement: VectorIndexCacheCoherence
+
+The vector index's process-lifetime caches (meta sidecar, BM25 corpus, LanceDB table handle) SHALL
+be invalidated when the on-disk index has changed since the cache entry was populated, regardless
+of which process performed the rebuild. Coherence SHALL be established structurally — by comparing
+the meta sidecar's on-disk state (mtime / `builtAt` stamp) against the state captured at cache
+population — not by a time-based expiry, and the watcher SHALL additionally clear the caches when
+a background rebuild it spawned completes. A remediation the system prints (such as "run
+`openlore analyze --force`") SHALL take effect in the live serving process once performed.
+Full and incremental mutations SHALL be serialized across processes. A full build SHALL publish
+its atomically replaced BM25 corpus before atomically publishing metadata as the coherence commit
+point. An incremental row mutation whose metadata commit fails SHALL restore its prior rows.
+
+#### Scenario: Out-of-process rebuild is picked up without restart
+
+- **GIVEN** a live MCP server with warm vector-index caches
+- **WHEN** a detached `analyze --force` child (or any other process) overwrites the LanceDB table
+  and meta sidecar
+- **THEN** the next search invalidates the stale per-dbPath caches and serves the rebuilt dataset,
+  routing BM25-vs-dense on the fresh meta
+
+#### Scenario: The printed remediation is honest
+
+- **GIVEN** the watcher deferred a vector update and told the user to run `openlore analyze --force`
+- **WHEN** the user (or the watcher's own background rebuild) completes that rebuild
+- **THEN** the live server serves the rebuilt index without a process restart
+
+#### Scenario: Publication failure preserves the prior coherent generation
+
+- **GIVEN** an incremental update replaced its changed-file rows
+- **WHEN** publishing the metadata coherence stamp fails
+- **THEN** the system restores the prior rows, and other warm processes remain coherent with the
+  unchanged metadata generation
+
+### Requirement: IncrementalIndexUpdateNeverDropsRowsSilently
+
+The incremental vector-index update SHALL NOT leave the index missing the changed files' rows when
+its add step fails after the delete step: the update SHALL either stage-then-swap or restore the
+deleted rows on add failure. If the index cannot be restored, the system SHALL record a degraded
+marker and disclose "index degraded — re-run analyze" through the search tools' output — a
+stderr-only log line SHALL NOT be the sole signal. A transient local-embedding extractor failure
+SHALL NOT be memoized: a failed extractor load is retried on the next embed call rather than
+replayed for the lifetime of the service instance.
+
+#### Scenario: Add failure restores the deleted rows
+
+- **GIVEN** an incremental update whose delete committed and whose add then fails
+- **WHEN** the failure is handled
+- **THEN** the previously-read rows are restored (or the delete never committed), and the changed
+  functions remain findable via search
+
+#### Scenario: Unrestorable failure is disclosed, not debug-logged
+
+- **GIVEN** both the add and the restore fail
+- **WHEN** the next search runs against that index
+- **THEN** the result carries an "index degraded — re-run analyze" disclosure
+
+#### Scenario: Extractor failure is retried, not replayed
+
+- **GIVEN** a local embedding service whose first extractor load threw transiently
+- **WHEN** a later embed call runs on the same instance
+- **THEN** the extractor load is attempted again instead of rethrowing the memoized rejection
+
 ## Sub-components
 
 > `SignatureExtractor` is an orchestrator. Each sub-component below implements one logical block.

--- a/openspec/specs/mcp-handlers/spec.md
+++ b/openspec/specs/mcp-handlers/spec.md
@@ -1709,6 +1709,33 @@ home) — telemetry remains opt-in and is never transmitted off the machine.
 - **THEN** the recorded field is relativized (project-relative or `~`-prefixed), and credentials
   redaction continues to apply
 
+### Requirement: SearchDisclosesDegradedVectorIndex
+
+The `search_code` and `suggest_insertion_points` handlers SHALL include an optional
+`indexDegraded` string when the vector index records, or the live process observes, an incremental
+update whose add and rollback both failed. The disclosure SHALL use the remediation
+`Index degraded — re-run "openlore analyze".` and SHALL remain present on normal and literal-text
+fallback results until a successful full rebuild establishes a healthy index. Healthy responses
+SHALL omit the field.
+
+#### Scenario: Search result carries persisted degradation
+
+- **GIVEN** an incremental vector-index update whose add and rollback both failed
+- **WHEN** `search_code` or `suggest_insertion_points` serves a result
+- **THEN** the response includes `indexDegraded` with the full-rebuild remediation
+
+#### Scenario: Literal fallback does not hide degradation
+
+- **GIVEN** a degraded vector index and a symbol query with no symbol matches
+- **WHEN** `search_code` returns literal-text fallback matches
+- **THEN** the fallback response still includes `indexDegraded`
+
+#### Scenario: Healthy search omits the warning
+
+- **GIVEN** a successful full vector-index rebuild with no degraded marker
+- **WHEN** either search handler serves a result
+- **THEN** the response omits `indexDegraded`
+
 ## Decisions
 
 ### Build the MCP live-data test harness as an integration-only, behavior-neutral verification layer

--- a/src/core/analyzer/local-embedding-service-retry.test.ts
+++ b/src/core/analyzer/local-embedding-service-retry.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pipeline = vi.fn();
+
+vi.mock('@huggingface/transformers', () => ({
+  env: {},
+  pipeline,
+}));
+
+import { LocalEmbeddingService } from './local-embedding-service.js';
+
+describe('LocalEmbeddingService extractor retry', () => {
+  beforeEach(() => pipeline.mockReset());
+
+  it('retries a transient model-load failure on the same service instance', async () => {
+    const extractor = vi.fn().mockResolvedValue({ tolist: () => [[0.1, 0.2]] });
+    pipeline
+      .mockRejectedValueOnce(new Error('transient download failure'))
+      .mockResolvedValueOnce(extractor);
+    const service = new LocalEmbeddingService('test/model');
+
+    await expect(service.embed(['first'])).rejects.toThrow('transient download failure');
+    await expect(service.embed(['second'])).resolves.toEqual([[0.1, 0.2]]);
+    expect(pipeline).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/core/analyzer/local-embedding-service.ts
+++ b/src/core/analyzer/local-embedding-service.ts
@@ -106,7 +106,12 @@ export class LocalEmbeddingService implements Embedder {
           { cause: err }
         );
       }
-    })();
+    })().catch((err) => {
+      // Preserve the actionable error for this call, but do not replay a
+      // transient loader failure for the lifetime of the service instance.
+      this.extractorPromise = null;
+      throw err;
+    });
     return this.extractorPromise;
   }
 

--- a/src/core/analyzer/vector-index-coherence.test.ts
+++ b/src/core/analyzer/vector-index-coherence.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  VectorIndex,
+  TOKENIZER_VERSION,
+  _replaceRowsWithRestoreForTesting,
+  _resetVectorIndexCachesForTesting,
+  _vectorIndexCacheIdentityForTesting,
+} from './vector-index.js';
+import type { FunctionNode } from './call-graph.js';
+import type { Embedder } from './embedding-service.js';
+
+const OLD_NODE: FunctionNode = {
+  id: 'src/old.ts::oldMarker',
+  name: 'oldMarker',
+  filePath: 'src/old.ts',
+  language: 'TypeScript',
+  isAsync: false,
+  startIndex: 0,
+  endIndex: 10,
+  fanIn: 1,
+  fanOut: 0,
+};
+
+function replacementRow(): Record<string, unknown> {
+  return {
+    id: 'src/new.ts::newMarker',
+    name: 'newMarker',
+    filePath: 'src/new.ts',
+    className: '',
+    language: 'TypeScript',
+    signature: '',
+    docstring: '',
+    fanIn: 1,
+    fanOut: 0,
+    isHub: false,
+    isEntryPoint: false,
+    text: '[TypeScript] src/new.ts newMarker',
+  };
+}
+
+describe('VectorIndex cross-process coherence', () => {
+  let outputDir: string;
+
+  beforeEach(async () => {
+    outputDir = await mkdtemp(join(tmpdir(), 'openlore-vector-coherence-'));
+    _resetVectorIndexCachesForTesting();
+  });
+
+  afterEach(() => _resetVectorIndexCachesForTesting());
+
+  it('reopens the table and rebuilds BM25 after an out-of-band overwrite', async () => {
+    await VectorIndex.build(outputDir, [OLD_NODE], [], new Set(), new Set(), null);
+    expect((await VectorIndex.search(outputDir, 'oldMarker', null))[0]?.record.name).toBe('oldMarker');
+
+    const { connect } = await import('@lancedb/lancedb');
+    const db = await connect(join(outputDir, 'vector-index'));
+    await db.createTable('functions', [replacementRow()], { mode: 'overwrite' });
+    await rm(join(outputDir, 'vector-index', 'bm25-corpus.json'), { force: true });
+    await writeFile(join(outputDir, 'vector-index-meta.json'), JSON.stringify({
+      hasEmbeddings: false,
+      dim: 0,
+      model: null,
+      builtAt: new Date(Date.now() + 1_000).toISOString(),
+      schemaVersion: 1,
+      tokenizerVersion: TOKENIZER_VERSION,
+    }));
+
+    const results = await VectorIndex.search(outputDir, 'newMarker', null);
+    expect(results[0]?.record.name).toBe('newMarker');
+    expect(results.some((result) => result.record.name === 'oldMarker')).toBe(false);
+  });
+
+  it('routes on fresh BM25 metadata instead of invoking a stale dense path', async () => {
+    const dense: Embedder = {
+      modelName: 'test-dense',
+      embed: vi.fn(async (texts: string[]) => texts.map(() => [0.1, 0.2, 0.3])),
+    };
+    await VectorIndex.build(outputDir, [OLD_NODE], [], new Set(), new Set(), dense);
+    await VectorIndex.search(outputDir, 'oldMarker', dense);
+    vi.mocked(dense.embed).mockClear();
+
+    const { connect } = await import('@lancedb/lancedb');
+    const db = await connect(join(outputDir, 'vector-index'));
+    await db.createTable('functions', [replacementRow()], { mode: 'overwrite' });
+    await rm(join(outputDir, 'vector-index', 'bm25-corpus.json'), { force: true });
+    await writeFile(join(outputDir, 'vector-index-meta.json'), JSON.stringify({
+      hasEmbeddings: false,
+      dim: 0,
+      model: null,
+      builtAt: new Date(Date.now() + 1_000).toISOString(),
+      schemaVersion: 1,
+      tokenizerVersion: TOKENIZER_VERSION,
+    }));
+
+    expect((await VectorIndex.search(outputDir, 'newMarker', dense))[0]?.record.name).toBe('newMarker');
+    expect(dense.embed).not.toHaveBeenCalled();
+  });
+
+  it('re-stamps a successful out-of-band row mutation for warm readers', async () => {
+    await VectorIndex.build(outputDir, [OLD_NODE], [], new Set(), new Set(), null);
+    await VectorIndex.search(outputDir, 'oldMarker', null);
+
+    const { connect } = await import('@lancedb/lancedb');
+    const db = await connect(join(outputDir, 'vector-index'));
+    const table = await db.openTable('functions');
+    await table.delete("`filePath` IN ('src/old.ts')");
+    await table.add([replacementRow()]);
+    await rm(join(outputDir, 'vector-index', 'bm25-corpus.json'), { force: true });
+    await writeFile(join(outputDir, 'vector-index-meta.json'), JSON.stringify({
+      hasEmbeddings: false,
+      dim: 0,
+      model: null,
+      builtAt: new Date(Date.now() + 1_000).toISOString(),
+      schemaVersion: 1,
+      tokenizerVersion: TOKENIZER_VERSION,
+    }));
+
+    expect((await VectorIndex.search(outputDir, 'newMarker', null))[0]?.record.name).toBe('newMarker');
+  });
+
+  it('canonicalizes symlink aliases to one cache identity', async () => {
+    if (process.platform === 'win32') return;
+    await mkdir(join(outputDir, 'vector-index'));
+    const alias = `${outputDir}-alias`;
+    await symlink(outputDir, alias, 'dir');
+    expect(_vectorIndexCacheIdentityForTesting(alias)).toBe(_vectorIndexCacheIdentityForTesting(outputDir));
+    await rm(alias, { force: true });
+  });
+
+  it('returns the persisted degraded disclosure', async () => {
+    await writeFile(join(outputDir, 'vector-index-meta.json'), JSON.stringify({
+      hasEmbeddings: false,
+      dim: 0,
+      model: null,
+      builtAt: new Date().toISOString(),
+      schemaVersion: 1,
+      degraded: { reason: 'incremental-update-restore-failed', recordedAt: new Date().toISOString() },
+    }));
+    expect(VectorIndex.degradationNotice(outputDir)).toBe('Index degraded — re-run "openlore analyze".');
+  });
+});
+
+describe('VectorIndex incremental replacement rollback', () => {
+  it('restores the captured rows when adding replacements fails', async () => {
+    const previous = [{ id: 'old' }];
+    const replacement = [{ id: 'new' }];
+    const table = {
+      delete: vi.fn().mockResolvedValue(undefined),
+      add: vi.fn()
+        .mockRejectedValueOnce(new Error('add failed'))
+        .mockResolvedValueOnce(undefined),
+    };
+    const markDegraded = vi.fn().mockResolvedValue(undefined);
+
+    await expect(_replaceRowsWithRestoreForTesting(
+      table, '`filePath` IN (\'src/a.ts\')', replacement, previous, markDegraded,
+    )).rejects.toThrow('add failed');
+    expect(table.add).toHaveBeenNthCalledWith(1, replacement);
+    expect(table.add).toHaveBeenNthCalledWith(2, previous);
+    expect(table.delete).toHaveBeenCalledTimes(2);
+    expect(markDegraded).not.toHaveBeenCalled();
+  });
+
+  it('marks the index degraded when adding and restoring both fail', async () => {
+    const table = {
+      delete: vi.fn().mockResolvedValue(undefined),
+      add: vi.fn().mockRejectedValueOnce(new Error('add failed')).mockRejectedValueOnce(new Error('restore failed')),
+    };
+    const markDegraded = vi.fn().mockResolvedValue(undefined);
+
+    await expect(_replaceRowsWithRestoreForTesting(
+      table, '`filePath` IN (\'src/a.ts\')', [{ id: 'new' }], [{ id: 'old' }], markDegraded,
+    )).rejects.toThrow('update and rollback both failed');
+    expect(markDegraded).toHaveBeenCalledOnce();
+  });
+
+  it('preserves add and rollback failures when degraded-marker persistence also fails', async () => {
+    const addError = new Error('add failed');
+    const restoreError = new Error('restore failed');
+    const markerError = new Error('disk full');
+    const table = {
+      delete: vi.fn().mockResolvedValue(undefined),
+      add: vi.fn().mockRejectedValueOnce(addError).mockRejectedValueOnce(restoreError),
+    };
+
+    let caught: unknown;
+    try {
+      await _replaceRowsWithRestoreForTesting(
+        table,
+        '`filePath` IN (\'src/a.ts\')',
+        [{ id: 'new' }],
+        [{ id: 'old' }],
+        vi.fn().mockRejectedValue(markerError),
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect((caught as AggregateError).errors).toEqual([addError, restoreError, markerError]);
+    expect((caught as Error).message).toContain('marker persistence failed');
+  });
+});

--- a/src/core/analyzer/vector-index-publication.test.ts
+++ b/src/core/analyzer/vector-index-publication.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FunctionNode } from './call-graph.js';
+
+const beforeMetaWrite = vi.hoisted(() => ({ run: null as null | (() => Promise<void>) }));
+
+vi.mock('../decisions/atomic-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../decisions/atomic-store.js')>();
+  return {
+    ...actual,
+    atomicWriteFile: async (path: string, data: string) => {
+      if (path.endsWith('vector-index-meta.json')) await beforeMetaWrite.run?.();
+      return actual.atomicWriteFile(path, data);
+    },
+  };
+});
+
+import { VectorIndex, _resetVectorIndexCachesForTesting } from './vector-index.js';
+
+function node(name: string): FunctionNode {
+  return {
+    id: `src/a.ts::${name}`,
+    name,
+    filePath: 'src/a.ts',
+    language: 'TypeScript',
+    isAsync: false,
+    startIndex: 0,
+    endIndex: 10,
+    fanIn: 1,
+    fanOut: 0,
+  };
+}
+
+describe('VectorIndex build publication', () => {
+  beforeEach(() => {
+    beforeMetaWrite.run = null;
+    _resetVectorIndexCachesForTesting();
+  });
+
+  it('publishes the replacement BM25 corpus before the metadata commit point', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'openlore-vector-publication-'));
+    await VectorIndex.build(outputDir, [node('oldMarker')], [], new Set(), new Set(), null);
+
+    beforeMetaWrite.run = async () => {
+      const corpus = JSON.parse(await readFile(
+        join(outputDir, 'vector-index', 'bm25-corpus.json'),
+        'utf-8',
+      )) as { docs: Array<{ id: string }> };
+      expect(corpus.docs.map((doc) => doc.id)).toEqual(['src/a.ts::newMarker']);
+    };
+
+    await VectorIndex.build(outputDir, [node('newMarker')], [], new Set(), new Set(), null);
+  });
+});

--- a/src/core/analyzer/vector-index-update-failure.test.ts
+++ b/src/core/analyzer/vector-index-update-failure.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FunctionNode } from './call-graph.js';
+
+const table = vi.hoisted(() => ({
+  query: vi.fn(),
+  delete: vi.fn(),
+  add: vi.fn(),
+}));
+const atomicWrite = vi.hoisted(() => vi.fn());
+
+vi.mock('@lancedb/lancedb', () => ({
+  connect: vi.fn().mockResolvedValue({
+    openTable: vi.fn().mockResolvedValue(table),
+  }),
+}));
+vi.mock('../decisions/atomic-store.js', () => ({ atomicWriteFile: atomicWrite }));
+
+import { VectorIndex, TOKENIZER_VERSION, _resetVectorIndexCachesForTesting } from './vector-index.js';
+
+const NODE: FunctionNode = {
+  id: 'src/a.ts::changed',
+  name: 'changed',
+  filePath: 'src/a.ts',
+  language: 'TypeScript',
+  isAsync: false,
+  startIndex: 0,
+  endIndex: 10,
+  fanIn: 1,
+  fanOut: 0,
+};
+
+describe('VectorIndex update failure persistence', () => {
+  let outputDir: string;
+  const previousRows = [{
+    id: 'src/a.ts::old', name: 'old', filePath: 'src/a.ts', className: '',
+    language: 'TypeScript', signature: '', docstring: '', fanIn: 1, fanOut: 0,
+    isHub: false, isEntryPoint: false, text: '[TypeScript] src/a.ts old',
+  }];
+
+  beforeEach(async () => {
+    outputDir = await mkdtemp(join(tmpdir(), 'openlore-update-failure-'));
+    await mkdir(join(outputDir, 'vector-index'), { recursive: true });
+    await writeFile(join(outputDir, 'vector-index-meta.json'), JSON.stringify({
+      hasEmbeddings: false,
+      dim: 0,
+      model: null,
+      builtAt: new Date().toISOString(),
+      schemaVersion: 1,
+      tokenizerVersion: TOKENIZER_VERSION,
+    }));
+    table.query.mockReset().mockReturnValue({
+      where: vi.fn().mockReturnValue({ toArray: vi.fn().mockResolvedValue(previousRows) }),
+    });
+    table.delete.mockReset().mockResolvedValue(undefined);
+    table.add.mockReset();
+    atomicWrite.mockReset().mockImplementation((path: string, data: string) => writeFile(path, data));
+    _resetVectorIndexCachesForTesting();
+  });
+
+  it('writes a degraded marker after add and restore fail, and a partial success cannot clear it', async () => {
+    table.add
+      .mockRejectedValueOnce(new Error('add failed'))
+      .mockRejectedValueOnce(new Error('restore failed'));
+
+    await expect(VectorIndex.updateFiles(
+      outputDir, [NODE], new Set(['src/a.ts']), [], new Set(), new Set(), null,
+    )).rejects.toThrow('update and rollback both failed');
+
+    const failedMeta = JSON.parse(await readFile(join(outputDir, 'vector-index-meta.json'), 'utf-8'));
+    expect(failedMeta.degraded?.reason).toBe('incremental-update-restore-failed');
+    expect(VectorIndex.degradationNotice(outputDir)).toBe('Index degraded — re-run "openlore analyze".');
+
+    table.add.mockReset().mockResolvedValue(undefined);
+    await VectorIndex.updateFiles(
+      outputDir, [NODE], new Set(['src/a.ts']), [], new Set(), new Set(), null,
+    );
+    expect(VectorIndex.degradationNotice(outputDir)).toBe('Index degraded — re-run "openlore analyze".');
+  });
+
+  it('keeps a process-local disclosure when the degraded marker cannot be persisted', async () => {
+    table.add
+      .mockRejectedValueOnce(new Error('add failed'))
+      .mockRejectedValueOnce(new Error('restore failed'));
+    atomicWrite.mockRejectedValueOnce(new Error('disk full'));
+
+    await expect(VectorIndex.updateFiles(
+      outputDir, [NODE], new Set(['src/a.ts']), [], new Set(), new Set(), null,
+    )).rejects.toThrow('marker persistence failed');
+    expect(VectorIndex.degradationNotice(outputDir)).toBe('Index degraded — re-run "openlore analyze".');
+  });
+
+  it('restores the previous rows when the coherence metadata cannot be published', async () => {
+    table.add.mockResolvedValue(undefined);
+    atomicWrite.mockRejectedValueOnce(new Error('disk full'));
+
+    await expect(VectorIndex.updateFiles(
+      outputDir, [NODE], new Set(['src/a.ts']), [], new Set(), new Set(), null,
+    )).rejects.toThrow('disk full');
+
+    expect(table.delete).toHaveBeenCalledTimes(2);
+    expect(table.add).toHaveBeenCalledTimes(2);
+    expect(table.add.mock.calls[1][0]).toEqual(previousRows);
+    expect(VectorIndex.degradationNotice(outputDir)).toBeNull();
+  });
+
+  it('does not mutate the table for an empty changed-file set', async () => {
+    const result = await VectorIndex.updateFiles(
+      outputDir, [NODE], new Set(), [], new Set(), new Set(), null,
+    );
+    expect(result.total).toBe(0);
+    expect(table.query).not.toHaveBeenCalled();
+    expect(table.delete).not.toHaveBeenCalled();
+    expect(table.add).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/analyzer/vector-index.ts
+++ b/src/core/analyzer/vector-index.ts
@@ -16,9 +16,8 @@
  *   const results = await VectorIndex.search(outputDir, "authenticate user with JWT", embedSvc);
  */
 
-import { existsSync, readFileSync, writeFileSync, rmSync, openSync, writeSync, closeSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { existsSync, readFileSync, writeFileSync, rmSync, openSync, writeSync, closeSync, statSync, realpathSync, renameSync, unlinkSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import type { FunctionNode } from './call-graph.js';
 import type { FileSignatureMap } from './signature-extractor.js';
 import type { Embedder } from './embedding-service.js';
@@ -26,6 +25,8 @@ import { getSkeletonContent, isSkeletonWorthIncluding } from './code-shaper.js';
 import { quietNativeLoggingOnce } from './lance-logging.js';
 import { noteUpdateAndMaybeCompact } from './index-compaction.js';
 import { TOKENIZER_VERSION, tokenize } from './bm25-tokenizer.js';
+import { atomicWriteFile } from '../decisions/atomic-store.js';
+import { acquireLockAt } from '../runtime/advisory-lock.js';
 
 export { TOKENIZER_VERSION, tokenize } from './bm25-tokenizer.js';
 
@@ -86,6 +87,8 @@ export interface VectorIndexMeta {
   dim: number;
   model: string | null;
   builtAt: string;
+  /** Changes only after a complete rebuild; incremental mutations preserve it. */
+  fullBuildAt?: string;
   schemaVersion: number;
   /**
    * Version of the BM25 tokenizer that produced this index's corpus. A mismatch
@@ -94,13 +97,43 @@ export interface VectorIndexMeta {
    * full rebuild re-stamps. A legacy meta without this field is treated as v1.
    */
   tokenizerVersion?: number;
+  /** Present only when an incremental update could neither add nor restore rows. */
+  degraded?: {
+    reason: 'incremental-update-restore-failed';
+    recordedAt: string;
+  };
 }
 
-// Module-level meta cache, keyed by dbPath. Invalidated by build().
-const _metaCache = new Map<string, VectorIndexMeta | null>();
+interface CachedMeta {
+  value: VectorIndexMeta | null;
+  /** Filesystem identity captured after the sidecar was read. */
+  stamp: string | null;
+}
+
+// Module-level meta cache, keyed by dbPath. The filesystem stamp makes it
+// coherent with rebuilds performed by another process.
+const _metaCache = new Map<string, CachedMeta>();
 
 function metaFilePath(outputDir: string): string {
   return join(outputDir, META_FILE);
+}
+
+function dbPathFor(outputDir: string): string {
+  const absolute = resolve(outputDir, DB_FOLDER);
+  try {
+    return realpathSync.native(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+function metaStamp(outputDir: string): string | null {
+  try {
+    const stat = statSync(metaFilePath(outputDir), { bigint: true });
+    return `${stat.dev}:${stat.ino}:${stat.mtimeNs}:${stat.ctimeNs}:${stat.size}`;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -110,20 +143,35 @@ function metaFilePath(outputDir: string): string {
  * present" to preserve pre-change behaviour for those indexes.
  */
 function readMeta(outputDir: string): VectorIndexMeta | null {
-  const dbPath = join(outputDir, DB_FOLDER);
-  if (_metaCache.has(dbPath)) return _metaCache.get(dbPath) ?? null;
-  let meta: VectorIndexMeta | null;
-  try {
-    meta = JSON.parse(readFileSync(metaFilePath(outputDir), 'utf-8')) as VectorIndexMeta;
-  } catch {
-    meta = null;
+  const dbPath = dbPathFor(outputDir);
+  const stamp = metaStamp(outputDir);
+  const cached = _metaCache.get(dbPath);
+  if (cached && cached.stamp === stamp) return cached.value;
+  if (cached) invalidateDbPathCaches(dbPath);
+
+  // Require a stable pre/post-read stamp. A concurrent atomic rename causes a
+  // retry; a malformed file that exists is never cached as legacy-null.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const before = metaStamp(outputDir);
+    let meta: VectorIndexMeta;
+    try {
+      meta = JSON.parse(readFileSync(metaFilePath(outputDir), 'utf-8')) as VectorIndexMeta;
+    } catch {
+      const after = metaStamp(outputDir);
+      if (before !== after) continue;
+      if (before === null) _metaCache.set(dbPath, { value: null, stamp: null });
+      return null;
+    }
+    const after = metaStamp(outputDir);
+    if (before !== after) continue;
+    _metaCache.set(dbPath, { value: meta, stamp: after });
+    return meta;
   }
-  _metaCache.set(dbPath, meta);
-  return meta;
+  return null;
 }
 
 async function writeMeta(outputDir: string, meta: VectorIndexMeta): Promise<void> {
-  await writeFile(metaFilePath(outputDir), JSON.stringify(meta, null, 2) + '\n', 'utf-8');
+  await atomicWriteFile(metaFilePath(outputDir), JSON.stringify(meta, null, 2) + '\n');
 }
 
 /** Convert a raw LanceDB row to a FunctionRecord (without the vector field). */
@@ -218,6 +266,37 @@ const _identifierVocabularyCache = new Map<string, string[]>();
 // Invalidated by build() when the index is rebuilt.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _tableCache = new Map<string, { table: any }>();
+const _degradedFallback = new Map<string, {
+  fullBuildAt: string | null;
+  marker: NonNullable<VectorIndexMeta['degraded']>;
+}>();
+
+function invalidateDbPathCaches(dbPath: string): void {
+  _bm25Cache.delete(dbPath);
+  _identifierVocabularyCache.delete(dbPath);
+  _tableCache.delete(dbPath);
+  _metaCache.delete(dbPath);
+}
+
+/** Clear every process-lifetime cache for one on-disk vector index. */
+export function invalidateVectorIndexCaches(outputDir: string): void {
+  invalidateDbPathCaches(dbPathFor(outputDir));
+}
+
+/** Test-only: expose the canonical cache identity used for an index path. */
+export const _vectorIndexCacheIdentityForTesting = dbPathFor;
+
+async function withVectorIndexMutation<T>(outputDir: string, operation: () => Promise<T>): Promise<T> {
+  let lockDir = resolve(outputDir);
+  try { lockDir = realpathSync.native(lockDir); } catch { /* output directory may not exist yet */ }
+  const lock = await acquireLockAt(lockDir, '.vector-index.lock');
+  if ('held' in lock) throw new Error(`Vector index mutation lock is held: ${lock.lockPath}`);
+  try {
+    return await operation();
+  } finally {
+    await lock.release();
+  }
+}
 
 /** Test-only: clear in-memory BM25 + LanceDB caches to force cold path. */
 export function _resetVectorIndexCachesForTesting(): void {
@@ -225,7 +304,57 @@ export function _resetVectorIndexCachesForTesting(): void {
   _identifierVocabularyCache.clear();
   _tableCache.clear();
   _metaCache.clear();
+  _degradedFallback.clear();
 }
+
+interface MutableTable {
+  delete(predicate: string): Promise<unknown>;
+  add(rows: Record<string, unknown>[]): Promise<unknown>;
+}
+
+async function replaceRowsWithRestore(
+  table: MutableTable,
+  predicate: string | null,
+  replacementRows: Record<string, unknown>[],
+  previousRows: Record<string, unknown>[],
+  onRestoreFailure: () => Promise<void>,
+): Promise<void> {
+  if (!predicate) {
+    if (replacementRows.length > 0) await table.add(replacementRows);
+    return;
+  }
+
+  await table.delete(predicate);
+  try {
+    if (replacementRows.length > 0) await table.add(replacementRows);
+  } catch (addError) {
+    try {
+      // An add that rejects is not assumed to be transactionally empty. Remove
+      // any replacement rows it may have partially committed before restoring
+      // the captured pre-update set.
+      await table.delete(predicate);
+      if (previousRows.length > 0) await table.add(previousRows);
+    } catch (restoreError) {
+      let markerError: unknown;
+      try {
+        await onRestoreFailure();
+      } catch (err) {
+        markerError = err;
+      }
+      throw new AggregateError(
+        markerError ? [addError, restoreError, markerError] : [addError, restoreError],
+        markerError
+          ? 'Vector index update, rollback, and degraded-marker persistence failed.'
+          : 'Vector index update and rollback both failed; the index is degraded.',
+        { cause: restoreError },
+      );
+    }
+    throw addError;
+  }
+}
+
+/** Test-only: exercise the transactional delete/add helper without LanceDB. */
+export const _replaceRowsWithRestoreForTesting = replaceRowsWithRestore;
 
 /**
  * Surgically patch the cached BM25 corpus for `dbPath` (Spec 13.1): drop the
@@ -392,6 +521,7 @@ function persistCorpusSidecar(dbPath: string, corpus: Bm25Corpus): void {
 
 /** How many bytes of sidecar text buffer before a write syscall. */
 const CORPUS_WRITE_BUFFER_BYTES = 1 << 20;
+let corpusTempCounter = 0;
 
 /**
  * Persist the sidecar WITHOUT ever holding the corpus, its serialized payload, or the finished
@@ -417,8 +547,11 @@ function persistCorpusSidecarStreaming(
   records: Iterable<{ id: string; text: string }>,
 ): void {
   let fd: number | undefined;
+  const target = corpusFilePath(dbPath);
+  const temp = `${target}.tmp-${process.pid}-${corpusTempCounter++}`;
+  let renamed = false;
   try {
-    fd = openSync(corpusFilePath(dbPath), 'w');
+    fd = openSync(temp, 'w');
     const df = new Map<string, number>();
     let totalLen = 0;
     let n = 0;
@@ -446,11 +579,18 @@ function persistCorpusSidecarStreaming(
     buf += `],"df":${JSON.stringify([...df])},`
       + `"avgLength":${JSON.stringify(n > 0 ? totalLen / n : 1)},"N":${n}}`;
     flush(true);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(temp, target);
+    renamed = true;
   } catch {
     /* optional cache — ignore */
   } finally {
     if (fd !== undefined) {
       try { closeSync(fd); } catch { /* already closed */ }
+    }
+    if (!renamed) {
+      try { unlinkSync(temp); } catch { /* absent or already renamed */ }
     }
   }
 }
@@ -578,6 +718,21 @@ function findSignatureEntry(
 // ============================================================================
 
 export class VectorIndex {
+  /** User-facing disclosure for an index whose incremental rollback also failed. */
+  static degradationNotice(outputDir: string): string | null {
+    const dbPath = dbPathFor(outputDir);
+    const meta = readMeta(outputDir);
+    if (meta?.degraded) return 'Index degraded — re-run "openlore analyze".';
+    const fallback = _degradedFallback.get(dbPath);
+    if (!fallback) return null;
+    const observedFullBuild = meta?.fullBuildAt ?? meta?.builtAt ?? null;
+    if (observedFullBuild !== fallback.fullBuildAt) {
+      _degradedFallback.delete(dbPath);
+      return null;
+    }
+    return 'Index degraded — re-run "openlore analyze".';
+  }
+
   /**
    * Build (or rebuild) the vector index from call graph nodes + signatures.
    *
@@ -605,6 +760,29 @@ export class VectorIndex {
     fileContents?: Map<string, string>,
     /** When true, reuse cached vectors for unchanged functions */
     incremental = false
+  ): Promise<{
+    embedded: number;
+    reused: number;
+    total: number;
+    hasEmbeddings: boolean;
+    productionFunctions: number;
+    testFunctions: number;
+    signatureOnlySymbols: number;
+  }> {
+    return withVectorIndexMutation(outputDir, () => VectorIndex.buildUnlocked(
+      outputDir, nodes, signatures, hubIds, entryPointIds, embedSvc, fileContents, incremental,
+    ));
+  }
+
+  private static async buildUnlocked(
+    outputDir: string,
+    nodes: FunctionNode[],
+    signatures: FileSignatureMap[],
+    hubIds: Set<string>,
+    entryPointIds: Set<string>,
+    embedSvc: Embedder | null,
+    fileContents?: Map<string, string>,
+    incremental = false,
   ): Promise<{
     embedded: number;
     reused: number;
@@ -689,7 +867,7 @@ export class VectorIndex {
       throw new Error('No repository functions to index');
     }
 
-    const dbPath = join(outputDir, DB_FOLDER);
+    const dbPath = dbPathFor(outputDir);
     const productionFunctions = repoNodes.filter((node) => !node.isTest).length;
     const testFunctions = repoNodes.length - productionFunctions;
     const signatureOnlySymbols = candidates.length - repoNodes.length;
@@ -699,29 +877,30 @@ export class VectorIndex {
     // searched with ANN, and record `hasEmbeddings: false` in the sidecar.
     if (!embedSvc) {
       const db = await connect(dbPath);
+      deleteCorpusSidecar(dbPath);
       await db.createTable(
         TABLE_NAME,
         candidates as unknown as Record<string, unknown>[],
         { mode: 'overwrite' }
       );
-      await writeMeta(outputDir, {
-        hasEmbeddings: false,
-        dim: 0,
-        model: null,
-        builtAt: new Date().toISOString(),
-        schemaVersion: META_SCHEMA_VERSION,
-        tokenizerVersion: TOKENIZER_VERSION,
-      });
-      // Persist the tokenized corpus so a cold-start query hydrates it instead of
-      // re-tokenizing the whole `text` column.
+      const builtAt = new Date().toISOString();
+      // Publish corpus first and metadata LAST: the meta rename is the coherence
+      // commit point observed by warm readers in other processes.
       persistCorpusSidecarStreaming(
         dbPath,
         (function* () { for (const r of candidates) yield { id: r.id, text: r.text }; })(),
       );
-      _tableCache.delete(dbPath);
-      _bm25Cache.delete(dbPath);
-      _identifierVocabularyCache.delete(dbPath);
-      _metaCache.delete(dbPath);
+      await writeMeta(outputDir, {
+        hasEmbeddings: false,
+        dim: 0,
+        model: null,
+        builtAt,
+        fullBuildAt: builtAt,
+        schemaVersion: META_SCHEMA_VERSION,
+        tokenizerVersion: TOKENIZER_VERSION,
+      });
+      _degradedFallback.delete(dbPath);
+      invalidateDbPathCaches(dbPath);
       return {
         embedded: 0,
         reused: 0,
@@ -813,28 +992,28 @@ export class VectorIndex {
 
     // ── Write table ──────────────────────────────────────────────────────────
     const db = await connect(dbPath);
+    deleteCorpusSidecar(dbPath);
     await db.createTable(TABLE_NAME, fullRecords as unknown as Record<string, unknown>[], { mode: 'overwrite' });
 
-    await writeMeta(outputDir, {
-      hasEmbeddings: true,
-      dim: fullRecords[0]?.vector.length ?? 0,
-      model: embedSvc.modelName,
-      builtAt: new Date().toISOString(),
-      schemaVersion: META_SCHEMA_VERSION,
-      tokenizerVersion: TOKENIZER_VERSION,
-    });
-    // Persist the tokenized corpus for cold-start hydration (hybrid search still
-    // uses the BM25 sparse half, so the corpus is needed here too).
+    const builtAt = new Date().toISOString();
+    // As above, metadata is the last-published coherence commit.
     persistCorpusSidecarStreaming(
       dbPath,
       (function* () { for (const r of fullRecords) yield { id: r.id, text: r.text }; })(),
     );
+    await writeMeta(outputDir, {
+      hasEmbeddings: true,
+      dim: fullRecords[0]?.vector.length ?? 0,
+      model: embedSvc.modelName,
+      builtAt,
+      fullBuildAt: builtAt,
+      schemaVersion: META_SCHEMA_VERSION,
+      tokenizerVersion: TOKENIZER_VERSION,
+    });
 
     // Invalidate search caches — index was just rebuilt
-    _tableCache.delete(dbPath);
-    _bm25Cache.delete(dbPath);
-    _identifierVocabularyCache.delete(dbPath);
-    _metaCache.delete(dbPath);
+    _degradedFallback.delete(dbPath);
+    invalidateDbPathCaches(dbPath);
 
     return {
       embedded: toEmbed.length,
@@ -871,12 +1050,30 @@ export class VectorIndex {
     embedSvc: Embedder | null | undefined,
     fileContents?: Map<string, string>,
   ): Promise<{ embedded: number; reused: number; total: number; hasEmbeddings: boolean; deferred?: 'model-changed' | 'tokenizer-changed' }> {
+    return withVectorIndexMutation(outputDir, () => VectorIndex.updateFilesUnlocked(
+      outputDir, nodes, changedFilePaths, signatures, hubIds, entryPointIds, embedSvc, fileContents,
+    ));
+  }
+
+  private static async updateFilesUnlocked(
+    outputDir: string,
+    nodes: FunctionNode[],
+    changedFilePaths: Set<string>,
+    signatures: FileSignatureMap[],
+    hubIds: Set<string>,
+    entryPointIds: Set<string>,
+    embedSvc: Embedder | null | undefined,
+    fileContents?: Map<string, string>,
+  ): Promise<{ embedded: number; reused: number; total: number; hasEmbeddings: boolean; deferred?: 'model-changed' | 'tokenizer-changed' }> {
     if (!VectorIndex.exists(outputDir)) {
       return { embedded: 0, reused: 0, total: 0, hasEmbeddings: false };
     }
-    const dbPath = join(outputDir, DB_FOLDER);
+    const dbPath = dbPathFor(outputDir);
     const existingMeta = readMeta(outputDir);
     const indexHasEmbeddings = existingMeta === null ? true : existingMeta.hasEmbeddings;
+    if (changedFilePaths.size === 0) {
+      return { embedded: 0, reused: 0, total: 0, hasEmbeddings: indexHasEmbeddings };
+    }
 
     // A changed tokenizer means the on-disk corpus was tokenized under different
     // rules; incrementally patching it in place would mix token sets. Refuse the
@@ -967,13 +1164,101 @@ export class VectorIndex {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const table: any = await db.openTable(TABLE_NAME);
     const predicate = filePathInPredicate(changedFilePaths);
+    const previousRows = predicate
+      ? await table.query().where(predicate).toArray() as Record<string, unknown>[]
+      : [];
+    const markDegraded = async (): Promise<void> => {
+      const marker: NonNullable<VectorIndexMeta['degraded']> = {
+        reason: 'incremental-update-restore-failed',
+        recordedAt: new Date().toISOString(),
+      };
+      const fullBuildAt = existingMeta?.fullBuildAt ?? existingMeta?.builtAt ?? null;
+      _degradedFallback.set(dbPath, { fullBuildAt, marker });
+      const baseMeta: VectorIndexMeta = existingMeta ?? {
+        hasEmbeddings: indexHasEmbeddings,
+        dim: 0,
+        model: null,
+        builtAt: new Date().toISOString(),
+        schemaVersion: META_SCHEMA_VERSION,
+        tokenizerVersion: TOKENIZER_VERSION,
+      };
+      try {
+        await writeMeta(outputDir, {
+          ...baseMeta,
+          degraded: marker,
+        });
+      } finally {
+        invalidateDbPathCaches(dbPath);
+      }
+    };
+    const publishMutation = async (): Promise<void> => {
+      const fallback = _degradedFallback.get(dbPath);
+      const publishedAt = new Date().toISOString();
+      const updatedMeta: VectorIndexMeta = {
+        ...(existingMeta ?? {
+          hasEmbeddings: indexHasEmbeddings,
+          dim: 0,
+          model: null,
+          schemaVersion: META_SCHEMA_VERSION,
+          tokenizerVersion: TOKENIZER_VERSION,
+        }),
+        builtAt: publishedAt,
+        fullBuildAt: existingMeta?.fullBuildAt ?? existingMeta?.builtAt ?? publishedAt,
+        ...(existingMeta?.degraded || fallback
+          ? { degraded: existingMeta?.degraded ?? fallback?.marker }
+          : {}),
+      };
+      await writeMeta(outputDir, updatedMeta);
+      _metaCache.set(dbPath, { value: updatedMeta, stamp: metaStamp(outputDir) });
+      if (updatedMeta.degraded) {
+        _degradedFallback.set(dbPath, {
+          fullBuildAt: updatedMeta.fullBuildAt ?? updatedMeta.builtAt,
+          marker: updatedMeta.degraded,
+        });
+      }
+    };
+    const publishMutationOrRestore = async (): Promise<void> => {
+      try {
+        await publishMutation();
+      } catch (publishError) {
+        try {
+          if (predicate) {
+            await table.delete(predicate);
+            if (previousRows.length > 0) await table.add(previousRows);
+          }
+        } catch (restoreError) {
+          let markerError: unknown;
+          try {
+            await markDegraded();
+          } catch (error) {
+            markerError = error;
+          }
+          const errors = [publishError, restoreError];
+          if (markerError !== undefined) errors.push(markerError);
+          throw new AggregateError(
+            errors,
+            markerError === undefined
+              ? 'Vector index metadata publication and rollback both failed'
+              : 'Vector index metadata publication, rollback, and degraded marker persistence failed',
+            { cause: restoreError },
+          );
+        } finally {
+          invalidateDbPathCaches(dbPath);
+        }
+        throw publishError;
+      }
+    };
 
     // ── BM25-only index ───────────────────────────────────────────────────────
     if (!embedSvc || !indexHasEmbeddings) {
-      if (predicate) await table.delete(predicate);
-      if (candidates.length > 0) {
-        await table.add(candidates as unknown as Record<string, unknown>[]);
-      }
+      await replaceRowsWithRestore(
+        table,
+        predicate,
+        candidates as unknown as Record<string, unknown>[],
+        previousRows,
+        markDegraded,
+      );
+      await publishMutationOrRestore();
       patchBm25Cache(dbPath, changedFilePaths, candidates as unknown as Record<string, unknown>[]);
       // Reclaim the versions this delete+add left behind (see index-compaction).
       await noteUpdateAndMaybeCompact(dbPath, table as unknown as Parameters<typeof noteUpdateAndMaybeCompact>[1]);
@@ -983,15 +1268,10 @@ export class VectorIndex {
     // ── Embedded index: reuse unchanged vectors for the changed files only ────
     const cachedVectors = new Map<string, number[]>(); // "id::text" → vector
     if (predicate) {
-      try {
-        const existingRows = await table.query().where(predicate).toArray() as Record<string, unknown>[];
-        for (const row of existingRows) {
-          const id = row.id as string;
-          const text = row.text as string;
-          cachedVectors.set(`${id}::${text}`, Array.from(row.vector as ArrayLike<number>));
-        }
-      } catch {
-        // unreadable subset — embed everything fresh
+      for (const row of previousRows) {
+        const id = row.id as string;
+        const text = row.text as string;
+        cachedVectors.set(`${id}::${text}`, Array.from(row.vector as ArrayLike<number>));
       }
     }
 
@@ -1021,10 +1301,14 @@ export class VectorIndex {
       fullRecords[toEmbedIdx[i]] = { ...candidates[toEmbedIdx[i]], vector: newVectors[i] };
     }
 
-    if (predicate) await table.delete(predicate);
-    if (fullRecords.length > 0) {
-      await table.add(fullRecords as unknown as Record<string, unknown>[]);
-    }
+    await replaceRowsWithRestore(
+      table,
+      predicate,
+      fullRecords as unknown as Record<string, unknown>[],
+      previousRows,
+      markDegraded,
+    );
+    await publishMutationOrRestore();
     // Reclaim the versions this delete+add left behind (see index-compaction).
     await noteUpdateAndMaybeCompact(dbPath, table as unknown as Parameters<typeof noteUpdateAndMaybeCompact>[1]);
 
@@ -1063,7 +1347,10 @@ export class VectorIndex {
       throw new Error('Vector index not found. Run "openlore analyze --embed" first.');
     }
 
-    const dbPath = join(outputDir, DB_FOLDER);
+    const dbPath = dbPathFor(outputDir);
+    // readMeta owns the cross-process coherence check and invalidates the table
+    // and corpus handles before either can be reused.
+    const meta = readMeta(outputDir);
     let tableEntry = _tableCache.get(dbPath);
     if (!tableEntry) {
       quietNativeLoggingOnce();
@@ -1080,7 +1367,6 @@ export class VectorIndex {
     // Force BM25 when no embedder is available OR when the index was built
     // without embeddings (no `vector` column). The sidecar is the source of
     // truth: a missing sidecar (legacy index) is treated as embeddings-present.
-    const meta = readMeta(outputDir);
     const indexHasEmbeddings = meta === null ? true : meta.hasEmbeddings;
     if (!embedSvc || !indexHasEmbeddings) {
       return VectorIndex._bm25Only(table, dbPath, query, limit, language, minFanIn);
@@ -1247,7 +1533,7 @@ export class VectorIndex {
     outputDir: string,
     query: string,
   ): Promise<KeywordMissDiagnostics> {
-    const dbPath = join(outputDir, DB_FOLDER);
+    const dbPath = dbPathFor(outputDir);
     let cachedEntry = _bm25Cache.get(dbPath);
 
     if (!cachedEntry) {
@@ -1294,6 +1580,6 @@ export class VectorIndex {
    * Returns true if a vector index has been built for this output directory.
    */
   static exists(outputDir: string): boolean {
-    return existsSync(join(outputDir, DB_FOLDER));
+    return existsSync(dbPathFor(outputDir));
   }
 }

--- a/src/core/services/mcp-handlers/semantic-degraded.test.ts
+++ b/src/core/services/mcp-handlers/semantic-degraded.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const vector = vi.hoisted(() => ({
+  exists: vi.fn().mockReturnValue(true),
+  search: vi.fn(),
+  degradationNotice: vi.fn().mockReturnValue('Index degraded — re-run "openlore analyze".'),
+}));
+const textSearch = vi.hoisted(() => vi.fn());
+
+vi.mock('../../analyzer/vector-index.js', () => ({ VectorIndex: vector }));
+vi.mock('../../analyzer/text-line-index.js', () => ({
+  TextLineIndex: {
+    exists: vi.fn().mockReturnValue(true),
+    searchText: textSearch,
+  },
+}));
+vi.mock('../../analyzer/embedder.js', () => ({
+  resolveEmbedder: vi.fn().mockResolvedValue(null),
+  servedRetrievalMode: vi.fn().mockReturnValue('keyword'),
+}));
+vi.mock('../config-manager.js', () => ({ readOpenLoreConfig: vi.fn().mockResolvedValue(null) }));
+vi.mock('./utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./utils.js')>();
+  return {
+    ...actual,
+    validateDirectory: vi.fn(async (directory: string) => directory),
+    loadMappingIndex: vi.fn().mockResolvedValue(null),
+    readCachedContext: vi.fn().mockResolvedValue(null),
+  };
+});
+
+import { handleSearchCode, handleSuggestInsertionPoints } from './semantic.js';
+
+describe('vector-index degradation disclosure', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'openlore-degraded-search-'));
+    vector.search.mockReset().mockResolvedValue([{
+      score: 1,
+      record: {
+        id: 'src/a.ts::a', name: 'a', filePath: 'src/a.ts', className: '',
+        language: 'TypeScript', signature: '', docstring: '', fanIn: 1, fanOut: 0,
+        isHub: false, isEntryPoint: false, text: 'a',
+      },
+    }]);
+    textSearch.mockReset().mockResolvedValue([{
+      filePath: 'web/index.html', lineNumber: 12, text: 'literal banner', score: 1,
+    }]);
+  });
+
+  it('discloses degradation through search_code', async () => {
+    const result = await handleSearchCode(root, 'a') as Record<string, unknown>;
+    expect(result.indexDegraded).toBe('Index degraded — re-run "openlore analyze".');
+  });
+
+  it('discloses degradation through suggest_insertion_points', async () => {
+    const result = await handleSuggestInsertionPoints(root, 'add a') as Record<string, unknown>;
+    expect(result.indexDegraded).toBe('Index degraded — re-run "openlore analyze".');
+  });
+
+  it('discloses degradation when search_code falls back to literal text', async () => {
+    vector.search.mockResolvedValueOnce([]);
+    const result = await handleSearchCode(root, 'literal banner') as Record<string, unknown>;
+    expect(result.searchMode).toBe('text_fallback');
+    expect(result.indexDegraded).toBe('Index degraded — re-run "openlore analyze".');
+  });
+});

--- a/src/core/services/mcp-handlers/semantic.ts
+++ b/src/core/services/mcp-handlers/semantic.ts
@@ -236,6 +236,7 @@ export async function handleSearchCode(
     loadMappingIndex(absDir),
     readCachedContext(absDir),
   ]);
+  const indexDegraded = VectorIndex.degradationNotice?.(outputDir) ?? null;
 
   // Zero symbol hits: the string may live in static markup/text that extracts
   // no symbols (UI copy, error messages). Fall back to the literal-text line
@@ -248,7 +249,10 @@ export async function handleSearchCode(
       if (textFallback) {
         return withIndexStaleness(
           absDir,
-          textFallback,
+          {
+            ...textFallback,
+            ...(indexDegraded ? { indexDegraded } : {}),
+          },
           llmCtx,
           textFallback.results.map(hit => hit.filePath),
         );
@@ -332,6 +336,7 @@ export async function handleSearchCode(
       ? { resultsOmitted: omissionNote(budgeted.omitted, 'raise tokenBudget or narrow the query') }
       : {}),
     ...(specPeers.length > 0 ? { specLinkedFunctions: specPeers } : {}),
+    ...(indexDegraded ? { indexDegraded } : {}),
   };
   return withIndexStaleness(absDir, result, llmCtx);
 }
@@ -370,6 +375,7 @@ export async function handleSuggestInsertionPoints(
     VectorIndex.search(outputDir, description, embedSvc, { limit: limit * 4, language }),
     readCachedContext(absDir),
   ]);
+  const indexDegraded = VectorIndex.degradationNotice?.(outputDir) ?? null;
 
   // Normalise search scores to [0, 1] for compositeScore (scores are RRF/BM25: higher = better)
   const maxScore = rawResults.length > 0 ? Math.max(...rawResults.map((r) => r.score)) : 1;
@@ -455,6 +461,7 @@ export async function handleSuggestInsertionPoints(
     description,
     count: top.length,
     candidates: top,
+    ...(indexDegraded ? { indexDegraded } : {}),
     nextSteps:
       top.length > 0
         ? [

--- a/src/core/services/mcp-watcher-vector-cache.test.ts
+++ b/src/core/services/mcp-watcher-vector-cache.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const handlers = vi.hoisted(() => new Map<string, (...args: unknown[]) => void>());
+const spawn = vi.hoisted(() => vi.fn());
+const invalidate = vi.hoisted(() => vi.fn());
+const child = vi.hoisted(() => ({
+  once: vi.fn((event: string, handler: (...args: unknown[]) => void) => { handlers.set(event, handler); return child; }),
+  on: vi.fn((event: string, handler: (...args: unknown[]) => void) => { handlers.set(event, handler); return child; }),
+  unref: vi.fn(),
+  kill: vi.fn(),
+  exitCode: null,
+}));
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...await importOriginal<typeof import('node:child_process')>(),
+  spawn,
+}));
+vi.mock('../analyzer/vector-index.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../analyzer/vector-index.js')>(),
+  invalidateVectorIndexCaches: invalidate,
+}));
+
+import { McpWatcher } from './mcp-watcher.js';
+
+describe('McpWatcher vector-cache handoff after self rebuild', () => {
+  let root: string;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    root = mkdtempSync(join(tmpdir(), 'openlore-watch-vector-cache-'));
+    handlers.clear();
+    spawn.mockReset().mockReturnValue(child);
+    invalidate.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('invalidates caches after a successful child completion', () => {
+    const watcher = new McpWatcher({ rootPath: root, selfRebuild: true });
+    watcher._triggerGraphStaleForTesting('head-change');
+    vi.advanceTimersByTime(2_000);
+    handlers.get('close')?.(0);
+    expect(invalidate).toHaveBeenCalledWith(join(root, '.openlore', 'analysis'));
+  });
+
+  it('does not invalidate caches after a failed child completion', () => {
+    const watcher = new McpWatcher({ rootPath: root, selfRebuild: true });
+    watcher._triggerGraphStaleForTesting('head-change');
+    vi.advanceTimersByTime(2_000);
+    handlers.get('close')?.(1);
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -40,6 +40,7 @@ import { extractSignatures, detectLanguage } from '../analyzer/signature-extract
 import type { FunctionNode } from '../analyzer/call-graph.js';
 import { extractFileStyle, extractFileParseHealth } from '../analyzer/call-graph.js';
 import { assembleFromRegions, type StyleFingerprint, type FileStyleRaw } from '../analyzer/style-fingerprint.js';
+import { invalidateVectorIndexCaches } from '../analyzer/vector-index.js';
 import { buildParseHealthReport, type ParseHealthReport, type FileParseHealth } from '../analyzer/parse-health.js';
 import { parseBudgetOverrunMs } from '../analyzer/parse-budget.js';
 import { isTestFile } from '../analyzer/test-file.js';
@@ -909,7 +910,10 @@ export class McpWatcher {
         { cwd: this.rootPath, stdio: 'ignore', detached: true }
       );
       this.rebuildChildren.add(child);
-      child.once('close', () => this.rebuildChildren.delete(child));
+      child.once('close', (code) => {
+        this.rebuildChildren.delete(child);
+        if (code === 0) invalidateVectorIndexCaches(this.outputPath);
+      });
       child.on('error', (err) => {
         process.stderr.write(`[mcp-watcher] background rebuild failed to start (${err.message}) — run "openlore analyze".\n`);
       });
@@ -1007,7 +1011,10 @@ export class McpWatcher {
         { cwd: this.rootPath, stdio: 'ignore', detached: true }
       );
       this.rebuildChildren.add(child);
-      child.once('close', () => this.rebuildChildren.delete(child));
+      child.once('close', (code) => {
+        this.rebuildChildren.delete(child);
+        if (code === 0) invalidateVectorIndexCaches(this.outputPath);
+      });
       child.on('error', (err) => {
         this.graphRebuildRunning = false;
         process.stderr.write(`[mcp-watcher] background graph rebuild failed to start (${err.message}) — run "openlore analyze".\n`);


### PR DESCRIPTION
## Status
LGTM.

## What was wrong
A live MCP process could keep serving stale vector-index metadata, BM25 data, and LanceDB handles after another process rebuilt or incrementally mutated the index. Incremental delete/add failures could also drop rows without a durable search response warning, and a transient local extractor failure stayed memoized.

## How it was fixed
Vector-index metadata is now an atomic coherence commit point backed by stable stat checks and canonical cache identities. Full and incremental mutations share a cross-process lock; full builds publish the corpus before metadata; failed incremental publication or add operations restore prior rows. Unrestorable damage is persisted and disclosed by search handlers until a successful full rebuild. Watcher rebuild completion invalidates caches, and local extractor initialization retries after failure.

## Replication / proof
Regression tests cover warm-reader out-of-process rebuilds, BM25-vs-dense routing, same-row-count publication ordering, canonical path aliases, update and publication rollback, degraded marker persistence and handler disclosure including literal fallback, watcher rebuild invalidation, and extractor retry.

- npm run build
- npm run typecheck
- npm run lint
- npm run test:run: 411 files, 7,754 passed, 2 skipped
- npm run test:e2e: 20 files, 185 passed
- MCP payload budget: 54 passed
- Relevant archived analyzer and mcp-handlers specs validate strictly

## Notes / nits
Completed OpenSpec change harden-vector-index-coherence is archived as 2026-08-16-harden-vector-index-coherence. Repository-wide OpenSpec validation still reports two unrelated pre-existing invalid active changes; both affected baseline specs pass strict validation.