### PR TITLE
fix(config): preserve older configs and consolidate dependency updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -63,6 +63,6 @@ jobs:
       # No build step: both languages are extracted directly from source, so
       # `autobuild` would only add a failure mode without changing what is analyzed.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -60,6 +60,6 @@ jobs:
           retention-days: 7
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif

--- a/openspec/specs/analyzer/spec.md
+++ b/openspec/specs/analyzer/spec.md
@@ -6500,6 +6500,13 @@ The system SHALL the function shall read and return the openlore configuration f
 - **WHEN** the function is called
 - **THEN** it SHALL return the OpenLoreConfig
 
+#### Scenario: Config from an older release has a safe nested default omitted
+- **GIVEN** a root path with a previously valid `.openlore/config.json` whose existing section omits
+  a newly required field supplied by the current canonical defaults
+- **WHEN** the function is called
+- **THEN** it SHALL return the normalized `OpenLoreConfig` with that default added in memory, preserve
+  all explicit values, and leave the file unchanged
+
 ### Sub-component: Bfs
 
 > Implements: `bfs`

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -1804,6 +1804,13 @@ commands.
 - **WHEN** `openlore doctor` and `openlore analyze` are both run against it
 - **THEN** either both accept it, or `doctor` reports a finding describing why the command rejected it
 
+#### Scenario: Doctor recognizes a backward-compatible default
+
+- **GIVEN** a previously valid config missing a newly required nested field with a canonical default
+- **WHEN** `openlore doctor` and a command both read it
+- **THEN** both use the same in-memory default, `doctor` names the compatibility value and unchanged
+  file, and its remediation does not recommend destructive reinitialization
+
 ### Requirement: ReviewMarkdownEscapesHeadControlledText
 
 The `openlore review` Markdown renderer SHALL treat every value originating from the diffed head —

--- a/openspec/specs/config/spec.md
+++ b/openspec/specs/config/spec.md
@@ -296,6 +296,35 @@ configuration problem.
 - **THEN** the error names `.openlore/config.json`, the missing key, and the remedy
 - **AND** the message contains no internal property-access text such as `Cannot read properties of undefined`
 
+### Requirement: PreviouslyWrittenConfigsRemainReadable
+
+The system SHALL read any configuration emitted by an earlier release when newly required nested
+fields have canonical defaults. It SHALL add those values in memory before validation, warn with
+the exact field and value, preserve every user-supplied setting, and leave the file unchanged.
+Present but invalid values and missing fields without a derivable default SHALL remain validation
+errors. The schema and canonical defaults SHALL be checked together so a required field cannot be
+added to a default-emitted section without a backfill value.
+
+#### Scenario: A pre-2.2 generation section receives the canonical domains default
+
+- **GIVEN** a valid older config whose customized `generation` section has no `domains` field
+- **WHEN** `readOpenLoreConfig` reads the file
+- **THEN** the returned config contains `generation.domains: "auto"`
+- **AND** the custom provider, model, endpoint, exclusions, and embedding settings are preserved
+- **AND** a warning names the in-memory default while the config file remains unchanged
+
+#### Scenario: An invalid present value is not replaced
+
+- **GIVEN** a config whose `generation.domains` is present with an invalid type
+- **WHEN** `readOpenLoreConfig` validates the file
+- **THEN** the read fails with an attributable error naming `generation.domains`
+
+#### Scenario: Required fields in canonical sections stay defaultable
+
+- **GIVEN** a schema change that makes a field required in a section emitted by `getDefaultConfig`
+- **WHEN** the schema-evolution guard runs
+- **THEN** it fails unless `getDefaultConfig` supplies a value for that field
+
 ## Technical Notes
 
 ## Decisions

--- a/openspec/specs/config/spec.md
+++ b/openspec/specs/config/spec.md
@@ -298,12 +298,13 @@ configuration problem.
 
 ### Requirement: PreviouslyWrittenConfigsRemainReadable
 
-The system SHALL read any configuration emitted by an earlier release when newly required nested
-fields have canonical defaults. It SHALL add those values in memory before validation, warn with
-the exact field and value, preserve every user-supplied setting, and leave the file unchanged.
-Present but invalid values and missing fields without a derivable default SHALL remain validation
-errors. The schema and canonical defaults SHALL be checked together so a required field cannot be
-added to a default-emitted section without a backfill value.
+The system SHALL read every frozen configuration accepted by an earlier supported release. A newly
+required field SHALL be backfilled only when its schema rule explicitly marks the canonical default
+as upgrade-safe. The reader SHALL add that value in memory before validation, warn with the exact
+field and value, preserve every user-supplied setting, and leave the file unchanged. Present but
+invalid values, missing legacy-required fields, and hand-truncated required sections SHALL remain
+validation errors. Schema compatibility metadata and `getDefaultConfig` SHALL be checked together,
+and immutable release fixtures SHALL catch unmarked additions, renames, and type narrowing.
 
 #### Scenario: A pre-2.2 generation section receives the canonical domains default
 
@@ -319,13 +320,39 @@ added to a default-emitted section without a backfill value.
 - **WHEN** `readOpenLoreConfig` validates the file
 - **THEN** the read fails with an attributable error naming `generation.domains`
 
-#### Scenario: Required fields in canonical sections stay defaultable
+#### Scenario: A truncated strict section is not repaired
 
-- **GIVEN** a schema change that makes a field required in a section emitted by `getDefaultConfig`
+- **GIVEN** a config whose `analysis` section omits its legacy-required fields
+- **WHEN** `readOpenLoreConfig` validates the file
+- **THEN** the read fails with attributable errors for the missing analysis fields
+- **AND** canonical defaults are not used to conceal the malformed section
+
+#### Scenario: Upgrade-safe fields have canonical values
+
+- **GIVEN** a schema field marked as safe to backfill during an upgrade
 - **WHEN** the schema-evolution guard runs
 - **THEN** it fails unless `getDefaultConfig` supplies a value for that field
 
+#### Scenario: Historical fixtures remain immutable and readable
+
+- **GIVEN** frozen default and customized configurations from supported release lines
+- **WHEN** the current reader loads the compatibility corpus
+- **THEN** every fixture loads without changing its bytes
+- **AND** a package version change fails the corpus guard until that release adds a fixture
+
+#### Scenario: Configuration producers write the current required field
+
+- **GIVEN** the Pi configuration wizard creates a new config or edits a legacy config without domains
+- **WHEN** it saves the generation section
+- **THEN** it writes `generation.domains: "auto"`
+- **AND** an existing explicit string or string-array domain selection is preserved
+
 ## Technical Notes
+
+- Compatibility schema and normalization: `src/core/services/config-schema.ts`,
+  `src/core/services/config-manager.ts`
+- Frozen corpus: `src/core/services/fixtures/configs/`
+- Secondary config producer: `src/pi/extension.ts`
 
 ## Decisions
 

--- a/openspec/specs/drift/spec.md
+++ b/openspec/specs/drift/spec.md
@@ -696,6 +696,19 @@ stand in for either outcome.
 - **WHEN** repository detection runs
 - **THEN** the directory is recognized as a git repository
 
+### Requirement: DriftLoadsBackwardCompatibleConfiguration
+
+The drift command SHALL use the shared normalized configuration read boundary. A config written by
+an earlier release that omits a newly required nested field with a canonical default SHALL NOT stop
+static drift detection, and the command SHALL preserve the user's config file and explicit values.
+
+#### Scenario: Older config does not block drift analysis
+
+- **GIVEN** a previously valid config whose existing generation section omits a newly required field
+  supplied by the canonical defaults
+- **WHEN** `openlore drift` loads its configuration
+- **THEN** drift analysis proceeds with the in-memory default and the config file remains unchanged
+
 ## Sub-components
 
 > `DriftDetector` is an orchestrator. Each sub-component below implements one logical block.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,6 +1172,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
       "version": "0.84.2",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
+      "integrity": "sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1189,6 +1190,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
       "version": "0.84.2",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1214,6 +1216,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
       "version": "0.84.2",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.2.tgz",
+      "integrity": "sha512-/RFSPhD/bZbpOp1oJj+UneSUFSgZhWxzcSENUY+8+8xhoBrWXMYI2t77XNx4Yf+c8YK2qTHquForhNcelYpXvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1226,6 +1229,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
       "version": "0.84.2",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.2.tgz",
+      "integrity": "sha512-jbBh03fkeckWEroHpcZBr4w5/Ibat8WwdXFlXHivYQImrQNFtLpDeL0t1cku4hmK0q3pceIRQHkw4fwbM4YILQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1238,6 +1242,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
       "version": "0.84.2",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1247,6 +1252,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
       "version": "0.84.2",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@earendil-works/pi-coding-agent": "^0.84.1",
         "@earendil-works/pi-tui": "^0.84.1",
         "@eslint/js": "^10.0.1",
-        "@fission-ai/openspec": "1.8.0",
+        "@fission-ai/openspec": "1.9.0",
         "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.8.0",
@@ -44,7 +44,7 @@
         "globals": "^17.7.0",
         "memfs": "^4.15.0",
         "tsx": "^4.19.2",
-        "typebox": "1.3.11",
+        "typebox": "1.3.14",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.19.1",
         "vitest": "^4.0.18"
@@ -634,22 +634,21 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
-      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -668,17 +667,17 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
-      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.2.tgz",
+      "integrity": "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.84.1",
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-client": "^0.84.1",
-        "@earendil-works/pi-protocol": "^0.84.1",
+        "@earendil-works/pi-agent-core": "^0.84.2",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-client": "^0.84.2",
+        "@earendil-works/pi-protocol": "^0.84.2",
         "@earendil-works/pi-tui": "^0.84.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
@@ -1170,14 +1169,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
-      "integrity": "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -1188,22 +1186,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
-      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -1215,22 +1211,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
-      "integrity": "sha512-/V5hGHE4Zq+jG0GtwIB9PyBUOGd6gBLZ7lkQYFKchKnxYHeH3rmWC5xw4kpnZKKBuBuFTdLVbU9vEjlAGMMb2A==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-protocol": "^0.84.1"
+        "@earendil-works/pi-protocol": "^0.84.2"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
-      "integrity": "sha512-Ox1pciyeSPGEEUcxvR0/dJcrY7C6hrEGA8y71rOsvSIUlXN1Cbp/be/eoL71OGDBk5O97TeQPfWN6Ju/2Ehjww==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1241,9 +1235,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
-      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1251,9 +1244,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
-      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1479,27 +1471,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1521,16 +1492,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
@@ -2317,14 +2278,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -2660,30 +2618,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
-      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2691,9 +2629,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
-      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3285,9 +3223,9 @@
       }
     },
     "node_modules/@fission-ai/openspec": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@fission-ai/openspec/-/openspec-1.8.0.tgz",
-      "integrity": "sha512-xtKj5hI/kBgxJjIsCk1r3LnPbwqS41/xnDy8JTtz1B78S0Ydj276GBR4BxYkd6WUpspPA07T0BjcgmUBYgl3zA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@fission-ai/openspec/-/openspec-1.9.0.tgz",
+      "integrity": "sha512-yKV8mFz+J5+epLugvcSt7B+mBkkCSycOB6euLJmW6JL+2jhL+Um0JZ6zuGIdXcbsd3jU2+YQfeDz2EVwft++LA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4807,14 +4745,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.68.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.0.tgz",
-      "integrity": "sha512-OAioDU3UGV34ECVTB4pt641OfUzuyDuyUmgrlVM+Fp9g4YyavZrB4xxWuupYrU66+81+um9D0DAzYhjXto5ysQ==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
+      "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.68.0",
-        "@jsonjoy.com/fs-node-utils": "4.68.0",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -4829,15 +4767,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.68.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.0.tgz",
-      "integrity": "sha512-dC6VeW8uqXMF9Hkqb7qYST/t165XCHG+bNwwMzRetoNZRxJC8anr5XCJSAk5B+YLHGn6SP+noNltU6OFg/oa7A==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
+      "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.68.0",
-        "@jsonjoy.com/fs-node-builtins": "4.68.0",
-        "@jsonjoy.com/fs-node-utils": "4.68.0",
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -4852,17 +4790,17 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.68.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.0.tgz",
-      "integrity": "sha512-xYDlpSk3UDHjcI0kiz6kNJ/oVTEzlS7kUzAoAsgJh2/+yOtYV/eZW7M8O9Fj+ED3BDONYKt7+8OiPlWl6xpFeA==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
+      "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.68.0",
-        "@jsonjoy.com/fs-node-builtins": "4.68.0",
-        "@jsonjoy.com/fs-node-utils": "4.68.0",
-        "@jsonjoy.com/fs-print": "4.68.0",
-        "@jsonjoy.com/fs-snapshot": "4.68.0",
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -4878,9 +4816,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.68.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.0.tgz",
-      "integrity": "sha512-j3bb+k4NuqpqXQzinCLeagS7LGLCUvPqA6TnpaBkBqhnPjbzETYiQFpD7pWaV8cGOhhZcAv9dmpzk5mxNb1qsg==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
+      "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4895,15 +4833,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.68.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.0.tgz",
-      "integrity": "sha512-dtLpmLQxw3IBcGxoK9tVvftwmQLl9qmQyivt8DZpeEwDUcQkxk2CLMZERXtmOlF1mWXfT9CqtjjMiswkb03rKw==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
+      "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.68.0",
-        "@jsonjoy.com/fs-node-builtins": "4.68.0",
-        "@jsonjoy.com/fs-node-utils": "4.68.0"
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1"
       },
       "engines": {
         "node": ">=10.0"
@@ -4917,13 +4855,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.68.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.0.tgz",
-      "integrity": "sha512-Q84pogSfRaz0WNrBBy+HzBmhNu4m6tWoM0po8bLwW4pKvrwrSadOgFpm1sku08sfg0QAtUubkWuZEBDpNI3toQ==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
+      "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.68.0",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
         "glob-to-regex.js": "^1.0.1"
       },
       "engines": {
@@ -4938,13 +4876,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.68.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.0.tgz",
-      "integrity": "sha512-sdy9F6N9QEcyAcU8OxEQmB91mlgiyuMphTFeijQ+qFgigCOeT16lW3X1dCWNzD7wwKLOKXnnYqsFyeq4LWSlYQ==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
+      "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.68.0",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -4959,14 +4897,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.68.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.0.tgz",
-      "integrity": "sha512-eV44t9KY9LH47aPR1a4Nv4xYxM1vQ+OKEw9Mx/3zkuxGOILwmtFddlh5HakdMFpFHwuFNPw1s+NGq2eVYFpQRA==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
+      "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.68.0",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -5361,27 +5299,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
@@ -5480,16 +5397,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -5990,9 +5897,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -6007,17 +5914,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
-      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/type-utils": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -6030,22 +5937,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.66.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
-      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6061,14 +5968,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.66.0",
-        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6083,14 +5990,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
-      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6101,9 +6008,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6118,15 +6025,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
-      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -6143,9 +6050,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6157,16 +6064,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.66.0",
-        "@typescript-eslint/tsconfig-utils": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -6185,16 +6092,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
-      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6209,13 +6116,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
-      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/types": "8.67.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -7169,9 +7076,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -7931,9 +7838,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8818,20 +8725,20 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.68.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.0.tgz",
-      "integrity": "sha512-qlU8XrIfXUuZcmXk/GODL47KXXnhSbbaWtW5z+L7cLFfIQbgAOWzL5lqUYn39kfJh+BHLaD/siaM94/UTweGow==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.1.tgz",
+      "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.68.0",
-        "@jsonjoy.com/fs-fsa": "4.68.0",
-        "@jsonjoy.com/fs-node": "4.68.0",
-        "@jsonjoy.com/fs-node-builtins": "4.68.0",
-        "@jsonjoy.com/fs-node-to-fsa": "4.68.0",
-        "@jsonjoy.com/fs-node-utils": "4.68.0",
-        "@jsonjoy.com/fs-print": "4.68.0",
-        "@jsonjoy.com/fs-snapshot": "4.68.0",
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -9218,14 +9125,11 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -10646,9 +10550,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.11",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
-      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10722,9 +10626,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.11.tgz",
-      "integrity": "sha512-tZGKIS02Opbh4EYMmAEVuXl+y3EQJ9ZlkitLZ1CmFCY4ZOqr/xWR9dDSCFmIjNDICGMWkOqMh6WxGTyRXqcSGQ==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.14.tgz",
+      "integrity": "sha512-uD3FHZb4St/7E7eY0YANSt+yZABDDlbeJbXhUU17x2GZLyHUiQ6+mxSpZhZtnJSjKy/7PZ49r7SDZHG4F3JsLw==",
       "dev": true,
       "license": "MIT"
     },
@@ -10743,16 +10647,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
-      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.66.0",
-        "@typescript-eslint/parser": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0"
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "ignore": "^7.0.6",
         "jsonc-parser": "^3.3.1",
         "ora": "^9.4.1",
+        "protobufjs": "8.7.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "tree-sitter-wasms": "0.1.13",
@@ -9391,9 +9392,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
-      "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.2.tgz",
+      "integrity": "sha512-oTVHV+oelUBtiu5iTuTNNZ0eLYsXSMxry4cgr30mayNkgIZL6qZ0IOQVPuSWGcyAaXKl/XgqwWHIC3a0khYVBA==",
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "@earendil-works/pi-coding-agent": "^0.84.1",
     "@earendil-works/pi-tui": "^0.84.1",
     "@eslint/js": "^10.0.1",
-    "@fission-ai/openspec": "1.8.0",
+    "@fission-ai/openspec": "1.9.0",
     "@types/node": "^26.1.1",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.8.0",
@@ -246,7 +246,7 @@
     "globals": "^17.7.0",
     "memfs": "^4.15.0",
     "tsx": "^4.19.2",
-    "typebox": "1.3.11",
+    "typebox": "1.3.14",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.19.1",
     "vitest": "^4.0.18"

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -35,6 +35,24 @@ vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
 
 vi.mock('../../core/services/config-manager.js', () => ({
   InvalidOpenLoreConfigError: class InvalidOpenLoreConfigError extends Error {},
+  normalizeOpenLoreConfig: (parsed: unknown) => {
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return { config: parsed, findings: [] };
+    }
+    const record = parsed as Record<string, unknown>;
+    const generation = record.generation;
+    if (typeof generation !== 'object' || generation === null || Array.isArray(generation)
+      || Object.prototype.hasOwnProperty.call(generation, 'domains')) {
+      return { config: parsed, findings: [] };
+    }
+    return {
+      config: { ...record, generation: { ...generation, domains: 'auto' } },
+      findings: [{
+        kind: 'default-added', key: 'generation.domains', fatal: false,
+        message: "added missing config key 'generation.domains' = \"auto\" from the current default (file unchanged)",
+      }],
+    };
+  },
   readOpenLoreConfig: vi.fn().mockResolvedValue({
     projectType: 'nodejs',
     createdAt: '2024-01-01T00:00:00Z',
@@ -580,6 +598,26 @@ describe('doctor command', () => {
       expect(schemaCheck.detail).toContain('analysis');
       expect(schemaCheck.detail).toContain('openlore init');
       expect(schemaCheck.detail).not.toContain('all keys known and well-typed');
+    });
+
+    it('reports an in-memory compatibility default without recommending init', async () => {
+      const { readFile } = await import('node:fs/promises');
+      vi.mocked(readFile).mockResolvedValue(
+        JSON.stringify({
+          version: '1.0.0', projectType: 'nodejs', openspecPath: 'openspec',
+          analysis: { maxFiles: 1, includePatterns: [], excludePatterns: ['dist/**'] },
+          generation: { model: 'custom-model' },
+          createdAt: '2026-01-01T00:00:00Z', lastRun: null,
+        }) as never
+      );
+
+      const checks = await runDoctorJson();
+      const schemaCheck = checks.find(c => c.name === 'Config schema')!;
+
+      expect(schemaCheck.status).toBe('warn');
+      expect(schemaCheck.detail).toContain('generation.domains');
+      expect(schemaCheck.detail).toContain('compatibility defaults');
+      expect(schemaCheck.fix).not.toContain('openlore init');
     });
 
     it('reports nested type mismatches', async () => {

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -33,35 +33,20 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 // function created at import time references our controllable vi.fn().
 vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
 
-vi.mock('../../core/services/config-manager.js', () => ({
-  InvalidOpenLoreConfigError: class InvalidOpenLoreConfigError extends Error {},
-  normalizeOpenLoreConfig: (parsed: unknown) => {
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      return { config: parsed, findings: [] };
-    }
-    const record = parsed as Record<string, unknown>;
-    const generation = record.generation;
-    if (typeof generation !== 'object' || generation === null || Array.isArray(generation)
-      || Object.prototype.hasOwnProperty.call(generation, 'domains')) {
-      return { config: parsed, findings: [] };
-    }
-    return {
-      config: { ...record, generation: { ...generation, domains: 'auto' } },
-      findings: [{
-        kind: 'default-added', key: 'generation.domains', fatal: false,
-        message: "added missing config key 'generation.domains' = \"auto\" from the current default (file unchanged)",
-      }],
-    };
-  },
-  readOpenLoreConfig: vi.fn().mockResolvedValue({
-    projectType: 'nodejs',
-    createdAt: '2024-01-01T00:00:00Z',
-    openspecPath: './openspec',
-    maxFiles: 500,
-  }),
-  // Default resolution: <root>/.openlore/config.json (no --config override in tests).
-  resolveOpenLoreConfigPath: (rootPath: string) => `${rootPath}/.openlore/config.json`,
-}));
+vi.mock('../../core/services/config-manager.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/services/config-manager.js')>();
+  return {
+    ...actual,
+    readOpenLoreConfig: vi.fn().mockResolvedValue({
+      projectType: 'nodejs',
+      createdAt: '2024-01-01T00:00:00Z',
+      openspecPath: './openspec',
+      maxFiles: 500,
+    }),
+    // Default resolution: <root>/.openlore/config.json (no --config override in tests).
+    resolveOpenLoreConfigPath: (rootPath: string) => `${rootPath}/.openlore/config.json`,
+  };
+});
 
 vi.mock('../../core/services/llm-service.js', () => ({
   createLLMService: vi.fn().mockReturnValue({
@@ -616,6 +601,7 @@ describe('doctor command', () => {
 
       expect(schemaCheck.status).toBe('warn');
       expect(schemaCheck.detail).toContain('generation.domains');
+      expect(schemaCheck.detail).toContain('"auto"');
       expect(schemaCheck.detail).toContain('compatibility defaults');
       expect(schemaCheck.fix).not.toContain('openlore init');
     });

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -310,7 +310,7 @@ async function checkConfigSchema(rootPath: string): Promise<CheckResult> {
       ? [`missing required keys: ${missing.map(f => f.key).join(', ')} — re-run 'openlore init'`]
       : []),
     ...(backfilled.length > 0
-      ? [`using compatibility defaults for: ${backfilled.map(f => f.key).join(', ')} (file unchanged)`]
+      ? [`using compatibility defaults: ${backfilled.map(f => f.message).join('; ')}`]
       : []),
     ...other.slice(0, 3).map(f => f.message),
   ];

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -18,6 +18,7 @@ import { palette } from '../../utils/colors.js';
 import {
   InvalidOpenLoreConfigError,
   readOpenLoreConfig,
+  normalizeOpenLoreConfig,
   resolveOpenLoreConfigPath,
 } from '../../core/services/config-manager.js';
 import { validateOpenLoreConfig } from '../../core/services/config-schema.js';
@@ -296,15 +297,20 @@ async function checkConfigSchema(rootPath: string): Promise<CheckResult> {
     // No config, or unparseable JSON — checkConfig already reports both. Nothing to add.
     return { name: 'Config schema', status: 'ok', detail: 'no config to validate' };
   }
-  const findings = validateOpenLoreConfig(parsed);
+  const normalized = normalizeOpenLoreConfig(parsed);
+  const findings = [...normalized.findings, ...validateOpenLoreConfig(normalized.config)];
   if (findings.length === 0) {
     return { name: 'Config schema', status: 'ok', detail: 'all required fields present and all declared fields well-typed' };
   }
   const missing = findings.filter(f => f.kind === 'missing-required');
-  const other = findings.filter(f => f.kind !== 'missing-required');
+  const backfilled = findings.filter(f => f.kind === 'default-added');
+  const other = findings.filter(f => f.kind !== 'missing-required' && f.kind !== 'default-added');
   const parts = [
     ...(missing.length > 0
       ? [`missing required keys: ${missing.map(f => f.key).join(', ')} — re-run 'openlore init'`]
+      : []),
+    ...(backfilled.length > 0
+      ? [`using compatibility defaults for: ${backfilled.map(f => f.key).join(', ')} (file unchanged)`]
       : []),
     ...other.slice(0, 3).map(f => f.message),
   ];
@@ -315,7 +321,9 @@ async function checkConfigSchema(rootPath: string): Promise<CheckResult> {
     name: 'Config schema',
     status: 'warn',
     detail: `${findings.length} config finding(s): ${summary}${more}`,
-    fix: `Edit ${OPENLORE_CONFIG_REL_PATH} to correct the key(s), or re-run 'openlore init'`,
+    fix: missing.length > 0 || other.length > 0
+      ? `Edit ${OPENLORE_CONFIG_REL_PATH} to correct the key(s), or re-run 'openlore init'`
+      : `Add the listed default key(s) to ${OPENLORE_CONFIG_REL_PATH} to silence this compatibility warning`,
   };
 }
 

--- a/src/core/services/config-manager.test.ts
+++ b/src/core/services/config-manager.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdir, writeFile, rm, readFile, symlink } from 'node:fs/promises';
+import { mkdir, writeFile, rm, readFile, readdir, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -18,6 +18,7 @@ import {
   createOpenSpecStructure,
   mergeOpenSpecConfig,
   detectExistingSpecDir,
+  normalizeOpenLoreConfig,
   resetConfigValidationWarnings,
 } from './config-manager.js';
 import { logger } from '../../utils/logger.js';
@@ -315,45 +316,82 @@ describe('config-manager', () => {
 
     it('loads a pre-2.2 config by backfilling domains without replacing custom settings', async () => {
       const s = spyStderr();
-      const legacy = {
-        version: '1.0.0',
-        projectType: 'nodejs',
-        openspecPath: './custom-specs',
-        analysis: {
-          maxFiles: 500,
-          includePatterns: [],
-          excludePatterns: ['dist/**', 'node_modules/**'],
-        },
-        generation: {
-          provider: 'openai-compat',
-          model: 'codestral-2508',
-          openaiCompatBaseUrl: 'https://api.mistral.ai/v1/',
-        },
-        embedding: { baseUrl: 'http://localhost:8765/v1', model: 'all-MiniLM-L6-v2' },
-        createdAt: '2026-02-28T13:15:28.693Z',
-        lastRun: null,
-      };
+      const source = await readFile(
+        new URL('./fixtures/configs/2.1.9-customized.json', import.meta.url),
+        'utf-8',
+      );
+      const legacy = JSON.parse(source) as Record<string, unknown>;
       try {
-        await writeRawConfig(legacy);
+        const configDir = join(testDir, '.openlore');
+        await mkdir(configDir, { recursive: true });
+        const configPath = join(configDir, 'config.json');
+        await writeFile(configPath, source, 'utf-8');
 
         const result = await readOpenLoreConfig(testDir);
 
-        expect(result).toMatchObject({
-          openspecPath: './custom-specs',
-          analysis: { excludePatterns: ['dist/**', 'node_modules/**'] },
-          generation: {
-            provider: 'openai-compat',
-            model: 'codestral-2508',
-            openaiCompatBaseUrl: 'https://api.mistral.ai/v1/',
-            domains: 'auto',
-          },
-          embedding: { baseUrl: 'http://localhost:8765/v1', model: 'all-MiniLM-L6-v2' },
+        expect(result).toEqual({
+          ...legacy,
+          generation: { ...(legacy.generation as Record<string, unknown>), domains: 'auto' },
         });
-        expect(JSON.parse(await readFile(join(testDir, '.openlore', 'config.json'), 'utf-8'))).toEqual(legacy);
+        expect(await readFile(configPath, 'utf-8')).toBe(source);
         expect(s.lines().some(line => line.includes("generation.domains") && line.includes('"auto"'))).toBe(true);
       } finally {
         s.restore();
       }
+    });
+
+    it('loads every immutable release fixture without changing its bytes', async () => {
+      const fixtureDir = new URL('./fixtures/configs/', import.meta.url);
+      const fixtureNames = (await readdir(fixtureDir)).filter(name => name.endsWith('.json')).sort();
+      const packageJson = JSON.parse(
+        await readFile(new URL('../../../package.json', import.meta.url), 'utf-8'),
+      ) as { version: string };
+      expect(fixtureNames.some(name => name.startsWith(`${packageJson.version}-`))).toBe(true);
+
+      const s = spyStderr();
+      try {
+        for (const fixtureName of fixtureNames) {
+          resetConfigValidationWarnings();
+          const source = await readFile(new URL(fixtureName, fixtureDir), 'utf-8');
+          const configDir = join(testDir, '.openlore');
+          await mkdir(configDir, { recursive: true });
+          const configPath = join(configDir, 'config.json');
+          await writeFile(configPath, source, 'utf-8');
+
+          await expect(readOpenLoreConfig(testDir), fixtureName).resolves.not.toBeNull();
+          expect(await readFile(configPath, 'utf-8'), fixtureName).toBe(source);
+        }
+      } finally {
+        s.restore();
+      }
+    });
+
+    it('normalization is idempotent and preserves explicit domain selections', () => {
+      const legacy = {
+        ...getDefaultConfig('nodejs', 'openspec'),
+        generation: { model: 'custom' },
+      };
+      const first = normalizeOpenLoreConfig(legacy);
+      const second = normalizeOpenLoreConfig(first.config);
+      expect(first.findings.map(finding => finding.key)).toEqual(['generation.domains']);
+      expect(second).toEqual({ config: first.config, findings: [] });
+
+      const explicit = {
+        ...legacy,
+        generation: { model: 'custom', domains: ['auth', 'payments'] },
+      };
+      expect(normalizeOpenLoreConfig(explicit)).toEqual({ config: explicit, findings: [] });
+    });
+
+    it('does not repair a missing or truncated required top-level section', async () => {
+      const defaults = getDefaultConfig('nodejs', 'openspec');
+      const missingGeneration: Partial<typeof defaults> = structuredClone(defaults);
+      delete missingGeneration.generation;
+      await writeRawConfig(missingGeneration);
+      await expect(readOpenLoreConfig(testDir)).rejects.toThrow(/generation/);
+
+      await writeRawConfig({ ...defaults, analysis: {} });
+      await expect(readOpenLoreConfig(testDir)).rejects.toThrow(/analysis\.(maxFiles|includePatterns|excludePatterns)/);
     });
 
     it('still rejects a present but invalid domains value', async () => {

--- a/src/core/services/config-manager.test.ts
+++ b/src/core/services/config-manager.test.ts
@@ -313,6 +313,58 @@ describe('config-manager', () => {
       }
     });
 
+    it('loads a pre-2.2 config by backfilling domains without replacing custom settings', async () => {
+      const s = spyStderr();
+      const legacy = {
+        version: '1.0.0',
+        projectType: 'nodejs',
+        openspecPath: './custom-specs',
+        analysis: {
+          maxFiles: 500,
+          includePatterns: [],
+          excludePatterns: ['dist/**', 'node_modules/**'],
+        },
+        generation: {
+          provider: 'openai-compat',
+          model: 'codestral-2508',
+          openaiCompatBaseUrl: 'https://api.mistral.ai/v1/',
+        },
+        embedding: { baseUrl: 'http://localhost:8765/v1', model: 'all-MiniLM-L6-v2' },
+        createdAt: '2026-02-28T13:15:28.693Z',
+        lastRun: null,
+      };
+      try {
+        await writeRawConfig(legacy);
+
+        const result = await readOpenLoreConfig(testDir);
+
+        expect(result).toMatchObject({
+          openspecPath: './custom-specs',
+          analysis: { excludePatterns: ['dist/**', 'node_modules/**'] },
+          generation: {
+            provider: 'openai-compat',
+            model: 'codestral-2508',
+            openaiCompatBaseUrl: 'https://api.mistral.ai/v1/',
+            domains: 'auto',
+          },
+          embedding: { baseUrl: 'http://localhost:8765/v1', model: 'all-MiniLM-L6-v2' },
+        });
+        expect(JSON.parse(await readFile(join(testDir, '.openlore', 'config.json'), 'utf-8'))).toEqual(legacy);
+        expect(s.lines().some(line => line.includes("generation.domains") && line.includes('"auto"'))).toBe(true);
+      } finally {
+        s.restore();
+      }
+    });
+
+    it('still rejects a present but invalid domains value', async () => {
+      await writeRawConfig({
+        ...getDefaultConfig('nodejs', 'openspec'),
+        generation: { domains: 42 },
+      });
+
+      await expect(readOpenLoreConfig(testDir)).rejects.toThrow(/generation\.domains/);
+    });
+
     it('warns with a did-you-mean on a typo\'d key, and still applies defaults', async () => {
       const s = spyStderr();
       try {

--- a/src/core/services/config-manager.ts
+++ b/src/core/services/config-manager.ts
@@ -22,6 +22,7 @@ import { fileExists } from '../../utils/command-helpers.js';
 import { safeJoin } from '../../utils/path-confinement.js';
 import {
   validateOpenLoreConfig,
+  backfillRequiredConfigDefaults,
   isFatalConfigFinding,
   CONFIG_SCHEMA_VERSION,
   type ConfigValidationFinding,
@@ -127,6 +128,23 @@ export function getDefaultConfig(projectType: ProjectType, openspecPath: string)
   };
 }
 
+/** Apply non-destructive compatibility defaults before schema validation. */
+export function normalizeOpenLoreConfig(parsed: unknown): {
+  config: unknown;
+  findings: ConfigValidationFinding[];
+} {
+  const record = typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {};
+  const projectType = typeof record.projectType === 'string'
+    ? record.projectType as ProjectType
+    : 'unknown';
+  const openspecPath = typeof record.openspecPath === 'string'
+    ? record.openspecPath
+    : './openspec';
+  return backfillRequiredConfigDefaults(parsed, getDefaultConfig(projectType, openspecPath));
+}
+
 /**
  * Per-process memory of config-validation warnings already emitted, so a hub caller
  * (`readOpenLoreConfig` has ~45 call sites) emits each finding at most once per process
@@ -193,21 +211,22 @@ export async function readOpenLoreConfig(rootPath: string): Promise<OpenLoreConf
   } catch {
     return null; // File doesn't exist — normal case before init
   }
-  let parsed: OpenLoreConfig;
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(content) as OpenLoreConfig;
+    parsed = JSON.parse(content) as unknown;
   } catch (err) {
     logger.warning(`Failed to parse ${configPath}: ${(err as Error).message}`);
     logger.warning(`Delete ${configPath} and run 'openlore init' to recreate it.`);
     return null;
   }
-  const findings = validateOpenLoreConfig(parsed);
-  emitConfigValidationWarnings(configPath, findings);
-  const fatalFindings = findings.filter(isFatalConfigFinding);
+  const normalized = normalizeOpenLoreConfig(parsed);
+  const validationFindings = validateOpenLoreConfig(normalized.config);
+  emitConfigValidationWarnings(configPath, [...normalized.findings, ...validationFindings]);
+  const fatalFindings = validationFindings.filter(isFatalConfigFinding);
   if (fatalFindings.length > 0) {
     throw new InvalidOpenLoreConfigError(configPath, fatalFindings);
   }
-  return parsed;
+  return normalized.config as OpenLoreConfig;
 }
 
 /**

--- a/src/core/services/config-schema.test.ts
+++ b/src/core/services/config-schema.test.ts
@@ -12,9 +12,11 @@ import {
   KNOWN_CONFIG_KEYS,
   CONFIG_SCHEMA_VERSION,
   backfillRequiredConfigDefaults,
+  findCompatibilityFieldsWithoutDefaults,
   findRequiredFieldsWithoutDefaults,
   type ConfigMigration,
 } from './config-schema.js';
+import { getDefaultConfig } from './config-manager.js';
 
 /**
  * A fully-populated config typed `Required<OpenLoreConfig>` — TypeScript forces every
@@ -62,17 +64,17 @@ describe('config-schema — type-completeness bind', () => {
   });
 
   it('canonical default sections populate every field the schema requires', () => {
-    const defaults = {
-      version: CONFIG_SCHEMA_VERSION,
-      projectType: 'nodejs',
-      openspecPath: 'openspec',
-      analysis: { maxFiles: 100_000, includePatterns: [], excludePatterns: [] },
-      generation: { model: 'model', domains: 'auto' },
-      createdAt: '2026-08-22T00:00:00.000Z',
-      lastRun: null,
-    };
-
+    const defaults = getDefaultConfig('nodejs', 'openspec');
     expect(findRequiredFieldsWithoutDefaults(defaults)).toEqual([]);
+    expect(findCompatibilityFieldsWithoutDefaults(defaults)).toEqual([]);
+  });
+
+  it('detects an upgrade-safe field missing from the canonical defaults', () => {
+    const defaults = getDefaultConfig('nodejs', 'openspec');
+    delete (defaults.generation as Partial<typeof defaults.generation>).domains;
+
+    expect(findRequiredFieldsWithoutDefaults(defaults)).toContain('generation.domains');
+    expect(findCompatibilityFieldsWithoutDefaults(defaults)).toEqual(['generation.domains']);
   });
 
   it('backfills only missing required values inside existing default sections', () => {
@@ -97,6 +99,25 @@ describe('config-schema — type-completeness bind', () => {
       expect.objectContaining({ kind: 'default-added', key: 'generation.domains', fatal: false }),
     ]);
     expect(parsed.generation).not.toHaveProperty('domains');
+  });
+
+  it('does not repair missing legacy-required fields in a truncated strict section', () => {
+    const defaults = getDefaultConfig('nodejs', 'openspec');
+    const parsed = {
+      ...defaults,
+      analysis: {},
+      generation: {},
+    };
+
+    const result = backfillRequiredConfigDefaults(parsed, defaults);
+
+    expect(result.config).toMatchObject({ analysis: {}, generation: { domains: 'auto' } });
+    expect(result.findings.map(finding => finding.key)).toEqual(['generation.domains']);
+    expect(validateOpenLoreConfig(result.config)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'missing-required', key: 'analysis.maxFiles', fatal: true }),
+      expect.objectContaining({ kind: 'missing-required', key: 'analysis.includePatterns', fatal: true }),
+      expect.objectContaining({ kind: 'missing-required', key: 'analysis.excludePatterns', fatal: true }),
+    ]));
   });
 
   it('requires every non-optional top-level config field', () => {

--- a/src/core/services/config-schema.test.ts
+++ b/src/core/services/config-schema.test.ts
@@ -11,6 +11,8 @@ import {
   CONFIG_FIELD_KINDS,
   KNOWN_CONFIG_KEYS,
   CONFIG_SCHEMA_VERSION,
+  backfillRequiredConfigDefaults,
+  findRequiredFieldsWithoutDefaults,
   type ConfigMigration,
 } from './config-schema.js';
 
@@ -57,6 +59,44 @@ describe('config-schema — type-completeness bind', () => {
 
   it('a fully-populated, correctly-typed config yields zero findings', () => {
     expect(validateOpenLoreConfig(FULLY_POPULATED)).toEqual([]);
+  });
+
+  it('canonical default sections populate every field the schema requires', () => {
+    const defaults = {
+      version: CONFIG_SCHEMA_VERSION,
+      projectType: 'nodejs',
+      openspecPath: 'openspec',
+      analysis: { maxFiles: 100_000, includePatterns: [], excludePatterns: [] },
+      generation: { model: 'model', domains: 'auto' },
+      createdAt: '2026-08-22T00:00:00.000Z',
+      lastRun: null,
+    };
+
+    expect(findRequiredFieldsWithoutDefaults(defaults)).toEqual([]);
+  });
+
+  it('backfills only missing required values inside existing default sections', () => {
+    const defaults = {
+      ...FULLY_POPULATED,
+      analysis: { maxFiles: 100_000, includePatterns: [], excludePatterns: [] },
+      generation: { model: 'default-model', domains: 'auto' },
+    };
+    const parsed = {
+      ...FULLY_POPULATED,
+      analysis: { maxFiles: 25, includePatterns: [], excludePatterns: ['dist/**'] },
+      generation: { model: 'custom-model' },
+    };
+
+    const result = backfillRequiredConfigDefaults(parsed, defaults);
+
+    expect(result.config).toMatchObject({
+      analysis: { maxFiles: 25, excludePatterns: ['dist/**'] },
+      generation: { model: 'custom-model', domains: 'auto' },
+    });
+    expect(result.findings).toEqual([
+      expect.objectContaining({ kind: 'default-added', key: 'generation.domains', fatal: false }),
+    ]);
+    expect(parsed.generation).not.toHaveProperty('domains');
   });
 
   it('requires every non-optional top-level config field', () => {

--- a/src/core/services/config-schema.ts
+++ b/src/core/services/config-schema.ts
@@ -54,13 +54,19 @@ type RequiredKeys<T> = {
 type RequiredFieldMap<T> = Record<RequiredKeys<T>, true>
   & Partial<Record<Exclude<keyof T, RequiredKeys<T>>, never>>;
 
-type ConfigRule =
+type ConfigRuleMetadata = {
+  /** Missing values written by older releases may be copied from canonical defaults. */
+  compatibilityDefault?: true;
+};
+
+type ConfigRule = ConfigRuleMetadata & (
   | { kind: 'string' | 'number' | 'boolean' | 'string-or-null' }
   | { kind: 'enum'; values: readonly string[] }
   | { kind: 'array'; element: ConfigRule }
   | { kind: 'string-or-string-array' }
   | { kind: 'record-enum'; values: readonly string[] }
-  | { kind: 'object'; fields: Record<string, ConfigRule>; required: readonly string[]; strict?: boolean };
+  | { kind: 'object'; fields: Record<string, ConfigRule>; required: readonly string[]; strict?: boolean }
+);
 
 function fieldsFor<T>(fields: Record<keyof T, ConfigRule>): Record<string, ConfigRule> {
   return fields as Record<string, ConfigRule>;
@@ -97,7 +103,7 @@ const generationRule: ConfigRule = {
     disableResponseFormat: booleanRule,
     timeout: numberRule,
     chunkMaxChars: numberRule,
-    domains: { kind: 'string-or-string-array' },
+    domains: { kind: 'string-or-string-array', compatibilityDefault: true },
   }),
   required: requiredFor<GenerationConfig>({ domains: true }),
 };
@@ -325,10 +331,10 @@ function isConfigObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Backfill missing required fields inside sections that already exist in both the
- * parsed config and the canonical defaults. Top-level sections are never invented:
- * an empty or hand-truncated config remains invalid, while a config written by an
- * older release can acquire newly-required nested defaults without losing custom values.
+ * Backfill only required fields explicitly marked as upgrade-safe. Nested sections
+ * must already exist in the parsed config; marked top-level fields may be introduced.
+ * This keeps malformed legacy-required structure fatal while allowing deliberate,
+ * default-backed schema additions to remain backward compatible.
  */
 export function backfillRequiredConfigDefaults(
   parsed: unknown,
@@ -347,19 +353,19 @@ export function backfillRequiredConfigDefaults(
     rule: Extract<ConfigRule, { kind: 'object' }>,
     path: string,
   ): void => {
-    if (path !== '') {
-      for (const key of rule.required) {
-        if (!Object.prototype.hasOwnProperty.call(target, key)
-          && Object.prototype.hasOwnProperty.call(fallback, key)) {
-          const childPath = `${path}.${key}`;
-          target[key] = structuredClone(fallback[key]);
-          findings.push({
-            kind: 'default-added',
-            key: childPath,
-            fatal: false,
-            message: `added missing config key '${childPath}' = ${JSON.stringify(fallback[key])} from the current default (file unchanged)`,
-          });
-        }
+    for (const key of rule.required) {
+      const childRule = rule.fields[key];
+      if (childRule?.compatibilityDefault !== true) continue;
+      if (!Object.prototype.hasOwnProperty.call(target, key)
+        && Object.prototype.hasOwnProperty.call(fallback, key)) {
+        const childPath = path ? `${path}.${key}` : key;
+        target[key] = structuredClone(fallback[key]);
+        findings.push({
+          kind: 'default-added',
+          key: childPath,
+          fatal: false,
+          message: `added missing config key '${childPath}' = ${JSON.stringify(fallback[key])} from the current default (file unchanged)`,
+        });
       }
     }
 
@@ -400,6 +406,32 @@ export function findRequiredFieldsWithoutDefaults(defaults: unknown): string[] {
       const childFallback = fallback[key];
       if (!isConfigObject(childFallback)) continue;
       visit(childFallback, childRule, path ? `${path}.${key}` : key);
+    }
+  };
+
+  visit(defaults, CONFIG_RULE, '');
+  return missing;
+}
+
+/** Upgrade-safe fields whose canonical fallback is absent at the same schema path. */
+export function findCompatibilityFieldsWithoutDefaults(defaults: unknown): string[] {
+  const missing: string[] = [];
+
+  const visit = (
+    fallback: unknown,
+    rule: Extract<ConfigRule, { kind: 'object' }>,
+    path: string,
+  ): void => {
+    const fallbackRecord = isConfigObject(fallback) ? fallback : undefined;
+    for (const [key, childRule] of Object.entries(rule.fields)) {
+      const childPath = path ? `${path}.${key}` : key;
+      if (childRule.compatibilityDefault === true
+        && !Object.prototype.hasOwnProperty.call(fallbackRecord ?? {}, key)) {
+        missing.push(childPath);
+      }
+      if (childRule.kind === 'object') {
+        visit(fallbackRecord?.[key], childRule, childPath);
+      }
     }
   };
 

--- a/src/core/services/config-schema.ts
+++ b/src/core/services/config-schema.ts
@@ -222,7 +222,7 @@ const bundleRule: ConfigRule = {
   required: requiredFor<BundleConfig>({}),
 };
 
-const CONFIG_RULE: ConfigRule = {
+const CONFIG_RULE: Extract<ConfigRule, { kind: 'object' }> = {
   kind: 'object',
   fields: fieldsFor<OpenLoreConfig>({
     version: stringRule,
@@ -304,7 +304,7 @@ export const CONFIG_MIGRATIONS: readonly ConfigMigration[] = [];
 
 /** A single deterministic finding from validating a config object. */
 export interface ConfigValidationFinding {
-  kind: 'unknown-key' | 'missing-required' | 'type-mismatch' | 'version-older' | 'version-newer';
+  kind: 'unknown-key' | 'missing-required' | 'type-mismatch' | 'version-older' | 'version-newer' | 'default-added';
   /** The offending key, when the finding is about one. */
   key?: string;
   /** Human-readable message. */
@@ -313,6 +313,98 @@ export interface ConfigValidationFinding {
   suggestion?: string;
   /** Whether returning the parsed object would expose an unsafe required runtime shape. */
   fatal?: boolean;
+}
+
+export interface ConfigCompatibilityResult {
+  config: unknown;
+  findings: ConfigValidationFinding[];
+}
+
+function isConfigObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Backfill missing required fields inside sections that already exist in both the
+ * parsed config and the canonical defaults. Top-level sections are never invented:
+ * an empty or hand-truncated config remains invalid, while a config written by an
+ * older release can acquire newly-required nested defaults without losing custom values.
+ */
+export function backfillRequiredConfigDefaults(
+  parsed: unknown,
+  defaults: unknown,
+): ConfigCompatibilityResult {
+  if (!isConfigObject(parsed) || !isConfigObject(defaults)) {
+    return { config: parsed, findings: [] };
+  }
+
+  const config = structuredClone(parsed) as Record<string, unknown>;
+  const findings: ConfigValidationFinding[] = [];
+
+  const visit = (
+    target: Record<string, unknown>,
+    fallback: Record<string, unknown>,
+    rule: Extract<ConfigRule, { kind: 'object' }>,
+    path: string,
+  ): void => {
+    if (path !== '') {
+      for (const key of rule.required) {
+        if (!Object.prototype.hasOwnProperty.call(target, key)
+          && Object.prototype.hasOwnProperty.call(fallback, key)) {
+          const childPath = `${path}.${key}`;
+          target[key] = structuredClone(fallback[key]);
+          findings.push({
+            kind: 'default-added',
+            key: childPath,
+            fatal: false,
+            message: `added missing config key '${childPath}' = ${JSON.stringify(fallback[key])} from the current default (file unchanged)`,
+          });
+        }
+      }
+    }
+
+    for (const [key, childRule] of Object.entries(rule.fields)) {
+      if (childRule.kind !== 'object') continue;
+      const childTarget = target[key];
+      const childFallback = fallback[key];
+      if (!isConfigObject(childTarget) || !isConfigObject(childFallback)) continue;
+      visit(childTarget, childFallback, childRule, path ? `${path}.${key}` : key);
+    }
+  };
+
+  visit(config, defaults, CONFIG_RULE, '');
+  return { config, findings };
+}
+
+/**
+ * Required fields missing from sections emitted by the canonical defaults. This is a
+ * schema-evolution guard: adding a required field to a default section must update the
+ * defaults in the same change, otherwise older configs cannot be backfilled safely.
+ */
+export function findRequiredFieldsWithoutDefaults(defaults: unknown): string[] {
+  if (!isConfigObject(defaults)) return CONFIG_RULE.required.map(key => key);
+  const missing: string[] = [];
+
+  const visit = (
+    fallback: Record<string, unknown>,
+    rule: Extract<ConfigRule, { kind: 'object' }>,
+    path: string,
+  ): void => {
+    for (const key of rule.required) {
+      if (!Object.prototype.hasOwnProperty.call(fallback, key)) {
+        missing.push(path ? `${path}.${key}` : key);
+      }
+    }
+    for (const [key, childRule] of Object.entries(rule.fields)) {
+      if (childRule.kind !== 'object') continue;
+      const childFallback = fallback[key];
+      if (!isConfigObject(childFallback)) continue;
+      visit(childFallback, childRule, path ? `${path}.${key}` : key);
+    }
+  };
+
+  visit(defaults, CONFIG_RULE, '');
+  return missing;
 }
 
 /** Findings that make the parsed object unsafe to expose as `OpenLoreConfig`. */

--- a/src/core/services/fixtures/configs/2.0.0-default.json
+++ b/src/core/services/fixtures/configs/2.0.0-default.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0",
+  "projectType": "nodejs",
+  "openspecPath": "./openspec",
+  "analysis": {
+    "maxFiles": 100000,
+    "includePatterns": [],
+    "excludePatterns": []
+  },
+  "generation": {
+    "model": "claude-sonnet-4-20250514",
+    "domains": "auto"
+  },
+  "createdAt": "2026-06-26T00:00:00.000Z",
+  "lastRun": null
+}

--- a/src/core/services/fixtures/configs/2.1.9-customized.json
+++ b/src/core/services/fixtures/configs/2.1.9-customized.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0.0",
+  "projectType": "nodejs",
+  "openspecPath": "./custom-specs",
+  "analysis": {
+    "maxFiles": 500,
+    "includePatterns": [],
+    "excludePatterns": [
+      "dist/**",
+      "node_modules/**"
+    ]
+  },
+  "generation": {
+    "provider": "openai-compat",
+    "model": "codestral-2508",
+    "openaiCompatBaseUrl": "https://api.mistral.ai/v1/"
+  },
+  "embedding": {
+    "baseUrl": "http://localhost:8765/v1",
+    "model": "all-MiniLM-L6-v2"
+  },
+  "panicResponse": {
+    "mode": "off"
+  },
+  "createdAt": "2026-08-15T00:00:00.000Z",
+  "lastRun": null
+}

--- a/src/core/services/fixtures/configs/2.2.0-default.json
+++ b/src/core/services/fixtures/configs/2.2.0-default.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0.0",
+  "projectType": "nodejs",
+  "openspecPath": "./openspec",
+  "analysis": {
+    "maxFiles": 100000,
+    "includePatterns": [],
+    "excludePatterns": []
+  },
+  "generation": {
+    "model": "claude-sonnet-4-6",
+    "domains": "auto"
+  },
+  "panicResponse": {
+    "mode": "off"
+  },
+  "createdAt": "2026-08-16T00:00:00.000Z",
+  "lastRun": null
+}

--- a/src/core/services/fixtures/configs/README.md
+++ b/src/core/services/fixtures/configs/README.md
@@ -1,0 +1,14 @@
+# Frozen configuration compatibility fixtures
+
+These files are immutable evidence of configuration shapes accepted by published OpenLore releases.
+They intentionally do not move with the current schema.
+
+- `2.0.0-default.json` captures the configuration factory shape from tag `v2.0.0`.
+- `2.1.9-customized.json` captures the customized pre-2.2 shape reported in issue #386, including a
+  missing `generation.domains` field that was accepted before strict validation.
+- `2.2.0-default.json` captures the configuration factory shape from tag `v2.2.0`.
+
+For each release, add at least one `<package-version>-*.json` fixture before changing the package
+version. Include both a factory-default shape and a realistic customized shape when the release
+changes configuration behavior. Never regenerate or edit an older fixture; add an explicit migration
+when a frozen fixture stops loading.

--- a/src/core/services/tls-coverage.test.ts
+++ b/src/core/services/tls-coverage.test.ts
@@ -44,12 +44,12 @@ const EXEMPT: { file: string; line: number; why: string }[] = [
   { file: 'src/core/services/serve-client.ts', line: 167, why: 'loopback http:// daemon call' },
   { file: 'src/cli/commands/serve.ts', line: 249, why: 'loopback http:// health and compatibility probe' },
   { file: 'src/cli/commands/serve.ts', line: 310, why: 'loopback http:// authenticated shutdown request' },
-  { file: 'src/pi/extension.ts', line: 545, why: 'loopback http:// health probe' },
-  { file: 'src/pi/extension.ts', line: 720, why: 'loopback http:// daemon call' },
-  { file: 'src/pi/extension.ts', line: 1559, why: 'loopback http:// health probe' },
+  { file: 'src/pi/extension.ts', line: 546, why: 'loopback http:// health probe' },
+  { file: 'src/pi/extension.ts', line: 721, why: 'loopback http:// daemon call' },
+  { file: 'src/pi/extension.ts', line: 1560, why: 'loopback http:// health probe' },
   {
     file: 'src/pi/extension.ts',
-    line: 194,
+    line: 195,
     why: 'pre-existing: the Pi host never opts in, so skipSslVerify is not honoured there at all',
   },
 ];

--- a/src/pi/extension.test.ts
+++ b/src/pi/extension.test.ts
@@ -639,9 +639,35 @@ describe('Pi configuration fidelity', () => {
     expect(saved.impactCertificate).toEqual(existing.impactCertificate);
     expect(saved.contextInjection).toEqual(existing.contextInjection);
     expect(saved.analysis.futureBudget).toBe(9);
-    expect(saved.generation).toMatchObject({ provider: 'anthropic', timeoutMs: 12_000 });
+    expect(saved.generation).toMatchObject({ provider: 'anthropic', timeoutMs: 12_000, domains: 'auto' });
     expect(saved.generation).not.toHaveProperty('model');
     expect(saved.generation).not.toHaveProperty('openaiCompatBaseUrl');
+  });
+
+  it('writes the compatibility default for a fresh config and preserves explicit domains', async () => {
+    const saveImmediately = () => ({
+      cwd: dir,
+      mode: 'tui',
+      hasUI: true,
+      ui: {
+        select: vi.fn(async () => '✓ Save & close'),
+        input: vi.fn(),
+        confirm: vi.fn(async () => false),
+        notify: vi.fn(),
+      },
+    }) as unknown as ExtensionContext;
+
+    await runConfigWizard(saveImmediately(), null);
+    let saved = JSON.parse(await readFile(join(dir, '.openlore', 'config.json'), 'utf-8'));
+    expect(saved.generation).toEqual({ domains: 'auto' });
+
+    const explicit = {
+      ...saved,
+      generation: { provider: 'openai', model: 'gpt-4o', domains: ['auth', 'payments'] },
+    };
+    await runConfigWizard(saveImmediately(), explicit);
+    saved = JSON.parse(await readFile(join(dir, '.openlore', 'config.json'), 'utf-8'));
+    expect(saved.generation.domains).toEqual(['auth', 'payments']);
   });
 
   it('preserves embedding siblings when its URL changes and removes only an explicitly removed block', async () => {

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -91,6 +91,7 @@ interface OpenLoreConfig {
     model?: string;
     openaiCompatBaseUrl?: string;
     skipSslVerify?: boolean;
+    domains?: string | string[];
   };
   embedding?: {
     [key: string]: unknown;
@@ -250,7 +251,7 @@ export async function runConfigWizard(ctx: ExtensionContext, existing?: Existing
   const existingGeneration = isPlainObject(existing?.generation) ? existing.generation : {};
   const existingEmbedding = isPlainObject(existing?.embedding) ? existing.embedding : undefined;
   const existingAnalysis = isPlainObject(existing?.analysis) ? existing.analysis : {};
-  let generation: OpenLoreConfig['generation'] = { ...existingGeneration };
+  let generation: OpenLoreConfig['generation'] = { domains: 'auto', ...existingGeneration };
   let embedding: OpenLoreConfig['embedding'] | undefined =
     existingEmbedding && typeof existingEmbedding.baseUrl === 'string' && typeof existingEmbedding.model === 'string'
       ? existingEmbedding as OpenLoreConfig['embedding']


### PR DESCRIPTION
Status: LGTM

## What was wrong

OpenLore 2.2.0 made `generation.domains` mandatory before config migration ran. Every older config therefore failed startup, and the suggested `openlore init` recovery could overwrite customized provider, model, path, exclusions, embedding, and endpoint settings.

The three queued Dependabot PRs also needed consolidation. The grouped pi package update omitted integrity digests for six nested packages, which the repository's supply-chain test correctly rejected.

## How it was fixed

- Backfill only fields explicitly marked upgrade-safe in the schema; `generation.domains` uses the canonical `"auto"` default.
- Preserve the config file byte-for-byte and retain every customized setting.
- Keep explicitly invalid values, missing top-level sections, and truncated legacy-required sections fatal rather than masking them with defaults.
- Make `doctor` use the production compatibility normalizer, show the exact default value, and recommend non-destructive guidance.
- Bind the schema-evolution guard to the real `getDefaultConfig`, including a check that every upgrade-safe field has a canonical value.
- Add immutable 2.0.0, customized 2.1.9, and 2.2.0 configuration fixtures plus a package-version freshness guard, so future additions, renames, and type narrowing fail CI.
- Make the Pi configuration wizard write `generation.domains` for fresh and legacy configs while preserving explicit domain selections.
- Update the OpenSpec baseline with the upgrade-safe metadata, malformed-input boundary, fixture-corpus, and producer contracts.
- Consolidate Dependabot PRs #383, #384, and #385, then restore verified SRI digests for the six pi 0.84.2 lockfile entries.

## Replication / proof

- An authentic pre-2.2 custom config now loads with `generation.domains` supplied in memory while its file and all custom settings remain unchanged.
- A present-but-invalid `generation.domains`, missing `generation` section, or truncated `analysis` section still fails validation.
- All frozen release fixtures load without changing a byte; normalization is idempotent and preserves explicit domain arrays.
- Three independent adversarial reviews identified and verified the strict-validation, Pi-producer, fixture-corpus, doctor-parity, and documentation gaps addressed here.
- `npm ci`: passed; 0 vulnerabilities.
- Live `npm audit`: 0 vulnerabilities across 739 dependencies.
- `npm run audit:gate`: passed; no unallowed high/critical advisories.
- Test suite: 8,014 passed, 2 skipped across 416 files.
- Typecheck, lint, and build: passed.
- OpenSpec strict validation: 120 passed, 0 failed.
- Spec corpus tests: 67 passed.
- Drift check against `origin/main`: no error-level gaps, stale mappings, or uncovered files.
- GitHub Dependabot alerts: 0 open.

## Notes / nits

- Closes #386.
- Supersedes #383, #384, and #385; those bot PRs are closed and link back to this consolidated replacement.
- One pre-existing orphaned-spec warning remains outside this change's scope.
