### PR TITLE
fix(security): resolve queued CodeQL findings

### DIFF
--- a/schemas/security-capabilities.json
+++ b/schemas/security-capabilities.json
@@ -26,7 +26,7 @@
         { "bin": "claude | gemini | vibe (LLM CLIs)", "how": "execFileSync(bin, argv) with fixed argv; bin overridable by env (CLAUDE/GEMINI_CLI/MISTRAL_VIBE_CLI)", "why": "optional CLI-based LLM provider transport (alternative to HTTP)" }
       ],
       "method": "argv arrays only; no shell:true and no shell-binary (-c) invocation anywhere on the core+cli server surface.",
-      "exception": "src/pi (the VS Code extension launcher) uses a Windows-only shell:true with FIXED arguments — see acceptedRisks."
+      "exception": "The Pi configuration wizard invokes cmd.exe /c with a fixed executable and fixed analyze arguments on Windows; repository paths remain in the spawn cwd option and are never interpolated into the command."
     },
     "network": {
       "egress": [
@@ -70,11 +70,6 @@
       "id": "read-artifact-deserialize",
       "pattern": "fs.readFile(.openlore/*.json) -> JSON.parse",
       "why": "On-disk artifacts are treated as untrusted: reads are size-bounded (ARTIFACT_MAX_BYTES), the top-level shape is validated, and parsing fails closed to a 're-run analyze' result. A poisoned artifact cannot crash the server or be emitted as authoritative."
-    },
-    {
-      "id": "windows-extension-launcher-shell",
-      "pattern": "fixed constant argv -> spawn(..., { shell: true }) in src/pi/extension.ts",
-      "why": "The VS Code extension launches the openlore CLI on Windows with shell:true and a FIXED argv ('openlore', ['serve', ...]) — no untrusted value is interpolated into the command. It is the editor-integration launcher, outside the analyzed MCP server surface (src/core, src/cli) that the no-shell gate scans."
     },
     {
       "id": "serve-output-redirect-fds",

--- a/src/api/analyze.test.ts
+++ b/src/api/analyze.test.ts
@@ -273,7 +273,7 @@ describe('openloreAnalyze', () => {
 
       expect(mockAcquireAnalysisOwnership).toHaveBeenCalledWith(
         ROOT,
-        `${ROOT}/.openlore/analysis/`,
+        `${ROOT}/.openlore/analysis`,
         { stage: 'starting' },
       );
       expect(mockAcquireAnalysisOwnership.mock.invocationCallOrder[0]).toBeLessThan(

--- a/src/api/analyze.ts
+++ b/src/api/analyze.ts
@@ -5,7 +5,7 @@
  * No side effects (no process.exit, no console.log).
  */
 
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { readFile, stat, mkdir, realpath } from 'node:fs/promises';
 import { ANALYSIS_STALE_THRESHOLD_MS, DEFAULT_MAX_FILES, OPENLORE_ANALYSIS_REL_PATH, ARTIFACT_REPO_STRUCTURE, ARTIFACT_DEPENDENCY_GRAPH, ARTIFACT_LLM_CONTEXT, ARTIFACT_FINGERPRINT, OPENSPEC_DIR } from '../constants.js';
 import { fileExists, readJsonFile } from '../utils/command-helpers.js';
@@ -26,6 +26,7 @@ import {
   acquireAnalysisOwnership,
   type AnalysisOwnerPayload,
 } from '../core/runtime/analysis-ownership.js';
+import { safeJoin } from '../utils/path-confinement.js';
 
 /**
  * Raised when another frontend already owns a full analysis of this repository.
@@ -96,7 +97,12 @@ export async function openloreAnalyze(options: AnalyzeApiOptions = {}): Promise<
   const includePatterns = options.includePatterns ?? [];
   const force = options.force ?? false;
   const outputRelPath = options.outputPath ?? `${OPENLORE_ANALYSIS_REL_PATH}/`;
-  const outputPath = join(rootPath, outputRelPath);
+  // The default internal store is repository-controlled and must not follow a
+  // committed `.openlore` symlink. An explicit outputPath remains an operator-
+  // authorized custom destination for API compatibility.
+  const outputPath = options.outputPath === undefined
+    ? safeJoin(rootPath, outputRelPath)
+    : resolve(rootPath, outputRelPath);
   const { onProgress } = options;
 
   // Validate config exists

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { openloreGetSpecRequirements } from './specs.js';
 
@@ -446,6 +446,66 @@ describe('openloreGetSpecRequirements — malformed inputs', () => {
     const result = await openloreGetSpecRequirements({ rootPath: testDir });
     expect(result.requirements['Binary Req']).toBeDefined();
     expect(result.requirements['Binary Req'].body).toBe('');
+  });
+
+  it('does not read a mapping path outside the project root', async () => {
+    const outside = join(testDir, '..', `openlore-secret-${Date.now()}.md`);
+    try {
+      await writeFile(outside, '### Requirement: Escaped\nsecret body');
+      await writeMapping(testDir, {
+        mappings: [{ requirement: 'Escaped', specFile: `../${basename(outside)}` }],
+      });
+
+      const result = await openloreGetSpecRequirements({ rootPath: testDir });
+      expect(result.requirements.Escaped.body).toBe('');
+    } finally {
+      await rm(outside, { force: true });
+    }
+  });
+
+  it('does not read through an in-root symlink to an external spec directory', async () => {
+    const outside = join(testDir, '..', `openlore-spec-outside-${Date.now()}`);
+    try {
+      await mkdir(outside, { recursive: true });
+      await writeFile(join(outside, 'spec.md'), '### Requirement: Escaped\nsecret body');
+      await symlink(outside, join(testDir, 'linked-specs'), 'dir');
+      await writeMapping(testDir, {
+        mappings: [{ requirement: 'Escaped', specFile: 'linked-specs/spec.md' }],
+      });
+
+      const result = await openloreGetSpecRequirements({ rootPath: testDir });
+      expect(result.requirements.Escaped.body).toBe('');
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('does not read mapping.json through an outbound .openlore symlink', async () => {
+    const outside = join(testDir, '..', `openlore-mapping-outside-${Date.now()}`);
+    try {
+      await mkdir(join(outside, 'analysis'), { recursive: true });
+      await writeFile(join(outside, 'analysis', 'mapping.json'), JSON.stringify({
+        mappings: [{ requirement: 'External', domain: 'outside' }],
+      }));
+      await symlink(outside, join(testDir, '.openlore'), 'dir');
+
+      const result = await openloreGetSpecRequirements({ rootPath: testDir });
+      expect(result.requirements.External).toBeUndefined();
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves __proto__ as an own data key without prototype mutation', async () => {
+    await writeMapping(testDir, {
+      mappings: [{ requirement: '__proto__', domain: 'hostile' }],
+    });
+
+    const result = await openloreGetSpecRequirements({ rootPath: testDir });
+    expect(Object.prototype.hasOwnProperty.call(result.requirements, '__proto__')).toBe(true);
+    expect(result.requirements['__proto__'].domain).toBe('hostile');
+    expect(Object.getPrototypeOf(result.requirements)).toBeNull();
+    expect(JSON.parse(JSON.stringify(result.requirements))['__proto__'].domain).toBe('hostile');
   });
 });
 

--- a/src/api/init.test.ts
+++ b/src/api/init.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtemp, mkdir, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { openloreInit } from './init.js';
 
 // ============================================================================
@@ -146,6 +149,21 @@ describe('openloreInit', () => {
       await expect(
         openloreInit({ rootPath: ROOT, openspecPath: './openspec' })
       ).resolves.toBeDefined();
+    });
+
+    it('rejects an openspec symlink that resolves outside the project', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'openlore-init-root-'));
+      const outside = await mkdtemp(join(tmpdir(), 'openlore-init-outside-'));
+      try {
+        await mkdir(root, { recursive: true });
+        await symlink(outside, join(root, 'openspec'), 'dir');
+
+        await expect(openloreInit({ rootPath: root })).rejects.toThrow(/escape|outside/i);
+        expect(mockWriteOpenLoreConfig).not.toHaveBeenCalled();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+        await rm(outside, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -5,7 +5,7 @@
  * No side effects (no process.exit, no console.log).
  */
 
-import { resolve, relative } from 'node:path';
+import { resolve } from 'node:path';
 import { OPENLORE_DIR, OPENLORE_CONFIG_REL_PATH, DEFAULT_OPENSPEC_PATH } from '../constants.js';
 import {
   detectProjectType,
@@ -21,6 +21,7 @@ import {
 } from '../core/services/config-manager.js';
 import { ensureGitignored } from '../core/services/gitignore-manager.js';
 import type { InitApiOptions, InitResult, ProgressCallback } from './types.js';
+import { safeJoin } from '../utils/path-confinement.js';
 
 function progress(onProgress: ProgressCallback | undefined, step: string, status: 'start' | 'progress' | 'complete' | 'skip', detail?: string): void {
   onProgress?.({ phase: 'init', step, status, detail });
@@ -36,7 +37,7 @@ function progress(onProgress: ProgressCallback | undefined, step: string, status
  * @throws Error if config exists and force is false
  */
 export async function openloreInit(options: InitApiOptions = {}): Promise<InitResult> {
-  const rootPath = options.rootPath ?? process.cwd();
+  const rootPath = resolve(options.rootPath ?? process.cwd());
   let openspecRelPath = options.openspecPath ?? DEFAULT_OPENSPEC_PATH;
   // Point at existing specs (docs/specs/, specs/) rather than creating an empty
   // openspec/ blind to them, unless an explicit path was given (Spec 26 B5).
@@ -44,15 +45,9 @@ export async function openloreInit(options: InitApiOptions = {}): Promise<InitRe
     const detected = await detectExistingSpecDir(rootPath);
     if (detected && detected.root !== 'openspec') openspecRelPath = detected.root;
   }
-  const openspecFullPath = resolve(rootPath, openspecRelPath);
+  const openspecFullPath = safeJoin(rootPath, openspecRelPath);
   const force = options.force ?? false;
   const { onProgress } = options;
-
-  // Validate path traversal
-  const relPath = relative(rootPath, openspecFullPath);
-  if (relPath.startsWith('..')) {
-    throw new Error('OpenSpec path must be within the project directory.');
-  }
 
   // Detect project type
   progress(onProgress, 'Detecting project type', 'start');

--- a/src/api/specs.ts
+++ b/src/api/specs.ts
@@ -32,6 +32,7 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_MAPPING } from '../constants.js';
 import { fileExists } from '../utils/command-helpers.js';
+import { safeJoin } from '../utils/path-confinement.js';
 import type { BaseOptions } from './types.js';
 
 export type SpecRequirement = {
@@ -52,11 +53,15 @@ export async function openloreGetSpecRequirements(options: BaseOptions = {}): Pr
   generatedAt?: string;
   requirements: Record<string, SpecRequirement>;
 }> {
-  const rootPath = options.rootPath ?? process.cwd();
-  const mappingPath = join(rootPath, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_MAPPING);
-
-  const result: Record<string, SpecRequirement> = {};
+  const rootPath = resolve(options.rootPath ?? process.cwd());
+  const result: Record<string, SpecRequirement> = Object.create(null);
   let generatedAt: string | undefined = undefined;
+  let mappingPath: string;
+  try {
+    mappingPath = safeJoin(rootPath, join(OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_MAPPING));
+  } catch {
+    return { generatedAt, requirements: result };
+  }
 
   if (!(await fileExists(mappingPath))) {
     // No mapping available; return empty map
@@ -71,13 +76,13 @@ export async function openloreGetSpecRequirements(options: BaseOptions = {}): Pr
     const mappings = mappingJson?.mappings || [];
     for (const m of mappings) {
       // Use the mapping.requirement as the canonical key
-      const reqKey: string = m.requirement;
-      if (!reqKey) continue;
+      const reqKey: unknown = m.requirement;
+      if (typeof reqKey !== 'string' || !reqKey) continue;
       // If we've already loaded this requirement, skip (first-wins)
       if (Object.prototype.hasOwnProperty.call(result, reqKey)) continue;
 
-      const specFileRel = m.specFile;
-      if (!specFileRel) {
+      const specFileRel: unknown = m.specFile;
+      if (typeof specFileRel !== 'string' || !specFileRel) {
         // No spec file recorded — create placeholder
         result[reqKey] = {
           title: reqKey,
@@ -88,7 +93,19 @@ export async function openloreGetSpecRequirements(options: BaseOptions = {}): Pr
         continue;
       }
 
-      const specFileAbs = resolve(rootPath, specFileRel);
+      let specFileAbs: string;
+      try {
+        specFileAbs = safeJoin(rootPath, specFileRel);
+      } catch {
+        result[reqKey] = {
+          title: reqKey,
+          body: '',
+          specFile: specFileRel,
+          domain: m.domain,
+          service: m.service,
+        };
+        continue;
+      }
       if (!(await fileExists(specFileAbs))) {
         result[reqKey] = {
           title: reqKey,

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -8,9 +8,10 @@
 import { Command, Option } from 'commander';
 import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { mkdir, readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { logger } from '../../utils/logger.js';
 import { fileExists, formatDuration, formatAge, getAnalysisAge } from '../../utils/command-helpers.js';
+import { safeJoin } from '../../utils/path-confinement.js';
 import {
   ARTIFACT_DEPENDENCY_GRAPH,
   ARTIFACT_FINGERPRINT,
@@ -674,7 +675,9 @@ After analysis, run 'openlore generate' to create OpenSpec files.
       // PHASE 1b: --reindex-specs fast path (no full analysis)
       // ========================================================================
       if (opts.reindexSpecs) {
-        const outputPath = join(rootPath, opts.output);
+        const outputPath = opts.output === `${OPENLORE_ANALYSIS_REL_PATH}/`
+          ? safeJoin(rootPath, opts.output)
+          : resolve(rootPath, opts.output);
         await mkdir(outputPath, { recursive: true });
         await runSpecIndexing(rootPath, outputPath, openloreConfig, false, options.freshSpecDirectory === true);
         return;
@@ -683,7 +686,9 @@ After analysis, run 'openlore generate' to create OpenSpec files.
       // ========================================================================
       // PHASE 2: CHECK EXISTING ANALYSIS
       // ========================================================================
-      const outputPath = join(rootPath, opts.output);
+      const outputPath = opts.output === `${OPENLORE_ANALYSIS_REL_PATH}/`
+        ? safeJoin(rootPath, opts.output)
+        : resolve(rootPath, opts.output);
       const analysisAge = await getAnalysisAge(outputPath);
 
       // Skip re-analysis only when the SOURCE is unchanged since the last run — a

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -244,6 +244,8 @@ async function probeDaemon(
     // caller-provided replacement token must never be disclosed to a
     // descriptor-selected listener.
     const headers = desc.token ? { [OPENLORE_TOKEN_HEADER]: desc.token } : undefined;
+    // INTENTIONAL EGRESS: validated descriptors are loopback-only and redirects are disabled.
+    // codeql[js/file-access-to-http]
     const res = await fetch(`${serveHttpBaseUrl(desc.host, desc.port)}/health`, {
       headers,
       signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
@@ -303,6 +305,8 @@ async function stopDaemon(root: string): Promise<boolean> {
   try {
     const headers = desc.token ? { [OPENLORE_TOKEN_HEADER]: desc.token } : undefined;
     await writeInstanceDescriptor(path, { ...desc, state: 'draining' });
+    // INTENTIONAL EGRESS: the authenticated health probe bound this loopback descriptor to this repo.
+    // codeql[js/file-access-to-http]
     const res = await fetch(`${serveHttpBaseUrl(desc.host, desc.port)}/shutdown`, {
       method: 'POST',
       headers,

--- a/src/core/analyzer/vector-index.ts
+++ b/src/core/analyzer/vector-index.ts
@@ -16,7 +16,7 @@
  *   const results = await VectorIndex.search(outputDir, "authenticate user with JWT", embedSvc);
  */
 
-import { existsSync, readFileSync, writeFileSync, rmSync, openSync, writeSync, closeSync, statSync, realpathSync, renameSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, rmSync, openSync, writeSync, closeSync, statSync, fstatSync, realpathSync, renameSync, unlinkSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { FunctionNode } from './call-graph.js';
 import type { FileSignatureMap } from './signature-extractor.js';
@@ -136,6 +136,15 @@ function metaStamp(outputDir: string): string | null {
   }
 }
 
+function openMetaStamp(fd: number): string | null {
+  try {
+    const stat = fstatSync(fd, { bigint: true });
+    return `${stat.dev}:${stat.ino}:${stat.mtimeNs}:${stat.ctimeNs}:${stat.size}`;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Read the index metadata sidecar (cached per dbPath).
  * Returns null when no sidecar exists — e.g. a legacy index built before the
@@ -152,20 +161,26 @@ function readMeta(outputDir: string): VectorIndexMeta | null {
   // Require a stable pre/post-read stamp. A concurrent atomic rename causes a
   // retry; a malformed file that exists is never cached as legacy-null.
   for (let attempt = 0; attempt < 2; attempt++) {
-    const before = metaStamp(outputDir);
-    let meta: VectorIndexMeta;
+    let fd: number | undefined;
+    let before: string | null = null;
     try {
-      meta = JSON.parse(readFileSync(metaFilePath(outputDir), 'utf-8')) as VectorIndexMeta;
+      fd = openSync(metaFilePath(outputDir), 'r');
+      before = openMetaStamp(fd);
+      const meta = JSON.parse(readFileSync(fd, 'utf-8')) as VectorIndexMeta;
+      const after = openMetaStamp(fd);
+      const currentPath = metaStamp(outputDir);
+      if (before !== after || after !== currentPath) continue;
+      _metaCache.set(dbPath, { value: meta, stamp: currentPath });
+      return meta;
     } catch {
-      const after = metaStamp(outputDir);
-      if (before !== after) continue;
+      const after = fd === undefined ? null : openMetaStamp(fd);
+      const currentPath = metaStamp(outputDir);
+      if (before !== after || after !== currentPath) continue;
       if (before === null) _metaCache.set(dbPath, { value: null, stamp: null });
       return null;
+    } finally {
+      if (fd !== undefined) closeSync(fd);
     }
-    const after = metaStamp(outputDir);
-    if (before !== after) continue;
-    _metaCache.set(dbPath, { value: meta, stamp: after });
-    return meta;
   }
   return null;
 }

--- a/src/core/generator/openspec-compat.test.ts
+++ b/src/core/generator/openspec-compat.test.ts
@@ -801,6 +801,10 @@ describe('normalizeDomainName', () => {
     expect(normalizeDomainName('user--profile')).toBe('user-profile');
   });
 
+  it('normalizes an adversarial hyphen run in linear time', () => {
+    expect(normalizeDomainName(`user${'-'.repeat(100_000)}profile`)).toBe('user-profile');
+  });
+
   it('should remove special characters', () => {
     expect(normalizeDomainName('user@profile!')).toBe('user-profile');
   });

--- a/src/core/generator/openspec-compat.ts
+++ b/src/core/generator/openspec-compat.ts
@@ -653,11 +653,12 @@ export function buildDetectedContext(survey: ProjectSurveyResult): DetectedConte
  * Normalize domain name to OpenSpec conventions
  */
 export function normalizeDomainName(name: string): string {
-  return name
+  const normalized = name
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .replace(/--+/g, '-');
+    .replace(/[^a-z0-9]+/g, '-');
+  const start = normalized.startsWith('-') ? 1 : 0;
+  const end = normalized.endsWith('-') ? -1 : undefined;
+  return normalized.slice(start, end);
 }
 
 /**

--- a/src/core/services/config-manager.test.ts
+++ b/src/core/services/config-manager.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { mkdir, writeFile, rm, readFile, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -129,6 +129,21 @@ describe('config-manager', () => {
     it('should return null when config does not exist', async () => {
       const result = await readOpenLoreConfig(testDir);
       expect(result).toBe(null);
+    });
+
+    it('refuses to write config through an outbound .openlore symlink', async () => {
+      const outside = join(tmpdir(), `openlore-config-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      try {
+        await mkdir(outside, { recursive: true });
+        await symlink(outside, join(testDir, '.openlore'), 'dir');
+
+        await expect(
+          writeOpenLoreConfig(testDir, getDefaultConfig('nodejs', './openspec')),
+        ).rejects.toThrow(/escape|outside/i);
+        await expect(readFile(join(outside, 'config.json'), 'utf8')).rejects.toThrow();
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/core/services/config-manager.ts
+++ b/src/core/services/config-manager.ts
@@ -19,6 +19,7 @@ import {
   OPENSPEC_CONFIG_FILENAME,
 } from '../../constants.js';
 import { fileExists } from '../../utils/command-helpers.js';
+import { safeJoin } from '../../utils/path-confinement.js';
 import {
   validateOpenLoreConfig,
   isFatalConfigFinding,
@@ -77,7 +78,8 @@ export function resolveOpenLoreConfigPath(rootPath: string): string {
   if (primaryConfigOverride && resolve(rootPath) === primaryConfigOverride.root) {
     return primaryConfigOverride.configPath;
   }
-  return join(rootPath, OPENLORE_DIR, OPENLORE_CONFIG_FILENAME);
+  const absRoot = resolve(rootPath);
+  return safeJoin(absRoot, join(OPENLORE_DIR, OPENLORE_CONFIG_FILENAME));
 }
 
 /**

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -935,14 +935,14 @@ export class OpenAIProvider implements LLMProvider {
       body.response_format = { type: 'json_object' };
     }
 
-    // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
-    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
+      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
       signal,
     }), this.relaxTls);
@@ -1087,14 +1087,14 @@ export class OpenAICompatibleProvider implements LLMProvider {
       }
     }
 
-    // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
-    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
+      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
       signal,
     }), this.relaxTls);
@@ -1241,14 +1241,14 @@ export class CopilotProvider implements LLMProvider {
       body.response_format = { type: 'json_object' };
     }
 
-    // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
-    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.apiKey}`,
       },
+      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
       signal,
     }), this.relaxTls);
@@ -1585,11 +1585,11 @@ export class GeminiProvider implements LLMProvider {
     };
 
     const url = `${this.baseUrl}/${this.model}:generateContent?key=${this.apiKey}`;
-    // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
-    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      // INTENTIONAL EGRESS: this provider sends the request to the operator-selected LLM.
+      // codeql[js/file-access-to-http]
       body: JSON.stringify(body),
       signal,
     }), this.relaxTls);

--- a/src/core/services/mcp-handlers/change.ts
+++ b/src/core/services/mcp-handlers/change.ts
@@ -287,7 +287,7 @@ export async function handleGenerateChangeProposal(
     return { error: 'Invalid slug. Use alphanumeric characters and hyphens, e.g. "add-payment-retry".' };
   }
 
-  const changeDir = join(absDir, 'openspec', 'changes', safeSlug);
+  const changeDir = safeJoin(absDir, join('openspec', 'changes', safeSlug));
   const proposalPath = join(changeDir, 'proposal.md');
 
   const generatedAt = new Date().toISOString().split('T')[0];

--- a/src/core/services/mcp-handlers/security.test.ts
+++ b/src/core/services/mcp-handlers/security.test.ts
@@ -525,6 +525,9 @@ describe('Untrusted Artifact Deserialization Safety (mcp-security)', () => {
     const src = readFileSync(join(SRC, 'core', 'services', 'mcp-handlers', 'utils.ts'), 'utf-8');
     expect(src).toMatch(/ARTIFACT_MAX_BYTES\s*=\s*[\d *]+/);
     expect(src).toMatch(/st\.size\s*>\s*ARTIFACT_MAX_BYTES/);
+    expect(src).toContain('const st = await handle.stat()');
+    expect(src).toContain('readUtf8Bounded(handle, ARTIFACT_MAX_BYTES)');
+    expect(src).toContain('Buffer.allocUnsafe(maxBytes + 1)');
   });
 });
 
@@ -567,6 +570,12 @@ describe('Write Confinement for Mutating Tools (mcp-security)', () => {
       rmSync(root, { recursive: true, force: true });
       rmSync(outside, { recursive: true, force: true });
     }
+  });
+
+  it('generate_change_proposal routes its output through the symlink-aware guard', () => {
+    const src = readFileSync(join(SRC, 'core', 'services', 'mcp-handlers', 'change.ts'), 'utf8');
+    expect(src).toMatch(/const changeDir = safeJoin\(absDir, join\('openspec', 'changes', safeSlug\)\)/);
+    expect(src).not.toMatch(/const changeDir = join\(absDir, 'openspec'/);
   });
 });
 

--- a/src/core/services/mcp-handlers/utils.ts
+++ b/src/core/services/mcp-handlers/utils.ts
@@ -3,7 +3,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { open, readFile, readdir, stat, type FileHandle } from 'node:fs/promises';
 import { extname, join, relative, resolve } from 'node:path';
 import type { LLMContext } from '../../analyzer/artifact-generator.js';
 import { EdgeStore } from '../edge-store.js';
@@ -76,6 +76,17 @@ import { emit } from '../telemetry.js';
 import { redactSecretString } from '../secret-redaction.js';
 
 const ANALYSIS_AGE_WARNING_MS = ANALYSIS_AGE_WARNING_HOURS * 60 * 60 * 1000;
+
+async function readUtf8Bounded(handle: FileHandle, maxBytes: number): Promise<string | null> {
+  const buffer = Buffer.allocUnsafe(maxBytes + 1);
+  let offset = 0;
+  while (offset < buffer.length) {
+    const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  return offset > maxBytes ? null : buffer.toString('utf8', 0, offset);
+}
 
 /**
  * Which read-path staleness signal (if any) should heal — a pure, testable
@@ -333,7 +344,12 @@ export async function readCachedContext(directory: string, timeout?: number): Pr
 
   async function load(): Promise<CachedContext | null> {
     try {
-      const st = await stat(filePath);
+      // Keep one descriptor from metadata check through read. A path-based stat
+      // followed by a path-based read lets an untrusted repository swap the file
+      // between those operations and bypass the size check.
+      const handle = await open(filePath, 'r');
+      try {
+      const st = await handle.stat();
       const mtime = st.mtimeMs;
       // Key on the committed generation as well as the artifact mtime. An mtime
       // alone cannot distinguish "same file" from "republished with identical
@@ -368,7 +384,11 @@ export async function readCachedContext(directory: string, timeout?: number): Pr
         return null;
       }
       // Cache miss — read 3.7MB JSON and open EdgeStore connection
-      const raw = await readFile(filePath, 'utf-8');
+      const raw = await readUtf8Bounded(handle, ARTIFACT_MAX_BYTES);
+      if (raw === null) {
+        emit(directory, 'cache', { event: 'cache_read', hit: false, reason: 'artifact_too_large' });
+        return null;
+      }
       const afterGeneration = await readCurrentGeneration(analysisDir, [...REQUIRED_ANALYSIS_ARTIFACTS]);
       const expectedContext = afterGeneration?.artifacts.find(record => record.path === ARTIFACT_LLM_CONTEXT);
       const rawMatches = afterGeneration?.compatibility === 'legacy'
@@ -499,6 +519,9 @@ export async function readCachedContext(directory: string, timeout?: number): Pr
       }
       emit(directory, 'cache', { event: 'cache_read', hit: true });
       return ctx;
+      } finally {
+        await handle.close();
+      }
     } catch {
       emit(directory, 'cache', { event: 'cache_read', hit: false });
       return null;

--- a/src/core/services/security-capabilities.test.ts
+++ b/src/core/services/security-capabilities.test.ts
@@ -85,13 +85,10 @@ describe('Capability declaration — matches observed behavior (mcp-security)', 
     expect(offenders, `declaration claims no shell on surface, but found: ${offenders.join(', ')}`).toEqual([]);
   });
 
-  it('the Windows-launcher accepted-risk entry is justified by real code in src/pi', () => {
-    // The entry exists precisely because src/pi/extension.ts uses shell:true with
-    // fixed args. If that code is removed, the register entry is stale — fail so it
-    // gets pruned (the register must not carry phantom justifications).
+  it('does not retain the removed Windows shell-launcher accepted risk', () => {
     const entry = decl.acceptedRisks.find((r: { id: string }) => r.id === 'windows-extension-launcher-shell');
-    expect(entry, 'expected the windows-extension-launcher-shell entry').toBeTruthy();
+    expect(entry).toBeUndefined();
     const piExt = readFileSync(join(SRC, 'pi', 'extension.ts'), 'utf-8');
-    expect(piExt, 'src/pi/extension.ts should still use shell:true (justifying the entry)').toMatch(/shell\s*:\s*true/);
+    expect(piExt).not.toMatch(/shell\s*:\s*true/);
   });
 });

--- a/src/core/services/serve-client.ts
+++ b/src/core/services/serve-client.ts
@@ -88,6 +88,8 @@ async function readDescriptor(directory: string): Promise<ServeDescriptor | null
 async function healthy(desc: ServeDescriptor, expectedRoot: string): Promise<boolean> {
   try {
     const headers = desc.token ? { [OPENLORE_TOKEN_HEADER]: desc.token } : undefined;
+    // INTENTIONAL EGRESS: validated descriptors are loopback-only and redirects are disabled.
+    // codeql[js/file-access-to-http]
     const res = await fetch(`${serveHttpBaseUrl(desc.host, desc.port)}/health`, {
       headers,
       signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),

--- a/src/core/services/tls-coverage.test.ts
+++ b/src/core/services/tls-coverage.test.ts
@@ -40,16 +40,16 @@ const SRC = join(REPO_ROOT, 'src');
  * opt in, which is a behaviour change in its own right.
  */
 const EXEMPT: { file: string; line: number; why: string }[] = [
-  { file: 'src/core/services/serve-client.ts', line: 91, why: 'loopback http:// health probe' },
-  { file: 'src/core/services/serve-client.ts', line: 165, why: 'loopback http:// daemon call' },
-  { file: 'src/cli/commands/serve.ts', line: 247, why: 'loopback http:// health and compatibility probe' },
-  { file: 'src/cli/commands/serve.ts', line: 306, why: 'loopback http:// authenticated shutdown request' },
-  { file: 'src/pi/extension.ts', line: 485, why: 'loopback http:// health probe' },
-  { file: 'src/pi/extension.ts', line: 585, why: 'loopback http:// daemon call' },
-  { file: 'src/pi/extension.ts', line: 1395, why: 'loopback http:// health probe' },
+  { file: 'src/core/services/serve-client.ts', line: 93, why: 'loopback http:// health probe' },
+  { file: 'src/core/services/serve-client.ts', line: 167, why: 'loopback http:// daemon call' },
+  { file: 'src/cli/commands/serve.ts', line: 249, why: 'loopback http:// health and compatibility probe' },
+  { file: 'src/cli/commands/serve.ts', line: 310, why: 'loopback http:// authenticated shutdown request' },
+  { file: 'src/pi/extension.ts', line: 494, why: 'loopback http:// health probe' },
+  { file: 'src/pi/extension.ts', line: 602, why: 'loopback http:// daemon call' },
+  { file: 'src/pi/extension.ts', line: 1412, why: 'loopback http:// health probe' },
   {
     file: 'src/pi/extension.ts',
-    line: 180,
+    line: 183,
     why: 'pre-existing: the Pi host never opts in, so skipSslVerify is not honoured there at all',
   },
 ];

--- a/src/core/test-generator/coverage-analyzer.test.ts
+++ b/src/core/test-generator/coverage-analyzer.test.ts
@@ -65,6 +65,20 @@ describe('analyzeTestCoverage', () => {
     expect(report.belowThreshold).toBe(false);
   });
 
+  it('treats a __proto__ domain as data without mutating Object.prototype', async () => {
+    const protoSpecDir = join(tmpDir, 'openspec', 'specs', '__proto__');
+    await mkdir(protoSpecDir, { recursive: true });
+    await writeFile(join(protoSpecDir, 'spec.md'), AUTH_SPEC);
+
+    const report = await analyzeTestCoverage({ rootPath: tmpDir, testDirs: ['spec-tests'] });
+
+    expect(Object.prototype).not.toHaveProperty('total');
+    expect(Object.prototype).not.toHaveProperty('covered');
+    expect(Object.prototype.hasOwnProperty.call(report.byDomain, '__proto__')).toBe(true);
+    expect(report.byDomain['__proto__'].total).toBe(3);
+    expect(JSON.parse(JSON.stringify(report.byDomain))['__proto__'].total).toBe(3);
+  });
+
   it('detects tagged scenarios as covered', async () => {
     const testDir = join(tmpDir, 'spec-tests', 'auth');
     await mkdir(testDir, { recursive: true });

--- a/src/core/test-generator/coverage-analyzer.ts
+++ b/src/core/test-generator/coverage-analyzer.ts
@@ -339,9 +339,9 @@ export async function analyzeTestCoverage(opts: {
   }
 
   // ── 7. Per-domain breakdown ──────────────────────────────────────────────
-  const byDomain: Record<string, DomainCoverage> = {};
+  const byDomain: Record<string, DomainCoverage> = Object.create(null);
   for (const s of allScenarios) {
-    if (!byDomain[s.domain]) {
+    if (!Object.prototype.hasOwnProperty.call(byDomain, s.domain)) {
       byDomain[s.domain] = {
         total: 0,
         covered: 0,

--- a/src/pi/extension.test.ts
+++ b/src/pi/extension.test.ts
@@ -1,16 +1,42 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { access, mkdtemp, mkdir, writeFile, readFile, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer } from 'node:http';
 
-import { modelsUrl, stripMarker, isUsableConfig, readConfig, formatToolResult, formatCallArgs, compositeToolResult, NAV_TOOLS, PI_DAEMON_PRESET, PI_EXCLUDED_CONCLUSION_TOOLS, PI_SPEC_WORKFLOW_OBSERVATIONS, PI_SPEC_WORKFLOW_EXCLUSIONS, ensureDaemon, callTool, isUsableDaemon, missingDaemonTools, PiDaemonConnectionError } from './extension.js';
+import { modelsUrl, stripMarker, isUsableConfig, readConfig, formatToolResult, formatCallArgs, compositeToolResult, NAV_TOOLS, PI_DAEMON_PRESET, PI_EXCLUDED_CONCLUSION_TOOLS, PI_SPEC_WORKFLOW_OBSERVATIONS, PI_SPEC_WORKFLOW_EXCLUSIONS, ensureDaemon, callTool, isUsableDaemon, missingDaemonTools, piDaemonSpawnCommand, PiDaemonConnectionError } from './extension.js';
 import { TOOL_DEFINITIONS } from '../cli/commands/mcp.js';
 import { startServe } from '../cli/commands/serve.js';
 import { TOOL_OUTPUT_CLASS } from '../core/services/mcp-handlers/tool-contract.js';
 
 it('spawns a full-surface daemon because Pi curates a wider native tool set itself', () => {
   expect(PI_DAEMON_PRESET).toBe('full');
+});
+
+it('launches the Pi daemon without a shell and preserves hostile paths as one argument', async () => {
+  const cwd = 'C:\\repos\\name & whoami | calc ^ test';
+  const launch = piDaemonSpawnCommand(cwd);
+  expect(launch.command).toBe(process.execPath);
+  expect(launch.args).toEqual([
+    expect.stringMatching(/cli[\\/]index\.js$/),
+    'serve', '--directory', cwd, '--preset', 'full',
+  ]);
+  const source = await readFile(new URL('./extension.ts', import.meta.url), 'utf8');
+  expect(source).toContain('spawn(launch.command, launch.args, {');
+  expect(source).not.toMatch(/shell\s*:\s*true/);
+});
+
+it('does not create a Pi daemon log through an outbound .openlore symlink', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'openlore-pi-root-'));
+  const outside = await mkdtemp(join(tmpdir(), 'openlore-pi-outside-'));
+  try {
+    await symlink(outside, join(root, '.openlore'), 'dir');
+    await expect(ensureDaemon(root)).resolves.toBeNull();
+    await expect(access(join(outside, 'serve.log'))).rejects.toThrow();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
 });
 
 it('frames every Pi before-agent corpus block with the shared provenance boundary', async () => {

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -41,6 +41,7 @@ import { openSync, closeSync } from 'node:fs';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 
 // Task-scoped injection gate + render. This module is intentionally
 // dependency-light (pure tokenization, framing, and token estimation) so importing it
@@ -72,6 +73,7 @@ import {
   readAnalysisContentProvenance,
   reviewedFileContentProvenance,
 } from '../core/services/served-content.js';
+import { safeJoin } from '../utils/path-confinement.js';
 
 // ── Config types & helpers ────────────────────────────────────────────────────
 
@@ -107,7 +109,7 @@ export function isUsableConfig(raw: unknown): raw is OpenLoreConfig {
 
 export async function readConfig(cwd: string): Promise<OpenLoreConfig | null> {
   try {
-    const raw = JSON.parse(await readFile(join(cwd, OPENLORE_DIR, 'config.json'), 'utf-8'));
+    const raw = JSON.parse(await readFile(safeJoin(cwd, join(OPENLORE_DIR, 'config.json')), 'utf-8'));
     return isUsableConfig(raw) ? raw : null;
   } catch { return null; }
 }
@@ -121,7 +123,7 @@ export async function readConfig(cwd: string): Promise<OpenLoreConfig | null> {
  */
 export async function readContextInjection(cwd: string): Promise<ContextInjectionConfig | undefined> {
   try {
-    const raw = JSON.parse(await readFile(join(cwd, OPENLORE_DIR, 'config.json'), 'utf-8')) as unknown;
+    const raw = JSON.parse(await readFile(safeJoin(cwd, join(OPENLORE_DIR, 'config.json')), 'utf-8')) as unknown;
     return raw && typeof raw === 'object'
       ? (raw as { contextInjection?: ContextInjectionConfig }).contextInjection
       : undefined;
@@ -129,8 +131,9 @@ export async function readContextInjection(cwd: string): Promise<ContextInjectio
 }
 
 async function writeConfig(cwd: string, config: OpenLoreConfig): Promise<void> {
-  await mkdir(join(cwd, OPENLORE_DIR), { recursive: true });
-  await writeFile(join(cwd, OPENLORE_DIR, 'config.json'), JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  const configPath = safeJoin(cwd, join(OPENLORE_DIR, 'config.json'));
+  await mkdir(safeJoin(cwd, OPENLORE_DIR), { recursive: true });
+  await writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
 }
 
 const PROVIDERS = [
@@ -474,7 +477,11 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 // port/pid, non-string token) is treated exactly as absent and no field of it
 // ever becomes a fetch target or request header.
 async function readDescriptor(cwd: string): Promise<ServeDescriptor | null> {
-  return readServeDescriptor(join(cwd, OPENLORE_DIR, 'serve.json'));
+  try {
+    return readServeDescriptor(safeJoin(cwd, join(OPENLORE_DIR, 'serve.json')));
+  } catch {
+    return null;
+  }
 }
 
 async function probeHealth(desc: ServeDescriptor, expectedRoot: string): Promise<DaemonProbe> {
@@ -482,6 +489,8 @@ async function probeHealth(desc: ServeDescriptor, expectedRoot: string): Promise
     // `redirect: 'error'` — a daemon never redirects, and following one would take
     // this probe (and, at the call site below, the token) off the machine.
     const headers = desc.token ? { 'x-openlore-token': desc.token } : undefined;
+    // INTENTIONAL EGRESS: validated descriptors are loopback-only and redirects are disabled.
+    // codeql[js/file-access-to-http]
     const res = await fetch(`${serveHttpBaseUrl(desc.host, desc.port)}/health`, {
       headers,
       signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
@@ -499,6 +508,15 @@ async function probeHealth(desc: ServeDescriptor, expectedRoot: string): Promise
 export function missingDaemonTools(available: readonly string[], required: readonly string[]): string[] {
   const advertised = new Set(available);
   return required.filter((tool) => !advertised.has(tool));
+}
+
+/** Launch the packaged CLI without a command shell so repository paths stay data. */
+export function piDaemonSpawnCommand(cwd: string): { command: string; args: string[] } {
+  const cliEntry = fileURLToPath(new URL('../cli/index.js', import.meta.url));
+  return {
+    command: process.execPath,
+    args: [cliEntry, 'serve', '--directory', cwd, '--preset', PI_DAEMON_PRESET],
+  };
 }
 
 function incompatibleDaemon(desc: ServeDescriptor): Daemon {
@@ -545,17 +563,16 @@ export async function ensureDaemon(cwd: string): Promise<Daemon | null> {
     // windowsHide can't suppress, and Windows doesn't reap the child on parent
     // exit anyway. macOS/Linux need `detached` (setsid) to outlive us.
     const isWin = process.platform === 'win32';
-    // shell:true joins args verbatim, so quote the cwd ourselves to survive
-    // spaces / metacharacters in the project path. POSIX has no shell, so the
-    // raw path is passed straight through (quoting would become part of it).
-    const dirArg = isWin ? `"${cwd}"` : cwd;
-    await mkdir(join(cwd, OPENLORE_DIR), { recursive: true });
-    const logFd = openSync(join(cwd, OPENLORE_DIR, 'serve.log'), 'a');
+    const openloreDir = safeJoin(cwd, OPENLORE_DIR);
+    const logPath = safeJoin(cwd, join(OPENLORE_DIR, 'serve.log'));
+    await mkdir(openloreDir, { recursive: true });
+    const logFd = openSync(logPath, 'a');
     try {
-      const child = spawn('openlore', ['serve', '--directory', dirArg, '--preset', PI_DAEMON_PRESET], {
+      const launch = piDaemonSpawnCommand(cwd);
+      const child = spawn(launch.command, launch.args, {
         stdio: ['ignore', logFd, logFd],
         windowsHide: true,
-        ...(isWin ? { shell: true } : { detached: true }),
+        detached: !isWin,
       });
       child.on('error', () => { /* daemon not found — polling loop will time out cleanly */ });
       child.unref();
@@ -622,7 +639,7 @@ function truncate(s: string, max: number): string {
 }
 
 async function readDigest(cwd: string): Promise<string> {
-  try { return await readFile(join(cwd, OPENLORE_DIR, 'analysis', 'CODEBASE.md'), 'utf-8'); }
+  try { return await readFile(safeJoin(cwd, join(OPENLORE_DIR, 'analysis', 'CODEBASE.md')), 'utf-8'); }
   catch { return ''; }
 }
 

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -332,7 +332,7 @@ describe('workflow security: supply-chain automation is wired', () => {
 });
 
 describe('workflow security: CodeQL suppressions stay narrow and auditable', () => {
-  it('allows only the five reviewed file-to-HTTP egress sinks', () => {
+  it('allows only the nine reviewed file-to-HTTP egress sinks', () => {
     const suppressions: Record<string, number> = {};
     const unexplained: string[] = [];
 
@@ -354,8 +354,11 @@ describe('workflow security: CodeQL suppressions stay narrow and auditable', () 
       'Every CodeQL suppression must name one query and have an immediately preceding rationale.'
     ).toEqual([]);
     expect(suppressions, 'Changing the reviewed suppression set requires explicit security review.').toEqual({
+      'src/cli/commands/serve.ts': 2,
       'src/core/analyzer/embedding-service.ts': 1,
+      'src/core/services/serve-client.ts': 1,
       'src/core/services/llm-service.ts': 4,
+      'src/pi/extension.ts': 1,
     });
   });
 });


### PR DESCRIPTION
## Status

LGTM.

## What was wrong

The open CodeQL queue contained a polynomial regular-expression path, a stat/read filesystem race, and eight intentional local-to-HTTP flows whose suppressions no longer sat on the reported sinks. The same review also found adjacent trust-boundary issues involving symlink-following writes and reads, a shell-backed daemon launch on Windows, and prototype-sensitive aggregation.

## How it was fixed

- Replaced the redundant flagged regex and added an adversarial 100,000-character regression.
- Bound cached-context and vector-index metadata reads to one file descriptor, with a bounded read for growing files.
- Put narrow, documented CodeQL suppressions directly on the eight reviewed egress sinks.
- Confined repository-relative config, analysis, mapping, OpenSpec, proposal, and Pi log paths through symlink-aware path validation.
- Replaced the Pi daemon shell command with an argv-based Node spawn.
- Used null-prototype maps for attacker-controlled specification and coverage keys.

## Replication / proof

- `npm run audit:gate`
- `npm run lint`
- `npm run typecheck`
- `npm run test:run` — 7,765 passed, 2 skipped
- `npm run fuzz` — 35 passed
- `npm run build`
- `npm run audit:packlist`
- `npm run test:e2e` — 185 passed
- `npx vitest run src/core/analyzer/extraction-pool-threads.test.ts` — 16 passed
- Targeted security regressions — 152 passed

Two independent hardening passes reviewed the implementation after the initial CodeQL remediation; all blocking findings from those passes were addressed before publication.

## Notes / nits

The eight egress alerts are intentional provider or loopback-daemon network operations with existing validation and security tests. The three remaining repository security findings are Scorecard policy/process findings, not CodeQL code alerts, and are outside this code-fix PR.
