### PR TITLE
docs(security): define CodeQL egress triage

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,6 +51,7 @@ Automated controls cover pull requests, scheduled scans, and releases:
 
 - **Dependency advisories** — the full tree (runtime and development) is gated at high severity.
 - **CodeQL** static analysis on each pull request and on a weekly schedule.
+- **Reviewed egress** — `codeql[js/file-access-to-http]` source comments are audit markers, not scanner suppressions. They keep intentional repository-to-provider flows count-pinned and rationale-bound in the unit suite. CodeQL alerts for those flows are triaged in GitHub as `won't fix` only after confirming the destination is fixed or operator-selected and the transmitted data is required by the feature.
 - **Published-package contents** are verified against the real `npm pack` manifest, in CI and again immediately before publish.
 - **Workflow hardening** — GitHub Actions are pinned to immutable commit SHAs, and a test in the unit suite keeps them pinned. The structural-review Action builds that pinned source with its committed lockfile, an isolated npm configuration, and lifecycle scripts disabled; it does not resolve OpenLore through a runtime npm selector.
 - **Dependabot** watches both npm packages and GitHub Actions.

--- a/src/core/services/chat-agent.ts
+++ b/src/core/services/chat-agent.ts
@@ -421,15 +421,14 @@ async function runOpenAILoop(
     let response: BufferedChatResponse;
     try {
       response = await fetchWithRetry(
-        attemptSignal => withRelaxedTls(() =>
+        attemptSignal => withRelaxedTls(() => fetch(`${cfg.baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers,
           // INTENTIONAL EGRESS: prompt-wrapped repository results go to the operator-selected LLM.
           // codeql[js/file-access-to-http]
-          fetch(`${cfg.baseUrl}/chat/completions`, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({ model: cfg.model, messages: history, tools: toolDefs, tool_choice: 'auto' }),
-            signal: attemptSignal,
-          })),
+          body: JSON.stringify({ model: cfg.model, messages: history, tools: toolDefs, tool_choice: 'auto' }),
+          signal: attemptSignal,
+        })),
         signal,
       );
     } catch (error) {
@@ -523,15 +522,19 @@ async function runGeminiLoop(
     let response: BufferedChatResponse;
     try {
       response = await fetchWithRetry(
-        attemptSignal => withRelaxedTls(() =>
-          // INTENTIONAL EGRESS: the encoded model and repository context go only to Google's fixed origin.
+        attemptSignal => withRelaxedTls(() => fetch(
+          // INTENTIONAL EGRESS: the encoded model selects a resource only at Google's fixed origin.
           // codeql[js/file-access-to-http]
-          fetch(url, {
+          url,
+          {
             method: 'POST',
             headers,
+            // INTENTIONAL EGRESS: prompt-wrapped repository results go to the fixed Gemini provider.
+            // codeql[js/file-access-to-http]
             body: JSON.stringify(body),
             signal: attemptSignal,
-          })),
+          },
+        )),
         signal,
       );
     } catch (error) {
@@ -633,21 +636,20 @@ async function runAnthropicLoop(
     let response: BufferedChatResponse;
     try {
       response = await fetchWithRetry(
-        attemptSignal => withRelaxedTls(() =>
+        attemptSignal => withRelaxedTls(() => fetch(`${cfg.baseUrl}/messages`, {
+          method: 'POST',
+          headers,
           // INTENTIONAL EGRESS: prompt-wrapped repository results go to the fixed Anthropic provider.
           // codeql[js/file-access-to-http]
-          fetch(`${cfg.baseUrl}/messages`, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({
-              model: cfg.model,
-              max_tokens: CHAT_AGENT_MAX_TOKENS,
-              system: chatSystemPrompt(directory, boundary),
-              tools,
-              messages: history,
-            }),
-            signal: attemptSignal,
-          })),
+          body: JSON.stringify({
+            model: cfg.model,
+            max_tokens: CHAT_AGENT_MAX_TOKENS,
+            system: chatSystemPrompt(directory, boundary),
+            tools,
+            messages: history,
+          }),
+          signal: attemptSignal,
+        })),
         signal,
       );
     } catch (error) {

--- a/src/core/services/chat-agent.ts
+++ b/src/core/services/chat-agent.ts
@@ -421,14 +421,15 @@ async function runOpenAILoop(
     let response: BufferedChatResponse;
     try {
       response = await fetchWithRetry(
-        attemptSignal => withRelaxedTls(() => fetch(`${cfg.baseUrl}/chat/completions`, {
-          method: 'POST',
-          headers,
+        attemptSignal => withRelaxedTls(() =>
           // INTENTIONAL EGRESS: prompt-wrapped repository results go to the operator-selected LLM.
           // codeql[js/file-access-to-http]
-          body: JSON.stringify({ model: cfg.model, messages: history, tools: toolDefs, tool_choice: 'auto' }),
-          signal: attemptSignal,
-        })),
+          fetch(`${cfg.baseUrl}/chat/completions`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ model: cfg.model, messages: history, tools: toolDefs, tool_choice: 'auto' }),
+            signal: attemptSignal,
+          })),
         signal,
       );
     } catch (error) {
@@ -522,19 +523,15 @@ async function runGeminiLoop(
     let response: BufferedChatResponse;
     try {
       response = await fetchWithRetry(
-        attemptSignal => withRelaxedTls(() => fetch(
-          // INTENTIONAL EGRESS: the encoded model selects a resource only at Google's fixed origin.
+        attemptSignal => withRelaxedTls(() =>
+          // INTENTIONAL EGRESS: the encoded model and repository context go only to Google's fixed origin.
           // codeql[js/file-access-to-http]
-          url,
-          {
+          fetch(url, {
             method: 'POST',
             headers,
-            // INTENTIONAL EGRESS: prompt-wrapped repository results go to the fixed Gemini provider.
-            // codeql[js/file-access-to-http]
             body: JSON.stringify(body),
             signal: attemptSignal,
-          },
-        )),
+          })),
         signal,
       );
     } catch (error) {
@@ -636,20 +633,21 @@ async function runAnthropicLoop(
     let response: BufferedChatResponse;
     try {
       response = await fetchWithRetry(
-        attemptSignal => withRelaxedTls(() => fetch(`${cfg.baseUrl}/messages`, {
-          method: 'POST',
-          headers,
+        attemptSignal => withRelaxedTls(() =>
           // INTENTIONAL EGRESS: prompt-wrapped repository results go to the fixed Anthropic provider.
           // codeql[js/file-access-to-http]
-          body: JSON.stringify({
-            model: cfg.model,
-            max_tokens: CHAT_AGENT_MAX_TOKENS,
-            system: chatSystemPrompt(directory, boundary),
-            tools,
-            messages: history,
-          }),
-          signal: attemptSignal,
-        })),
+          fetch(`${cfg.baseUrl}/messages`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+              model: cfg.model,
+              max_tokens: CHAT_AGENT_MAX_TOKENS,
+              system: chatSystemPrompt(directory, boundary),
+              tools,
+              messages: history,
+            }),
+            signal: attemptSignal,
+          })),
         signal,
       );
     } catch (error) {

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -395,9 +395,9 @@ describe('workflow security: supply-chain automation is wired', () => {
   });
 });
 
-describe('workflow security: CodeQL suppressions stay narrow and auditable', () => {
+describe('workflow security: reviewed CodeQL egress stays narrow and auditable', () => {
   it('allows only the thirteen reviewed file-to-HTTP egress sinks', () => {
-    const suppressions: Record<string, number> = {};
+    const markers: Record<string, number> = {};
     const unexplained: string[] = [];
 
     for (const file of sourceFiles(join(REPO_ROOT, 'src'))) {
@@ -409,15 +409,15 @@ describe('workflow security: CodeQL suppressions stay narrow and auditable', () 
             lines[index - 1]?.trim().startsWith('// INTENTIONAL EGRESS:') !== true) {
           unexplained.push(location);
         }
-        suppressions[rel(file)] = (suppressions[rel(file)] ?? 0) + 1;
+        markers[rel(file)] = (markers[rel(file)] ?? 0) + 1;
       });
     }
 
     expect(
       unexplained,
-      'Every CodeQL suppression must name one query and have an immediately preceding rationale.'
+      'Every reviewed CodeQL egress marker must name one query and have an immediately preceding rationale.'
     ).toEqual([]);
-    expect(suppressions, 'Changing the reviewed suppression set requires explicit security review.').toEqual({
+    expect(markers, 'Changing the reviewed egress set requires explicit security review.').toEqual({
       'src/cli/commands/serve.ts': 2,
       'src/core/analyzer/embedding-service.ts': 1,
       'src/core/services/chat-agent.ts': 4,

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -396,7 +396,7 @@ describe('workflow security: supply-chain automation is wired', () => {
 });
 
 describe('workflow security: CodeQL suppressions stay narrow and auditable', () => {
-  it('allows only the twelve reviewed file-to-HTTP egress sinks', () => {
+  it('allows only the thirteen reviewed file-to-HTTP egress sinks', () => {
     const suppressions: Record<string, number> = {};
     const unexplained: string[] = [];
 
@@ -420,24 +420,10 @@ describe('workflow security: CodeQL suppressions stay narrow and auditable', () 
     expect(suppressions, 'Changing the reviewed suppression set requires explicit security review.').toEqual({
       'src/cli/commands/serve.ts': 2,
       'src/core/analyzer/embedding-service.ts': 1,
-      'src/core/services/chat-agent.ts': 3,
+      'src/core/services/chat-agent.ts': 4,
       'src/core/services/serve-client.ts': 1,
       'src/core/services/llm-service.ts': 4,
       'src/pi/extension.ts': 1,
     });
-  });
-
-  it('attaches chat egress suppressions to the fetch sinks', () => {
-    const lines = read(join(REPO_ROOT, 'src/core/services/chat-agent.ts')).split('\n');
-    const misplaced = lines
-      .map((line, index) => ({ line, index }))
-      .filter(({ line }) => line.includes('codeql[js/file-access-to-http]'))
-      .filter(({ index }) => lines[index + 1]?.trim().startsWith('fetch(') !== true)
-      .map(({ index }) => index + 1);
-
-    expect(
-      misplaced,
-      'A suppression on a request URL or body does not suppress the fetch sink selected by CodeQL.'
-    ).toEqual([]);
   });
 });

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -396,7 +396,7 @@ describe('workflow security: supply-chain automation is wired', () => {
 });
 
 describe('workflow security: CodeQL suppressions stay narrow and auditable', () => {
-  it('allows only the thirteen reviewed file-to-HTTP egress sinks', () => {
+  it('allows only the twelve reviewed file-to-HTTP egress sinks', () => {
     const suppressions: Record<string, number> = {};
     const unexplained: string[] = [];
 
@@ -420,10 +420,24 @@ describe('workflow security: CodeQL suppressions stay narrow and auditable', () 
     expect(suppressions, 'Changing the reviewed suppression set requires explicit security review.').toEqual({
       'src/cli/commands/serve.ts': 2,
       'src/core/analyzer/embedding-service.ts': 1,
-      'src/core/services/chat-agent.ts': 4,
+      'src/core/services/chat-agent.ts': 3,
       'src/core/services/serve-client.ts': 1,
       'src/core/services/llm-service.ts': 4,
       'src/pi/extension.ts': 1,
     });
+  });
+
+  it('attaches chat egress suppressions to the fetch sinks', () => {
+    const lines = read(join(REPO_ROOT, 'src/core/services/chat-agent.ts')).split('\n');
+    const misplaced = lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line }) => line.includes('codeql[js/file-access-to-http]'))
+      .filter(({ index }) => lines[index + 1]?.trim().startsWith('fetch(') !== true)
+      .map(({ index }) => index + 1);
+
+    expect(
+      misplaced,
+      'A suppression on a request URL or body does not suppress the fetch sink selected by CodeQL.'
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Status

LGTM.

## What was wrong

The main-branch CodeQL scan opened alerts #523 through #527 after #376. These are the same intentional product flow previously reviewed in #472: OpenLore reads repository context and sends it to the fixed or operator-selected LLM endpoint. A live PR scan proved the repository's inline `codeql[...]` comments do not suppress GitHub alerts, but the policy test and documentation described them as suppressions. That created a misleading control claim.

## How it was fixed

- Define the inline comments as audit markers, not scanner suppressions.
- Document the required GitHub triage: use `won't fix` only after verifying destination trust and that the transmitted data is required by the feature.
- Keep every marker rationale-bound and the complete egress set count-pinned in the unit suite.
- Keep the `security-extended` query enabled and continue scanning `chat-agent.ts`.

## Replication / proof

The first revision moved the comments to the `fetch` calls. CodeQL still produced 5 new alerts, proving that source placement was not a fix; that revision was reverted.

The prior alert #472 records the established disposition: “By design: OpenLore reads your repository and configuration and sends them to the LLM/embedding endpoint you configured. That flow is the product; removing it removes the feature.”

Verified locally:

- `npx vitest run src/workflow-security.test.ts` — 12 passed.
- `npx eslint src/workflow-security.test.ts` — passed.
- `npm run typecheck` — passed.
- `git diff --check` — passed.

## Notes / nits

This PR does not weaken or filter CodeQL. After its checks pass, alerts #523–#527 should be triaged in GitHub with the documented rationale; the subsequent main scan will confirm the queue is clear.