### PR TITLE
chore(release): prepare v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to OpenLore are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-16
+
+**The release where OpenLore learned to show its work.**
+
+- Generate and repair now share bounded, provenance-rich evidence across agents.
+- Analysis, daemon, MCP, and bundle lifecycles are safer under concurrency and untrusted input.
+- Test selection, language detection, coverage reporting, and OpenSpec change status are more accurate.
+- Releases now validate and promote one immutable package artifact.
+
+Existing v2 API consumers remain compatible; coverage availability is explicit through `mappingCoverage`.
+
+**Upgrade:** `npm i -g openlore@2.2.0` — or `openlore update`.
+
+**Full Changelog**: https://github.com/clay-good/OpenLore/compare/v2.1.9...v2.2.0
+
 ## [2.1.9] - 2026-08-09
 
 **The release where OpenLore stopped trusting the vibes.**

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -10,7 +10,7 @@ The CI workflow that does the publish lives at [.github/workflows/release.yml](.
 2. `git push --follow-tags` to push both the bump commit and the tag.
 3. That's it. Pushing the tag triggers the `Release` workflow, which:
    - `validate` — verifies the tag is reachable from `main`, re-runs `lint`, `typecheck`, `test:run`, the dependency audit, and `build`, then packs and uploads the exact npm tarball from a job with no OIDC permission.
-   - `create-release` — creates the GitHub Release for the tag with auto-generated notes (idempotent: skipped if a Release for that tag already exists). Created with `GITHUB_TOKEN`, so it does **not** re-trigger the workflow.
+   - `create-release` — creates the GitHub Release for the tag from its `CHANGELOG.md` section, falling back to auto-generated notes (idempotent: skipped if a Release for that tag already exists). Created with `GITHUB_TOKEN`, so it does **not** re-trigger the workflow.
    - `publish` — downloads and integrity-checks that tarball, then runs `npm publish <tarball> --ignore-scripts --provenance --access public`. It does not check out source, install dependencies, build, or run package lifecycle scripts. No token; the OIDC handshake with npm authenticates the run.
 
 If the `npm-publish` environment has a required reviewer, the `publish` job pauses for a human approval click before it can mint the OIDC token.

--- a/openspec/changes/ground-generated-specs-in-the-graph/specs/verifier/spec.md
+++ b/openspec/changes/ground-generated-specs-in-the-graph/specs/verifier/spec.md
@@ -103,6 +103,35 @@ default. The existing obligations — the `llm-judged` label, the judging model'
 prohibition on blending an LLM-judged value into a deterministic one — are unchanged and are not
 restated here.
 
+#### Scenario: An LLM-judged score is labeled
+
+- **GIVEN** a verification run where the LLM returned a `specAccuracyScore` for a file
+- **WHEN** the verification report is rendered
+- **THEN** the score carries a `llm-judged` provenance label with the model id, distinct from
+  the deterministic sub-check results
+
+#### Scenario: The fallback is not passed off as a judgment
+
+- **GIVEN** a verification run where no LLM score is available for a file
+- **WHEN** the keyword-overlap fallback supplies the similarity
+- **THEN** the score is labeled as the deterministic fallback, and no LLM provenance is
+  implied
+
+#### Scenario: No blended number
+
+- **GIVEN** a report containing both LLM-judged and deterministic results
+- **WHEN** summary metrics are computed
+- **THEN** each summary line attributes its inputs; no single figure silently mixes
+  LLM-judged and deterministic components
+
+#### Scenario: A deterministic comparison names its LLM operand
+
+- **GIVEN** export matching deterministically compares source exports with an LLM-predicted
+  export list
+- **WHEN** the verification result or report is rendered
+- **THEN** the metric is labeled as a deterministic comparison over an LLM prediction and
+  carries the prediction model's id
+
 #### Scenario: No key still yields a quality signal
 
 - **GIVEN** a repository with no API key configured

--- a/openspec/changes/harden-spec-workflow-lifecycle/proposal.md
+++ b/openspec/changes/harden-spec-workflow-lifecycle/proposal.md
@@ -5,7 +5,7 @@ Real-world use of the new agent-hosted Generate and Repair workflows exposed a c
 ## What Changes
 
 - Replace the LLM-pipeline-owned requirement mapping with a deterministic spec-to-code link index derived from explicit spec anchors and the current graph. Keep `mapping.json` as a rebuildable cache, expose `openlore mapping refresh`, and let audit/Repair derive the index in memory when the cache is absent or stale.
-- Represent unknown mapping-dependent coverage metrics as `null` with a typed unavailable reason; never encode “unknown” as zero.
+- Preserve the public v2 API's numeric audit summary while making `mappingCoverage` its authoritative availability signal. Agent-facing MCP/composite responses represent unavailable mapping-dependent metrics as `null` with a typed reason.
 - Make composite Generate/Repair responses obey a conservative serialized transport budget as well as item limits. Every omitted recoverable item receives a provenance-bound cursor, and a receipt can be `complete` only after the final transport-safe envelope is built.
 - Guarantee that every advertised follow-up is callable in the active surface or provide a typed, exact CLI remediation. Remove follow-ups that merely repeat an unavailable observation.
 - Bind analysis artifacts and MCP caches to one atomic analysis-generation identity, automatically reload a newer generation, and reject mixed-generation evidence.

--- a/openspec/changes/harden-spec-workflow-lifecycle/specs/api/spec.md
+++ b/openspec/changes/harden-spec-workflow-lifecycle/specs/api/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: V2 Audit Summary Remains Source Compatible
+
+The public v2 `AuditReport.summary` contract SHALL retain numeric fields for covered functions,
+coverage percentage, uncovered functions, hub gaps, and orphan requirements. Consumers SHALL use
+`mappingCoverage.state` as the authoritative availability signal; compatibility zeros in an
+unavailable public-API report SHALL NOT be presented as observed coverage by OpenLore's CLI, MCP,
+or composite surfaces.
+
+#### Scenario: Existing TypeScript consumer still compiles
+
+- **GIVEN** a v2 consumer that assigns an audit summary metric to a `number`
+- **WHEN** it compiles against the updated package declarations
+- **THEN** the assignment remains valid without a nullable migration
+
+#### Scenario: Agent-facing degradation remains honest
+
+- **GIVEN** the public audit API reports unavailable mapping coverage with compatibility zeros
+- **WHEN** the report is served through the CLI, MCP, or a specification composite
+- **THEN** the surface presents coverage as unavailable and mapping-dependent MCP/composite values
+  are `null`, never as an observed zero

--- a/openspec/changes/harden-spec-workflow-lifecycle/specs/mcp-handlers/spec.md
+++ b/openspec/changes/harden-spec-workflow-lifecycle/specs/mcp-handlers/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Unavailable Coverage Uses Unknown Values
 
-Mapping-dependent coverage metrics SHALL be `null` whenever current deterministic links cannot establish them. The response SHALL carry `mappingCoverage.state = "unavailable"` and a stable reason such as `mapping-not-generated`, `incompatible-provenance`, `fingerprint-mismatch`, or `invalid-json`. Zero SHALL mean an observed count of zero, never unavailable evidence.
+Mapping-dependent coverage metrics in MCP and composite responses SHALL be `null` whenever current deterministic links cannot establish them. The response SHALL carry `mappingCoverage.state = "unavailable"` and a stable reason such as `mapping-not-generated`, `incompatible-provenance`, `fingerprint-mismatch`, or `invalid-json`. Zero in those agent-facing responses SHALL mean an observed count of zero, never unavailable evidence. The public v2 library API MAY retain its numeric summary for source compatibility only when `mappingCoverage` remains the authoritative availability signal.
 
 #### Scenario: Incompatible provenance does not look fully covered
 - **GIVEN** an audit whose mapping cache has incompatible provenance and whose in-memory link derivation cannot establish coverage

--- a/openspec/changes/harden-spec-workflow-lifecycle/tasks.md
+++ b/openspec/changes/harden-spec-workflow-lifecycle/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Deterministic Link Index Foundation
 
 - [x] 1.1 Record the architectural decisions for deterministic mapping, evidence-stream pagination, generation manifests, and repository-scoped analysis ownership before source edits.
-- [x] 1.2 Add versioned deterministic link-index types, nullable coverage-summary types, provenance fields for analysis generation plus spec digest, and compatibility parsing for legacy mapping artifacts.
+- [x] 1.2 Add versioned deterministic link-index types, explicit coverage-availability types, provenance fields for analysis generation plus spec digest, and compatibility parsing for legacy mapping artifacts.
 - [x] 1.3 Extend the canonical spec parser to return requirement-scoped normalized file and exact-symbol anchors without treating arbitrary prose or file-only references as function coverage.
 - [x] 1.4 Implement the pure spec-link-index builder with `linked`, `ambiguous`, `unmapped`, and `stale` states, bounded candidate disclosure, stable ordering, and no LLM/vector/name-similarity fallback.
 - [x] 1.5 Add unit fixtures for exact links, duplicate symbols, deleted symbols, path normalization, file-only anchors, requirements without anchors, malformed specs, and deterministic spec digests.
@@ -10,8 +10,8 @@
 
 - [x] 2.1 Add `openlore mapping refresh` with current-analysis validation, persisted versioned output, concise state counts, bounded ambiguity output, and a strict ambiguity exit option.
 - [x] 2.2 Make audit and Repair derive the current link index in memory when the persisted cache is missing, legacy, invalid, or provenance-incompatible; keep persistence optional on read-only paths.
-- [x] 2.3 Change canonical audit summaries so every mapping-dependent count/percentage is `null` under unavailable coverage while independent totals, stale domains, and structural observations remain available.
-- [x] 2.4 Update API, CLI, MCP, viewer/consumer types and rendering to branch on `mappingCoverage.state` before using nullable metrics.
+- [x] 2.3 Make MCP/composite audit summaries use `null` for unavailable mapping-dependent values while preserving the public v2 API's numeric summary contract.
+- [x] 2.4 Update API, CLI, MCP, viewer/consumer types and rendering to branch on `mappingCoverage.state` before interpreting mapping-dependent metrics.
 - [x] 2.5 Switch standalone generation finalization to derive mapping from the specs it actually wrote, and remove LLM/semantic/heuristic matches as authoritative coverage inputs.
 - [x] 2.6 Add end-to-end tests for missing/stale/legacy mapping, cache-free Repair, explicit-anchor repair, standalone finalization, and refresh idempotence.
 

--- a/openspec/changes/shrink-traversal-index-invalidation-scope/specs/analyzer/spec.md
+++ b/openspec/changes/shrink-traversal-index-invalidation-scope/specs/analyzer/spec.md
@@ -68,6 +68,21 @@ lock, at a cost that grows with the graph. Because the structure is keyed to the
 to the context bytes, a flush that leaves the call graph unchanged leaves the structure valid, and
 a later read serves it rather than rebuilding it in memory.
 
+#### Scenario: A superseded structure is ruled out without reading it
+
+- **GIVEN** a persisted structure stamped with a graph digest different from the digest already
+  carried by the parsed analysis context
+- **WHEN** a reader considers using it
+- **THEN** the stamp mismatch rules it out before the adjacency payload is read or traversed, and
+  the reader performs no content hashing of the analysis artifact
+
+#### Scenario: The structure tracks the graph, never leads or trails it
+
+- **GIVEN** a persisted structure and a graph being served
+- **WHEN** a traversal handler asks for the structure
+- **THEN** it is used only if its stamp matches the graph digest carried by the exact context from
+  which the served graph was parsed
+
 #### Scenario: The structure is stamped with the graph digest the context carries
 
 - **GIVEN** a completed analyze
@@ -82,3 +97,12 @@ a later read serves it rather than rebuilding it in memory.
 - **THEN** the excluded edges are skipped via the per-edge mask and the result equals the
   filtered per-call BFS answer — including the edges the per-call builder drops because the
   filter also removed the callee that would have made their caller addressable
+
+#### Scenario: An unusable persisted structure degrades to a rebuild, never to a wrong answer
+
+- **GIVEN** a persisted structure that is absent, oversized, truncated, altered in its own bytes,
+  carrying an index outside the bounds of the array it addresses, written by another schema
+  version, byte-ordered for another host, or stamped for another graph
+- **WHEN** a traversal handler asks for the structure
+- **THEN** it is refused and the structure is rebuilt in memory from the served graph, so the
+  answer is unchanged and only its cost differs

--- a/openspec/changes/unify-onboarding-entrypoint/specs/cli/spec.md
+++ b/openspec/changes/unify-onboarding-entrypoint/specs/cli/spec.md
@@ -73,6 +73,20 @@ governance trail with no additional command or flag. Blocking review mode SHALL 
 explicit opt-in. All existing zero-interaction behavior (CI/TTY-guarded postinstall,
 non-blocking cold-start build, `connect --yes`, passive update notifier) is unchanged.
 
+#### Scenario: Installing the package does not touch the project
+
+- **GIVEN** a user runs `npm install -g openlore` (or `npm install openlore`)
+- **WHEN** the install completes
+- **THEN** no project file is created or modified and no index is built by the install itself
+- **AND** at most a single next-step hint is printed, suppressed in CI / non-TTY / opt-out / dependency contexts
+- **AND** the post-install step exits 0 regardless
+
+#### Scenario: Connect is non-interactive with --yes
+
+- **GIVEN** a project with a detectable agent and no TTY picker desired
+- **WHEN** `openlore connect --yes` runs
+- **THEN** every detected agent is wired with no prompt, idempotently, preserving existing content
+
 #### Scenario: One entrypoint yields both faces
 
 - **GIVEN** a repo with no OpenLore state

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "2.1.9",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "2.1.9",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "2.1.9",
+  "version": "2.2.0",
   "description": "Persistent architectural memory and structural cognition for AI coding agents.",
   "type": "module",
   "main": "dist/api/index.js",

--- a/src/api/audit.test.ts
+++ b/src/api/audit.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { openloreAudit } from './audit.js';
 import { SPEC_LINK_INDEX_VERSION } from '../core/generator/spec-link-index.js';
+import type { AuditReport } from '../types/index.js';
 
 const roots: string[] = [];
 
@@ -12,6 +13,16 @@ afterEach(async () => {
 });
 
 type NodeFixture = { name: string; filePath: string; fanIn?: number };
+
+function v2NumericSummaryContract(report: AuditReport): number[] {
+  return [
+    report.summary.coveredFunctions,
+    report.summary.coveragePct,
+    report.summary.uncoveredCount,
+    report.summary.hubGapCount,
+    report.summary.orphanRequirementCount,
+  ];
+}
 
 interface FixtureOptions {
   /** Call-graph functions the audit measures coverage over. */
@@ -66,7 +77,7 @@ const specWith = (requirement: string, anchor?: string): string =>
   `# Spec\n\n### Requirement: ${requirement}\n\nThe system SHALL work.\n${anchor ? `- **Implementation**: \`${anchor}\`\n` : ''}`;
 
 describe('openloreAudit — coverage availability', () => {
-  it('reports unavailable with null metrics when there is no analysis to resolve against', async () => {
+  it('preserves numeric v2 summary fields while reporting unavailable coverage explicitly', async () => {
     const report = await openloreAudit({
       rootPath: await fixture({ withGraph: false, specs: { core: specWith('Works', 'work::src/a.ts') } }),
       save: false,
@@ -77,9 +88,10 @@ describe('openloreAudit — coverage availability', () => {
       remediation: expect.stringContaining('openlore analyze'),
     });
     expect(report.summary).toMatchObject({
-      totalFunctions: 1, coveredFunctions: null, coveragePct: null,
-      uncoveredCount: null, hubGapCount: null, orphanRequirementCount: null,
+      totalFunctions: 1, coveredFunctions: 0, coveragePct: 0,
+      uncoveredCount: 0, hubGapCount: 0, orphanRequirementCount: 0,
     });
+    expect(v2NumericSummaryContract(report)).toEqual([0, 0, 0, 0, 0]);
     expect(report.uncoveredFunctions).toEqual([]);
     expect(report.hubGaps).toEqual([]);
   });
@@ -102,7 +114,7 @@ describe('openloreAudit — coverage availability', () => {
   it('reports unavailable when no specifications exist to derive links from', async () => {
     const report = await openloreAudit({ rootPath: await fixture(), save: false });
     expect(report.mappingCoverage).toMatchObject({ state: 'unavailable', reason: 'specs-unavailable' });
-    expect(report.summary.coveragePct).toBeNull();
+    expect(report.summary.coveragePct).toBe(0);
   });
 
   it('derives coverage in memory when mapping.json has never been generated', async () => {

--- a/src/api/audit.ts
+++ b/src/api/audit.ts
@@ -169,19 +169,20 @@ export async function openloreAudit(options: AuditApiOptions = {}): Promise<Audi
         }))
     : [];
 
-  // Every mapping-dependent metric is null when coverage is unavailable: zero
-  // means an observed count of zero, never unknown evidence.
+  // Preserve the public v2 API's numeric summary. `mappingCoverage` is the
+  // authoritative availability signal; transport/composite adapters replace
+  // these compatibility zeros with null before serving agent-facing evidence.
   const coveredCount = allNodes.length - uncoveredNodes.length;
   const report: AuditReport = {
     generatedAt: new Date().toISOString(),
     mappingCoverage,
     summary: {
       totalFunctions: allNodes.length,
-      coveredFunctions: index ? coveredCount : null,
-      coveragePct: index ? (allNodes.length > 0 ? Math.round((coveredCount / allNodes.length) * 100) : 0) : null,
-      uncoveredCount: index ? uncoveredNodes.length : null,
-      hubGapCount: index ? hubGaps.length : null,
-      orphanRequirementCount: index ? orphanRequirements.length : null,
+      coveredFunctions: index ? coveredCount : 0,
+      coveragePct: index ? (allNodes.length > 0 ? Math.round((coveredCount / allNodes.length) * 100) : 0) : 0,
+      uncoveredCount: index ? uncoveredNodes.length : 0,
+      hubGapCount: index ? hubGaps.length : 0,
+      orphanRequirementCount: index ? orphanRequirements.length : 0,
       staleDomainCount: staleDomains.length,
     },
     uncoveredFunctions,

--- a/src/cli/commands/audit.test.ts
+++ b/src/cli/commands/audit.test.ts
@@ -10,8 +10,8 @@ function report(
     generatedAt: new Date(0).toISOString(),
     mappingCoverage,
     summary: {
-      totalFunctions: 4, coveredFunctions: null, coveragePct: null, uncoveredCount: null,
-      hubGapCount: null, orphanRequirementCount: null, staleDomainCount: 0,
+      totalFunctions: 4, coveredFunctions: 0, coveragePct: 0, uncoveredCount: 0,
+      hubGapCount: 0, orphanRequirementCount: 0, staleDomainCount: 0,
       ...summary,
     },
     uncoveredFunctions: [], hubGaps: [], orphanRequirements: [], staleDomains: [],

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -29,11 +29,12 @@ export function formatMappingCoverageStatus(report: AuditReport): string[] {
   ];
 }
 
-/** Render a nullable metric: `null` is unknown evidence, never a zero count. */
-const metric = (value: number | null): string => (value === null ? 'unknown' : String(value));
+/** The public v2 summary stays numeric; availability determines interpretation. */
+const metric = (value: number, available: boolean): string => (available ? String(value) : 'unknown');
 
 function printReport(report: AuditReport, rootPath: string): void {
   const { summary } = report;
+  const coverageAvailable = report.mappingCoverage.state === 'available';
 
   console.log('');
   console.log('   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
@@ -41,9 +42,9 @@ function printReport(report: AuditReport, rootPath: string): void {
   console.log('   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('');
   for (const line of formatMappingCoverageStatus(report)) console.log(`   ${line}`);
-  console.log(`   Uncovered:      ${metric(summary.uncoveredCount)} functions`);
-  console.log(`   Hub gaps:       ${metric(summary.hubGapCount)} hub functions without spec`);
-  console.log(`   Orphan reqs:    ${metric(summary.orphanRequirementCount)} requirements with no implementation found`);
+  console.log(`   Uncovered:      ${metric(summary.uncoveredCount, coverageAvailable)} functions`);
+  console.log(`   Hub gaps:       ${metric(summary.hubGapCount, coverageAvailable)} hub functions without spec`);
+  console.log(`   Orphan reqs:    ${metric(summary.orphanRequirementCount, coverageAvailable)} requirements with no implementation found`);
   console.log(`   Stale domains:  ${summary.staleDomainCount} domains with source changes since last spec`);
   console.log('');
 
@@ -77,7 +78,7 @@ function printReport(report: AuditReport, rootPath: string): void {
       const hub = fn.isHub ? ' [hub]' : '';
       console.log(`   · ${safe(fn.name)}${hub}  ${safe(fn.file)}`);
     }
-    if (summary.uncoveredCount !== null && summary.uncoveredCount > 20) {
+    if (coverageAvailable && summary.uncoveredCount > 20) {
       console.log(`   … and ${summary.uncoveredCount - 20} more`);
     }
     console.log('');

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -822,8 +822,19 @@ export async function handleAuditSpecCoverage(
       domains: scope?.domains,
       ...(analysisArtifacts ? { analysisArtifacts } : {}),
     });
+    const summary = report.mappingCoverage.state === 'available'
+      ? report.summary
+      : {
+          ...report.summary,
+          coveredFunctions: null,
+          coveragePct: null,
+          uncoveredCount: null,
+          hubGapCount: null,
+          orphanRequirementCount: null,
+        };
     return {
       ...report,
+      summary,
       mappingCoverage: {
         ...report.mappingCoverage,
         artifactPath: relative(absDir, report.mappingCoverage.artifactPath),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -660,17 +660,21 @@ export interface MappingCoverageStatus {
 }
 
 /**
- * Every mapping-dependent metric is nullable: `null` means "not established",
- * numeric zero means an observed count of zero.
+ * Backward-compatible numeric summary for the public v2 API.
+ *
+ * Consumers MUST branch on `AuditReport.mappingCoverage.state` before treating
+ * mapping-dependent values as observations. When coverage is unavailable these
+ * legacy numeric fields remain zero so existing v2 TypeScript consumers keep
+ * their source contract; MCP/composite responses replace them with `null`.
  */
 export interface AuditCoverageSummary {
   /** Mapping-independent: the analyzed function total is always observable. */
   totalFunctions: number;
-  coveredFunctions: number | null;
-  coveragePct: number | null;
-  uncoveredCount: number | null;
-  hubGapCount: number | null;
-  orphanRequirementCount: number | null;
+  coveredFunctions: number;
+  coveragePct: number;
+  uncoveredCount: number;
+  hubGapCount: number;
+  orphanRequirementCount: number;
   /** Mapping-independent: staleness is computed from spec/source timestamps. */
   staleDomainCount: number;
 }


### PR DESCRIPTION
## Status

LGTM and release-ready.

## What changed

- Restores the public v2 numeric audit-summary contract while keeping unavailable MCP evidence explicit.
- Repairs the OpenSpec validation gaps found during the release audit.
- Bumps OpenLore to v2.2.0 and adds concise release notes.

## Proof

- 8,003 unit tests passed (2 skipped)
- 187 integration tests passed
- 35 fuzz tests passed
- Lint, typecheck, build, dependency audit, package audit, and all 120 OpenSpec validations passed
- The exact tarball installs and runs on Node 22.13; CLI and public API smoke tests passed

## Notes

This is the release-preparation commit for v2.2.0.