### PR TITLE
fix(security): harden trust and release boundaries

### DIFF
--- a/.github/actions/openlore-review/action.yml
+++ b/.github/actions/openlore-review/action.yml
@@ -35,10 +35,6 @@ inputs:
     description: 'Run `openlore analyze` before the review so the blast radius is fully populated.'
     required: false
     default: 'true'
-  openlore-version:
-    description: 'npm version/tag of openlore to run (e.g. "latest", "2.1.4").'
-    required: false
-    default: 'latest'
   gate:
     description: 'Pass `--hook` so a configured blastRadius.block pattern fails the job (opt-in gating).'
     required: false
@@ -47,30 +43,48 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Require a resolved OpenLore version pin
-      shell: bash
-      env:
-        OPENLORE_VERSION: ${{ inputs.openlore-version }}
-      run: |
-        if [[ "$OPENLORE_VERSION" == REPLACE_WITH_* ]]; then
-          echo "openlore-version is still a placeholder; pin the reviewed release that matches this Action revision." >&2
-          exit 2
-        fi
-
     - name: Set up Node
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
-        node-version: '22'
+        node-version: '24'
+
+    - name: Build the SHA-pinned OpenLore Action source
+      id: openlore
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        NPM_CONFIG_CACHE: ${{ runner.temp }}/openlore-npm-cache
+        NPM_CONFIG_GLOBALCONFIG: ${{ runner.temp }}/openlore-empty-global-npmrc
+        NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+        NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/'
+        NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/openlore-empty-user-npmrc
+      run: |
+        : > "$NPM_CONFIG_GLOBALCONFIG"
+        : > "$NPM_CONFIG_USERCONFIG"
+        ACTION_REPO_ROOT="$(cd "$ACTION_PATH/../../.." && pwd -P)"
+        if [ ! -f "$ACTION_REPO_ROOT/package-lock.json" ]; then
+          echo "The SHA-pinned OpenLore Action checkout has no package-lock.json." >&2
+          exit 2
+        fi
+        cd "$ACTION_REPO_ROOT"
+        npm ci --ignore-scripts --no-audit --no-fund --registry=https://registry.npmjs.org/
+        npm run build
+        CLI="$ACTION_REPO_ROOT/dist/cli/index.js"
+        if [ ! -f "$CLI" ]; then
+          echo "The SHA-pinned OpenLore Action source did not build dist/cli/index.js." >&2
+          exit 2
+        fi
+        echo "cli=$CLI" >> "$GITHUB_OUTPUT"
 
     - name: Build the OpenLore index (optional, for full blast radius)
       id: analyze
       if: ${{ inputs.analyze == 'true' }}
       shell: bash
       env:
-        OPENLORE_VERSION: ${{ inputs.openlore-version }}
+        OPENLORE_CLI: ${{ steps.openlore.outputs.cli }}
       run: |
         set +e
-        npx --yes "openlore@$OPENLORE_VERSION" analyze --no-embed
+        node "$OPENLORE_CLI" analyze --no-embed
         RC=$?
         set -e
         if [ "$RC" -ne 0 ]; then
@@ -84,7 +98,7 @@ runs:
       id: review
       shell: bash
       env:
-        OPENLORE_VERSION: ${{ inputs.openlore-version }}
+        OPENLORE_CLI: ${{ steps.openlore.outputs.cli }}
         REVIEW_BASE: ${{ inputs.base }}
         REVIEW_HEAD: ${{ inputs.head }}
         REVIEW_GATE: ${{ inputs.gate }}
@@ -95,7 +109,7 @@ runs:
         ARGS=(review --base "$REVIEW_BASE" --head "$REVIEW_HEAD" --format markdown --out "$OUT")
         if [ "$REVIEW_GATE" = "true" ]; then ARGS+=(--hook); fi
         set +e
-        npx --yes "openlore@$OPENLORE_VERSION" "${ARGS[@]}"
+        node "$OPENLORE_CLI" "${ARGS[@]}"
         RC=$?
         set -e
         # Exit 3 is the review CLI's reserved policy-gate receipt. Defer that failure
@@ -111,7 +125,7 @@ runs:
           fi
         fi
         if [ ! -s "$OUT" ]; then
-          echo "openlore review produced no briefing — the published 'openlore' (openlore-version: $OPENLORE_VERSION) may not yet ship the 'review' command, or the base..head range was unreachable. Skipping the comment (advisory)."
+          echo "openlore review produced no briefing — the SHA-pinned Action source may not ship the 'review' command, or the base..head range was unreachable. Skipping the comment (advisory)."
         fi
 
     - name: Post or update the sticky review comment

--- a/.github/workflows/openlore-review.yml.example
+++ b/.github/workflows/openlore-review.yml.example
@@ -8,10 +8,9 @@
 # Requirements: a full-history checkout (`fetch-depth: 0`) so the base..head range is
 # reachable, and write permission on pull-request comments.
 #
-# This example is deliberately non-runnable until both placeholders below are replaced
-# with the synchronized immutable Action commit and package release containing this
-# hardening. The composite rejects an unresolved package placeholder instead of silently
-# running an older renderer with a write-capable token.
+# This example is deliberately non-runnable until the placeholder below is replaced
+# with a reviewed immutable Action commit containing this hardening. The composite builds
+# that revision with its committed lockfile instead of resolving OpenLore by a mutable npm selector.
 #
 # Fork PRs: GitHub hands a READ-ONLY `GITHUB_TOKEN` to `pull_request` runs triggered from a
 # fork, so this job cannot post the sticky comment for external contributors. Do NOT switch
@@ -27,8 +26,8 @@
 # repository/event/conclusion from trusted run metadata, derive the PR number from that metadata
 # (never the artifact), clamp the body, and normalize exactly one leading sticky marker before
 # posting with its own `github-script`; this composite's post step is pull_request-only. Treat the
-# artifact as untrusted data. Pin the Action and `openlore-version` to reviewed immutable releases
-# whenever a write-capable token is in scope.
+# artifact as untrusted data. Pin the Action to a reviewed immutable commit whenever a
+# write-capable token is in scope.
 
 name: OpenLore review
 
@@ -55,13 +54,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }} # analyze the same head passed to review
           persist-credentials: false # never leave the write-capable token in the head checkout
 
-      # Replace both placeholders with the first reviewed release/commit that contains this
-      # hardening. They intentionally fail closed instead of silently selecting a pre-fix build.
+      # Replace the placeholder with the first reviewed commit that contains this hardening.
+      # The Action builds that exact revision with its committed dependency lockfile.
       - uses: clay-good/OpenLore/.github/actions/openlore-review@REPLACE_WITH_REVIEWED_COMMIT_SHA
         with:
           # github-token: ${{ secrets.GITHUB_TOKEN }}   # default; uncomment to override
           # base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}
           analyze: 'true'            # build the index for the full blast radius
-          openlore-version: 'REPLACE_WITH_REVIEWED_RELEASE'
           gate: 'false'              # 'true' = fail the job on a configured blastRadius.block pattern

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Release
 # (OIDC) — no long-lived NPM_TOKEN required. See docs/publishing.md for the
 # one-time setup steps on the npmjs.com side.
 #
-# Triggers (any of these runs validate → [create GitHub Release] → publish):
+# Triggers (any of these runs validate/build/pack → [create GitHub Release] → publish):
 #   - push of a `v*` tag  — the normal path. Pushing the tag auto-creates the
 #     GitHub Release (with generated notes) and publishes to npm in one run.
 #   - a GitHub Release published manually in the UI — the create-release job is
@@ -49,6 +49,8 @@ jobs:
           # workflow_dispatch → the explicitly-named tag.
           # push (tag) and release events → github.ref already points at the tag.
           ref: ${{ github.event.inputs.tag || github.ref }}
+          fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -82,6 +84,26 @@ jobs:
           fi
           echo "Tag '$TAG' matches package.json version '$PKG'."
 
+      # A tag is not a reviewed release boundary by itself: a collaborator could tag
+      # an off-main commit and bypass branch protection. Require both a real tag at
+      # this checkout and ancestry from the protected default branch.
+      - name: Verify release commit is reachable from main
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          TAG_REF="refs/tags/$RELEASE_TAG^{commit}"
+          TAG_COMMIT="$(git rev-parse --verify "$TAG_REF")"
+          CHECKED_OUT_COMMIT="$(git rev-parse HEAD)"
+          if [ "$TAG_COMMIT" != "$CHECKED_OUT_COMMIT" ]; then
+            echo "::error::Checked-out commit $CHECKED_OUT_COMMIT does not match tag $RELEASE_TAG ($TAG_COMMIT)."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" refs/remotes/origin/main; then
+            echo "::error::Release tag $RELEASE_TAG points to a commit that is not reachable from origin/main."
+            exit 1
+          fi
+
       - name: Run linting
         run: npm run lint
 
@@ -91,8 +113,37 @@ jobs:
       - name: Run tests
         run: npm run test:run
 
+      - name: Audit dependencies
+        run: npm run audit:gate
+
       - name: Build
         run: npm run build
+
+      - name: Verify the published tarball contents
+        run: npm run audit:packlist
+
+      # Build the exact immutable input consumed by the OIDC job. Dependency
+      # installation, tests, builds, and package scripts stay in this read-only job.
+      - name: Pack the npm release artifact
+        run: |
+          npm pack --json
+          shopt -s nullglob
+          packages=(openlore-*.tgz)
+          if [ "${#packages[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one npm tarball, found ${#packages[@]}."
+            exit 1
+          fi
+          sha256sum "${packages[0]}" > openlore-package.sha256
+
+      - name: Upload the npm release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-package
+          path: |
+            openlore-*.tgz
+            openlore-package.sha256
+          if-no-files-found: error
+          retention-days: 1
 
   create-release:
     name: Create GitHub Release
@@ -167,33 +218,35 @@ jobs:
       url: https://www.npmjs.com/package/openlore
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # This job deliberately has no checkout, dependency install, build, or package
+      # lifecycle execution. Only the tarball produced by the no-OIDC validation job
+      # crosses into the trusted-publishing boundary.
+      - name: Download the npm release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
-          # Publishing authenticates via OIDC, never via the git-stored token.
-          persist-credentials: false
+          name: npm-package
+          path: release-artifact
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
-          cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      # Last gate before the one step that cannot be undone. CI already ran this on
-      # the PR, but the tarball is assembled from THIS checkout of THIS tag, so the
-      # only assertion that counts is the one made against the artifact about to be
-      # uploaded.
-      - name: Verify the published tarball contents
-        run: npm run audit:packlist
+      - name: Verify the npm release artifact
+        working-directory: release-artifact
+        run: sha256sum --check openlore-package.sha256
 
       # No NODE_AUTH_TOKEN — npm picks up the OIDC token automatically when
       # `id-token: write` is set and the package is configured for Trusted
       # Publishing on npmjs.com. --provenance attaches a signed attestation
       # linking this build to this repo + this workflow run.
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        working-directory: release-artifact
+        run: |
+          shopt -s nullglob
+          packages=(openlore-*.tgz)
+          if [ "${#packages[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one npm tarball, found ${#packages[@]}."
+            exit 1
+          fi
+          npm publish "${packages[0]}" --ignore-scripts --provenance --access public

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,15 +47,15 @@ is not a safety guarantee and does not block by default.
 
 ## Automated checks
 
-Every pull request and release runs these:
+Automated controls cover pull requests, scheduled scans, and releases:
 
 - **Dependency advisories** — the full tree (runtime and development) is gated at high severity.
 - **CodeQL** static analysis on each pull request and on a weekly schedule.
 - **Published-package contents** are verified against the real `npm pack` manifest, in CI and again immediately before publish.
-- **Workflow hardening** — GitHub Actions are pinned to immutable commit SHAs, and a test in the unit suite keeps them pinned.
+- **Workflow hardening** — GitHub Actions are pinned to immutable commit SHAs, and a test in the unit suite keeps them pinned. The structural-review Action builds that pinned source with its committed lockfile, an isolated npm configuration, and lifecycle scripts disabled; it does not resolve OpenLore through a runtime npm selector.
 - **Dependabot** watches both npm packages and GitHub Actions.
 - **OpenSSF Scorecard** tracks supply-chain posture weekly.
-- **Releases** are published with npm Trusted Publishing (short-lived OIDC, no long-lived token) and carry a signed `--provenance` attestation tying each tarball to the commit and workflow run that built it.
+- **Releases** build, test, audit, and pack in a job without OIDC. A separate minimal job receives only that integrity-checked tarball, publishes it with npm Trusted Publishing (short-lived OIDC, no long-lived token), and attaches a signed `--provenance` attestation.
 
 Two conventions to follow when changing anything under `.github/`:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -425,18 +425,21 @@ it shows the structural delta and says "run `openlore analyze`"; a non-git direc
 base is disclosed rather than emitted as a misleading empty briefing. The structural delta works
 without an index (it builds the old/new graphs from just the changed files).
 
-**GitHub Action.** The repo ships `.github/actions/openlore-review` (composite action: checkout →
-`openlore analyze` → `openlore review` → one sticky comment matched by a hidden `<!-- openlore-review -->`
-marker, created once and updated in place — duplicate-proof via paginated comment lookup) and a
-copy-paste workflow (`.github/workflows/openlore-review.yml.example`). Adoption is one file; it needs a
-full-history checkout (`fetch-depth: 0`) and `pull-requests: write` permission. The Action runs
-`npx openlore@<version>`, so it activates once a **published** `openlore` ships `review` (until then it
-no-ops gracefully — no comment, the check stays green). Advisory by default; gate mode fails the job
+**GitHub Action.** The repo ships `.github/actions/openlore-review` (composite action: build the
+SHA-pinned Action source with its committed lockfile → `openlore analyze` → `openlore review` → one
+sticky comment matched by a hidden `<!-- openlore-review -->` marker, created once and updated in
+place — duplicate-proof via paginated comment lookup) and a copy-paste workflow
+(`.github/workflows/openlore-review.yml.example`). Adoption is one file; it needs a full-history
+checkout (`fetch-depth: 0`) and `pull-requests: write` permission. Dependencies are installed with
+`npm ci` from the reviewed Action revision in an isolated npm configuration with lifecycle scripts
+disabled; the Action does not resolve or execute a mutable `openlore` npm selector. Advisory by
+default; gate mode fails the job
 **only** when the briefing was produced and a configured `blastRadius.block` pattern fired (a missing
 `openlore`/`review` or an unreachable range never produces a false-positive red check). A comment-post
 failure never fails the check either: on a **fork PR** GitHub gives `pull_request` a read-only token, so
 the comment can't be posted for external contributors — the Action warns and leaves the briefing in the
-job log (use `pull_request_target`, with its security trade-offs, if you need the comment on fork PRs).
+job log. Do not combine `pull_request_target` with a checkout of the pull-request head; use a split
+unprivileged analysis workflow and trusted artifact-posting workflow if fork comments are required.
 The briefing is always clamped to GitHub's 65,536-char comment limit.
 
 ### Federation (multi-repo)

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -9,9 +9,9 @@ The CI workflow that does the publish lives at [.github/workflows/release.yml](.
 1. Bump the version locally: `npm version <patch|minor|major>` (this creates a `vX.Y.Z` tag).
 2. `git push --follow-tags` to push both the bump commit and the tag.
 3. That's it. Pushing the tag triggers the `Release` workflow, which:
-   - `validate` — re-runs `lint`, `typecheck`, `test:run`, `build` against the tagged commit.
+   - `validate` — verifies the tag is reachable from `main`, re-runs `lint`, `typecheck`, `test:run`, the dependency audit, and `build`, then packs and uploads the exact npm tarball from a job with no OIDC permission.
    - `create-release` — creates the GitHub Release for the tag with auto-generated notes (idempotent: skipped if a Release for that tag already exists). Created with `GITHUB_TOKEN`, so it does **not** re-trigger the workflow.
-   - `publish` — re-builds and runs `npm publish --provenance --access public`. No token; the OIDC handshake with npm authenticates the run.
+   - `publish` — downloads and integrity-checks that tarball, then runs `npm publish <tarball> --ignore-scripts --provenance --access public`. It does not check out source, install dependencies, build, or run package lifecycle scripts. No token; the OIDC handshake with npm authenticates the run.
 
 If the `npm-publish` environment has a required reviewer, the `publish` job pauses for a human approval click before it can mint the OIDC token.
 
@@ -41,7 +41,7 @@ Sign in to npmjs.com as a maintainer of the `openlore` package, then:
 - Repo → **Settings → Environments → New environment**
 - Name: `npm-publish`
 - (Optional but recommended) Add a **required reviewer** so every publish requires a human approval click before the workflow can mint an OIDC token.
-- (Optional) Restrict to the `main` branch under **Deployment branches**.
+- Restrict deployments to protected release tags under **Deployment branches and tags**. Also protect `v*` tag creation, update, and deletion with a repository ruleset; the workflow independently rejects a release commit that is not reachable from `main`.
 
 ### 3. Revoke any existing npm automation tokens
 
@@ -65,7 +65,7 @@ The attestation includes the GitHub workflow file, the commit SHA, and the run I
 
 ## Why Trusted Publishing matters
 
-Long-lived publish tokens are the supply-chain attacker's favorite target — they bypass 2FA, often live in CI secret stores indefinitely, and have been exploited by worms like Shai-Hulud. Trusted Publishing replaces the token with a short-lived OIDC token minted per-workflow-run, scoped to a specific repo + workflow file + environment. There's nothing useful to steal even if a CI runner is compromised.
+Long-lived publish tokens are the supply-chain attacker's favorite target — they bypass 2FA, often live in CI secret stores indefinitely, and have been exploited by worms like Shai-Hulud. Trusted Publishing replaces the token with a short-lived OIDC token minted per-workflow-run, scoped to a specific repo + workflow file + environment. The workflow further limits exposure by keeping dependency installation, builds, and package scripts out of the OIDC-enabled job; that job receives only the already-built, integrity-checked tarball.
 
 ## Troubleshooting
 

--- a/docs/shareable-bundle.md
+++ b/docs/shareable-bundle.md
@@ -110,9 +110,10 @@ since a rebuild is a successful outcome, not an error. A genuine *user* error ex
 that doesn't exist, a file that isn't an OpenLore bundle at all (wrong path / not a `.olbundle`), or `export`
 run before `openlore analyze` (no index to bundle). These are clean errors, never a silent rebuild.
 
-**Untrusted-input safety.** A `.olbundle` is treated as untrusted on-disk input. Import bounds the
-decompressed artifact (2 GiB cap) and fails closed on anything larger — a crafted bundle cannot exhaust
-memory (zip-bomb guard). Every bundled file name must be a plain basename: a payload entry containing a path
+**Untrusted-input safety.** A `.olbundle` is treated as untrusted on-disk input. Import rejects a file over
+64 MiB before reading it and caps decompression at 96 MiB — about 1.7× the 58,717,652-byte expanded
+bundle measured for this repository — so a crafted bundle cannot expand without bound
+(compression-bomb guard). Every bundled file name must be a plain basename: a payload entry containing a path
 separator, `..`, or an absolute path is **rejected before anything is written to disk** (no path-traversal
 arbitrary write), and the manifest's file list must exactly match the payload it describes. The graph itself
 (`call-graph.db`) is validated against the attestation's content digest; the remaining bundled artifacts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,6 +1172,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+      "integrity": "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1189,6 +1190,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1215,6 +1217,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+      "integrity": "sha512-/V5hGHE4Zq+jG0GtwIB9PyBUOGd6gBLZ7lkQYFKchKnxYHeH3rmWC5xw4kpnZKKBuBuFTdLVbU9vEjlAGMMb2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1227,6 +1230,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+      "integrity": "sha512-Ox1pciyeSPGEEUcxvR0/dJcrY7C6hrEGA8y71rOsvSIUlXN1Cbp/be/eoL71OGDBk5O97TeQPfWN6Ju/2Ehjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1239,6 +1243,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1248,6 +1253,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -80,6 +80,18 @@ async function runDoctorJson(): Promise<Array<{ name: string; status: string; de
   return JSON.parse(jsonLine!);
 }
 
+async function runDoctorText(): Promise<string> {
+  doctorCommand.setOptionValue('json', false);
+  const outputs: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((msg: string) => { outputs.push(String(msg)); });
+  try {
+    await doctorCommand.parseAsync([], { from: 'user' });
+  } finally {
+    spy.mockRestore();
+  }
+  return outputs.join('\n');
+}
+
 // ============================================================================
 // TESTS
 // ============================================================================
@@ -224,7 +236,14 @@ describe('doctor command', () => {
 
   // --------------------------------------------------------------------------
   describe('LLM connection check', () => {
-    const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'OPENAI_COMPAT_API_KEY'];
+    const keyVars = [
+      'ANTHROPIC_API_KEY',
+      'OPENAI_API_KEY',
+      'GEMINI_API_KEY',
+      'GOOGLE_API_KEY',
+      'OPENAI_COMPAT_API_KEY',
+      'OPENAI_COMPAT_BASE_URL',
+    ];
 
     function clearLLMKeys(): Record<string, string | undefined> {
       const saved: Record<string, string | undefined> = {};
@@ -265,6 +284,55 @@ describe('doctor command', () => {
         expect(llmCheck.detail).toContain('gemini');
       } finally {
         restoreLLMKeys(saved);
+      }
+    });
+
+    it('refuses a repository-selected remote OpenAI-compatible endpoint', async () => {
+      const saved = clearLLMKeys();
+      const configManager = await import('../../core/services/config-manager.js');
+      const llmService = await import('../../core/services/llm-service.js');
+      process.env.OPENAI_COMPAT_API_KEY = 'operator-secret';
+      vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+        projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec',
+        maxFiles: 500,
+        generation: { provider: 'openai-compat', openaiCompatBaseUrl: 'https://attacker.invalid/v1' },
+      } as never);
+
+      try {
+        await runDoctorJson();
+        expect(vi.mocked(llmService.createLLMService)).toHaveBeenCalledWith(
+          expect.objectContaining({ openaiCompatBaseUrl: undefined }),
+        );
+      } finally {
+        restoreLLMKeys(saved);
+        vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+          projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec', maxFiles: 500,
+        } as never);
+      }
+    });
+
+    it('prefers an operator-selected compatibility endpoint over repository config', async () => {
+      const saved = clearLLMKeys();
+      const configManager = await import('../../core/services/config-manager.js');
+      const llmService = await import('../../core/services/llm-service.js');
+      process.env.OPENAI_COMPAT_API_KEY = 'operator-secret';
+      process.env.OPENAI_COMPAT_BASE_URL = 'https://operator.example/v1';
+      vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+        projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec',
+        maxFiles: 500,
+        generation: { provider: 'openai-compat', openaiCompatBaseUrl: 'https://attacker.invalid/v1' },
+      } as never);
+
+      try {
+        await runDoctorJson();
+        expect(vi.mocked(llmService.createLLMService)).toHaveBeenCalledWith(
+          expect.objectContaining({ openaiCompatBaseUrl: 'https://operator.example/v1' }),
+        );
+      } finally {
+        restoreLLMKeys(saved);
+        vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+          projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec', maxFiles: 500,
+        } as never);
       }
     });
 
@@ -327,6 +395,28 @@ describe('doctor command', () => {
       }
     });
 
+    it.each([
+      ['JSON', runDoctorJson],
+      ['human-readable', runDoctorText],
+    ])('redacts an exact echoed LLM credential from %s results', async (_format, runDoctor) => {
+      const saved = clearLLMKeys();
+      const credential = 'local-llm-value';
+      process.env.ANTHROPIC_API_KEY = credential;
+      const llmService = await import('../../core/services/llm-service.js');
+      vi.mocked(llmService.createLLMService).mockReturnValueOnce({
+        complete: vi.fn().mockRejectedValue(new Error(`provider reflected ${credential}`)),
+        saveLogs: vi.fn().mockResolvedValue(undefined),
+      } as never);
+      try {
+        const output = JSON.stringify(await runDoctor());
+        expect(output).not.toContain(credential);
+        expect(output).toContain('[REDACTED:api-key]');
+        expect(output).toContain('anthropic');
+      } finally {
+        restoreLLMKeys(saved);
+      }
+    });
+
     it('should include a fix suggestion when degraded', async () => {
       const saved = clearLLMKeys();
       const llmService = await import('../../core/services/llm-service.js');
@@ -339,6 +429,79 @@ describe('doctor command', () => {
         expect(llmCheck.fix).toBeDefined();
       } finally {
         restoreLLMKeys(saved);
+      }
+    });
+  });
+
+  describe('embedding connection check', () => {
+    it('skips a repository-selected remote endpoint instead of sending the operator key', async () => {
+      const configManager = await import('../../core/services/config-manager.js');
+      const savedKey = process.env.EMBED_API_KEY;
+      const savedBase = process.env.EMBED_BASE_URL;
+      delete process.env.EMBED_BASE_URL;
+      process.env.EMBED_API_KEY = 'operator-embedding-secret';
+      vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+        projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec',
+        maxFiles: 500,
+        embedding: { baseUrl: 'https://attacker.invalid/v1', model: 'hostile-model' },
+      } as never);
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+
+      try {
+        const checks = await runDoctorJson();
+        expect(checks.find(c => c.name === 'Embedding connection')).toBeUndefined();
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
+        if (savedKey === undefined) delete process.env.EMBED_API_KEY;
+        else process.env.EMBED_API_KEY = savedKey;
+        if (savedBase === undefined) delete process.env.EMBED_BASE_URL;
+        else process.env.EMBED_BASE_URL = savedBase;
+        vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+          projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec', maxFiles: 500,
+        } as never);
+      }
+    });
+
+    it.each([
+      ['JSON', runDoctorJson],
+      ['human-readable', runDoctorText],
+    ])('redacts an exact echoed embedding credential from %s results', async (_format, runDoctor) => {
+      const configManager = await import('../../core/services/config-manager.js');
+      const savedKey = process.env.EMBED_API_KEY;
+      const savedBase = process.env.EMBED_BASE_URL;
+      const credential = 'local-embedding-value';
+      process.env.EMBED_API_KEY = credential;
+      process.env.EMBED_BASE_URL = 'https://localhost:11434/v1';
+      vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+        projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec', maxFiles: 500,
+        embedding: { model: 'local-embedding-model' },
+      } as never);
+      const fetchSpy = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: vi.fn().mockResolvedValue(`provider reflected ${credential}`),
+      });
+      vi.stubGlobal('fetch', fetchSpy);
+
+      try {
+        const output = JSON.stringify(await runDoctor());
+        expect(output).not.toContain(credential);
+        expect(output).toContain('[REDACTED:api-key]');
+        expect(fetchSpy).toHaveBeenCalledWith(
+          'https://localhost:11434/v1/embeddings',
+          expect.any(Object),
+        );
+      } finally {
+        vi.unstubAllGlobals();
+        if (savedKey === undefined) delete process.env.EMBED_API_KEY;
+        else process.env.EMBED_API_KEY = savedKey;
+        if (savedBase === undefined) delete process.env.EMBED_BASE_URL;
+        else process.env.EMBED_BASE_URL = savedBase;
+        vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+          projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec', maxFiles: 500,
+        } as never);
       }
     });
   });

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -43,11 +43,17 @@ import {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_COPILOT_MODEL,
 } from '../../constants.js';
-import { resolveTrustedSslVerify, rejectRepoConfiguredTlsOptOut, discloseRepoConfiguredEndpoint } from '../../core/services/repo-config-trust.js';
+import {
+  refuseRepoConfiguredEndpoint,
+  rejectRepoConfiguredTlsOptOut,
+  resolveTrustedCompatBase,
+  resolveTrustedSslVerify,
+} from '../../core/services/repo-config-trust.js';
 import { describeExclusions, totalExcluded, type ParseHealthReport } from '../../core/analyzer/parse-health.js';
 import { describeMemoryDegradation } from '../../core/analyzer/memory-strategy.js';
 import type { GovernanceFinding } from '../../core/services/mcp-handlers/enforcement-policy.js';
 import { detectInjectionShapes, INJECTION_SHAPE_LIMITS } from '../../core/services/served-content.js';
+import { redactSecretTextWithKnownValues } from '../../core/services/secret-redaction.js';
 import {
   hookManagerWarning,
   isResolvedGitRepository,
@@ -80,6 +86,37 @@ export interface CheckResult {
   fix?: string;
   remediation?: Remediation;
   findings?: GovernanceFinding[];
+}
+
+const DOCTOR_CREDENTIAL_ENV_VARS = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'OPENAI_COMPAT_API_KEY',
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'EMBED_API_KEY',
+] as const;
+
+async function knownDoctorCredentials(rootPath: string): Promise<string[]> {
+  const values = DOCTOR_CREDENTIAL_ENV_VARS.flatMap(name => process.env[name] ? [process.env[name]!] : []);
+  try {
+    const config = await readOpenLoreConfig(rootPath);
+    if (config?.embedding?.apiKey) values.push(config.embedding.apiKey);
+  } catch {
+    // A malformed config is already reported by its check; environment credentials
+    // still cross the redaction boundary below.
+  }
+  return values;
+}
+
+function redactDoctorResults(checks: CheckResult[], knownCredentials: readonly string[]): CheckResult[] {
+  return checks.map(check => ({
+    ...check,
+    detail: redactSecretTextWithKnownValues(check.detail, knownCredentials).value,
+    ...(check.fix === undefined
+      ? {}
+      : { fix: redactSecretTextWithKnownValues(check.fix, knownCredentials).value }),
+  }));
 }
 
 // ============================================================================
@@ -636,8 +673,12 @@ async function checkLLMConnection(rootPath: string): Promise<CheckResult> {
   const sslVerify = resolveTrustedSslVerify(undefined, config?.llm?.sslVerify);
   rejectRepoConfiguredTlsOptOut('generation.skipSslVerify', gen?.skipSslVerify);
 
-  const baseUrl = gen?.openaiCompatBaseUrl ?? process.env.OPENAI_COMPAT_BASE_URL;
-  discloseRepoConfiguredEndpoint('generation.openaiCompatBaseUrl', gen?.openaiCompatBaseUrl);
+  const baseUrl = provider === 'openai-compat'
+    ? resolveTrustedCompatBase(
+        process.env.OPENAI_COMPAT_BASE_URL,
+        gen?.openaiCompatBaseUrl,
+      )
+    : undefined;
 
   let llm;
   try {
@@ -695,8 +736,15 @@ async function checkEmbeddingConnection(rootPath: string): Promise<CheckResult |
     };
   }
 
-  // Resolve base URL from config or env
-  const baseUrl = emb?.baseUrl ?? process.env.EMBED_BASE_URL;
+  // Environment configuration is operator-authorized. A repository-selected remote
+  // endpoint is refused here just as it is in the normal embedding path: `doctor`
+  // must not become a credential-exfiltration side channel.
+  const envBaseUrl = process.env.EMBED_BASE_URL;
+  const baseUrl = envBaseUrl ?? refuseRepoConfiguredEndpoint(
+    'embedding.baseUrl',
+    emb?.baseUrl,
+    'The doctor embedding check is skipped; search/orient still use BM25.',
+  );
   if (!baseUrl) return null; // Embedding not configured — keyword default; skip
 
   // Refused, not honoured: this value comes from the analyzed repo's config.
@@ -865,12 +913,16 @@ Checks performed:
       checkEmbeddingConnection(rootPath),
     ]);
 
-    const checks = [
+    const unredactedChecks = [
       ...staticChecks,
       ...(mcpCheck ? [mcpCheck] : []),
       llmCheck,
       ...(embeddingCheck ? [embeddingCheck] : []),
     ];
+    // One shared output boundary covers human and JSON rendering. Provider error
+    // bodies are attacker-controlled and may reflect the exact credential they
+    // received, including test/local keys that have no recognizable token shape.
+    const checks = redactDoctorResults(unredactedChecks, await knownDoctorCredentials(rootPath));
 
     if (options.json) {
       // Strip the internal `remediation` field so the --json contract is

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -19,7 +19,7 @@
 
 import { Command } from 'commander';
 import { existsSync } from 'node:fs';
-import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { readFile, mkdtemp, open, rm } from 'node:fs/promises';
 import { resolve, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFile } from 'node:child_process';
@@ -47,6 +47,7 @@ import {
   removeDir,
   BundleError,
   BUNDLE_VERSION,
+  BUNDLE_MAX_COMPRESSED_BYTES,
   type Bundle,
   type BundleSignatureVerdict,
 } from '../../core/analyzer/index-bundle.js';
@@ -263,6 +264,34 @@ async function fullRebuild(rootPath: string, analysisDir: string, detail: string
   return 0;
 }
 
+/** Read at most the size verified on one open descriptor; later appends are ignored. */
+async function readBundleFileBounded(artifactPath: string): Promise<Buffer> {
+  const handle = await open(artifactPath, 'r');
+  try {
+    const artifactStat = await handle.stat();
+    if (!artifactStat.isFile()) {
+      throw new BundleError('unreadable', `Artifact is not a regular file: ${artifactPath}`);
+    }
+    if (artifactStat.size > BUNDLE_MAX_COMPRESSED_BYTES) {
+      throw new BundleError(
+        'unreadable',
+        `Artifact exceeds the ${BUNDLE_MAX_COMPRESSED_BYTES}-byte compressed bundle size cap: ${artifactPath}`,
+      );
+    }
+
+    const raw = Buffer.allocUnsafe(artifactStat.size);
+    let offset = 0;
+    while (offset < raw.length) {
+      const { bytesRead } = await handle.read(raw, offset, raw.length - offset, offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    return raw.subarray(0, offset);
+  } finally {
+    await handle.close();
+  }
+}
+
 async function runImportWithEffectiveConfig(artifact: string, opts: ImportOptions): Promise<number> {
   const projectRoot = resolve(opts.projectRoot ?? process.cwd());
   const analysisDir = join(projectRoot, OPENLORE_ANALYSIS_REL_PATH);
@@ -277,13 +306,17 @@ async function runImportWithEffectiveConfig(artifact: string, opts: ImportOption
   // trust failure — we do not silently full-analyze something the user did not intend.
   let bundle: Bundle;
   try {
-    bundle = parseBundle(await readFile(artifactPath));
+    // Size-check and read through one descriptor so path replacement cannot swap in an
+    // oversized file between metadata validation and allocation. A concurrent append is
+    // ignored because the read is capped to the descriptor size observed above.
+    bundle = parseBundle(await readBundleFileBounded(artifactPath));
   } catch (err) {
     if (err instanceof BundleError) {
       logger.error(err.message);
       return 2;
     }
-    throw err;
+    logger.error(`Could not read artifact: ${err instanceof Error ? err.message : String(err)}`);
+    return 2;
   }
 
   // Signature failures are artifact rejections, not rebuild triggers. A hostile signed bundle

--- a/src/cli/commands/review-action-contract.test.ts
+++ b/src/cli/commands/review-action-contract.test.ts
@@ -25,11 +25,10 @@ describe('OpenLore review Action trust contract', () => {
     expect(example).toMatch(/workflow_run\.id[\s\S]*trusted run metadata[\s\S]*never the artifact[\s\S]*exactly one leading sticky marker/);
   });
 
-  it('requires reviewed immutable Action and package pins when the token can write', () => {
+  it('requires a reviewed immutable Action pin when the token can write', () => {
     expect(example).toContain('pull-requests: write');
     expect(example).toContain('@REPLACE_WITH_REVIEWED_COMMIT_SHA');
-    expect(example).toContain("openlore-version: 'REPLACE_WITH_REVIEWED_RELEASE'");
-    expect(example).not.toContain("openlore-version: 'latest'");
+    expect(example).not.toContain('openlore-version:');
     expect(example).not.toMatch(/openlore-review@main/);
   });
 
@@ -68,9 +67,15 @@ describe('OpenLore review Action trust contract', () => {
     expect(postIndex).toBeLessThan(failIndex);
   });
 
-  it('rejects an unresolved package pin before advisory execution can swallow it', () => {
-    const guard = actionDoc.runs.steps.find((step) => step.name === 'Require a resolved OpenLore version pin');
-    expect(guard?.run).toContain('REPLACE_WITH_*');
-    expect(guard?.run).toContain('exit 2');
+  it('builds the SHA-pinned Action source with its committed dependency lockfile', () => {
+    const build = actionDoc.runs.steps.find((step) => step.name === 'Build the SHA-pinned OpenLore Action source');
+    expect(build?.env?.ACTION_PATH).toBe('${{ github.action_path }}');
+    expect(build?.run).toContain('ACTION_PATH/../../..');
+    expect(build?.run).toContain('package-lock.json');
+    expect(build?.run).toContain('npm ci --ignore-scripts');
+    expect(build?.run).toContain('npm run build');
+    expect(build?.run).toContain('dist/cli/index.js');
+    expect(action).not.toContain('openlore-version:');
+    expect(action).not.toContain('npx ');
   });
 });

--- a/src/cli/commands/serve.test.ts
+++ b/src/cli/commands/serve.test.ts
@@ -134,6 +134,35 @@ function rawGet(
   });
 }
 
+/** Raw JSON GET variant for asserting wildcard-Host response disclosure. */
+function rawJsonGet(
+  port: number,
+  path: string,
+  headers: Record<string, string>,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      { host: '127.0.0.1', port, path, method: 'GET', headers, setHost: false },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          try {
+            resolve({
+              status: res.statusCode ?? 0,
+              body: JSON.parse(Buffer.concat(chunks).toString('utf-8')) as Record<string, unknown>,
+            });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
 describe('idleTimeoutMs', () => {
   it('defaults to 15 minutes when the option is absent or empty', () => {
     expect(idleTimeoutMs(undefined)).toBe(15 * 60_000);
@@ -1057,6 +1086,45 @@ describe('openlore serve', () => {
     expect(process.exitCode).toBe(1);
     expect(await fileExists(join(root, OPENLORE_DIR))).toBe(false);
     process.exitCode = prev; // don't fail the suite
+  });
+
+  it('limits unauthenticated wildcard-bind health to liveness while authenticated health proves identity', async () => {
+    root = await mkdtemp(join(tmpdir(), 'openlore-serve-wildcard-health-'));
+    const h = await startServe({
+      directory: root,
+      port: '0',
+      watch: false,
+      host: '0.0.0.0',
+      token: 'protected-health',
+    });
+    expect(h).toBeDefined();
+    handle = h;
+    const hostHeader = `0.0.0.0:${h!.port}`;
+
+    const unauthenticated = await rawJsonGet(h!.port, '/health', { Host: hostHeader });
+    expect(unauthenticated.status).toBe(200);
+    expect(unauthenticated.body).toEqual({ ok: true, tokenProtected: true });
+    expect(unauthenticated.body).not.toHaveProperty('root');
+    expect(unauthenticated.body).not.toHaveProperty('pid');
+    expect(unauthenticated.body).not.toHaveProperty('preset');
+    expect(unauthenticated.body).not.toHaveProperty('tools');
+    expect(unauthenticated.body).not.toHaveProperty('version');
+
+    const authenticated = await rawJsonGet(h!.port, '/health', {
+      Host: hostHeader,
+      'x-openlore-token': 'protected-health',
+    });
+    expect(authenticated.status).toBe(200);
+    expect(authenticated.body).toMatchObject({
+      ok: true,
+      tokenProtected: true,
+      tokenAuthenticated: true,
+      root: await realpath(root),
+      pid: process.pid,
+      preset: 'substrate',
+    });
+    expect(authenticated.body.tools).toEqual(expect.arrayContaining(['orient', 'search_code']));
+    expect(typeof authenticated.body.version).toBe('string');
   });
 
   it('rejects an unknown preset at startup', async () => {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -656,6 +656,15 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
 
     if (req.method === 'GET' && url.pathname === '/health') {
       touchActivity();
+      // A wildcard bind is network-reachable even though daemon discovery uses its
+      // loopback alias. Keep unauthenticated liveness available, but do not disclose
+      // the repository path, PID, version, preset, or tool surface to a remote caller
+      // that merely supplies the allowed wildcard Host header. Authenticated clients
+      // still receive the full root-bound identity proof used by descriptor validation.
+      if (!isLoopbackHost(host) && token && !tokenAuthenticated) {
+        sendJson(res, 200, { ok: true, tokenProtected: true });
+        return;
+      }
       sendJson(res, 200, {
         ok: true,
         presetDispatchEnforced: true,

--- a/src/core/analyzer/index-bundle.test.ts
+++ b/src/core/analyzer/index-bundle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, writeFile, open } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { EdgeStore, SCHEMA_VERSION } from '../services/edge-store.js';
@@ -17,10 +17,13 @@ import {
   isSafeBundleFileName,
   BundleError,
   BUNDLE_VERSION,
+  BUNDLE_MAX_COMPRESSED_BYTES,
+  BUNDLE_MAX_DECOMPRESSED_BYTES,
   verifyBundleSignature,
   verifyBundledSourceIdentity,
 } from './index-bundle.js';
-import { gzipSync } from 'node:zlib';
+import { createGzip, gzipSync } from 'node:zlib';
+import { once } from 'node:events';
 import { mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { generateKeyPairSync } from 'node:crypto';
@@ -507,8 +510,39 @@ describe('index-bundle: promoteStagedIndex clears orphaned search indexes', () =
 });
 
 describe('index-bundle: parse + tamper detection', () => {
+  it('keeps the decompressed memory boundary at the measured 96 MiB policy cap', () => {
+    expect(BUNDLE_MAX_DECOMPRESSED_BYTES).toBe(96 * 1024 * 1024);
+  });
+
   it('rejects a non-bundle buffer as unreadable', () => {
     expect(() => parseBundle(Buffer.from('not a bundle'))).toThrow(BundleError);
+  });
+
+  it('rejects an oversized compressed buffer before attempting gzip parsing', () => {
+    const oversized = Buffer.allocUnsafe(BUNDLE_MAX_COMPRESSED_BYTES + 1);
+    expect(() => parseBundle(oversized)).toThrow(/compressed artifact exceeds.*size cap/i);
+  });
+
+  it('rejects a high-ratio gzip one block past the decompressed cap as BundleError', async () => {
+    const gzip = createGzip({ level: 9 });
+    const chunks: Buffer[] = [];
+    gzip.on('data', chunk => chunks.push(Buffer.from(chunk)));
+    const block = Buffer.alloc(1024 * 1024);
+    for (let written = 0; written <= BUNDLE_MAX_DECOMPRESSED_BYTES; written += block.length) {
+      if (!gzip.write(block)) await once(gzip, 'drain');
+    }
+    gzip.end();
+    await once(gzip, 'end');
+    const bomb = Buffer.concat(chunks);
+
+    expect(bomb.byteLength).toBeLessThan(BUNDLE_MAX_COMPRESSED_BYTES);
+    try {
+      parseBundle(bomb);
+      expect.fail('expected the near-cap compression bomb to be rejected');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BundleError);
+      expect((error as Error).message).toMatch(/size cap/i);
+    }
   });
 
   it('detects a tampered payload (flipped byte) via the payload digest', async () => {
@@ -744,6 +778,20 @@ describe('index-bundle: runImport trust boundary', () => {
     expect(await runImport(artifact, { projectRoot: project.root })).toBe(0);
     expect(success.mock.calls.flat().join(' ')).toMatch(/provenance UNVERIFIED/i);
     expect(await readCurrentGeneration(project.analysis, [...REQUIRED_ANALYSIS_ARTIFACTS])).not.toBeNull();
+  });
+
+  it('rejects an oversized compressed artifact before reading it into memory', async () => {
+    const artifact = join(work, 'oversized.olbundle');
+    const handle = await open(artifact, 'w');
+    try {
+      await handle.truncate(BUNDLE_MAX_COMPRESSED_BYTES + 1);
+    } finally {
+      await handle.close();
+    }
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    expect(await runImport(artifact, { projectRoot: work })).toBe(2);
+    expect(error.mock.calls.flat().join(' ')).toMatch(/compressed bundle size cap/i);
   });
 
   it('rejects signed manifest tampering before promotion or rebuild', async () => {

--- a/src/core/analyzer/index-bundle.ts
+++ b/src/core/analyzer/index-bundle.ts
@@ -73,12 +73,14 @@ export const BUNDLE_VERSION = 2;
 export const BUNDLE_DEFAULT_FILENAME = 'index-bundle.olbundle';
 
 /**
- * Upper bound on the decompressed bundle size read at import. The bundle is untrusted
- * on-disk input (mcp-security: Untrusted Artifact Deserialization Safety) — bound the
- * gunzip output so a maliciously-crafted artifact cannot exhaust memory (zip bomb). A
- * generous 2 GiB cap clears any real index while failing closed on an absurd one.
+ * Import memory bounds for an untrusted on-disk bundle. Real and fixture bundles in this
+ * repository are well below these limits; a measured export of this repository expanded to
+ * 58,717,652 bytes. A 96 MiB decompressed cap leaves about 1.7x growth headroom while bounding
+ * the synchronous gzip buffer, UTF-8 string, and parsed JSON object graph. Keep the compressed
+ * check in both the CLI (before read) and the codec (for direct callers and file-swap races).
  */
-const BUNDLE_MAX_DECOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024;
+export const BUNDLE_MAX_COMPRESSED_BYTES = 64 * 1024 * 1024;
+export const BUNDLE_MAX_DECOMPRESSED_BYTES = 96 * 1024 * 1024;
 
 /**
  * Files never bundled. Transient SQLite sidecars are WAL scratch folded into the main db by a
@@ -659,6 +661,12 @@ export function isSafeBundleFileName(name: string): boolean {
  * failure from an artifact that parses but fails trust validation (which degrades to rebuild).
  */
 export function parseBundle(raw: Buffer): ImportedBundle {
+  if (raw.byteLength > BUNDLE_MAX_COMPRESSED_BYTES) {
+    throw new BundleError(
+      'unreadable',
+      `Not an OpenLore bundle: compressed artifact exceeds the ${BUNDLE_MAX_COMPRESSED_BYTES}-byte size cap.`,
+    );
+  }
   let json: string;
   try {
     json = gunzipSync(raw, { maxOutputLength: BUNDLE_MAX_DECOMPRESSED_BYTES }).toString('utf-8');

--- a/src/core/services/chat-agent.test.ts
+++ b/src/core/services/chat-agent.test.ts
@@ -642,6 +642,25 @@ describe('runChatAgent', () => {
       expect(result.reply).toBe('Gemini says hi');
     });
 
+    it('encodes a repository-selected model as one URL path segment', async () => {
+      mockReadConfig.mockResolvedValue({
+        generation: { provider: 'gemini', model: '../../other?key=attacker#fragment' },
+      });
+      fetchSpy.mockResolvedValue(mockResponse({
+        candidates: [{ content: { parts: [{ text: 'ok' }], role: 'model' }, finishReason: 'STOP' }],
+      }));
+
+      await runChatAgent({
+        directory: '/project',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+
+      expect(fetchSpy.mock.calls[0][0]).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models/' +
+        '..%2F..%2Fother%3Fkey%3Dattacker%23fragment:generateContent?key=gem-key',
+      );
+    });
+
     it('reports an abort before the first request', async () => {
       const controller = new AbortController();
       controller.abort();

--- a/src/core/services/chat-agent.ts
+++ b/src/core/services/chat-agent.ts
@@ -255,8 +255,7 @@ function waitForRetry(delay: number, signal?: AbortSignal): Promise<void> {
 }
 
 async function fetchWithRetry(
-  url: string,
-  init: RequestInit,
+  request: (signal: AbortSignal) => Promise<Response>,
   signal?: AbortSignal
 ): Promise<BufferedChatResponse> {
   let lastError: Error = new Error('fetch failed');
@@ -279,7 +278,7 @@ async function fetchWithRetry(
     let response: Response;
     let responseBody: string;
     try {
-      response = await withRelaxedTls(() => fetch(url, { ...init, signal: attemptController.signal }));
+      response = await request(attemptController.signal);
       // Native fetch resolves when headers arrive. Consume the body while the
       // same timeout and caller-abort listener are still active so a provider
       // that stalls mid-stream cannot hang the chat loop indefinitely.
@@ -422,12 +421,14 @@ async function runOpenAILoop(
     let response: BufferedChatResponse;
     try {
       response = await fetchWithRetry(
-        `${cfg.baseUrl}/chat/completions`,
-        {
+        attemptSignal => withRelaxedTls(() => fetch(`${cfg.baseUrl}/chat/completions`, {
           method: 'POST',
           headers,
+          // INTENTIONAL EGRESS: prompt-wrapped repository results go to the operator-selected LLM.
+          // codeql[js/file-access-to-http]
           body: JSON.stringify({ model: cfg.model, messages: history, tools: toolDefs, tool_choice: 'auto' }),
-        },
+          signal: attemptSignal,
+        })),
         signal,
       );
     } catch (error) {
@@ -503,7 +504,9 @@ async function runGeminiLoop(
     parts: [{ text: m.content }],
   }));
 
-  const url = `${cfg.baseUrl}/${cfg.model}:generateContent?key=${cfg.apiKey}`;
+  // A model can come from the analyzed repository's config. Keep it as one path
+  // segment so repository data cannot become request-path or query syntax.
+  const url = `${cfg.baseUrl}/${encodeURIComponent(cfg.model)}:generateContent?key=${cfg.apiKey}`;
   const headers = { 'Content-Type': 'application/json' };
 
   for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
@@ -518,7 +521,22 @@ async function runGeminiLoop(
 
     let response: BufferedChatResponse;
     try {
-      response = await fetchWithRetry(url, { method: 'POST', headers, body: JSON.stringify(body) }, signal);
+      response = await fetchWithRetry(
+        attemptSignal => withRelaxedTls(() => fetch(
+          // INTENTIONAL EGRESS: the encoded model selects a resource only at Google's fixed origin.
+          // codeql[js/file-access-to-http]
+          url,
+          {
+            method: 'POST',
+            headers,
+            // INTENTIONAL EGRESS: prompt-wrapped repository results go to the fixed Gemini provider.
+            // codeql[js/file-access-to-http]
+            body: JSON.stringify(body),
+            signal: attemptSignal,
+          },
+        )),
+        signal,
+      );
     } catch (error) {
       if (signal?.aborted) break;
       throw error;
@@ -618,10 +636,11 @@ async function runAnthropicLoop(
     let response: BufferedChatResponse;
     try {
       response = await fetchWithRetry(
-        `${cfg.baseUrl}/messages`,
-        {
+        attemptSignal => withRelaxedTls(() => fetch(`${cfg.baseUrl}/messages`, {
           method: 'POST',
           headers,
+          // INTENTIONAL EGRESS: prompt-wrapped repository results go to the fixed Anthropic provider.
+          // codeql[js/file-access-to-http]
           body: JSON.stringify({
             model: cfg.model,
             max_tokens: CHAT_AGENT_MAX_TOKENS,
@@ -629,7 +648,8 @@ async function runAnthropicLoop(
             tools,
             messages: history,
           }),
-        },
+          signal: attemptSignal,
+        })),
         signal,
       );
     } catch (error) {

--- a/src/core/services/llm-service.test.ts
+++ b/src/core/services/llm-service.test.ts
@@ -1557,6 +1557,19 @@ describe('GeminiProvider', () => {
     expect(result.finishReason).toBe('stop');
   });
 
+  it('encodes the model as one request-path segment', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(SUCCESS_BODY));
+    vi.stubGlobal('fetch', fetchMock);
+    const provider = new GeminiProvider('key', '../../other?key=attacker#fragment');
+
+    await provider.generateCompletion({ systemPrompt: 'sys', userPrompt: 'hello' });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/' +
+      '..%2F..%2Fother%3Fkey%3Dattacker%23fragment:generateContent?key=key',
+    );
+  });
+
   it('maps MAX_TOKENS finish reason to "length"', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
       ...SUCCESS_BODY, candidates: [{ ...SUCCESS_BODY.candidates[0], finishReason: 'MAX_TOKENS' }],

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -1590,7 +1590,7 @@ export class GeminiProvider implements LLMProvider {
       },
     };
 
-    const url = `${this.baseUrl}/${this.model}:generateContent?key=${this.apiKey}`;
+    const url = `${this.baseUrl}/${encodeURIComponent(this.model)}:generateContent?key=${this.apiKey}`;
     const response = await withRelaxedTls(() => fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/src/core/services/mcp-handlers/analysis.test.ts
+++ b/src/core/services/mcp-handlers/analysis.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -978,6 +978,74 @@ describe('handleGetMinimalContext', () => {
     expect((result.callers as unknown[]).length).toBeGreaterThanOrEqual(0);
     expect(Array.isArray(result.callees)).toBe(true);
     expect(Array.isArray(result.testedBy)).toBe(true);
+  });
+
+  it('reads a valid in-root function body', async () => {
+    const source = 'export function safeFn() { return 42; }\n';
+    await mkdir(join(tmpDir, 'src'), { recursive: true });
+    await writeFile(join(tmpDir, 'src', 'safe.ts'), source, 'utf-8');
+    readCachedContext.mockResolvedValue({
+      callGraph: makeCallGraph({
+        nodes: [{
+          id: 'src/safe.ts::safeFn', name: 'safeFn', filePath: join(tmpDir, 'src', 'safe.ts'),
+          signature: 'safeFn()', language: 'typescript', fanIn: 0, fanOut: 0,
+          startIndex: 0, endIndex: source.length, isExternal: false, isTest: false,
+        }],
+      }),
+    });
+
+    const { handleGetMinimalContext } = await import('./analysis.js');
+    const result = await handleGetMinimalContext(tmpDir, 'safeFn') as { function: { file: string; body: string } };
+
+    expect(result.function.file).toBe('src/safe.ts');
+    expect(result.function.body).toBe(source);
+  });
+
+  it('does not read an absolute node path outside the project root', async () => {
+    const outside = await createTmpDir();
+    const secret = 'outside-absolute-secret';
+    const secretPath = join(outside, 'secret.ts');
+    await writeFile(secretPath, secret, 'utf-8');
+    readCachedContext.mockResolvedValue({
+      callGraph: makeCallGraph({
+        nodes: [{
+          id: 'poison::leakAbsolute', name: 'leakAbsolute', filePath: secretPath,
+          signature: 'leakAbsolute()', language: 'typescript', fanIn: 0, fanOut: 0,
+          startIndex: 0, endIndex: secret.length, isExternal: false, isTest: false,
+        }],
+      }),
+    });
+
+    const { handleGetMinimalContext } = await import('./analysis.js');
+    const result = await handleGetMinimalContext(tmpDir, 'leakAbsolute') as { error: string };
+
+    expect(result.error).toMatch(/not found/);
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it('does not read a node path through an in-root symlink that escapes the root', async () => {
+    const outside = await createTmpDir();
+    const secret = 'outside-symlink-secret';
+    const secretPath = join(outside, 'secret.ts');
+    await writeFile(secretPath, secret, 'utf-8');
+    await mkdir(join(tmpDir, 'src'), { recursive: true });
+    const linkedPath = join(tmpDir, 'src', 'linked.ts');
+    await symlink(secretPath, linkedPath);
+    readCachedContext.mockResolvedValue({
+      callGraph: makeCallGraph({
+        nodes: [{
+          id: 'src/linked.ts::leakSymlink', name: 'leakSymlink', filePath: linkedPath,
+          signature: 'leakSymlink()', language: 'typescript', fanIn: 0, fanOut: 0,
+          startIndex: 0, endIndex: secret.length, isExternal: false, isTest: false,
+        }],
+      }),
+    });
+
+    const { handleGetMinimalContext } = await import('./analysis.js');
+    const result = await handleGetMinimalContext(tmpDir, 'leakSymlink') as { error: string };
+
+    expect(result.error).toMatch(/not found/);
+    expect(JSON.stringify(result)).not.toContain(secret);
   });
 
   it('includes testedBy edges when present', async () => {

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -12,6 +12,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, openSync, closeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { escapeRegExp } from '../../../utils/misc.js';
+import { readFileConfined } from '../../../utils/path-confinement.js';
 import {
   DEFAULT_MAX_FILES,
   DEFAULT_DRIFT_MAX_FILES,
@@ -949,17 +950,40 @@ export async function handleGetMinimalContext(
   if (!ctx?.callGraph) return { error: 'No call graph. Run analyze_codebase first.' };
 
   const cg = ctx.callGraph as SerializedCallGraph;
-  const nodeMap = new Map(cg.nodes.map(n => [n.id, n]));
+  // `llm-context.json` is an untrusted repository artifact (and may arrive through an
+  // unsigned portable bundle). Never let one of its node paths become a read target or
+  // an output path until it has crossed the same symlink-aware root boundary as a tool
+  // argument. Invalid internal neighbours are omitted; an invalid target fails closed as
+  // not-found rather than disclosing where the poisoned path points.
+  const confinedPaths = new Map<string, string>();
+  const confinedPath = (node: (typeof cg.nodes)[number]): string | null => {
+    const cached = confinedPaths.get(node.id);
+    if (cached) return cached;
+    try {
+      const path = safeJoin(absDir, node.filePath);
+      confinedPaths.set(node.id, path);
+      return path;
+    } catch {
+      return null;
+    }
+  };
+  const nodeMap = new Map(
+    cg.nodes
+      .filter(n => n.isExternal || confinedPath(n) !== null)
+      .map(n => [n.id, n]),
+  );
 
   // Find target node(s)
   const candidates = cg.nodes.filter(n =>
     n.name === functionName &&
     !n.isExternal && !n.isTest &&
+    confinedPath(n) !== null &&
     // Anchor on a path separator so "config.ts" doesn't also match "app-config.ts".
     (!filePath || n.filePath === filePath || n.filePath.endsWith('/' + filePath.replace(/^\//, ''))),
   );
   if (candidates.length === 0) return { error: `Function "${functionName}" not found. Run analyze_codebase first.` };
   const target = candidates[0];
+  const targetPath = confinedPath(target)!;
 
   // Risk tier → distance budget + k cap. Neighbours are ranked by nearest
   // call-distance (not arbitrary edge order), so a tightly-coupled chain two hops
@@ -1025,7 +1049,7 @@ export async function handleGetMinimalContext(
       const n = nodeMap.get(id);
       if (!n || n.isExternal) return null;
       const callType = callTypeByEdge.get(`${id}\0${r.predecessor}`) ?? 'direct';
-      return { id, name: n.name, file: relative(absDir, n.filePath), sig: sig(n), callType, isExternal: false, distance: r.distance, hops: r.hops, _rank: n.fanIn, _rel: callerScores.get(id) ?? 0 };
+      return { id, name: n.name, file: relative(absDir, confinedPath(n)!), sig: sig(n), callType, isExternal: false, distance: r.distance, hops: r.hops, _rank: n.fanIn, _rel: callerScores.get(id) ?? 0 };
     })
     .filter((n): n is NonNullable<typeof n> => !!n);
   const { list: callers, omitted: callersOmitted } = select(callerItems);
@@ -1039,7 +1063,7 @@ export async function handleGetMinimalContext(
       const n = nodeMap.get(id);
       if (!n || n.isExternal) return null;
       const callType = callTypeByEdge.get(`${r.predecessor}\0${id}`) ?? 'direct';
-      return { id, name: n.name, file: relative(absDir, n.filePath), sig: sig(n), callType, isExternal: false, kind: undefined as string | undefined, distance: r.distance, hops: r.hops, _rank: n.fanOut, _rel: calleeScores.get(id) ?? 0 };
+      return { id, name: n.name, file: relative(absDir, confinedPath(n)!), sig: sig(n), callType, isExternal: false, kind: undefined as string | undefined, distance: r.distance, hops: r.hops, _rank: n.fanOut, _rel: calleeScores.get(id) ?? 0 };
     })
     .filter((n): n is NonNullable<typeof n> => !!n);
 
@@ -1072,7 +1096,7 @@ export async function handleGetMinimalContext(
   // Function body (byte-range slice from source)
   let body: string | null = null;
   try {
-    const src = await readFile(target.filePath, 'utf-8');
+    const src = await readFileConfined(absDir, relative(absDir, targetPath));
     body = src.slice(target.startIndex, target.endIndex);
   } catch { /* source unavailable */ }
 
@@ -1084,7 +1108,7 @@ export async function handleGetMinimalContext(
   return {
     function: {
       name: target.name,
-      file: relative(absDir, target.filePath),
+      file: relative(absDir, targetPath),
       signature: target.signature ?? target.name,
       language: target.language,
       className: target.className ?? null,

--- a/src/core/services/mcp-handlers/error-propagation.test.ts
+++ b/src/core/services/mcp-handlers/error-propagation.test.ts
@@ -6,9 +6,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { handleAnalyzeErrorPropagation } from './error-propagation.js';
 import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_LLM_CONTEXT } from '../../../constants.js';
 
@@ -134,6 +134,41 @@ describe('handleAnalyzeErrorPropagation', () => {
     const res = (await handleAnalyzeErrorPropagation({ directory: dir, symbol: 'help' })) as Result;
     expect(res.error).toMatch(/No indexed function/);
     expect(res.candidates).toContain('helper');
+  });
+
+  it('does not parse a traversal node outside the project root', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'errprop-outside-'));
+    try {
+      const secretType = 'OutsideTraversalSecretError';
+      const source = `function leakTraversal() { throw new ${secretType}(); }\n`;
+      const secretPath = join(outside, 'secret.ts');
+      writeFileSync(secretPath, source, 'utf-8');
+      writeCache(dir, [node('poison-traversal', 'leakTraversal', relative(dir, secretPath), source)], []);
+
+      const res = await handleAnalyzeErrorPropagation({ directory: dir, symbol: 'leakTraversal' });
+      expect(res).toMatchObject({ error: expect.stringMatching(/No indexed function/) });
+      expect(JSON.stringify(res)).not.toContain(secretType);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('does not parse an in-root symlink that escapes the project root', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'errprop-link-outside-'));
+    try {
+      const secretType = 'OutsideSymlinkSecretError';
+      const source = `function leakSymlink() { throw new ${secretType}(); }\n`;
+      const secretPath = join(outside, 'secret.ts');
+      writeFileSync(secretPath, source, 'utf-8');
+      symlinkSync(secretPath, join(dir, 'linked.ts'));
+      writeCache(dir, [node('poison-link', 'leakSymlink', 'linked.ts', source)], []);
+
+      const res = await handleAnalyzeErrorPropagation({ directory: dir, symbol: 'leakSymlink' });
+      expect(res).toMatchObject({ error: expect.stringMatching(/No indexed function/) });
+      expect(JSON.stringify(res)).not.toContain(secretType);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it('discloses an unresolved-ambiguous call site as a boundary, never assumed exception-free', async () => {

--- a/src/core/services/mcp-handlers/error-propagation.ts
+++ b/src/core/services/mcp-handlers/error-propagation.ts
@@ -19,10 +19,10 @@
  * explicit `unsupported` result, never an empty escape set.
  */
 
-import { join } from 'node:path';
-import { readFile } from 'node:fs/promises';
+import { relative } from 'node:path';
 import type Parser from 'tree-sitter';
-import { validateDirectory, readCachedContext } from './utils.js';
+import { validateDirectory, readCachedContext, safeJoin } from './utils.js';
+import { readFileConfined } from '../../../utils/path-confinement.js';
 import {
   ERROR_PROPAGATION_LANGUAGES,
   getExceptionParser,
@@ -88,7 +88,19 @@ export async function handleAnalyzeErrorPropagation(
   if (!ctx.callGraph) return { error: 'Call graph not available. Re-run analyze_codebase.' };
 
   const cg = ctx.callGraph as SerializedCallGraph;
-  const allNodes = (cg.nodes ?? []) as FunctionNode[];
+  // Normalize every internal artifact path through the symlink-aware project-root
+  // boundary before resolution, traversal, parsing, or output. Poisoned nodes are
+  // omitted; edges to them become the existing unresolved-callee boundary rather
+  // than an out-of-root read.
+  const allNodes = ((cg.nodes ?? []) as FunctionNode[]).flatMap(n => {
+    if (n.isExternal) return [n];
+    try {
+      const absPath = safeJoin(absDir, n.filePath);
+      return [{ ...n, filePath: relative(absDir, absPath) }];
+    } catch {
+      return [];
+    }
+  });
   const edges = (cg.edges ?? []) as CallEdge[];
 
   // ── Resolve the query symbol (find_clones resolution discipline) ───────────
@@ -213,7 +225,9 @@ export async function handleAnalyzeErrorPropagation(
     let tree = treeByFile.get(n.filePath);
     if (tree === undefined) {
       try {
-        const content = await readFile(join(absDir, n.filePath), 'utf-8');
+        // Re-check at the point of use as defense in depth: artifact nodes were
+        // normalized above, but the filesystem may contain symlinks.
+        const content = await readFileConfined(absDir, n.filePath);
         const parser = await getExceptionParser(n.language, n.filePath);
         // Bounded (change: fix-analyze-native-abort-and-file-cost-budget): this parse runs inside
         // the long-lived daemon, so one pathological file must not be able to wedge it. On the

--- a/src/core/services/mcp-handlers/symbol-span.test.ts
+++ b/src/core/services/mcp-handlers/symbol-span.test.ts
@@ -10,9 +10,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync, statSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync, statSync, readFileSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { handleLocateSymbolSpan } from './symbol-span.js';
 import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_LLM_CONTEXT } from '../../../constants.js';
 
@@ -138,6 +138,51 @@ describe('handleLocateSymbolSpan', () => {
     };
     expect(res.verdict).toBe('not-found');
     expect(res.candidates).toContain('foo'); // substring near-miss
+  });
+
+  it('does not resolve or hash a traversal node outside the project root', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'symbol-span-outside-'));
+    try {
+      const secret = 'outside-traversal-secret';
+      const secretPath = join(outside, 'secret.ts');
+      writeFileSync(secretPath, secret, 'utf-8');
+      const poisoned = node('poison-traversal', 'leakTraversal', relative(dir, secretPath), secret);
+      writeFileSync(
+        join(analysisDir, ARTIFACT_LLM_CONTEXT),
+        JSON.stringify({ callGraph: { nodes: [poisoned], edges: [] } }),
+        'utf-8',
+      );
+
+      const res = await handleLocateSymbolSpan({ directory: dir, symbol: 'leakTraversal' });
+      expect(res).toMatchObject({ verdict: 'not-found' });
+      expect(JSON.stringify(res)).not.toContain(secret);
+      expect(JSON.stringify(res)).not.toMatch(/[0-9a-f]{16}/);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('does not resolve or hash an in-root symlink that escapes the project root', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'symbol-span-link-outside-'));
+    try {
+      const secret = 'outside-symlink-secret';
+      const secretPath = join(outside, 'secret.ts');
+      writeFileSync(secretPath, secret, 'utf-8');
+      symlinkSync(secretPath, join(dir, 'linked.ts'));
+      const poisoned = node('poison-link', 'leakSymlink', 'linked.ts', secret);
+      writeFileSync(
+        join(analysisDir, ARTIFACT_LLM_CONTEXT),
+        JSON.stringify({ callGraph: { nodes: [poisoned], edges: [] } }),
+        'utf-8',
+      );
+
+      const res = await handleLocateSymbolSpan({ directory: dir, symbol: 'leakSymlink' });
+      expect(res).toMatchObject({ verdict: 'not-found' });
+      expect(JSON.stringify(res)).not.toContain(secret);
+      expect(JSON.stringify(res)).not.toMatch(/[0-9a-f]{16}/);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it('discloses an unlocatable bodyless symbol instead of a fake span', async () => {

--- a/src/core/services/mcp-handlers/symbol-span.ts
+++ b/src/core/services/mcp-handlers/symbol-span.ts
@@ -33,14 +33,15 @@
  */
 
 import { createHash } from 'node:crypto';
-import { join } from 'node:path';
-import { readFile, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { stat } from 'node:fs/promises';
 import {
   OPENLORE_DIR,
   OPENLORE_ANALYSIS_SUBDIR,
   ARTIFACT_LLM_CONTEXT,
 } from '../../../constants.js';
-import { validateDirectory, readCachedContext } from './utils.js';
+import { validateDirectory, readCachedContext, safeJoin } from './utils.js';
+import { readFileConfined } from '../../../utils/path-confinement.js';
 import { hashSpan } from '../../decisions/anchor.js';
 import type { SerializedCallGraph } from '../../analyzer/call-graph.js';
 import { resolveFileFreshness } from './freshness.js';
@@ -91,8 +92,19 @@ export async function handleLocateSymbolSpan(input: LocateSymbolSpanInput): Prom
   const cg = ctx.callGraph as SerializedCallGraph;
   const allNodes = (cg.nodes ?? []) as unknown as SerNode[];
   // Resolution pool: internal symbols only — external/synthesized nodes carry no
-  // source span to locate.
-  const pool = allNodes.filter(n => !n.isExternal);
+  // source span to locate. The cached graph is an untrusted repository artifact,
+  // so drop any internal node whose path escapes the root lexically or through a
+  // symlink before it can participate in resolution or appear in output.
+  const confinedPaths = new Map<SerNode, string>();
+  const pool = allNodes.filter(n => {
+    if (n.isExternal) return false;
+    try {
+      confinedPaths.set(n, safeJoin(absDir, n.filePath));
+      return true;
+    } catch {
+      return false;
+    }
+  });
 
   const sep = sym.indexOf('::');
   const namePart = sep >= 0 ? sym.slice(0, sep) : sym;
@@ -105,7 +117,7 @@ export async function handleLocateSymbolSpan(input: LocateSymbolSpanInput): Prom
 
   if (candidates.length === 0) {
     const nameLower = namePart.toLowerCase();
-    const near = [...new Set(allNodes.map(n => n.name))]
+    const near = [...new Set(pool.map(n => n.name))]
       .filter(nm => nm.toLowerCase().includes(nameLower))
       .slice(0, 10);
     return {
@@ -121,13 +133,15 @@ export async function handleLocateSymbolSpan(input: LocateSymbolSpanInput): Prom
     return {
       verdict: 'ambiguous' as const,
       query: sym,
-      candidates: candidates.slice(0, 10).map(n => `${n.name}::${n.filePath}`),
+      candidates: candidates.slice(0, 10).map(n => `${n.name}::${relative(absDir, confinedPaths.get(n)!)}`),
       hint: `"${sym}" matches ${candidates.length} symbols. Pass name::path to disambiguate.`,
     };
   }
 
   const node = candidates[0];
-  const symbolId = `${node.name}::${node.filePath}`;
+  const abs = confinedPaths.get(node)!;
+  const confinedFile = relative(absDir, abs);
+  const symbolId = `${node.name}::${confinedFile}`;
 
   // Locatability guards — a symbol that resolves but has no trustworthy raw-source
   // span. Disclosed as an explicit reason, never a fabricated offset.
@@ -136,7 +150,7 @@ export async function handleLocateSymbolSpan(input: LocateSymbolSpanInput): Prom
       error: `"${symbolId}" has no source span (external or synthesized symbol) — nothing to locate.`,
     };
   }
-  if (HTML_RE.test(node.filePath)) {
+  if (HTML_RE.test(confinedFile)) {
     return {
       error:
         `"${symbolId}" is an HTML inline-script symbol: its indexed offsets are against transformed ` +
@@ -146,16 +160,15 @@ export async function handleLocateSymbolSpan(input: LocateSymbolSpanInput): Prom
 
   // Re-read the one file the symbol spans. Unreadable/deleted since analysis → the
   // offsets are meaningless; fail safe to `stale`.
-  const abs = join(absDir, node.filePath);
   let content: string;
   try {
-    content = await readFile(abs, 'utf-8');
+    content = await readFileConfined(absDir, confinedFile);
   } catch {
     return {
       verdict: 'stale' as const,
       symbol: symbolId,
-      file: node.filePath,
-      hint: `${node.filePath} could not be read (moved or deleted since analysis). Re-run analyze_codebase.`,
+      file: confinedFile,
+      hint: `${confinedFile} could not be read (moved or deleted since analysis). Re-run analyze_codebase.`,
     };
   }
 
@@ -180,7 +193,7 @@ export async function handleLocateSymbolSpan(input: LocateSymbolSpanInput): Prom
     return {
       verdict,
       symbol: symbolId,
-      file: node.filePath,
+      file: confinedFile,
       hint: 'The index is behind the working tree — the recorded offsets are not trustworthy. Re-run analyze_codebase (or let the watcher catch up) before editing at these offsets.',
     };
   }
@@ -196,7 +209,7 @@ export async function handleLocateSymbolSpan(input: LocateSymbolSpanInput): Prom
   return {
     verdict,
     symbol: symbolId,
-    file: node.filePath,
+    file: confinedFile,
     language: node.language,
     startLine,
     endLine,

--- a/src/core/services/secret-redaction.test.ts
+++ b/src/core/services/secret-redaction.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { redactSecretText, redactSecretsWithReport } from './secret-redaction.js';
+import { redactSecretText, redactSecretTextWithKnownValues, redactSecretsWithReport } from './secret-redaction.js';
 
 describe('repository secret redaction', () => {
+  it('redacts an exact known credential without treating benign config as secret', () => {
+    const credential = 'local-test-value';
+    const result = redactSecretTextWithKnownValues(
+      `model=local-test-model url=https://localhost:11434/v1 echoed=${credential}`,
+      [credential],
+    );
+
+    expect(result.value).toBe(
+      'model=local-test-model url=https://localhost:11434/v1 echoed=[REDACTED:api-key]',
+    );
+    expect(result.redactions).toEqual({ count: 1, kinds: ['api-key'] });
+  });
+
   it.each([
     ['api-key', 'sk-' + 'a'.repeat(24)],
     ['api-key', 'ghp_' + 'g'.repeat(24)],

--- a/src/core/services/secret-redaction.ts
+++ b/src/core/services/secret-redaction.ts
@@ -127,6 +127,40 @@ export function redactSecretText(s: string): RedactionResult<string> {
 }
 
 /**
+ * Redact both credential-shaped text and exact credentials already known to the
+ * caller. Exact matching closes the diagnostic-echo case where a real operator
+ * key is intentionally short or otherwise does not resemble a provider token.
+ * Callers must pass credential values only — URLs, model names, and other config
+ * are deliberately not inferred as secrets here.
+ */
+export function redactSecretTextWithKnownValues(
+  s: string,
+  knownValues: Iterable<string | undefined>,
+): RedactionResult<string> {
+  const initial = redactStringWithReport(s, true);
+  let value = initial.value;
+  let count = initial.redactions.count;
+  const kinds = new Set(initial.redactions.kinds);
+  const unique = [...new Set([...knownValues].filter((candidate): candidate is string => Boolean(candidate)))]
+    .sort((a, b) => b.length - a.length);
+
+  for (const secret of unique) {
+    let occurrences = 0;
+    let cursor = 0;
+    while ((cursor = value.indexOf(secret, cursor)) !== -1) {
+      occurrences++;
+      cursor += secret.length;
+    }
+    if (occurrences === 0) continue;
+    value = value.split(secret).join(marker('api-key', true));
+    count += occurrences;
+    kinds.add('api-key');
+  }
+
+  return { value, redactions: { count, kinds: [...kinds].sort() } };
+}
+
+/**
  * Deep-redact a value before it leaves the server on a non-error channel:
  * - strings → credential-shaped substrings replaced;
  * - object fields whose KEY name denotes a secret → value replaced with `[REDACTED]`;

--- a/src/utils/path-confinement.test.ts
+++ b/src/utils/path-confinement.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtemp, mkdir, writeFile, symlink, rm, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { safeJoin, safeOpenspecDir, isConfinedPath } from './path-confinement.js';
+import { readFileConfined, safeJoin, safeOpenspecDir, isConfinedPath } from './path-confinement.js';
 
 let root: string;
 let outside: string;
@@ -132,6 +132,16 @@ describe('safeOpenspecDir', () => {
 
   it('neutralizes a symlinked openspec path', () => {
     expect(safeOpenspecDir(root, 'openspec/escaping-dir')).toBe(join(root, 'openspec'));
+  });
+});
+
+describe('readFileConfined', () => {
+  it('reads a stable in-root regular file through its confined descriptor', async () => {
+    await expect(readFileConfined(root, 'openspec/specs/core/spec.md')).resolves.toBe('# real spec\n');
+  });
+
+  it('refuses an escaping symlink before returning any bytes', async () => {
+    await expect(readFileConfined(root, 'openspec/escaping-spec.md')).rejects.toThrow(/Path escape blocked/);
   });
 });
 

--- a/src/utils/path-confinement.ts
+++ b/src/utils/path-confinement.ts
@@ -13,7 +13,8 @@
  * motivated this file happened in the first place.
  */
 
-import { realpathSync, lstatSync, readlinkSync } from 'node:fs';
+import { constants, realpathSync, lstatSync, readlinkSync, type Stats } from 'node:fs';
+import { open, realpath, stat } from 'node:fs/promises';
 import { dirname, resolve, sep } from 'node:path';
 
 /** Upper bound on a symlink chain, so a cycle cannot spin the resolver. */
@@ -123,6 +124,48 @@ export function safeJoin(absDir: string, filePath: string): string {
     throw new Error(`Path escape blocked: "${filePath}" canonicalizes outside the project directory`);
   }
   return resolved;
+}
+
+function sameFile(
+  left: Pick<Stats, 'dev' | 'ino'>,
+  right: Pick<Stats, 'dev' | 'ino'>,
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+/**
+ * Read a repository file through one descriptor and disclose its contents only while
+ * that descriptor still names the canonically confined file. The repeated identity
+ * check closes the `safeJoin` -> `readFile` swap window for artifact-derived paths:
+ * replacing the file or one of its parent directories makes the read fail closed.
+ */
+export async function readFileConfined(absDir: string, filePath: string): Promise<string> {
+  const lexicalPath = safeJoin(absDir, filePath);
+  const canonicalRoot = await realpath(absDir);
+  const canonicalPath = await realpath(lexicalPath);
+  safeJoin(canonicalRoot, canonicalPath);
+
+  const handle = await open(canonicalPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = await handle.stat();
+    if (!opened.isFile()) throw new Error(`Confined read requires a regular file: "${filePath}"`);
+
+    const verifyIdentity = async (): Promise<void> => {
+      const currentCanonicalPath = await realpath(canonicalPath);
+      safeJoin(canonicalRoot, currentCanonicalPath);
+      const current = await stat(currentCanonicalPath);
+      if (!current.isFile() || !sameFile(opened, current)) {
+        throw new Error(`Confined read target changed during access: "${filePath}"`);
+      }
+    };
+
+    await verifyIdentity();
+    const content = await handle.readFile({ encoding: 'utf-8' });
+    await verifyIdentity();
+    return content;
+  } finally {
+    await handle.close();
+  }
 }
 
 /**

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -329,10 +329,74 @@ describe('workflow security: supply-chain automation is wired', () => {
       expect.arrayContaining(['pull_request', 'schedule'])
     );
   });
+
+  it('builds the release outside the minimal OIDC publishing job', () => {
+    const workflow = parse(read(join(WORKFLOW_DIR, 'release.yml'))) as {
+      jobs: Record<string, {
+        permissions?: Record<string, string>;
+        steps?: { uses?: string; run?: string }[];
+      }>;
+    };
+    const validate = workflow.jobs.validate;
+    const publish = workflow.jobs.publish;
+    const validateRuns = (validate.steps ?? []).map(step => step.run ?? '').join('\n');
+    const publishRuns = (publish.steps ?? []).map(step => step.run ?? '').join('\n');
+    const publishActions = (publish.steps ?? []).map(step => step.uses ?? '').filter(Boolean);
+
+    expect(validate.permissions?.['id-token']).toBeUndefined();
+    expect(validateRuns).toContain('git merge-base --is-ancestor');
+    expect(validateRuns).toContain('npm run audit:gate');
+    expect(validateRuns).toContain('npm pack --json');
+
+    expect(publish.permissions?.['id-token']).toBe('write');
+    expect(publishActions.some(action => action.startsWith('actions/checkout@'))).toBe(false);
+    expect(publishActions.some(action => action.startsWith('actions/download-artifact@'))).toBe(true);
+    expect(publishRuns).toContain('sha256sum --check');
+    expect(publishRuns).toContain('npm publish');
+    expect(publishRuns).toContain('--ignore-scripts');
+    expect(publishRuns).not.toMatch(/npm (ci|install|run|pack)\b/);
+  });
+
+  it('builds the SHA-pinned Action checkout with its locked dependencies and isolated npm config', () => {
+    const action = parse(read(join(REPO_ROOT, '.github', 'actions', 'openlore-review', 'action.yml'))) as {
+      inputs: Record<string, { required?: boolean; default?: string }>;
+      runs: { steps?: { run?: string; env?: Record<string, string> }[] };
+    };
+    const build = (action.runs.steps ?? []).find(step => step.run?.includes('npm ci'));
+    const allRuns = (action.runs.steps ?? []).map(step => step.run ?? '').join('\n');
+
+    expect(action.inputs['openlore-version']).toBeUndefined();
+    expect(build?.env?.ACTION_PATH).toBe('${{ github.action_path }}');
+    expect(build?.run).toContain('ACTION_PATH/../../..');
+    expect(build?.run).toContain('package-lock.json');
+    expect(build?.run).toContain('npm ci --ignore-scripts');
+    expect(build?.run).toContain('npm run build');
+    expect(build?.run).toContain('dist/cli/index.js');
+    expect(build?.env?.NPM_CONFIG_REGISTRY).toBe('https://registry.npmjs.org/');
+    expect(build?.env?.NPM_CONFIG_IGNORE_SCRIPTS).toBe('true');
+    expect(build?.env?.NPM_CONFIG_USERCONFIG).toContain('runner.temp');
+    expect(build?.env?.NPM_CONFIG_GLOBALCONFIG).toContain('runner.temp');
+    expect(allRuns).not.toContain('npm install');
+    expect(allRuns).not.toContain('npx ');
+  });
+
+  it('pins every registry tarball to an integrity digest', () => {
+    const lock = JSON.parse(read(join(REPO_ROOT, 'package-lock.json'))) as {
+      packages?: Record<string, { resolved?: string; integrity?: string }>;
+    };
+    const missing = Object.entries(lock.packages ?? {})
+      .filter(([, pkg]) => pkg.resolved?.startsWith('https://registry.npmjs.org/') && !pkg.integrity)
+      .map(([path]) => path);
+
+    expect(
+      missing,
+      'Every registry tarball must have an SRI digest so npm ci verifies the locked bytes.'
+    ).toEqual([]);
+  });
 });
 
 describe('workflow security: CodeQL suppressions stay narrow and auditable', () => {
-  it('allows only the nine reviewed file-to-HTTP egress sinks', () => {
+  it('allows only the thirteen reviewed file-to-HTTP egress sinks', () => {
     const suppressions: Record<string, number> = {};
     const unexplained: string[] = [];
 
@@ -356,6 +420,7 @@ describe('workflow security: CodeQL suppressions stay narrow and auditable', () 
     expect(suppressions, 'Changing the reviewed suppression set requires explicit security review.').toEqual({
       'src/cli/commands/serve.ts': 2,
       'src/core/analyzer/embedding-service.ts': 1,
+      'src/core/services/chat-agent.ts': 4,
       'src/core/services/serve-client.ts': 1,
       'src/core/services/llm-service.ts': 4,
       'src/pi/extension.ts': 1,


### PR DESCRIPTION
## Status

LGTM.

## What was wrong

The live code-scanning queue contained CodeQL alert #521, where a repository-selected Gemini model flowed into an HTTP request. The broader security review also found exploitable trust-boundary and release issues: imported analysis artifacts could read files outside the repository, `doctor` could send operator credentials to repository-selected endpoints and echo secrets into logs, bundle imports allowed excessive synchronous memory expansion, wildcard health checks disclosed repository/process metadata, the review Action resolved mutable npm code inside a write-token workflow, and the release job exposed OIDC to dependency/build code and accepted off-main release tags.

## How it was fixed

- Encoded Gemini model identifiers as one request-path segment and kept CodeQL intentional-egress annotations at provider-specific sinks.
- Confined artifact-derived paths and bound reads to a verified file descriptor in minimal-context, symbol-span, and error-propagation handlers.
- Applied the existing endpoint-trust policy to `doctor` generation/embedding checks and redacted generic plus exact known credentials at the shared output boundary.
- Capped bundles at 64 MiB compressed / 96 MiB expanded and read imports through one size-checked descriptor.
- Reduced unauthenticated wildcard `/health` to liveness-only fields.
- Made the review Action build its SHA-pinned source with its committed SRI lockfile, isolated npm configuration, and lifecycle scripts disabled; removed runtime npm selectors and `npx`.
- Split release validation/build/pack from the minimal OIDC publish job, verified release ancestry from `main`, transferred a checksum-verified tarball, restored the dependency audit gate, and completed missing lockfile integrity metadata.

## Replication / proof

- Added regressions for malicious model strings, hostile repository endpoints, reflected credentials, absolute/traversal/symlink artifact paths, oversized/high-ratio bundles, wildcard health metadata, mutable Action resolution, missing lockfile integrity, and off-main/OIDC release structure.
- `npm run test:run`: 414 files; 7,880 passed; 2 skipped.
- Focused security suites: 471 passed; 2 skipped.
- `npm run typecheck`, `npm run lint`, `npm run build`, `npm run audit:gate`, and `npm run audit:packlist` pass.
- OpenLore analyzed 1,133 files and reports no new spec gaps, stale mappings, or uncovered code.
- `npm run test:e2e`: 180 passed and 5 failed. The same 5 failures reproduce unchanged on parent commit `03f7af52` in an isolated worktree, so they predate this patch.

## Notes / nits

- CodeQL #521 is necessary provider egress; this patch removes URL syntax control and narrows the reviewed suppression to the Gemini-specific sink instead of suppressing the shared retry helper.
- Repository administration still needs a protected `v*` tag ruleset and required approval on the `npm-publish` environment. Those controls cannot be enforced from a PR.
- The remaining live Scorecard findings are operational: historical code-review coverage, branch-protection settings, and CII Best Practices registration.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] Added/updated tests for the change
- [x] Ran `npm run test:e2e`; 5 pre-existing failures are documented above
- [x] MCP/Pi parity is unchanged; no tool surface or Pi behavior was added
- [x] Updated security, publishing, CLI, bundle, and workflow documentation
