### PR TITLE
feat(governance): validate knowledge corpus integrity

### DIFF
--- a/openspec/changes/archive/2026-08-23-add-knowledge-corpus-integrity/proposal.md
+++ b/openspec/changes/archive/2026-08-23-add-knowledge-corpus-integrity/proposal.md
@@ -1,6 +1,6 @@
 # Knowledge-corpus integrity: the governance corpus is a typed graph, and nothing checks it
 
-> Status: PROPOSED (2026-07-31, external-pattern study). OpenLore verifies the *code* graph
+> Status: BUILT (2026-08-23). OpenLore verifies the *code* graph
 > exhaustively and the *knowledge* graph not at all. Specs cite decision ids, changes cite spec
 > domains, decisions supersede decisions, memories anchor to symbols and cite decisions — every one
 > of those is a typed edge with a declared range, direction, and liveness rule, and every one can

--- a/openspec/changes/archive/2026-08-23-add-knowledge-corpus-integrity/specs/openspec/spec.md
+++ b/openspec/changes/archive/2026-08-23-add-knowledge-corpus-integrity/specs/openspec/spec.md
@@ -5,8 +5,8 @@
 ### Requirement: CorpusEdgesAreDeclaredAndResolved
 
 The governance corpus SHALL be validated as a typed graph. Every cross-artifact reference kind —
-a requirement citing a decision, a decision superseding a decision, a change delta targeting a
-spec domain, a memory citing a decision, and an artifact anchoring to a symbol or file — SHALL be
+a requirement or proposal citing a decision or requirement, a decision superseding a decision, a
+change delta targeting a spec domain, a memory citing a decision, and an artifact anchoring to a symbol or file — SHALL be
 declared in a single source-declared edge registry stating that edge's source artifact type,
 target range, directionality, whether it may form a cycle, and whether a live source may reference
 a retired target.
@@ -25,6 +25,11 @@ operator's enforcement policy, and the pass SHALL introduce no finding that the 
 The check SHALL be deterministic and offline: identical corpus bytes SHALL produce an identical,
 ordered finding list, with no model, embedding, or network call in the path. Adding an artifact
 type or reference kind without registering its edge SHALL fail a closure guard in CI.
+
+A change delta that targets a capability declared under its proposal's `New Capabilities` section
+SHALL resolve to that prospective domain; it SHALL NOT be misreported as orphaned merely because
+the main corpus does not contain the new domain before archival. An unreadable or malformed corpus
+source SHALL make the assessment unavailable rather than being treated as an empty artifact set.
 
 #### Scenario: A requirement citing a superseded decision is reported
 
@@ -47,6 +52,13 @@ type or reference kind without registering its edge SHALL fail a closure guard i
 - **WHEN** the corpus integrity pass runs
 - **THEN** a `corpus-reference-unresolved` finding names the change, the delta path, and the
   unresolved domain
+
+#### Scenario: A declared new capability is a valid delta target
+
+- **GIVEN** a proposal declaring a capability under `New Capabilities`
+- **AND** a delta directory targeting that capability
+- **WHEN** the corpus integrity pass runs before archival creates the main spec domain
+- **THEN** the delta target resolves without an unresolved-reference finding
 
 #### Scenario: Duplicate identity is detected before it is trusted
 

--- a/openspec/changes/archive/2026-08-23-add-knowledge-corpus-integrity/tasks.md
+++ b/openspec/changes/archive/2026-08-23-add-knowledge-corpus-integrity/tasks.md
@@ -1,51 +1,51 @@
 # Tasks — add-knowledge-corpus-integrity
 
 ## Implementation
-- [ ] `src/core/decisions/corpus-integrity.ts`: `CORPUS_EDGE_REGISTRY` in the
+- [x] `src/core/decisions/corpus-integrity.ts`: `CORPUS_EDGE_REGISTRY` in the
       `FINDING_CODE_REGISTRY` style (`enforcement-policy.ts`) — each edge declares source artifact
       type, target range, directionality, cycle rule, live-source-to-retired-target rule
-- [ ] Resolver over the artifacts already on disk: `openspec/specs/<domain>/spec.md` requirements
+- [x] Resolver over the artifacts already on disk: `openspec/specs/<domain>/spec.md` requirements
       and their `> Decision recorded:` lines (written by `src/core/decisions/syncer.ts`),
       `openspec/changes/*/specs/<domain>/`, the decision store (`src/core/decisions/store.ts`)
       including `supersedes`, and the memory store's decision citations and symbol anchors
-- [ ] Fold the existing memory verdict in rather than reimplementing it: `stale-decision-reference.ts`
+- [x] Fold the existing memory verdict in rather than reimplementing it: `stale-decision-reference.ts`
       becomes the `memory-cites-decision` edge's evaluator, and the spec face reuses it
-- [ ] Emit findings in the unified `GovernanceFinding` shape; register
+- [x] Emit findings in the unified `GovernanceFinding` shape; register
       `corpus-reference-unresolved`, `corpus-reference-ambiguous`, `corpus-self-reference`,
       `corpus-duplicate-identifier`, `corpus-edge-unsupported`, `corpus-target-type-mismatch`,
       `corpus-target-retired`, `corpus-supersession-cycle`, `corpus-anchor-target-missing`,
       `corpus-reference-undeclared` in `enforcement-policy.ts` with source-declared default classes
-- [ ] Supersession-cycle detection: cycle members are reported and NONE of them is presented as
+- [x] Supersession-cycle detection: cycle members are reported and NONE of them is presented as
       authoritative by `verify_claim decision-current` while the cycle stands
-- [ ] Undeclared-reference detector: exact id / exact requirement-name matching only; excludes
+- [x] Undeclared-reference detector: exact id / exact requirement-name matching only; excludes
       fenced blocks, declared-reference lines, self-references, and already-declared targets;
       at most one finding per (source, target); writes nothing
-- [ ] Surface in `src/cli/commands/doctor.ts` (corpus section) and as a finding source in
+- [x] Surface in `src/cli/commands/doctor.ts` (corpus section) and as a finding source in
       `src/cli/commands/enforce.ts`. No new MCP tool
-- [ ] Registry-closure guard test in the `tool-contract.test.ts` style: an unregistered edge kind
+- [x] Registry-closure guard test in the `tool-contract.test.ts` style: an unregistered edge kind
       or an unregistered finding code fails CI
 
 ## Verification
-- [ ] Fixture corpus per finding code: each fires on the artifact that violates it and stays
+- [x] Fixture corpus per finding code: each fires on the artifact that violates it and stays
       silent otherwise
-- [ ] Retired-target: a live requirement citing a superseded decision reports
+- [x] Retired-target: a live requirement citing a superseded decision reports
       `corpus-target-retired` and names the superseder; re-pointing it clears the finding
-- [ ] Cycle: A supersedes B supersedes A reports every member; `verify_claim decision-current`
+- [x] Cycle: A supersedes B supersedes A reports every member; `verify_claim decision-current`
       returns `unverifiable` (never a confident verdict) for ids inside the cycle
-- [ ] Duplicate identity: two same-named requirements in one domain report the duplicate AND make
+- [x] Duplicate identity: two same-named requirements in one domain report the duplicate AND make
       every inbound reference ambiguous
-- [ ] Undeclared-reference precision: a fenced-code occurrence, a self-reference, and an
+- [x] Undeclared-reference precision: a fenced-code occurrence, a self-reference, and an
       already-declared target each produce no finding; no file on disk is modified by the run
-- [ ] Determinism: two runs on unchanged corpus bytes produce byte-identical ordered findings; no
+- [x] Determinism: two runs on unchanged corpus bytes produce byte-identical ordered findings; no
       network access occurs
-- [ ] Policy: a downgrade entry moves a finding to advisory without changing which findings exist;
+- [x] Policy: a downgrade entry moves a finding to advisory without changing which findings exist;
       an absent policy is a pure no-op over the source-declared defaults
-- [ ] Full suite green, including the existing memory stale-decision-reference tests, which must
+- [x] Full suite green, including the existing memory stale-decision-reference tests, which must
       keep passing unchanged after the fold-in
 
 ## Spec
-- [ ] `openspec` delta: ADD CorpusEdgesAreDeclaredAndResolved and
+- [x] `openspec` delta: ADD CorpusEdgesAreDeclaredAndResolved and
       UndeclaredCorpusReferencesAreSuggestedNeverWritten
-- [ ] Cross-reference in the proposal trail: `add-corpus-change-intent-review` owns corpus deltas
+- [x] Cross-reference in the proposal trail: `add-corpus-change-intent-review` owns corpus deltas
       between refs; `check_spec_drift` owns spec-to-code; `add-enforcement-baseline-ratchet` owns
       the adoption ramp for the blocking defaults

--- a/openspec/specs/openspec/spec.md
+++ b/openspec/specs/openspec/spec.md
@@ -6,7 +6,9 @@
 
 [PARTIAL SPEC — file too large to fully analyze (3 parts)] Handles compatibility and validation of
 OpenSpec configurations and specifications.
+
 ## Requirements
+
 ### Requirement: Validateconfig
 
 The system SHALL validates the openspec configuration file against the expected schema.
@@ -352,6 +354,121 @@ different domains never cross-match.
 - **GIVEN** a change with verdict `built` that passes validation
 - **WHEN** the audit reports it
 - **THEN** it is labeled `archivable-candidate` and the changes directory is unmodified
+
+### Requirement: CorpusEdgesAreDeclaredAndResolved
+
+The governance corpus SHALL be validated as a typed graph. Every cross-artifact reference kind —
+a requirement or proposal citing a decision or requirement, a decision superseding a decision, a
+change delta targeting a spec domain, a memory citing a decision, and an artifact anchoring to a symbol or file — SHALL be
+declared in a single source-declared edge registry stating that edge's source artifact type,
+target range, directionality, whether it may form a cycle, and whether a live source may reference
+a retired target.
+
+The system SHALL emit a finding, in the unified `GovernanceFinding` shape with a registered stable
+code, for each reference that fails its declared semantics: a target that resolves to nothing, a
+target that resolves ambiguously, a self-reference, two artifacts resolving to the same identifier,
+an edge kind the source type does not declare, a target of the wrong type for the edge, a live
+source referencing a retired target, a cycle in an acyclic edge, and an anchor whose target no
+longer exists. Each finding SHALL name the source artifact, the edge kind, the reference exactly as
+written, and the reason it failed.
+
+Resolution and graph-shape failures SHALL default to the blocking enforcement class; liveness and
+anchor failures SHALL default to advisory. Every default SHALL remain overridable through the
+operator's enforcement policy, and the pass SHALL introduce no finding that the policy cannot name.
+The check SHALL be deterministic and offline: identical corpus bytes SHALL produce an identical,
+ordered finding list, with no model, embedding, or network call in the path. Adding an artifact
+type or reference kind without registering its edge SHALL fail a closure guard in CI.
+
+A change delta that targets a capability declared under its proposal's `New Capabilities` section
+SHALL resolve to that prospective domain; it SHALL NOT be misreported as orphaned merely because
+the main corpus does not contain the new domain before archival. An unreadable or malformed corpus
+source SHALL make the assessment unavailable rather than being treated as an empty artifact set.
+
+#### Scenario: A requirement citing a superseded decision is reported
+
+- **GIVEN** a live spec requirement carrying a recorded-decision reference
+- **AND** that decision has since been superseded in the decision store
+- **WHEN** the corpus integrity pass runs
+- **THEN** a `corpus-target-retired` finding names the requirement, the decision id as written, and
+  the superseding decision to cite instead
+
+#### Scenario: A supersession cycle is refused, not averaged
+
+- **GIVEN** decisions whose `supersedes` references form a cycle
+- **WHEN** the corpus integrity pass runs
+- **THEN** a `corpus-supersession-cycle` finding names every artifact in the cycle
+- **AND** the system does not present any decision in that cycle as authoritative
+
+#### Scenario: A change delta naming a nonexistent spec domain is reported
+
+- **GIVEN** an open change whose delta directory names a spec domain that is not in the corpus
+- **WHEN** the corpus integrity pass runs
+- **THEN** a `corpus-reference-unresolved` finding names the change, the delta path, and the
+  unresolved domain
+
+#### Scenario: A declared new capability is a valid delta target
+
+- **GIVEN** a proposal declaring a capability under `New Capabilities`
+- **AND** a delta directory targeting that capability
+- **WHEN** the corpus integrity pass runs before archival creates the main spec domain
+- **THEN** the delta target resolves without an unresolved-reference finding
+
+#### Scenario: Duplicate identity is detected before it is trusted
+
+- **GIVEN** two requirements in one spec domain resolving to the same requirement name
+- **WHEN** the corpus integrity pass runs
+- **THEN** a `corpus-duplicate-identifier` finding names both artifacts
+- **AND** every reference to that name is additionally reported as `corpus-reference-ambiguous`
+
+#### Scenario: The edge registry cannot drift open
+
+- **GIVEN** a newly added cross-artifact reference kind with no entry in the edge registry
+- **WHEN** the closure guard runs in CI
+- **THEN** the build fails until the edge declares its source type, range, directionality, cycle
+  rule, and liveness rule
+
+#### Scenario: Findings are governable, never self-invented
+
+- **GIVEN** an operator enforcement policy that downgrades a corpus finding code to advisory
+- **WHEN** the enforcement gate runs
+- **THEN** the finding is still reported and still annotates, but does not block
+- **AND** the policy entry changes only that finding's class; it never creates or suppresses a
+  finding the corpus did not produce
+
+### Requirement: UndeclaredCorpusReferencesAreSuggestedNeverWritten
+
+The system SHALL detect references in an artifact's prose to another corpus artifact — matched by
+exact identifier or exact requirement name only — that are absent from that artifact's declared
+edges, and SHALL report each as an advisory finding naming the source artifact, the matched target,
+the token that matched, and the declared edge that would capture it.
+
+The system SHALL NOT create, write, or modify any corpus edge automatically; a suggestion is
+material for human review, never an applied change. Detection SHALL exclude self-references,
+targets already declared as edges, fenced code blocks, and the declared-reference lines themselves,
+and SHALL emit at most one finding per source-and-target pair. Matching SHALL NOT use titles,
+fuzzy similarity, embeddings, or a model, so that identical corpus bytes yield byte-identical
+findings. The advisory SHALL NOT change any exit code on its own.
+
+#### Scenario: A prose mention becomes a suggestion
+
+- **GIVEN** a change proposal whose body names a decision id that the proposal does not declare as
+  a reference
+- **WHEN** the detector runs
+- **THEN** an advisory finding names the proposal, the decision, the matching token, and the edge
+  that would capture it
+- **AND** no file is modified
+
+#### Scenario: A code fence is not a reference
+
+- **GIVEN** an artifact whose fenced code block contains a string matching a decision identifier
+- **WHEN** the detector runs
+- **THEN** no finding is emitted for that occurrence
+
+#### Scenario: The advisory never gates
+
+- **GIVEN** a corpus whose only findings are undeclared-reference advisories
+- **WHEN** the enforcement gate runs under the default policy
+- **THEN** the gate reports the advisories and exits successfully
 
 ## Technical Notes
 

--- a/src/cli/commands/corpus-integrity-surfaces.test.ts
+++ b/src/cli/commands/corpus-integrity-surfaces.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkCorpusIntegrity } from './doctor.js';
+import { collectGovernanceFindings } from './enforce.js';
+import {
+  CORPUS_EDGE_KINDS,
+  CORPUS_EDGE_REGISTRY,
+  CORPUS_DISCOVERY_EDGE_KINDS,
+  CORPUS_FINDING_CODES,
+} from '../../core/decisions/corpus-integrity.js';
+import { isKnownFindingCode } from '../../core/services/mcp-handlers/enforcement-policy.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function fixture(spec: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-surfaces-'));
+  roots.push(root);
+  const dir = join(root, 'openspec', 'specs', 'example');
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'spec.md'), spec, 'utf8');
+  return root;
+}
+
+describe('knowledge-corpus integrity surfaces', () => {
+  it('keeps the edge and finding registries closed', () => {
+    expect(Object.keys(CORPUS_EDGE_REGISTRY).sort()).toEqual([...CORPUS_EDGE_KINDS].sort());
+    expect([...new Set(Object.values(CORPUS_DISCOVERY_EDGE_KINDS).flat())].sort())
+      .toEqual([...CORPUS_EDGE_KINDS].sort());
+    expect(CORPUS_FINDING_CODES.every(isKnownFindingCode)).toBe(true);
+  });
+
+  it('doctor reports unresolved declared references as corpus errors', async () => {
+    const root = await fixture([
+      '# Example Specification',
+      '',
+      '## Requirements',
+      '',
+      '### Requirement: Example',
+      '',
+      '> Decision recorded: deadbeef',
+      '',
+      'The system SHALL work.',
+      '',
+    ].join('\n'));
+
+    const result = await checkCorpusIntegrity(root);
+
+    expect(result.status).toBe('fail');
+    expect(result.findings?.map((finding) => finding.code)).toContain('corpus-reference-unresolved');
+  });
+
+  it('enforce collects the same corpus finding set and marks every code assessed', async () => {
+    const root = await fixture([
+      '# Example Specification',
+      '',
+      '## Requirements',
+      '',
+      '### Requirement: Example',
+      '',
+      '> Decision recorded: deadbeef',
+      '',
+    ].join('\n'));
+
+    const result = await collectGovernanceFindings(root, null, {});
+
+    expect(result.findings.map((finding) => finding.code)).toContain('corpus-reference-unresolved');
+    expect([...result.assessedCodes].filter((code) => code.startsWith('corpus-')).sort())
+      .toEqual([...CORPUS_FINDING_CODES].sort());
+    expect(result.failedCodes.size).toBe(0);
+  });
+
+  it('doctor stays clean for a corpus with no declared cross-artifact references', async () => {
+    const root = await fixture([
+      '# Example Specification',
+      '',
+      '## Requirements',
+      '',
+      '### Requirement: Example',
+      '',
+      'The system SHALL work.',
+      '',
+    ].join('\n'));
+
+    const result = await checkCorpusIntegrity(root);
+
+    expect(result).toMatchObject({ name: 'Corpus integrity', status: 'ok' });
+    expect(result.findings).toBeUndefined();
+  });
+});

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -55,6 +55,10 @@ vi.mock('../../core/services/llm-service.js', () => ({
   }),
 }));
 
+vi.mock('../../core/decisions/corpus-integrity.js', () => ({
+  detectCorpusIntegrity: vi.fn().mockResolvedValue([]),
+}));
+
 // ============================================================================
 // HELPERS
 // ============================================================================
@@ -149,9 +153,14 @@ describe('doctor command', () => {
       expect(Array.isArray(checks)).toBe(true);
     });
 
-    it('should include exactly 12 checks', async () => {
+    it('should include exactly 13 checks', async () => {
       const checks = await runDoctorJson();
-      expect(checks).toHaveLength(12);
+      expect(checks).toHaveLength(13);
+    });
+
+    it('should include a governance corpus integrity check', async () => {
+      const checks = await runDoctorJson();
+      expect(checks.find(c => c.name === 'Corpus integrity')).toBeDefined();
     });
 
     it('should include a Git hook reachability check', async () => {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -53,6 +53,7 @@ import {
 import { describeExclusions, totalExcluded, type ParseHealthReport } from '../../core/analyzer/parse-health.js';
 import { describeMemoryDegradation } from '../../core/analyzer/memory-strategy.js';
 import type { GovernanceFinding } from '../../core/services/mcp-handlers/enforcement-policy.js';
+import { detectCorpusIntegrity } from '../../core/decisions/corpus-integrity.js';
 import { detectInjectionShapes, INJECTION_SHAPE_LIMITS } from '../../core/services/served-content.js';
 import { redactSecretTextWithKnownValues } from '../../core/services/secret-redaction.js';
 import {
@@ -390,6 +391,36 @@ export async function checkServedContentTrust(
     findings,
     fix: 'Review the named content and its provenance; do not rewrite it automatically.',
   };
+}
+
+/** Validate the governance corpus as a closed typed graph. Read-only and offline. */
+export async function checkCorpusIntegrity(rootPath: string): Promise<CheckResult> {
+  try {
+    const config = await readOpenLoreConfig(rootPath);
+    const findings = await detectCorpusIntegrity(rootPath, { openspecPath: config?.openspecPath });
+    if (findings.length === 0) {
+      return {
+        name: 'Corpus integrity',
+        status: 'ok',
+        detail: 'all declared governance references resolve',
+      };
+    }
+    const errors = findings.filter((finding) => finding.severity === 'error').length;
+    return {
+      name: 'Corpus integrity',
+      status: errors > 0 ? 'fail' : 'warn',
+      detail: `${findings.length} finding(s): ${errors} graph error(s), ${findings.length - errors} advisory`,
+      findings,
+      fix: 'Repair the named corpus references; OpenLore never rewrites governance edges automatically.',
+    };
+  } catch (error) {
+    return {
+      name: 'Corpus integrity',
+      status: 'warn',
+      detail: `check unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      fix: 'Restore readable OpenSpec and .openlore decision/memory stores, then rerun doctor.',
+    };
+  }
 }
 
 /** JSON stores serve their string values, not their serialized line layout. */
@@ -883,6 +914,7 @@ Checks performed:
   • Analysis artifacts freshness
   • Graph store lifecycle (schema mismatch / quarantined index)
   • OpenSpec directory presence
+  • Governance corpus reference integrity
   • Injection-shaped unreviewed content (lexical advisory; never a guarantee)
   • MCP wiring (Claude Code reads .mcp.json, not .claude/settings.json)
   • LLM connection (live request with 10s timeout)
@@ -913,6 +945,7 @@ Checks performed:
         checkGraphStore(rootPath),
         checkParseHealth(rootPath),
         checkOpenSpecDir(rootPath),
+        checkCorpusIntegrity(rootPath),
         checkServedContentTrust(rootPath),
         checkDiskSpace(rootPath),
       ]),

--- a/src/cli/commands/enforce.test.ts
+++ b/src/cli/commands/enforce.test.ts
@@ -146,6 +146,17 @@ async function gateHuman(root: string): Promise<string> {
   return out.join('');
 }
 
+async function gateHookHuman(root: string): Promise<{ code: number; stderr: string }> {
+  const out: string[] = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((s: string | Uint8Array) => { out.push(String(s)); return true; }) as typeof process.stderr.write;
+  try {
+    return { code: await runEnforceCli({ cwd: root, hook: true }), stderr: out.join('') };
+  } finally {
+    process.stderr.write = orig;
+  }
+}
+
 describe('enforce git hook install/uninstall', () => {
   const readHook = (root: string) => readFile(join(root, '.git', 'hooks', 'pre-commit'), 'utf-8');
 
@@ -386,6 +397,77 @@ describe('impactCertificateFindings — surface severities map to per-severity c
 });
 
 describe('enforce gate decision', () => {
+  it('applies corpus source defaults and honors an explicit advisory downgrade', async () => {
+    const root = await mkRepo();
+    await initializeGitHead(root);
+    const specDir = join(root, 'openspec', 'specs', 'demo');
+    await mkdir(specDir, { recursive: true });
+    await writeFile(join(specDir, 'spec.md'),
+      '# Demo\n\n## Requirements\n\n### Requirement: Broken\n\n> Decision recorded: deadbeef\n');
+    await execFileAsync('git', ['add', 'openspec/specs/demo/spec.md'], { cwd: root });
+
+    const blocked = await gateJson(root, true);
+    expect(blocked.code).toBe(1);
+    expect(blocked.json.blocking.map((finding) => finding.code)).toContain('corpus-reference-unresolved');
+
+    await writePolicy(root, { 'corpus-reference-unresolved': 'advisory' });
+    await execFileAsync('git', ['add', '.openlore/config.json'], { cwd: root });
+    const downgraded = await gateJson(root, true);
+    expect(downgraded.code).toBe(0);
+    expect(downgraded.json.advisory.map((finding) => finding.code)).toContain('corpus-reference-unresolved');
+  });
+
+  it('does not gate when undeclared-reference advice is the only corpus finding', async () => {
+    const root = await mkRepo();
+    await initializeGitHead(root);
+    const specDir = join(root, 'openspec', 'specs', 'demo');
+    const changeDir = join(root, 'openspec', 'changes', 'active');
+    await mkdir(specDir, { recursive: true });
+    await mkdir(changeDir, { recursive: true });
+    await writeFile(join(specDir, 'spec.md'),
+      '# Demo\n\n## Decisions\n\n### Known\n\n**Status:** Approved\n**ID:** aaaaaaaa\n');
+    await writeFile(join(changeDir, 'proposal.md'), '# Proposal\n\nDecision aaaaaaaa informs this work.\n');
+    await execFileAsync('git', ['add', 'openspec'], { cwd: root });
+
+    const result = await gateJson(root, true);
+    expect(result.code).toBe(0);
+    expect(result.json.gated).toBe(false);
+    expect(result.json.advisory.map((finding) => finding.code)).toEqual(['corpus-reference-undeclared']);
+  });
+
+  it('checks index/worktree parity for source-default blocking corpus findings', async () => {
+    const root = await mkRepo();
+    await initializeGitHead(root);
+    const specDir = join(root, 'openspec', 'specs', 'demo');
+    await mkdir(specDir, { recursive: true });
+    const bad = '# Demo\n\n## Requirements\n\n### Requirement: Broken\n\nThe system SHALL fail closed.\n\n> Decision recorded: deadbeef\n';
+    const clean = '# Demo\n\n## Requirements\n\n### Requirement: Clean\n\nThe system SHALL remain valid.\n';
+    await writeFile(join(specDir, 'spec.md'), bad, 'utf8');
+    await execFileAsync('git', ['add', 'openspec/specs/demo/spec.md'], { cwd: root });
+    await writeFile(join(specDir, 'spec.md'), clean, 'utf8');
+
+    const { code, json } = await gateJson(root, true);
+    expect(code).toBe(1);
+    expect(json.gated).toBe(true);
+    expect(json.ratchet.unstaged).toBe(true);
+  });
+
+  it('sanitizes repository-authored control bytes in hook output', async () => {
+    const root = await mkRepo();
+    await initializeGitHead(root);
+    const specDir = join(root, 'openspec', 'specs', 'demo');
+    await mkdir(specDir, { recursive: true });
+    await writeFile(join(specDir, 'spec.md'),
+      '# Demo\n\n## Requirements\n\n### Requirement: hostile-\u001b[2J-name\n\nThe system SHALL cite.\n\n> Decision recorded: deadbeef\n', 'utf8');
+    await execFileAsync('git', ['add', 'openspec/specs/demo/spec.md'], { cwd: root });
+
+    const result = await gateHookHuman(root);
+    expect(result.code).toBe(1);
+    expect(result.stderr).not.toContain('\u001b');
+    expect(result.stderr).not.toContain('\r');
+    expect(result.stderr).toContain('hostile-[2J-name');
+  });
+
   it('advisory by default — a stale-decision-reference does not block (exit 0)', async () => {
     const root = await mkRepo();
     await writeStaleScenario(root);

--- a/src/cli/commands/enforce.ts
+++ b/src/cli/commands/enforce.ts
@@ -7,8 +7,8 @@
  * `enforcement.policy` (with the legacy `blastRadius.block` / `impactCertificate.block`
  * sugar lowered onto it), and — in `--hook` mode — fails the commit ONLY when at
  * least one finding resolves to `blocking`. Findings are sorted by a stable key so
- * output is reproducible. Advisory by default: a repository that declares no policy
- * never blocks. An `off`-classed finding is still listed (silenced, not invisible).
+ * output is reproducible. Each source declares its default class; an `off`-classed
+ * finding remains listed (silenced, not invisible).
  *
  * Sources:
  *   - stale-decision-reference — always (cheap: a pure walk of the decision graph
@@ -19,8 +19,8 @@
  *   - impact-certificate surfaces — collected only when the repo declared covering
  *     surfaces, for the same reason.
  *
- * Sources remain advisory by default; configured frozen sources fail closed when
- * their assessment cannot be completed. Deterministic, no LLM (north star `c6d1ad07`).
+ * Blocking and frozen sources fail closed when their assessment cannot be completed.
+ * Deterministic, no LLM (north star `c6d1ad07`).
  */
 
 import { execFile } from 'node:child_process';
@@ -31,16 +31,22 @@ import { Command } from 'commander';
 import { gitPathArgs } from '../../utils/git-args.js';
 import { logger, configureLogger } from '../../utils/logger.js';
 import { writeStdout } from '../output.js';
+import { sanitizeForTerminal } from '../../utils/misc.js';
 import { readOpenLoreConfigStrict } from '../../core/services/config-manager.js';
 import {
   effectivePolicy,
   normalizeEnforcementPolicy,
   unknownPolicyCodes,
   classifyFindings,
+  resolveEnforcementClass,
   type GovernanceFinding,
 } from '../../core/services/mcp-handlers/enforcement-policy.js';
 import { applyEnforcementBaseline } from '../../core/services/mcp-handlers/enforcement-baseline.js';
 import { detectStaleDecisionReferences } from '../../core/services/mcp-handlers/stale-decision-reference.js';
+import {
+  CORPUS_FINDING_CODES,
+  detectCorpusIntegrity,
+} from '../../core/decisions/corpus-integrity.js';
 import { computeBlastRadius, type BlastRadiusBriefing } from '../../core/services/mcp-handlers/blast-radius.js';
 import { computeImpactCertificate, type ImpactCertificate } from '../../core/services/mcp-handlers/impact-certificate.js';
 import type { OpenLoreConfig } from '../../types/index.js';
@@ -262,6 +268,17 @@ export async function collectGovernanceFindings(
     failedCodes.add('stale-decision-reference');
   }
 
+  // Governance-corpus integrity — always (bounded local artifact walk, no LLM).
+  // Keep the legacy stale-decision source above for compatibility; this pass owns
+  // the closed typed-edge contract and the corpus-* finding vocabulary.
+  try {
+    findings.push(...await detectCorpusIntegrity(cwd, { openspecPath: config?.openspecPath }));
+    for (const code of CORPUS_FINDING_CODES) assessedCodes.add(code);
+  } catch (err) {
+    caveats.push(`corpus-integrity check unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    for (const code of CORPUS_FINDING_CODES) failedCodes.add(code);
+  }
+
   // blast-radius orphan patterns — only when configured (diff-heavy).
   if (blastRadiusInUse(config, policy)) {
     try {
@@ -415,8 +432,19 @@ export async function runEnforceCli(opts: EnforceCliOptions): Promise<number> {
     .some(([code, enforcementClass]) => enforcementClass === 'frozen' && collected.assessedCodes.has(code));
   const activeGatePolicy = Object.values(policy)
     .some((enforcementClass) => enforcementClass === 'blocking' || enforcementClass === 'frozen');
-  const failedFrozenCodes = [...collected.failedCodes]
-    .filter((code) => policy[code] === 'frozen')
+  // Source-declared defaults are policy too. A default-blocking source must
+  // compare the working tree with the index even when the operator has not
+  // repeated that default in .openlore/config.json.
+  const activeGateAssessment = [...collected.assessedCodes]
+    .some((code) => {
+      const enforcementClass = resolveEnforcementClass(code, policy);
+      return enforcementClass === 'blocking' || enforcementClass === 'frozen';
+    });
+  const failedGateCodes = [...collected.failedCodes]
+    .filter((code) => {
+      const cls = resolveEnforcementClass(code, policy);
+      return cls === 'blocking' || cls === 'frozen';
+    })
     .sort();
   const trustedBaseline = activeFrozenAssessment || opts.hook
     ? await trustedBaselineAtHead(cwd)
@@ -454,9 +482,9 @@ export async function runEnforceCli(opts: EnforceCliOptions): Promise<number> {
     result.gated = true;
     collected.caveats.push(`enforcement config unavailable: ${configReadError}`);
   }
-  if (failedFrozenCodes.length > 0) {
+  if (failedGateCodes.length > 0) {
     result.gated = true;
-    collected.caveats.push(`frozen assessment failed for ${failedFrozenCodes.join(', ')}; baseline bytes were preserved`);
+    collected.caveats.push(`frozen assessment failed or blocking source unavailable for ${failedGateCodes.join(', ')}; baseline bytes were preserved where applicable`);
   }
   if (trustedBaselineError) {
     result.gated = true;
@@ -473,9 +501,9 @@ export async function runEnforceCli(opts: EnforceCliOptions): Promise<number> {
     result.gated = true;
     collected.caveats.push('enforcement config differs between the Git index and working tree');
   }
-  const requiresFullWorktreeCheck = activeGatePolicy || activeFrozenAssessment || failedFrozenCodes.length > 0 ||
+  const requiresFullWorktreeCheck = activeGatePolicy || activeGateAssessment || activeFrozenAssessment || failedGateCodes.length > 0 ||
     configReadError !== null || configMismatch;
-  const worktreeStatus = opts.hook && requiresFullWorktreeCheck
+  const worktreeStatus = opts.hook && requiresFullWorktreeCheck && !irrelevantNoPolicyAbsence
     ? await inspectWorktreeStatus(cwd)
     : { dirty: false };
   const baselineDirty = configMismatch || worktreeStatus.dirty;
@@ -501,16 +529,16 @@ export async function runEnforceCli(opts: EnforceCliOptions): Promise<number> {
         retiredCount: reconciled.baseline.removed,
         baselineChanged: reconciled.baseline.written,
         requiresInitialization: reconciled.baseline.requiresInitialization ?? [],
-        failedAssessmentCodes: failedFrozenCodes,
+        failedAssessmentCodes: failedGateCodes,
         unstaged: baselineDirty,
       },
       unknownPolicyCodes: unknown,
       caveats: collected.caveats,
     }, null, 2) + '\n');
   } else {
-    const showRatchetReceipt = activeFrozenAssessment || failedFrozenCodes.length > 0;
+    const showRatchetReceipt = activeFrozenAssessment || failedGateCodes.length > 0;
     const out = renderHuman(result, unknown, collected.caveats, reconciled.baseline, baselineDirty, showRatchetReceipt);
-    if (opts.hook) process.stderr.write(out + '\n');
+    if (opts.hook) process.stderr.write(sanitizeForTerminal(out + '\n', { keepNewlines: true }));
     else await writeStdout(out + '\n');
   }
 
@@ -521,8 +549,8 @@ export async function runEnforceCli(opts: EnforceCliOptions): Promise<number> {
         ? `   Run openlore enforce outside hook mode, review the new baseline, and stage it before committing.\n`
         : configReadError
           ? `   Repair or restore .openlore/config.json so the enforcement policy can be verified.\n`
-          : failedFrozenCodes.length > 0
-            ? `   Restore a complete assessment for ${failedFrozenCodes.join(', ')}; the frozen baseline was preserved.\n`
+          : failedGateCodes.length > 0
+            ? `   Restore a complete assessment for ${failedGateCodes.join(', ')}; blocking/frozen sources were not treated as clean.\n`
         : trustedBaselineError
           ? `   Restore a readable Git HEAD so the committed frozen baseline can be verified.\n`
         : worktreeStatus.error
@@ -573,7 +601,7 @@ function renderHuman(
 }
 
 export const enforceCommand = new Command('enforce')
-  .description('Unified finding-enforcement gate: blocking fails immediately; frozen adopts existing debt and blocks only new findings; advisory is the default.')
+  .description('Unified finding-enforcement gate: each source declares its default; frozen adopts existing debt and blocks only new findings.')
   .option('--base <ref>', 'Git ref to diff the working tree against for diff-based sources (default HEAD)')
   .option('--json', 'Emit the gate result as JSON', false)
   .option('--hook', 'Hook mode: exit 1 on blocking/new frozen findings, invalid config, incomplete frozen assessment, or unverifiable staged bytes', false)

--- a/src/core/decisions/corpus-integrity.test.ts
+++ b/src/core/decisions/corpus-integrity.test.ts
@@ -1,0 +1,561 @@
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import {
+  CORPUS_ARTIFACT_TYPES,
+  CORPUS_EDGE_KINDS,
+  CORPUS_EDGE_REGISTRY,
+  CORPUS_FINDING_CODES,
+  CORPUS_RESOURCE_LIMITS,
+  detectCorpusIntegrity,
+  evaluateCorpusGraph,
+  supersessionCycleMembers,
+  type CorpusArtifact,
+  type CorpusEdge,
+} from './corpus-integrity.js';
+
+function artifact(
+  key: string,
+  type: CorpusArtifact['type'],
+  identifier: string,
+  extra: Partial<CorpusArtifact> = {},
+): CorpusArtifact {
+  return { key, type, identifier, path: `${key}.md`, live: true, ...extra };
+}
+
+function codes(artifacts: CorpusArtifact[], edges: CorpusEdge[]): string[] {
+  return evaluateCorpusGraph({ artifacts, edges }).map((finding) => finding.code);
+}
+
+describe('CORPUS_EDGE_REGISTRY', () => {
+  it('is closed over every supported edge and declares all graph semantics', () => {
+    expect(Object.keys(CORPUS_EDGE_REGISTRY).sort()).toEqual([...CORPUS_EDGE_KINDS].sort());
+    for (const spec of Object.values(CORPUS_EDGE_REGISTRY)) {
+      expect(CORPUS_ARTIFACT_TYPES).toContain(spec.sourceArtifactType);
+      expect(spec.targetRange.length).toBeGreaterThan(0);
+      for (const target of spec.targetRange) expect(CORPUS_ARTIFACT_TYPES).toContain(target);
+      expect(typeof spec.directional).toBe('boolean');
+      expect(typeof spec.mayCycle).toBe('boolean');
+      expect(typeof spec.liveSourceMayReferenceRetiredTarget).toBe('boolean');
+    }
+    expect(new Set(CORPUS_FINDING_CODES).size).toBe(CORPUS_FINDING_CODES.length);
+  });
+});
+
+describe('evaluateCorpusGraph', () => {
+  it('reports unresolved, wrong-type, self, unsupported, and missing-anchor references precisely', () => {
+    const decision = artifact('decision-a', 'decision', 'aaaaaaaa');
+    const requirement = artifact('requirement-a', 'requirement', 'RequireA');
+    const memory = artifact('memory-a', 'memory', 'm1');
+    const findings = evaluateCorpusGraph({
+      artifacts: [decision, requirement, memory],
+      edges: [
+        { kind: 'spec-cites-decision', sourceKey: requirement.key, reference: 'deadbeef' },
+        { kind: 'spec-cites-decision', sourceKey: requirement.key, reference: 'm1' },
+        { kind: 'decision-supersedes', sourceKey: decision.key, reference: 'aaaaaaaa' },
+        { kind: 'not-registered', sourceKey: requirement.key, reference: 'anything' },
+        { kind: 'memory-anchors-symbol', sourceKey: memory.key, reference: 'gone::symbol', anchorMissing: true },
+      ],
+    });
+
+    expect(findings.map((finding) => finding.code)).toEqual(expect.arrayContaining([
+      'corpus-reference-unresolved',
+      'corpus-target-type-mismatch',
+      'corpus-self-reference',
+      'corpus-edge-unsupported',
+      'corpus-anchor-target-missing',
+    ]));
+    for (const finding of findings) {
+      expect(finding.source).toBe('corpus-integrity');
+      expect(finding.message).toContain(JSON.stringify(finding.discriminator!.split(':').slice(1).join(':')));
+    }
+  });
+
+  it('reports duplicate identities and makes an inbound edge ambiguous', () => {
+    const requirement = artifact('requirement', 'requirement', 'R');
+    const first = artifact('decision-1', 'decision', 'aaaaaaaa');
+    const second = artifact('decision-2', 'decision', 'aaaaaaaa');
+    const findings = evaluateCorpusGraph({
+      artifacts: [requirement, first, second],
+      edges: [{ kind: 'spec-cites-decision', sourceKey: requirement.key, reference: 'aaaaaaaa' }],
+    });
+    expect(findings.filter((finding) => finding.code === 'corpus-duplicate-identifier')).toHaveLength(1);
+    expect(findings.filter((finding) => finding.code === 'corpus-reference-ambiguous')).toHaveLength(1);
+    expect(findings.every((finding) => finding.message.includes('aaaaaaaa'))).toBe(true);
+  });
+
+  it('reports a retired target with the terminal superseder and clears when re-pointed', () => {
+    const old = artifact('old', 'decision', 'aaaaaaaa', { retiredBy: 'cccccccc' });
+    const current = artifact('current', 'decision', 'cccccccc');
+    const requirement = artifact('requirement', 'requirement', 'UseCurrent');
+    const retired = evaluateCorpusGraph({
+      artifacts: [old, current, requirement],
+      edges: [{ kind: 'spec-cites-decision', sourceKey: requirement.key, reference: 'aaaaaaaa' }],
+    });
+    expect(retired).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'corpus-target-retired',
+        message: expect.stringContaining('cite cccccccc instead'),
+      }),
+    ]));
+    expect(codes(
+      [old, current, requirement],
+      [{ kind: 'spec-cites-decision', sourceKey: requirement.key, reference: 'cccccccc' }],
+    )).not.toContain('corpus-target-retired');
+  });
+
+  it('reports every supersession-cycle member and exposes the same member set to claim verification', () => {
+    const a = artifact('a', 'decision', 'aaaaaaaa');
+    const b = artifact('b', 'decision', 'bbbbbbbb');
+    const graph = {
+      artifacts: [a, b],
+      edges: [
+        { kind: 'decision-supersedes', sourceKey: a.key, reference: 'bbbbbbbb' },
+        { kind: 'decision-supersedes', sourceKey: b.key, reference: 'aaaaaaaa' },
+      ],
+    };
+    expect(supersessionCycleMembers(graph)).toEqual(['aaaaaaaa', 'bbbbbbbb']);
+    const cycle = evaluateCorpusGraph(graph).filter((finding) => finding.code === 'corpus-supersession-cycle');
+    expect(cycle).toHaveLength(2);
+    expect(cycle.map((finding) => finding.subject).sort()).toEqual([
+      'decision:a.md#aaaaaaaa',
+      'decision:b.md#bbbbbbbb',
+    ]);
+  });
+
+  it('keeps disjoint supersession cycles separate in each finding', () => {
+    const decisions = ['aaaaaaaa', 'bbbbbbbb', 'cccccccc', 'dddddddd'].map((id) =>
+      artifact(id, 'decision', id));
+    const findings = evaluateCorpusGraph({
+      artifacts: decisions,
+      edges: [
+        { kind: 'decision-supersedes', sourceKey: 'aaaaaaaa', reference: 'bbbbbbbb' },
+        { kind: 'decision-supersedes', sourceKey: 'bbbbbbbb', reference: 'aaaaaaaa' },
+        { kind: 'decision-supersedes', sourceKey: 'cccccccc', reference: 'dddddddd' },
+        { kind: 'decision-supersedes', sourceKey: 'dddddddd', reference: 'cccccccc' },
+      ],
+    }).filter((finding) => finding.code === 'corpus-supersession-cycle');
+
+    expect(findings.find((finding) => finding.subject.endsWith('#aaaaaaaa'))?.message)
+      .not.toContain('cccccccc');
+    expect(findings.find((finding) => finding.subject.endsWith('#cccccccc'))?.message)
+      .not.toContain('aaaaaaaa');
+  });
+
+  it('validates requirement cycles while ignoring rejected decision cycles', () => {
+    const first = artifact('first', 'requirement', 'First', { identityScope: 'x' });
+    const second = artifact('second', 'requirement', 'Second', { identityScope: 'x' });
+    const rejected = artifact('rejected', 'decision', 'aaaaaaaa', { live: false });
+    const phantom = artifact('phantom', 'decision', 'bbbbbbbb', { live: false });
+    const findings = evaluateCorpusGraph({
+      artifacts: [first, second, rejected, phantom],
+      edges: [
+        { kind: 'spec-cites-requirement', sourceKey: first.key, reference: 'Second' },
+        { kind: 'spec-cites-requirement', sourceKey: second.key, reference: 'First' },
+        { kind: 'decision-supersedes', sourceKey: rejected.key, reference: 'bbbbbbbb' },
+        { kind: 'decision-supersedes', sourceKey: phantom.key, reference: 'aaaaaaaa' },
+      ],
+    }).filter((finding) => finding.code === 'corpus-supersession-cycle');
+
+    expect(findings).toHaveLength(2);
+    expect(findings.every((finding) => finding.discriminator?.startsWith('spec-cites-requirement:'))).toBe(true);
+  });
+
+  it('walks a long acyclic chain within the focused-test timeout', () => {
+    const count = 20_000;
+    const artifacts = Array.from({ length: count }, (_, index) =>
+      artifact(`r${index}`, 'requirement', `R${index}`, { identityScope: 'scale' }));
+    const edges = artifacts.slice(0, -1).map((source, index) => ({
+      kind: 'spec-cites-requirement', sourceKey: source.key, reference: `R${index + 1}`,
+    }));
+    expect(evaluateCorpusGraph({ artifacts, edges }).filter((finding) =>
+      finding.code === 'corpus-supersession-cycle')).toEqual([]);
+  }, 3_000);
+
+  it('fails closed before evaluating a graph beyond its artifact ceiling', () => {
+    const artifacts = Array.from({ length: CORPUS_RESOURCE_LIMITS.artifacts + 1 }, (_, index) =>
+      artifact(`a${index}`, 'file', `f${index}`));
+    expect(() => evaluateCorpusGraph({ artifacts, edges: [] })).toThrow('corpus artifact limit exceeded');
+  });
+
+  it('suggests exact undeclared references once and excludes fences, self, and declared lines', () => {
+    const decision = artifact('decision', 'decision', 'aaaaaaaa');
+    const declared = artifact('declared', 'requirement', 'Declared', {
+      text: '### Requirement: Declared\n> Decision recorded: aaaaaaaa\nThe basis is aaaaaaaa.',
+    });
+    const prose = artifact('prose', 'requirement', 'Prose', {
+      text: '### Requirement: Prose\nDecision aaaaaaaa applies. Again: aaaaaaaa.',
+    });
+    const fenced = artifact('fenced', 'requirement', 'Fenced', {
+      text: '### Requirement: Fenced\n```text\naaaaaaaa\n```',
+    });
+    const self = artifact('self', 'requirement', 'SelfName', {
+      identityScope: 'x',
+      text: '### Requirement: SelfName\nSelfName remains itself.',
+    });
+    const findings = evaluateCorpusGraph({
+      artifacts: [decision, declared, prose, fenced, self],
+      edges: [{ kind: 'spec-cites-decision', sourceKey: declared.key, reference: 'aaaaaaaa' }],
+    }).filter((finding) => finding.code === 'corpus-reference-undeclared');
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      subject: 'requirement:prose.md#Prose',
+      discriminator: 'spec-cites-decision:aaaaaaaa',
+      severity: 'warning',
+    });
+  });
+
+  it('is byte-deterministic regardless of artifact and edge input order', () => {
+    const req = artifact('req', 'requirement', 'R');
+    const decision = artifact('decision', 'decision', 'aaaaaaaa');
+    const edge = { kind: 'spec-cites-decision', sourceKey: req.key, reference: 'deadbeef' };
+    const first = evaluateCorpusGraph({ artifacts: [req, decision], edges: [edge] });
+    const second = evaluateCorpusGraph({ artifacts: [decision, req], edges: [edge] });
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+});
+
+describe('detectCorpusIntegrity', () => {
+  const storedDecision = (id: string, supersedes?: string, status = 'approved') => ({
+    id, status, title: id, rationale: '', consequences: '', proposedRequirement: null,
+    affectedDomains: [], affectedFiles: [], supersedes, syncedToSpecs: [],
+  });
+
+  it('reports an on-disk self-supersession edge', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-self-'));
+    await mkdir(join(root, '.openlore', 'decisions'), { recursive: true });
+    await writeFile(join(root, '.openlore', 'decisions', 'pending.json'), JSON.stringify({
+      decisions: [storedDecision('aaaaaaaa', 'aaaaaaaa')],
+    }));
+    expect(await detectCorpusIntegrity(root)).toContainEqual(expect.objectContaining({
+      code: 'corpus-self-reference', discriminator: 'decision-supersedes:aaaaaaaa',
+    }));
+  });
+
+  it('does not hide an unproven pending/durable id collision', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-pending-durable-'));
+    await mkdir(join(root, '.openlore', 'decisions'), { recursive: true });
+    await mkdir(join(root, 'openspec', 'specs', 'demo'), { recursive: true });
+    await writeFile(join(root, '.openlore', 'decisions', 'pending.json'), JSON.stringify({
+      decisions: [storedDecision('aaaaaaaa', undefined, 'draft')],
+    }));
+    await writeFile(join(root, 'openspec', 'specs', 'demo', 'spec.md'),
+      '# Demo\n\n## Decisions\n\n### Durable\n\n**Status:** Approved\n**ID:** aaaaaaaa\n');
+    expect(await detectCorpusIntegrity(root)).toContainEqual(expect.objectContaining({
+      code: 'corpus-duplicate-identifier', discriminator: 'identity:aaaaaaaa',
+    }));
+  });
+
+  it('keeps an orphaned memory non-authoritative while reporting its missing anchor', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-orphan-memory-'));
+    await mkdir(join(root, '.openlore', 'decisions'), { recursive: true });
+    await mkdir(join(root, '.openlore', 'memory'), { recursive: true });
+    await writeFile(join(root, '.openlore', 'decisions', 'pending.json'), JSON.stringify({
+      decisions: [storedDecision('aaaaaaaa'), storedDecision('bbbbbbbb', 'aaaaaaaa')],
+    }));
+    await writeFile(join(root, '.openlore', 'memory', 'notes.json'), JSON.stringify({ memories: [{
+      id: 'm1', kind: 'note', content: 'aaaaaaaa', anchors: [{ filePath: 'missing.ts' }],
+    }] }));
+    const findings = await detectCorpusIntegrity(root);
+    expect(findings).toContainEqual(expect.objectContaining({ code: 'corpus-anchor-target-missing' }));
+    expect(findings).not.toContainEqual(expect.objectContaining({
+      code: 'corpus-target-retired', subject: expect.stringContaining('memory:'),
+    }));
+  });
+
+  it('reports root-relative paths with a nested custom OpenSpec directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-nested-path-'));
+    const dir = join(root, 'docs', 'governance', 'openspec', 'specs', 'demo');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'spec.md'),
+      '# Demo\n\n## Requirements\n\n### Requirement: Broken\n\n> Decision recorded: deadbeef\n');
+    expect(await detectCorpusIntegrity(root, { openspecPath: 'docs/governance/openspec' }))
+      .toContainEqual(expect.objectContaining({
+        code: 'corpus-reference-unresolved',
+        subject: 'requirement:docs/governance/openspec/specs/demo/spec.md#Broken',
+      }));
+  });
+
+  it('reads the on-disk corpus without modifying it and reports an orphaned delta', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-'));
+    await mkdir(join(root, 'openspec', 'specs', 'known'), { recursive: true });
+    await mkdir(join(root, 'openspec', 'changes', 'active', 'specs', 'missing'), { recursive: true });
+    await mkdir(join(root, '.openlore', 'decisions'), { recursive: true });
+    await mkdir(join(root, '.openlore', 'memory'), { recursive: true });
+    await writeFile(join(root, 'openspec', 'specs', 'known', 'spec.md'), '# Known\n\n## Requirements\n');
+    await writeFile(join(root, 'openspec', 'changes', 'active', 'proposal.md'), '# Proposal\n');
+    await writeFile(join(root, '.openlore', 'decisions', 'pending.json'), '{"decisions":[]}\n');
+    await writeFile(join(root, '.openlore', 'memory', 'notes.json'), '{"memories":[]}\n');
+    const before = await Promise.all([
+      readFile(join(root, 'openspec', 'changes', 'active', 'proposal.md'), 'utf8'),
+      readFile(join(root, '.openlore', 'decisions', 'pending.json'), 'utf8'),
+    ]);
+
+    const first = await detectCorpusIntegrity(root);
+    const second = await detectCorpusIntegrity(root);
+
+    expect(first).toEqual(second);
+    expect(first).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'corpus-reference-unresolved',
+        discriminator: 'change-delta-targets-domain:missing',
+      }),
+    ]));
+    expect(await Promise.all([
+      readFile(join(root, 'openspec', 'changes', 'active', 'proposal.md'), 'utf8'),
+      readFile(join(root, '.openlore', 'decisions', 'pending.json'), 'utf8'),
+    ])).toEqual(before);
+  });
+
+  it('accepts a delta that targets a proposal-declared new capability', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-new-domain-'));
+    await mkdir(join(root, 'openspec', 'changes', 'active', 'specs', 'new-domain'), { recursive: true });
+    await writeFile(join(root, 'openspec', 'changes', 'active', 'proposal.md'), [
+      '# Proposal',
+      '',
+      '## Capabilities',
+      '',
+      '### New Capabilities',
+      '',
+      '- `new-domain`: A new domain.',
+      '',
+      '### Modified Capabilities',
+      '',
+    ].join('\n'));
+
+    const findings = await detectCorpusIntegrity(root);
+
+    expect(findings).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'corpus-reference-unresolved',
+        discriminator: 'change-delta-targets-domain:new-domain',
+      }),
+    ]));
+  });
+
+  it('lets a proposal clear an exact-reference advisory with a declared corpus edge', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-proposal-edge-'));
+    await mkdir(join(root, 'openspec', 'specs', 'known'), { recursive: true });
+    await mkdir(join(root, 'openspec', 'changes', 'active'), { recursive: true });
+    await writeFile(join(root, 'openspec', 'specs', 'known', 'spec.md'), [
+      '# Known',
+      '',
+      '## Decisions',
+      '',
+      '**ID:** aaaaaaaa',
+      '',
+    ].join('\n'));
+    await writeFile(join(root, 'openspec', 'changes', 'active', 'proposal.md'), [
+      '# Proposal',
+      '',
+      '> Corpus edge: proposal-cites-decision aaaaaaaa',
+      '',
+      'Decision aaaaaaaa governs this change.',
+      '',
+    ].join('\n'));
+
+    const findings = await detectCorpusIntegrity(root);
+
+    expect(findings.filter((finding) => finding.discriminator?.endsWith(':aaaaaaaa'))).toEqual([]);
+  });
+
+  it('confines a configured OpenSpec path to the repository root', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-confined-'));
+    const outside = await mkdtemp(join(tmpdir(), 'openlore-corpus-outside-'));
+    await mkdir(join(outside, 'specs', 'x'), { recursive: true });
+    await writeFile(join(outside, 'specs', 'x', 'spec.md'), '# Outside\n');
+
+    await expect(detectCorpusIntegrity(root, { openspecPath: outside })).rejects.toThrow(/outside project directory/);
+  });
+
+  it('rejects symlink escapes from stores, specs, proposals, delta directories, and anchors', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'openlore-corpus-outside-files-'));
+    await writeFile(join(outside, 'pending.json'), '{"decisions":[]}');
+    await writeFile(join(outside, 'spec.md'), '# Outside\n');
+    await writeFile(join(outside, 'proposal.md'), '# Outside proposal\n');
+    await mkdir(join(outside, 'specs'));
+    await writeFile(join(outside, 'anchor.ts'), 'export {};\n');
+
+    const storeRoot = await mkdtemp(join(tmpdir(), 'openlore-corpus-store-link-'));
+    await mkdir(join(storeRoot, '.openlore', 'decisions'), { recursive: true });
+    await symlink(join(outside, 'pending.json'), join(storeRoot, '.openlore', 'decisions', 'pending.json'));
+    await expect(detectCorpusIntegrity(storeRoot)).rejects.toThrow(/Path escape blocked/);
+
+    const specRoot = await mkdtemp(join(tmpdir(), 'openlore-corpus-spec-link-'));
+    await mkdir(join(specRoot, 'openspec', 'specs', 'domain'), { recursive: true });
+    await symlink(join(outside, 'spec.md'), join(specRoot, 'openspec', 'specs', 'domain', 'spec.md'));
+    await expect(detectCorpusIntegrity(specRoot)).rejects.toThrow(/Path escape blocked/);
+
+    const domainRoot = await mkdtemp(join(tmpdir(), 'openlore-corpus-domain-link-'));
+    await mkdir(join(domainRoot, 'openspec', 'specs'), { recursive: true });
+    await symlink(outside, join(domainRoot, 'openspec', 'specs', 'escaped'));
+    await expect(detectCorpusIntegrity(domainRoot)).rejects.toThrow(/symbolic-link directory entry/);
+
+    const proposalRoot = await mkdtemp(join(tmpdir(), 'openlore-corpus-proposal-link-'));
+    await mkdir(join(proposalRoot, 'openspec', 'changes', 'active'), { recursive: true });
+    await symlink(join(outside, 'proposal.md'), join(proposalRoot, 'openspec', 'changes', 'active', 'proposal.md'));
+    await expect(detectCorpusIntegrity(proposalRoot)).rejects.toThrow(/Path escape blocked/);
+
+    const deltaRoot = await mkdtemp(join(tmpdir(), 'openlore-corpus-delta-link-'));
+    await mkdir(join(deltaRoot, 'openspec', 'changes', 'active'), { recursive: true });
+    await symlink(join(outside, 'specs'), join(deltaRoot, 'openspec', 'changes', 'active', 'specs'));
+    await expect(detectCorpusIntegrity(deltaRoot)).rejects.toThrow(/Path escape blocked/);
+
+    const anchorRoot = await mkdtemp(join(tmpdir(), 'openlore-corpus-anchor-link-'));
+    await mkdir(join(anchorRoot, '.openlore', 'memory'), { recursive: true });
+    await symlink(join(outside, 'anchor.ts'), join(anchorRoot, 'anchor.ts'));
+    await writeFile(join(anchorRoot, '.openlore', 'memory', 'notes.json'), JSON.stringify({
+      memories: [{ id: 'aaaaaaaa', kind: 'note', content: 'anchored', anchors: [{ filePath: 'anchor.ts' }], recordedAt: '' }],
+    }));
+    await expect(detectCorpusIntegrity(anchorRoot)).rejects.toThrow(/Path escape blocked/);
+  });
+
+  it.each([
+    ['invalid JSON', '{not-json'],
+    ['non-object root', '[]'],
+    ['missing property', '{}'],
+    ['non-array property', '{"decisions":{}}'],
+    ['malformed entry', '{"decisions":[null]}'],
+    ['malformed entry fields', '{"decisions":[{"id":7}]}'],
+  ])('does not misreport a malformed decision store as empty: %s', async (_label, contents) => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-malformed-decision-'));
+    await mkdir(join(root, '.openlore', 'decisions'), { recursive: true });
+    await writeFile(join(root, '.openlore', 'decisions', 'pending.json'), contents);
+
+    await expect(detectCorpusIntegrity(root)).rejects.toThrow();
+  });
+
+  it.each([
+    ['non-object root', 'null'],
+    ['missing property', '{}'],
+    ['non-array property', '{"memories":"none"}'],
+    ['malformed entry', '{"memories":[null]}'],
+    ['malformed anchor', '{"memories":[{"id":"aaaaaaaa","kind":"note","content":"x","anchors":[null]}]}'],
+  ])('does not misreport a malformed memory store as empty: %s', async (_label, contents) => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-malformed-memory-'));
+    await mkdir(join(root, '.openlore', 'memory'), { recursive: true });
+    await writeFile(join(root, '.openlore', 'memory', 'notes.json'), contents);
+
+    await expect(detectCorpusIntegrity(root)).rejects.toThrow();
+  });
+
+  it('reconstructs ADR-only supersession and ignores a rejected superseder', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-adr-'));
+    await mkdir(join(root, 'openspec', 'specs', 'known'), { recursive: true });
+    await mkdir(join(root, 'openspec', 'decisions'), { recursive: true });
+    await writeFile(join(root, 'openspec', 'specs', 'known', 'spec.md'), [
+      '# Known', '', '## Requirements', '',
+      '### Requirement: CiteOldDecision', '',
+      'The system SHALL cite the original decision.', '',
+      '> Corpus edge: spec-cites-decision aaaaaaaa', '',
+    ].join('\n'));
+    await writeFile(join(root, 'openspec', 'decisions', 'adr-0001-old.md'), [
+      '# ADR-0001: Old', '', '## Status', '', 'accepted', '',
+      '> Decision ID: aaaaaaaa', '',
+    ].join('\n'));
+    const replacementPath = join(root, 'openspec', 'decisions', 'adr-0002-new.md');
+    await writeFile(replacementPath, [
+      '# ADR-0002: New', '', '## Status', '', 'accepted', '',
+      '> Decision ID: bbbbbbbb',
+      '> Supersedes: aaaaaaaa', '',
+    ].join('\n'));
+
+    expect(await detectCorpusIntegrity(root)).toContainEqual(expect.objectContaining({
+      code: 'corpus-target-retired',
+      message: expect.stringContaining('cite bbbbbbbb instead'),
+    }));
+
+    await writeFile(replacementPath, [
+      '# ADR-0002: New', '', '## Status', '', 'rejected', '',
+      '> Decision ID: bbbbbbbb',
+      '> Supersedes: aaaaaaaa', '',
+    ].join('\n'));
+    expect((await detectCorpusIntegrity(root)).filter((finding) =>
+      finding.code === 'corpus-target-retired' || finding.code === 'corpus-supersession-cycle',
+    )).toEqual([]);
+  });
+
+  it('discovers delta requirements and stops requirement prose at later headings', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-delta-requirements-'));
+    await mkdir(join(root, 'openspec', 'specs', 'known'), { recursive: true });
+    await mkdir(join(root, 'openspec', 'changes', 'active', 'specs', 'known'), { recursive: true });
+    await writeFile(join(root, 'openspec', 'specs', 'known', 'spec.md'), [
+      '# Known', '## Requirements', '### Requirement: First', 'The system SHALL work.',
+      '### Requirement: Second', 'The system SHALL also work.', '## Decisions', 'First', '',
+    ].join('\n'));
+    await writeFile(join(root, 'openspec', 'changes', 'active', 'specs', 'known', 'spec.md'), [
+      '# Delta', '## ADDED Requirements', '### Requirement: DeltaRequirement',
+      '> Decision recorded: deadbeef', 'The system SHALL cite its decision.', '',
+    ].join('\n'));
+
+    const findings = await detectCorpusIntegrity(root);
+    expect(findings).toContainEqual(expect.objectContaining({
+      code: 'corpus-reference-unresolved',
+      subject: expect.stringContaining('#DeltaRequirement'),
+      discriminator: 'spec-cites-decision:deadbeef',
+    }));
+    expect(findings).not.toContainEqual(expect.objectContaining({
+      code: 'corpus-reference-undeclared',
+      subject: expect.stringContaining('#Second'),
+      discriminator: 'spec-cites-requirement:First',
+    }));
+  });
+
+  it('preserves duplicate durable decisions and competing prospective domains', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-duplicates-'));
+    await mkdir(join(root, 'openspec', 'specs', 'one'), { recursive: true });
+    await writeFile(join(root, 'openspec', 'specs', 'one', 'spec.md'),
+      '# one\n\n### First decision\n\n**ID:** aaaaaaaa\n\n### Duplicate decision\n\n**ID:** aaaaaaaa\n');
+    for (const change of ['first', 'second']) {
+      await mkdir(join(root, 'openspec', 'changes', change, 'specs', 'future'), { recursive: true });
+      await writeFile(join(root, 'openspec', 'changes', change, 'proposal.md'), [
+        '# Proposal', '### New Capabilities', '- `future`: Future capability.', '',
+      ].join('\n'));
+    }
+
+    const findings = await detectCorpusIntegrity(root);
+    expect(findings.filter((finding) =>
+      finding.code === 'corpus-duplicate-identifier' && finding.discriminator === 'identity:aaaaaaaa')).toHaveLength(1);
+    expect(findings.filter((finding) =>
+      finding.code === 'corpus-duplicate-identifier' && finding.discriminator === 'identity:future')).toHaveLength(1);
+    expect(findings.filter((finding) =>
+      finding.code === 'corpus-reference-ambiguous'
+      && finding.discriminator === 'change-delta-targets-domain:future')).toHaveLength(2);
+  });
+
+  it('coalesces one synced decision projected byte-identically into multiple domains', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-decision-projections-'));
+    const entry = [
+      '### Shared decision',
+      '',
+      '**Status:** Approved',
+      '**Date:** 2026-08-23',
+      '**ID:** aaaaaaaa',
+      '',
+      'One decision governs both domains.',
+      '',
+      '**Consequences:** Both specs carry the same durable projection.',
+      '',
+    ].join('\n');
+    for (const domain of ['one', 'two']) {
+      await mkdir(join(root, 'openspec', 'specs', domain), { recursive: true });
+      await writeFile(join(root, 'openspec', 'specs', domain, 'spec.md'), `# ${domain}\n\n## Decisions\n\n${entry}`);
+    }
+
+    const findings = await detectCorpusIntegrity(root);
+    expect(findings).not.toContainEqual(expect.objectContaining({
+      code: 'corpus-duplicate-identifier',
+      discriminator: 'identity:aaaaaaaa',
+    }));
+  });
+
+  it('fails closed when one corpus document exceeds its byte ceiling', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-corpus-oversize-'));
+    await mkdir(join(root, 'openspec', 'changes', 'active'), { recursive: true });
+    await writeFile(join(root, 'openspec', 'changes', 'active', 'proposal.md'),
+      'x'.repeat(CORPUS_RESOURCE_LIMITS.fileBytes + 1));
+    await expect(detectCorpusIntegrity(root)).rejects.toThrow('exceeds byte limit');
+  });
+});

--- a/src/core/decisions/corpus-integrity.ts
+++ b/src/core/decisions/corpus-integrity.ts
@@ -1,0 +1,1070 @@
+/**
+ * Deterministic integrity checking for OpenLore's on-disk governance corpus.
+ * (change: add-knowledge-corpus-integrity)
+ *
+ * The evaluator is deliberately split from discovery. `evaluateCorpusGraph` is a
+ * pure typed-graph pass (and is useful to callers that already have the corpus in
+ * memory); `detectCorpusIntegrity` only reads the stores and OpenSpec tree before
+ * invoking it. Neither path writes, calls a model, or uses the network.
+ */
+
+import { readdir, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import type { AnchoredMemory, PendingDecision, StructuralAnchor } from '../../types/index.js';
+import type { GovernanceFinding } from '../services/mcp-handlers/enforcement-policy.js';
+import {
+  buildRetirementGraph,
+  staleRefsInText,
+} from '../services/mcp-handlers/stale-decision-reference.js';
+import { readFileConfined, safeJoin } from '../../utils/path-confinement.js';
+
+export const CORPUS_ARTIFACT_TYPES = [
+  'requirement',
+  'decision',
+  'spec-domain',
+  'change-delta',
+  'memory',
+  'symbol',
+  'file',
+  'proposal',
+] as const;
+
+export type CorpusArtifactType = (typeof CORPUS_ARTIFACT_TYPES)[number];
+
+export const CORPUS_EDGE_KINDS = [
+  'spec-cites-decision',
+  'spec-cites-requirement',
+  'proposal-cites-decision',
+  'proposal-cites-requirement',
+  'decision-supersedes',
+  'change-delta-targets-domain',
+  'memory-cites-decision',
+  'memory-anchors-symbol',
+  'spec-anchors-symbol',
+] as const;
+
+export type CorpusEdgeKind = (typeof CORPUS_EDGE_KINDS)[number];
+
+/** Edge kinds emitted by each independent on-disk discovery path. */
+export const CORPUS_DISCOVERY_EDGE_KINDS = {
+  requirementLines: ['spec-cites-decision', 'spec-cites-requirement', 'spec-anchors-symbol'],
+  proposalLines: ['proposal-cites-decision', 'proposal-cites-requirement'],
+  decisionRecords: ['decision-supersedes'],
+  changeDeltas: ['change-delta-targets-domain'],
+  memoryRecords: ['memory-cites-decision', 'memory-anchors-symbol'],
+} as const satisfies Record<string, readonly CorpusEdgeKind[]>;
+
+export interface CorpusEdgeSpec {
+  sourceArtifactType: CorpusArtifactType;
+  targetRange: readonly CorpusArtifactType[];
+  directional: boolean;
+  mayCycle: boolean;
+  liveSourceMayReferenceRetiredTarget: boolean;
+}
+
+/** The closed, source-declared contract for every supported corpus edge. */
+export const CORPUS_EDGE_REGISTRY: Record<CorpusEdgeKind, CorpusEdgeSpec> = {
+  'spec-cites-decision': {
+    sourceArtifactType: 'requirement',
+    targetRange: ['decision'],
+    directional: true,
+    mayCycle: false,
+    liveSourceMayReferenceRetiredTarget: false,
+  },
+  'spec-cites-requirement': {
+    sourceArtifactType: 'requirement',
+    targetRange: ['requirement'],
+    directional: true,
+    mayCycle: false,
+    liveSourceMayReferenceRetiredTarget: false,
+  },
+  'proposal-cites-decision': {
+    sourceArtifactType: 'proposal',
+    targetRange: ['decision'],
+    directional: true,
+    mayCycle: false,
+    liveSourceMayReferenceRetiredTarget: false,
+  },
+  'proposal-cites-requirement': {
+    sourceArtifactType: 'proposal',
+    targetRange: ['requirement'],
+    directional: true,
+    mayCycle: false,
+    liveSourceMayReferenceRetiredTarget: false,
+  },
+  'decision-supersedes': {
+    sourceArtifactType: 'decision',
+    targetRange: ['decision'],
+    directional: true,
+    mayCycle: false,
+    liveSourceMayReferenceRetiredTarget: true,
+  },
+  'change-delta-targets-domain': {
+    sourceArtifactType: 'change-delta',
+    targetRange: ['spec-domain'],
+    directional: true,
+    mayCycle: false,
+    liveSourceMayReferenceRetiredTarget: true,
+  },
+  'memory-cites-decision': {
+    sourceArtifactType: 'memory',
+    targetRange: ['decision'],
+    directional: true,
+    mayCycle: false,
+    liveSourceMayReferenceRetiredTarget: false,
+  },
+  'memory-anchors-symbol': {
+    sourceArtifactType: 'memory',
+    targetRange: ['symbol', 'file'],
+    directional: true,
+    mayCycle: false,
+    liveSourceMayReferenceRetiredTarget: true,
+  },
+  'spec-anchors-symbol': {
+    sourceArtifactType: 'requirement',
+    targetRange: ['symbol', 'file'],
+    directional: true,
+    mayCycle: false,
+    liveSourceMayReferenceRetiredTarget: true,
+  },
+};
+
+export const CORPUS_FINDING_CODES = [
+  'corpus-reference-unresolved',
+  'corpus-reference-ambiguous',
+  'corpus-self-reference',
+  'corpus-duplicate-identifier',
+  'corpus-edge-unsupported',
+  'corpus-target-type-mismatch',
+  'corpus-target-retired',
+  'corpus-supersession-cycle',
+  'corpus-anchor-target-missing',
+  'corpus-reference-undeclared',
+] as const;
+
+export type CorpusFindingCode = (typeof CORPUS_FINDING_CODES)[number];
+
+export const CORPUS_RESOURCE_LIMITS = {
+  fileBytes: 4 * 1024 * 1024,
+  totalBytes: 64 * 1024 * 1024,
+  directoryEntries: 20_000,
+  artifacts: 100_000,
+  edges: 250_000,
+  findings: 100_000,
+  mentionPairs: 25_000_000,
+} as const;
+
+export interface CorpusArtifact {
+  /** Unique internal key; unlike `identifier`, this never participates in resolution. */
+  key: string;
+  type: CorpusArtifactType;
+  /** The exact externally referenced identifier (decision id, requirement name, domain, and so on). */
+  identifier: string;
+  path: string;
+  /** Requirement identities are scoped to their spec domain. Other identities are global. */
+  identityScope?: string;
+  text?: string;
+  live?: boolean;
+  retiredBy?: string;
+}
+
+export interface CorpusEdge {
+  /** Kept open at the input boundary so an undeclared kind produces a finding, not a cast failure. */
+  kind: string;
+  sourceKey: string;
+  /** The reference exactly as written in the source artifact. */
+  reference: string;
+  /** For structured anchors, discovery can prove absence without inventing a target artifact. */
+  anchorMissing?: boolean;
+  /** Discovery-only hint retained from an explicit Symbol/File anchor line. */
+  anchorTargetType?: 'symbol' | 'file';
+}
+
+export interface CorpusGraph {
+  artifacts: readonly CorpusArtifact[];
+  edges: readonly CorpusEdge[];
+}
+
+const DECISION_ID_GLOBAL = /\b[0-9a-f]{8}\b/g;
+
+function stableCompare(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function finding(
+  code: CorpusFindingCode,
+  source: CorpusArtifact | undefined,
+  edgeKind: string,
+  reference: string,
+  reason: string,
+): GovernanceFinding {
+  const subject = source ? `${source.type}:${source.path}#${source.identifier}` : 'corpus:unknown';
+  return {
+    code,
+    severity: code === 'corpus-target-retired' || code === 'corpus-anchor-target-missing' || code === 'corpus-reference-undeclared'
+      ? 'warning'
+      : 'error',
+    source: 'corpus-integrity',
+    subject,
+    discriminator: `${edgeKind}:${reference}`,
+    message: `${subject} has ${edgeKind} reference ${JSON.stringify(reference)}: ${reason}`,
+  };
+}
+
+function identityKey(artifact: CorpusArtifact): string {
+  return `${artifact.type}\0${artifact.identityScope ?? ''}\0${artifact.identifier}`;
+}
+
+function findingKey(value: GovernanceFinding): string {
+  return [value.code, value.subject, value.discriminator ?? '', value.message].join('\0');
+}
+
+interface CorpusCycle {
+  kind: CorpusEdgeKind;
+  memberKeys: string[];
+  identifiers: string[];
+}
+
+/** Validate every registry edge declared acyclic whose range can connect back to its source type. */
+function acyclicEdgeCycles(graph: CorpusGraph): CorpusCycle[] {
+  const liveArtifacts = new Map(graph.artifacts
+    .filter((artifact) => artifact.live ?? true)
+    .map((artifact) => [artifact.key, artifact]));
+  const byIdentifier = new Map<string, CorpusArtifact[]>();
+  for (const artifact of liveArtifacts.values()) {
+    const matches = byIdentifier.get(artifact.identifier) ?? [];
+    matches.push(artifact);
+    byIdentifier.set(artifact.identifier, matches);
+  }
+
+  const cycles = new Map<string, CorpusCycle>();
+  for (const kind of CORPUS_EDGE_KINDS) {
+    const spec = CORPUS_EDGE_REGISTRY[kind];
+    if (spec.mayCycle || !spec.targetRange.includes(spec.sourceArtifactType)) continue;
+    const sources = new Map([...liveArtifacts]
+      .filter(([, artifact]) => artifact.type === spec.sourceArtifactType));
+    const next = new Map<string, string>();
+    for (const edge of graph.edges) {
+      if (edge.kind !== kind || !sources.has(edge.sourceKey)) continue;
+      const matches = (byIdentifier.get(edge.reference) ?? [])
+        .filter((artifact) => spec.targetRange.includes(artifact.type));
+      if (matches.length === 1 && sources.has(matches[0].key)) next.set(edge.sourceKey, matches[0].key);
+    }
+
+    const completed = new Set<string>();
+    for (const start of [...sources.keys()].sort(stableCompare)) {
+      if (completed.has(start)) continue;
+      const path: string[] = [];
+      const at = new Map<string, number>();
+      let current: string | undefined = start;
+      while (current !== undefined && !completed.has(current) && !at.has(current)) {
+        at.set(current, path.length);
+        path.push(current);
+        current = next.get(current);
+      }
+      if (current !== undefined && at.has(current)) {
+        const memberKeys = path.slice(at.get(current)!).sort(stableCompare);
+        const identifiers = memberKeys.map((key) => sources.get(key)!.identifier).sort(stableCompare);
+        cycles.set(`${kind}\0${memberKeys.join('\0')}`, { kind, memberKeys, identifiers });
+      }
+      for (const member of path) completed.add(member);
+    }
+  }
+  return [...cycles.values()].sort((a, b) =>
+    stableCompare(`${a.kind}\0${a.memberKeys.join('\0')}`, `${b.kind}\0${b.memberKeys.join('\0')}`));
+}
+
+/** Return each live decision-supersession cycle independently, in canonical order. */
+function supersessionCycles(graph: CorpusGraph): string[][] {
+  return acyclicEdgeCycles(graph)
+    .filter((cycle) => cycle.kind === 'decision-supersedes')
+    .map((cycle) => cycle.identifiers);
+}
+
+/** Return every member of every decision-supersession cycle, in stable order. */
+export function supersessionCycleMembers(graph: CorpusGraph): string[] {
+  return supersessionCycles(graph).flat().sort(stableCompare);
+}
+
+function withoutFencedCodeAndReferenceLines(text: string): string {
+  let fenced = false;
+  return text.split('\n').map((line) => {
+    if (/^\s*(```|~~~)/.test(line)) {
+      fenced = !fenced;
+      return '';
+    }
+    if (fenced) return '';
+    if (/^>\s*(?:Decision recorded|Decision pointer|Decision citation|Symbol anchor|File anchor|Corpus edge)\s*:/i.test(line)) return '';
+    return line;
+  }).join('\n');
+}
+
+function exactMentions(text: string, identifiers: readonly string[]): Set<string> {
+  const found = new Set<string>();
+  // A bounded alternation avoids rescanning every source once per corpus target.
+  // Longest-first keeps a shorter identifier from consuming a longer phrase.
+  const ordered = [...new Set(identifiers.filter(Boolean))]
+    .sort((a, b) => b.length - a.length || stableCompare(a, b));
+  for (let offset = 0; offset < ordered.length; offset += 200) {
+    const alternatives = ordered.slice(offset, offset + 200).map((token) => {
+      const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const left = /^[A-Za-z0-9_]/.test(token) ? '(?<![A-Za-z0-9_])' : '';
+      const right = /[A-Za-z0-9_]$/.test(token) ? '(?![A-Za-z0-9_])' : '';
+      return `${left}${escaped}${right}`;
+    });
+    for (const match of text.matchAll(new RegExp(alternatives.join('|'), 'g'))) found.add(match[0]);
+  }
+  return found;
+}
+
+function suggestedEdge(source: CorpusArtifact, target: CorpusArtifact): string | undefined {
+  if (target.type === 'decision') {
+    if (source.type === 'memory') return 'memory-cites-decision';
+    if (source.type === 'requirement') return 'spec-cites-decision';
+    if (source.type === 'proposal') return 'proposal-cites-decision';
+  }
+  if (target.type === 'requirement') {
+    if (source.type === 'requirement') return 'spec-cites-requirement';
+    if (source.type === 'proposal') return 'proposal-cites-requirement';
+  }
+  return undefined;
+}
+
+/** Pure, deterministic validation over a fully discovered graph. */
+export function evaluateCorpusGraph(graph: CorpusGraph): GovernanceFinding[] {
+  if (graph.artifacts.length > CORPUS_RESOURCE_LIMITS.artifacts) {
+    throw new Error(`corpus artifact limit exceeded (${CORPUS_RESOURCE_LIMITS.artifacts})`);
+  }
+  if (graph.edges.length > CORPUS_RESOURCE_LIMITS.edges) {
+    throw new Error(`corpus edge limit exceeded (${CORPUS_RESOURCE_LIMITS.edges})`);
+  }
+  const findings: GovernanceFinding[] = [];
+  const addFinding = (value: GovernanceFinding): void => {
+    if (findings.length >= CORPUS_RESOURCE_LIMITS.findings) {
+      throw new Error(`corpus finding limit exceeded (${CORPUS_RESOURCE_LIMITS.findings})`);
+    }
+    findings.push(value);
+  };
+  const artifactsByKey = new Map(graph.artifacts.map((artifact) => [artifact.key, artifact]));
+  const identities = new Map<string, CorpusArtifact[]>();
+  const artifactsByIdentifier = new Map<string, CorpusArtifact[]>();
+  for (const artifact of graph.artifacts) {
+    const matches = identities.get(identityKey(artifact)) ?? [];
+    matches.push(artifact);
+    identities.set(identityKey(artifact), matches);
+    const identifierMatches = artifactsByIdentifier.get(artifact.identifier) ?? [];
+    identifierMatches.push(artifact);
+    artifactsByIdentifier.set(artifact.identifier, identifierMatches);
+  }
+
+  for (const duplicates of identities.values()) {
+    if (duplicates.length < 2) continue;
+    const sorted = [...duplicates].sort((a, b) => stableCompare(a.key, b.key));
+    const source = sorted[0];
+    addFinding(finding(
+      'corpus-duplicate-identifier',
+      source,
+      'identity',
+      source.identifier,
+      `identifier resolves to multiple artifacts: ${sorted.map((item) => item.path).join(', ')}`,
+    ));
+  }
+
+  const declaredTargets = new Map<string, Set<string>>();
+  for (const edge of graph.edges) {
+    const source = artifactsByKey.get(edge.sourceKey);
+    const spec = CORPUS_EDGE_REGISTRY[edge.kind as CorpusEdgeKind];
+    if (!source || !spec || source.type !== spec.sourceArtifactType) {
+      addFinding(finding(
+        'corpus-edge-unsupported', source, edge.kind, edge.reference,
+        !spec ? 'edge kind is not declared in CORPUS_EDGE_REGISTRY' : `source type ${source?.type ?? 'missing'} does not declare this edge`,
+      ));
+      continue;
+    }
+
+    const declared = declaredTargets.get(source.key) ?? new Set<string>();
+    declared.add(edge.reference);
+    declaredTargets.set(source.key, declared);
+
+    if (edge.anchorMissing) {
+      addFinding(finding(
+        'corpus-anchor-target-missing', source, edge.kind, edge.reference,
+        'the anchored symbol or file no longer exists',
+      ));
+      continue;
+    }
+
+    const identifierMatches = artifactsByIdentifier.get(edge.reference) ?? [];
+    const allowed = identifierMatches.filter((artifact) =>
+      spec.targetRange.includes(artifact.type) && artifact.identifier === edge.reference,
+    );
+    const anyType = identifierMatches;
+    if (allowed.length === 0) {
+      addFinding(finding(
+        anyType.length > 0 ? 'corpus-target-type-mismatch' : 'corpus-reference-unresolved',
+        source,
+        edge.kind,
+        edge.reference,
+        anyType.length > 0
+          ? `target resolves as ${[...new Set(anyType.map((item) => item.type))].sort().join(', ')}, not ${spec.targetRange.join(' or ')}`
+          : `no ${spec.targetRange.join(' or ')} target resolves`,
+      ));
+      continue;
+    }
+    if (allowed.length > 1) {
+      addFinding(finding(
+        'corpus-reference-ambiguous', source, edge.kind, edge.reference,
+        `target resolves to multiple artifacts: ${allowed.map((item) => item.path).sort(stableCompare).join(', ')}`,
+      ));
+      continue;
+    }
+    const target = allowed[0];
+    if (target.key === source.key) {
+      addFinding(finding('corpus-self-reference', source, edge.kind, edge.reference, 'an artifact may not reference itself'));
+    }
+    if ((source.live ?? true) && target.retiredBy && !spec.liveSourceMayReferenceRetiredTarget) {
+      addFinding(finding(
+        'corpus-target-retired', source, edge.kind, edge.reference,
+        `target is retired${target.retiredBy !== target.identifier ? `; cite ${target.retiredBy} instead` : ''}`,
+      ));
+    }
+  }
+
+  for (const cycle of acyclicEdgeCycles(graph)) {
+    for (const memberKey of cycle.memberKeys) {
+      const source = artifactsByKey.get(memberKey);
+      addFinding(finding(
+        'corpus-supersession-cycle', source, cycle.kind, source?.identifier ?? memberKey,
+        `acyclic ${cycle.kind} edge forms a cycle containing ${cycle.identifiers.join(', ')}; none of these artifacts is authoritative`,
+      ));
+    }
+  }
+
+  // Exact mentioned-but-unlinked suggestions. Only identifier/name targets are
+  // considered; paths, titles, fuzzy matches, and self mentions are excluded.
+  const mentionTargets = graph.artifacts.filter((artifact) => artifact.type === 'decision' || artifact.type === 'requirement');
+  const mentionIdentifiers = mentionTargets.map((target) => target.identifier);
+  const mentionSources = graph.artifacts.filter((source) =>
+    source.text && (source.type === 'requirement' || source.type === 'proposal'));
+  if (mentionSources.length * mentionTargets.length > CORPUS_RESOURCE_LIMITS.mentionPairs) {
+    throw new Error(`corpus mention-work limit exceeded (${CORPUS_RESOURCE_LIMITS.mentionPairs} pairs)`);
+  }
+  for (const source of mentionSources) {
+    if (!source.text || (source.type !== 'requirement' && source.type !== 'proposal')) continue;
+    const prose = withoutFencedCodeAndReferenceLines(source.text);
+    const mentioned = exactMentions(prose, mentionIdentifiers);
+    const already = declaredTargets.get(source.key) ?? new Set<string>();
+    const seenTargets = new Set<string>();
+    for (const target of mentionTargets) {
+      const mentionIdentity = identityKey(target);
+      if (target.key === source.key || already.has(target.identifier) || seenTargets.has(mentionIdentity)) continue;
+      const edgeKind = suggestedEdge(source, target);
+      if (!edgeKind || !mentioned.has(target.identifier)) continue;
+      seenTargets.add(mentionIdentity);
+      const duplicateTargets = identities.get(mentionIdentity) ?? [];
+      if (duplicateTargets.length > 1) {
+        addFinding(finding(
+          'corpus-reference-ambiguous', source, edgeKind, target.identifier,
+          `exact token resolves to multiple ${target.type} artifacts: ${duplicateTargets.map((item) => item.path).sort(stableCompare).join(', ')}`,
+        ));
+      }
+      addFinding(finding(
+        'corpus-reference-undeclared', source, edgeKind, target.identifier,
+        `exact token matches ${target.type} ${target.identifier}; declare a ${edgeKind} edge for human review`,
+      ));
+    }
+  }
+
+  const unique = new Map<string, GovernanceFinding>();
+  for (const value of findings) unique.set(findingKey(value), value);
+  return [...unique.values()].sort((a, b) => stableCompare(findingKey(a), findingKey(b)));
+}
+
+interface SpecDocument {
+  domain: string;
+  file: string;
+  text: string;
+}
+
+function requirementBlocks(spec: SpecDocument): CorpusArtifact[] {
+  const matches = [...spec.text.matchAll(/^### Requirement:\s*(\S.*)$/gm)];
+  return matches.map((match) => {
+    const start = match.index!;
+    const following = spec.text.slice(start + match[0].length);
+    const nextPeerOrParentHeading = following.match(/^#{1,3}\s+\S.*$/m);
+    const end = nextPeerOrParentHeading?.index === undefined
+      ? spec.text.length
+      : start + match[0].length + nextPeerOrParentHeading.index;
+    const name = match[1].trim();
+    return {
+      key: `requirement:${spec.file}:${start}`,
+      type: 'requirement',
+      identifier: name,
+      identityScope: spec.domain,
+      path: spec.file,
+      text: spec.text.slice(start, end),
+      live: true,
+    };
+  });
+}
+
+function exactDecisionIds(text: string): string[] {
+  return [...new Set([...text.matchAll(DECISION_ID_GLOBAL)].map((match) => match[0]))].sort(stableCompare);
+}
+
+function declaredRequirementEdges(requirement: CorpusArtifact): CorpusEdge[] {
+  const edges: CorpusEdge[] = [];
+  for (const line of (requirement.text ?? '').split('\n')) {
+    const decision = line.match(/^>\s*(?:Decision recorded|Decision pointer|Decision citation):\s*([0-9a-f]{8})\b/i);
+    if (decision) edges.push({ kind: 'spec-cites-decision', sourceKey: requirement.key, reference: decision[1] });
+    const anchor = line.match(/^>\s*(Symbol anchor|File anchor):\s*(\S.*?)\s*$/i);
+    if (anchor) edges.push({
+      kind: 'spec-anchors-symbol',
+      sourceKey: requirement.key,
+      reference: anchor[2],
+      anchorTargetType: anchor[1].toLowerCase().startsWith('symbol') ? 'symbol' : 'file',
+    });
+    const generic = line.match(/^>\s*Corpus edge:\s*(\S+)\s+(.+?)\s*$/i);
+    if (generic) edges.push({ kind: generic[1], sourceKey: requirement.key, reference: generic[2] });
+  }
+  return edges;
+}
+
+function declaredProposalEdges(proposal: CorpusArtifact): CorpusEdge[] {
+  const edges: CorpusEdge[] = [];
+  for (const line of (proposal.text ?? '').split('\n')) {
+    const match = line.match(/^>\s*Corpus edge:\s*(\S+)\s+(.+?)\s*$/i);
+    if (match) edges.push({ kind: match[1], sourceKey: proposal.key, reference: match[2] });
+  }
+  return edges;
+}
+
+function declaredNewCapabilities(proposalText: string): string[] {
+  const section = proposalText.match(/^### New Capabilities\s*$([\s\S]*?)(?=^### |^## |$(?![\s\S]))/m)?.[1] ?? '';
+  return [...new Set([...section.matchAll(/^\s*-\s+`([^`]+)`\s*:/gm)].map((match) => match[1]))]
+    .sort(stableCompare);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+function isDecision(value: unknown): value is PendingDecision {
+  if (!isRecord(value)) return false;
+  return typeof value.id === 'string'
+    && typeof value.status === 'string'
+    && typeof value.title === 'string'
+    && typeof value.rationale === 'string'
+    && typeof value.consequences === 'string'
+    && (value.proposedRequirement === null || typeof value.proposedRequirement === 'string')
+    && Array.isArray(value.affectedDomains)
+    && value.affectedDomains.every((domain) => typeof domain === 'string')
+    && Array.isArray(value.affectedFiles)
+    && value.affectedFiles.every((file) => typeof file === 'string')
+    && isOptionalString(value.supersedes);
+}
+
+function isAnchor(value: unknown): value is StructuralAnchor {
+  return isRecord(value)
+    && typeof value.filePath === 'string'
+    && isOptionalString(value.nodeId);
+}
+
+function isMemory(value: unknown): value is AnchoredMemory {
+  if (!isRecord(value)) return false;
+  return typeof value.id === 'string'
+    && value.kind === 'note'
+    && typeof value.content === 'string'
+    && Array.isArray(value.anchors)
+    && value.anchors.every(isAnchor)
+    && isOptionalString(value.invalidatedAt);
+}
+
+interface CorpusReadBudget { bytes: number; directoryEntries: number }
+
+async function readCorpusFile(rootPath: string, filePath: string, budget: CorpusReadBudget): Promise<string> {
+  const remaining = CORPUS_RESOURCE_LIMITS.totalBytes - budget.bytes;
+  const text = await readFileConfined(rootPath, filePath, Math.min(CORPUS_RESOURCE_LIMITS.fileBytes, remaining));
+  const bytes = Buffer.byteLength(text);
+  if (bytes > CORPUS_RESOURCE_LIMITS.fileBytes) {
+    throw new Error(`${filePath} exceeds corpus file limit (${CORPUS_RESOURCE_LIMITS.fileBytes} bytes)`);
+  }
+  budget.bytes += bytes;
+  if (budget.bytes > CORPUS_RESOURCE_LIMITS.totalBytes) {
+    throw new Error(`corpus read limit exceeded (${CORPUS_RESOURCE_LIMITS.totalBytes} bytes)`);
+  }
+  return text;
+}
+
+async function readJsonArray<T>(
+  rootPath: string,
+  filePath: string,
+  property: string,
+  isEntry: (value: unknown) => value is T,
+  budget: CorpusReadBudget,
+): Promise<T[]> {
+  try {
+    const parsed: unknown = JSON.parse(await readCorpusFile(rootPath, filePath, budget));
+    if (!isRecord(parsed)) throw new Error(`${filePath} must contain a JSON object`);
+    const entries = parsed[property];
+    if (!Array.isArray(entries)) throw new Error(`${filePath} must contain a ${property} array`);
+    const malformedIndex = entries.findIndex((entry) => !isEntry(entry));
+    if (malformedIndex !== -1) throw new Error(`${filePath} has a malformed ${property}[${malformedIndex}] entry`);
+    return entries;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+async function directories(rootPath: string, filePath: string, budget: CorpusReadBudget): Promise<string[]> {
+  try {
+    const entries = await readdir(safeJoin(rootPath, filePath), { withFileTypes: true });
+    if (entries.length > CORPUS_RESOURCE_LIMITS.directoryEntries) {
+      throw new Error(`${filePath} exceeds corpus directory-entry limit (${CORPUS_RESOURCE_LIMITS.directoryEntries})`);
+    }
+    budget.directoryEntries += entries.length;
+    if (budget.directoryEntries > CORPUS_RESOURCE_LIMITS.directoryEntries) {
+      throw new Error(`corpus directory-entry limit exceeded (${CORPUS_RESOURCE_LIMITS.directoryEntries})`);
+    }
+    const symlink = entries.find((entry) => entry.isSymbolicLink());
+    if (symlink) throw new Error(`Path escape blocked: symbolic-link directory entry "${join(filePath, symlink.name)}"`);
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort(stableCompare);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+async function readSpecs(
+  rootPath: string,
+  openspecRoot: string,
+  budget: CorpusReadBudget,
+): Promise<SpecDocument[]> {
+  const specsRoot = join(openspecRoot, 'specs');
+  const out: SpecDocument[] = [];
+  for (const domain of await directories(rootPath, relative(rootPath, specsRoot), budget)) {
+    const path = join(specsRoot, domain, 'spec.md');
+    try {
+      out.push({
+        domain,
+        file: relative(rootPath, path),
+        text: await readCorpusFile(rootPath, relative(rootPath, path), budget),
+      });
+    } catch (error) {
+      // A directory without spec.md is not a domain; other read failures make
+      // the assessment unavailable rather than manufacturing unresolved edges.
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+  return out;
+}
+
+interface DurableDecision {
+  decision: PendingDecision;
+  path: string;
+  text: string;
+}
+
+function durableStatus(value: string | undefined): PendingDecision['status'] {
+  if (/^rejected\b/i.test(value ?? '')) return 'rejected';
+  if (/^phantom\b/i.test(value ?? '')) return 'phantom';
+  return 'synced';
+}
+
+function durableDecision(
+  id: string,
+  status: string | undefined,
+  supersedes: string | undefined,
+  path: string,
+  text: string,
+): DurableDecision {
+  return {
+    decision: {
+      id,
+      status: durableStatus(status),
+      title: '',
+      rationale: '',
+      consequences: '',
+      proposedRequirement: null,
+      affectedDomains: [],
+      affectedFiles: [],
+      supersedes,
+      confidence: 'high',
+      sessionId: 'durable-corpus',
+      recordedAt: '',
+      contentOrigin: 'legacy-unknown',
+      syncedToSpecs: [path],
+    },
+    path,
+    text,
+  };
+}
+
+function specDecisionEntries(spec: SpecDocument): DurableDecision[] {
+  const out: DurableDecision[] = [];
+  for (const match of spec.text.matchAll(/^\*\*ID:\*\*\s*([0-9a-f]{8})\s*$/gm)) {
+    const matchIndex = match.index ?? 0;
+    const headingIndex = spec.text.lastIndexOf('\n### ', matchIndex);
+    const start = headingIndex < 0 ? 0 : headingIndex + 1;
+    const remainder = spec.text.slice(matchIndex + match[0].length);
+    const nextHeading = remainder.search(/^#{2,3}\s+/m);
+    const end = nextHeading < 0
+      ? spec.text.length
+      : matchIndex + match[0].length + nextHeading;
+    const block = spec.text.slice(start, end);
+    out.push(durableDecision(
+      match[1],
+      block.match(/^\*\*Status:\*\*\s*(.+?)\s*$/m)?.[1],
+      block.match(/^\*\*Supersedes:\*\*\s*([0-9a-f]{8})\s*$/m)?.[1],
+      spec.file,
+      block,
+    ));
+  }
+  return out;
+}
+
+/**
+ * One synced decision is intentionally projected into every affected domain.
+ * Entries in distinct affected-domain specs are therefore one durable identity.
+ * Repeated entries in one file remain distinct so an actual duplicate record is
+ * still reported; content drift between projections is a separate concern.
+ */
+function coalesceSpecDecisionProjections(entries: readonly DurableDecision[]): DurableDecision[] {
+  const groups = new Map<string, DurableDecision[]>();
+  for (const entry of entries) {
+    const key = entry.decision.id;
+    const matches = groups.get(key) ?? [];
+    matches.push(entry);
+    groups.set(key, matches);
+  }
+  const out: DurableDecision[] = [];
+  for (const matches of groups.values()) {
+    const paths = new Set(matches.map((entry) => entry.path));
+    if (matches.length > 1 && paths.size === matches.length) {
+      out.push([...matches].sort((a, b) => stableCompare(a.path, b.path))[0]);
+    } else {
+      out.push(...matches);
+    }
+  }
+  return out.sort((a, b) => stableCompare(
+    `${a.decision.id}\0${a.path}\0${a.text}`,
+    `${b.decision.id}\0${b.path}\0${b.text}`,
+  ));
+}
+
+async function readADRDecisions(
+  rootPath: string,
+  openspecRoot: string,
+  budget: CorpusReadBudget,
+): Promise<DurableDecision[]> {
+  const decisionsDir = join(openspecRoot, 'decisions');
+  let files: string[];
+  try {
+    const entries = await readdir(safeJoin(rootPath, relative(rootPath, decisionsDir)));
+    if (entries.length > CORPUS_RESOURCE_LIMITS.directoryEntries) {
+      throw new Error(`openspec/decisions exceeds corpus directory-entry limit (${CORPUS_RESOURCE_LIMITS.directoryEntries})`);
+    }
+    files = entries.filter((name) => name.endsWith('.md')).sort(stableCompare);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  const out: DurableDecision[] = [];
+  for (const filename of files) {
+    const path = join(decisionsDir, filename);
+    const text = await readCorpusFile(rootPath, relative(rootPath, path), budget);
+    const id = text.match(/^> Decision ID:\s*([0-9a-f]{8})\s*$/m)?.[1];
+    if (!id) continue;
+    out.push(durableDecision(
+      id,
+      text.match(/^## Status\s*\n\s*\n([^\n]+)/m)?.[1],
+      text.match(/^> Supersedes:\s*([0-9a-f]{8})\s*$/m)?.[1],
+      relative(rootPath, path),
+      text,
+    ));
+  }
+  return out;
+}
+
+export interface DetectCorpusIntegrityOptions {
+  openspecPath?: string;
+  /** `false` proves absence, `true` proves presence, `undefined` means the graph cannot decide. */
+  anchorExists?: (anchor: StructuralAnchor) => boolean | undefined | Promise<boolean | undefined>;
+}
+
+/** Read the existing stores/OpenSpec tree and evaluate them without modifying any bytes. */
+export async function detectCorpusIntegrity(
+  rootPath: string,
+  options: DetectCorpusIntegrityOptions = {},
+): Promise<GovernanceFinding[]> {
+  const openspecRoot = safeJoin(rootPath, options.openspecPath || 'openspec');
+  const readBudget: CorpusReadBudget = { bytes: 0, directoryEntries: 0 };
+  const [decisions, memories, specs, changeNames, adrDecisions] = await Promise.all([
+    readJsonArray(rootPath, join('.openlore', 'decisions', 'pending.json'), 'decisions', isDecision, readBudget),
+    readJsonArray(rootPath, join('.openlore', 'memory', 'notes.json'), 'memories', isMemory, readBudget),
+    readSpecs(rootPath, openspecRoot, readBudget),
+    directories(rootPath, relative(rootPath, join(openspecRoot, 'changes')), readBudget),
+    readADRDecisions(rootPath, openspecRoot, readBudget),
+  ]);
+  const artifacts: CorpusArtifact[] = [];
+  const edges: CorpusEdge[] = [];
+  const addArtifact = (artifact: CorpusArtifact): void => {
+    if (artifacts.length >= CORPUS_RESOURCE_LIMITS.artifacts) {
+      throw new Error(`corpus artifact limit exceeded (${CORPUS_RESOURCE_LIMITS.artifacts})`);
+    }
+    artifacts.push(artifact);
+  };
+  const addEdges = (values: readonly CorpusEdge[]): void => {
+    if (edges.length + values.length > CORPUS_RESOURCE_LIMITS.edges) {
+      throw new Error(`corpus edge limit exceeded (${CORPUS_RESOURCE_LIMITS.edges})`);
+    }
+    edges.push(...values);
+  };
+
+  const allSpecDecisions = specs.flatMap(specDecisionEntries);
+  const specDecisions = coalesceSpecDecisionProjections(allSpecDecisions);
+  const durableById = new Map<string, DurableDecision>();
+  for (const durable of [...specDecisions, ...adrDecisions]) {
+    if (!durableById.has(durable.decision.id)) durableById.set(durable.decision.id, durable);
+  }
+  const pendingIds = new Set(decisions.map((decision) => decision.id));
+  const durableOnly = [...durableById.values()]
+    .filter(({ decision }) => !pendingIds.has(decision.id))
+    .sort((a, b) => stableCompare(a.decision.id, b.decision.id));
+  const graphDecisions = [...decisions, ...durableOnly.map(({ decision }) => decision)];
+  const retirement = buildRetirementGraph(graphDecisions);
+  for (const decision of decisions) {
+    const artifact: CorpusArtifact = {
+      key: `decision:${decision.id}:${artifacts.length}`,
+      type: 'decision',
+      identifier: decision.id,
+      path: '.openlore/decisions/pending.json',
+      text: [decision.title, decision.rationale, decision.consequences, decision.proposedRequirement ?? ''].join('\n'),
+      live: decision.status !== 'rejected' && decision.status !== 'phantom',
+      retiredBy: retirement.supersededBy.get(decision.id)
+        ?? (retirement.retiredDecisionIds.has(decision.id) ? decision.id : undefined)
+        ?? (decision.status === 'rejected' || decision.status === 'phantom' ? decision.id : undefined),
+    };
+    addArtifact(artifact);
+  }
+  const specDecisionCounts = new Map<string, number>();
+  const pendingDecisionCounts = new Map<string, number>();
+  for (const decision of decisions) {
+    pendingDecisionCounts.set(decision.id, (pendingDecisionCounts.get(decision.id) ?? 0) + 1);
+  }
+  for (const { decision } of specDecisions) {
+    specDecisionCounts.set(decision.id, (specDecisionCounts.get(decision.id) ?? 0) + 1);
+  }
+  for (const spec of specs) {
+    addArtifact({ key: `domain:${spec.domain}`, type: 'spec-domain', identifier: spec.domain, path: spec.file, live: true });
+    for (const requirement of requirementBlocks(spec)) {
+      addArtifact(requirement);
+      addEdges(declaredRequirementEdges(requirement));
+    }
+  }
+
+  // Synced decisions are purged from pending.json after the durable spec write.
+  // Their `## Decisions` entries are therefore part of the decision range, not
+  // merely prose. Identical cross-domain projections were coalesced above;
+  // conflicting or same-file duplicates remain visible here.
+  for (const durable of specDecisions) {
+    const { decision } = durable;
+    const pendingProjection = decisions.find((candidate) => candidate.id === decision.id);
+    const atomicTransition = pendingDecisionCounts.get(decision.id) === 1
+      && specDecisionCounts.get(decision.id) === 1
+      && (pendingProjection?.status === 'synced'
+        || pendingProjection?.syncedToSpecs.includes(durable.path));
+    if (atomicTransition) continue;
+    addArtifact({
+      key: `decision-spec:${durable.path}:${artifacts.length}`,
+      type: 'decision',
+      identifier: decision.id,
+      path: durable.path,
+      text: durable.text,
+      live: decision.status !== 'rejected' && decision.status !== 'phantom',
+      retiredBy: retirement.supersededBy.get(decision.id)
+        ?? (retirement.retiredDecisionIds.has(decision.id) ? decision.id : undefined)
+        ?? (decision.status === 'rejected' || decision.status === 'phantom' ? decision.id : undefined),
+    });
+  }
+
+  // ADRs are the sole durable representation when a cross-domain/system
+  // decision had no resolvable owning spec. A matching spec entry is the same
+  // intentional projection, not a second decision artifact.
+  for (const durable of adrDecisions) {
+    const { decision } = durable;
+    if (specDecisionCounts.has(decision.id) || pendingDecisionCounts.has(decision.id)) continue;
+    addArtifact({
+      key: `decision-adr:${durable.path}:${artifacts.length}`,
+      type: 'decision',
+      identifier: decision.id,
+      path: durable.path,
+      text: durable.text,
+      live: decision.status !== 'rejected' && decision.status !== 'phantom',
+      retiredBy: retirement.supersededBy.get(decision.id)
+        ?? (retirement.retiredDecisionIds.has(decision.id) ? decision.id : undefined)
+        ?? (decision.status === 'rejected' || decision.status === 'phantom' ? decision.id : undefined),
+    });
+  }
+
+  for (const decision of graphDecisions) {
+    if (!decision.supersedes) continue;
+    const source = artifacts.find((artifact) =>
+      artifact.type === 'decision' && artifact.identifier === decision.id,
+    );
+    if (source) addEdges([{
+      kind: 'decision-supersedes',
+      sourceKey: source.key,
+      reference: decision.supersedes!,
+    }]);
+  }
+
+  // Resolve explicit requirement anchors through the same caller-supplied graph
+  // verdict as memory anchors. File anchors remain decidable without an index.
+  const unresolvedSpecAnchors = edges.filter((edge) => edge.kind === 'spec-anchors-symbol');
+  for (const edge of unresolvedSpecAnchors) {
+    let exists: boolean | undefined;
+    if (edge.anchorTargetType === 'file') {
+      try { exists = (await stat(safeJoin(rootPath, edge.reference))).isFile(); } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') exists = false;
+        else throw error;
+      }
+    } else if (edge.anchorTargetType === 'symbol') {
+      exists = await options.anchorExists?.({ nodeId: edge.reference, filePath: '' });
+    }
+    if (exists === false) edge.anchorMissing = true;
+    if (exists === true) {
+      const type = edge.anchorTargetType!;
+      const key = `${type}:${edge.reference}`;
+      if (!artifacts.some((candidate) => candidate.key === key)) {
+        addArtifact({ key, type, identifier: edge.reference, path: edge.reference, live: true });
+      }
+    }
+  }
+  // Unknown symbol state is not an unresolved reference: without a graph there
+  // is no evidence either way, so omit that edge from this pass.
+  const decidedEdges = edges.filter((edge) =>
+    edge.kind !== 'spec-anchors-symbol'
+      || edge.anchorMissing !== undefined
+      || artifacts.some((candidate) =>
+        (candidate.type === 'symbol' || candidate.type === 'file') && candidate.identifier === edge.reference,
+      ),
+  );
+  edges.length = 0;
+  edges.push(...decidedEdges);
+
+  for (const memory of memories) {
+    const artifact: CorpusArtifact = {
+      key: `memory:${memory.id}`,
+      type: 'memory',
+      identifier: memory.id,
+      path: '.openlore/memory/notes.json',
+      text: memory.content,
+      live: !memory.invalidatedAt,
+    };
+    addArtifact(artifact);
+    let orphaned = false;
+    for (const anchor of memory.anchors) {
+      const reference = anchor.nodeId ?? anchor.filePath;
+      let exists = await options.anchorExists?.(anchor);
+      if (exists === undefined && !anchor.nodeId) {
+        try { exists = (await stat(safeJoin(rootPath, anchor.filePath))).isFile(); } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') exists = false;
+          else throw error;
+        }
+      }
+      if (exists === true) {
+        const type: CorpusArtifactType = anchor.nodeId ? 'symbol' : 'file';
+        const key = `${type}:${reference}`;
+        if (!artifacts.some((candidate) => candidate.key === key)) {
+          addArtifact({ key, type, identifier: reference, path: anchor.filePath, live: true });
+        }
+      }
+      if (exists === false) orphaned = true;
+      // Unknown is intentionally omitted: without an index the pass cannot prove
+      // a symbol exists or is missing. File anchors can always be decided above.
+      if (exists !== undefined) {
+        addEdges([{
+          kind: 'memory-anchors-symbol',
+          sourceKey: artifact.key,
+          reference,
+          ...(exists === false ? { anchorMissing: true } : {}),
+        }]);
+      }
+    }
+    // Match recall's authority rule: an invalidated or orphaned memory remains
+    // diagnosable, but cannot create a live-to-retired liveness finding.
+    if (orphaned) artifact.live = false;
+    const citations = new Set(exactDecisionIds(memory.content));
+    for (const stale of staleRefsInText(memory.content, retirement)) citations.add(stale.retired);
+    for (const id of [...citations].sort(stableCompare)) {
+      addEdges([{ kind: 'memory-cites-decision', sourceKey: artifact.key, reference: id }]);
+    }
+  }
+
+  for (const change of changeNames.filter((name) => name !== 'archive')) {
+    const changeRoot = join(openspecRoot, 'changes', change);
+    try {
+      const proposalPath = join(changeRoot, 'proposal.md');
+      const text = await readCorpusFile(rootPath, relative(rootPath, proposalPath), readBudget);
+      const proposal: CorpusArtifact = {
+        key: `proposal:${change}`,
+        type: 'proposal',
+        identifier: change,
+        path: relative(rootPath, proposalPath),
+        text,
+        live: true,
+      };
+      addArtifact(proposal);
+      addEdges(declaredProposalEdges(proposal));
+      for (const domain of declaredNewCapabilities(text)) {
+        addArtifact({
+          key: `new-domain:${change}:${domain}`,
+          type: 'spec-domain',
+          identifier: domain,
+          path: relative(rootPath, proposalPath),
+          live: true,
+        });
+      }
+    } catch (error) {
+      // A change need not have a proposal to have a delta. Other failures must
+      // not silently turn a declared new capability into an unresolved target.
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    for (const domain of await directories(rootPath, relative(rootPath, join(changeRoot, 'specs')), readBudget)) {
+      const deltaSpecPath = join(changeRoot, 'specs', domain, 'spec.md');
+      const source: CorpusArtifact = {
+        key: `delta:${change}:${domain}`,
+        type: 'change-delta',
+        identifier: `${change}/${domain}`,
+        path: relative(rootPath, join(changeRoot, 'specs', domain)),
+        live: true,
+      };
+      addArtifact(source);
+      addEdges([{ kind: 'change-delta-targets-domain', sourceKey: source.key, reference: domain }]);
+      try {
+        const deltaSpec: SpecDocument = {
+          domain: `${domain}@change:${change}`,
+          file: relative(rootPath, deltaSpecPath),
+          text: await readCorpusFile(rootPath, relative(rootPath, deltaSpecPath), readBudget),
+        };
+        for (const requirement of requirementBlocks(deltaSpec)) {
+          addArtifact(requirement);
+          addEdges(declaredRequirementEdges(requirement));
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    }
+  }
+
+  return evaluateCorpusGraph({ artifacts, edges });
+}

--- a/src/core/decisions/syncer.test.ts
+++ b/src/core/decisions/syncer.test.ts
@@ -8,6 +8,7 @@ import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { syncApprovedDecisions } from './syncer.js';
+import { detectCorpusIntegrity } from './corpus-integrity.js';
 import type { PendingDecision, DecisionStore, SpecMap } from '../../types/index.js';
 
 vi.mock('../../utils/logger.js', () => ({
@@ -661,6 +662,65 @@ describe('syncApprovedDecisions — filesystem writes', () => {
     expect(ids).not.toContain('app00001');
     expect(ids).toContain('ver00001');
   });
+
+  it('preserves supersession authority after sync purges the pending store', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const specDir = join(tmpDir, 'openspec', 'specs', 'services');
+    await mkdir(specDir, { recursive: true });
+    const specPath = join(specDir, 'spec.md');
+    await writeFile(specPath, `${MINIMAL_SPEC.trimEnd()}
+
+### Requirement: DurableDecisionCitation
+
+The system SHALL retain a durable decision citation.
+
+> Corpus edge: spec-cites-decision aaaaaaaa
+`, 'utf8');
+
+    const oldDecision = makeDecision({
+      id: 'aaaaaaaa',
+      title: 'Use the original cache',
+      proposedRequirement: null,
+    });
+    const replacement = makeDecision({
+      id: 'bbbbbbbb',
+      title: 'Replace the original cache',
+      proposedRequirement: null,
+      supersedes: oldDecision.id,
+    });
+    const store = makeStore([oldDecision, replacement]);
+    await mkdir(join(tmpDir, '.openlore', 'decisions'), { recursive: true });
+    await writeFile(
+      join(tmpDir, '.openlore', 'decisions', 'pending.json'),
+      JSON.stringify(store, null, 2) + '\n',
+      'utf8',
+    );
+
+    const before = await detectCorpusIntegrity(tmpDir);
+    expect(before).toContainEqual(expect.objectContaining({
+      code: 'corpus-target-retired',
+      discriminator: 'spec-cites-decision:aaaaaaaa',
+      message: expect.stringContaining('cite bbbbbbbb instead'),
+    }));
+
+    const { store: persisted } = await syncApprovedDecisions(store, {
+      rootPath: tmpDir,
+      openspecPath: join(tmpDir, 'openspec'),
+      specMap: makeSpecMap('services', 'openspec/specs/services/spec.md'),
+    });
+    expect(persisted.decisions).toEqual([]);
+    const syncedSpec = await readFile(specPath, 'utf8');
+    expect(syncedSpec).toContain('**ID:** bbbbbbbb\n**Supersedes:** aaaaaaaa');
+
+    const after = await detectCorpusIntegrity(tmpDir);
+    expect(after).toContainEqual(expect.objectContaining({
+      code: 'corpus-target-retired',
+      discriminator: 'spec-cites-decision:aaaaaaaa',
+      message: expect.stringContaining('cite bbbbbbbb instead'),
+    }));
+    expect(after.filter((finding) => finding.code === 'corpus-target-retired'))
+      .toEqual(before.filter((finding) => finding.code === 'corpus-target-retired'));
+  });
 });
 
 // ============================================================================
@@ -724,6 +784,25 @@ describe('ADR creation — always writes ADR regardless of content', () => {
 
     const files = await readdir(join(tmpDir, 'openspec', 'decisions'));
     expect(files.some((f) => f.startsWith('adr-'))).toBe(true);
+  });
+
+  it('writes optional supersession metadata to the ADR', async () => {
+    const { writeFile, readdir } = await import('node:fs/promises');
+    const specDir = join(tmpDir, 'openspec', 'specs', 'services');
+    await mkdir(specDir, { recursive: true });
+    await writeFile(join(specDir, 'spec.md'), MINIMAL_SPEC, 'utf8');
+    await syncApprovedDecisions(makeStore([makeDecision({
+      scope: 'system',
+      supersedes: '1234abcd',
+    })]), {
+      rootPath: tmpDir,
+      openspecPath: join(tmpDir, 'openspec'),
+      specMap: makeSpecMap('services', 'openspec/specs/services/spec.md'),
+    });
+
+    const [filename] = await readdir(join(tmpDir, 'openspec', 'decisions'));
+    expect(await readFile(join(tmpDir, 'openspec', 'decisions', filename), 'utf8'))
+      .toContain('> Supersedes: 1234abcd');
   });
 
   it('increments ADR number for each successive decision', async () => {

--- a/src/core/decisions/syncer.ts
+++ b/src/core/decisions/syncer.ts
@@ -339,6 +339,9 @@ function validateDecisionRenderInputs(decision: PendingDecision): void {
       : [['proposedRequirement', decision.proposedRequirement] as [string, string]]),
     ...decision.affectedDomains.map((value, index) => [`affectedDomains[${index}]`, value] as [string, string]),
     ...decision.affectedFiles.map((value, index) => [`affectedFiles[${index}]`, value] as [string, string]),
+    ...(decision.supersedes == null
+      ? []
+      : [['supersedes', decision.supersedes] as [string, string]]),
   ];
   const multiline = fields.find(([, value]) => /[\r\n]/.test(value));
   if (multiline) {
@@ -485,6 +488,7 @@ function buildDecisionEntry(decision: PendingDecision): string {
 **Status:** ${specStatusLabel(decision)}
 **Date:** ${(decision.syncedAt ?? new Date().toISOString()).slice(0, 10)}
 **ID:** ${decision.id}
+${decision.supersedes ? `**Supersedes:** ${decision.supersedes}\n` : ''}
 
 ${decision.rationale}
 
@@ -550,6 +554,7 @@ ${decision.consequences}
 
 > Recorded by openlore decisions on ${(decision.syncedAt ?? new Date().toISOString()).slice(0, 10)}
 > Decision ID: ${decision.id}
+${decision.supersedes ? `> Supersedes: ${decision.supersedes}\n` : ''}
 `;
 
   await writeFile(adrPath, content, 'utf-8');

--- a/src/core/services/mcp-handlers/claim-verification.test.ts
+++ b/src/core/services/mcp-handlers/claim-verification.test.ts
@@ -292,6 +292,21 @@ describe('verify_claim — decision-current', () => {
     expect(r.reason).toMatch(/cite cccccccc instead/);
   });
 
+  it('is unverifiable when the decision belongs to a supersession cycle', async () => {
+    await writeStore([
+      decision({ id: 'aaaaaaaa', title: 'Approach A', supersedes: 'bbbbbbbb' }),
+      decision({ id: 'bbbbbbbb', title: 'Approach B', supersedes: 'aaaaaaaa' }),
+    ]);
+    for (const subject of ['aaaaaaaa', 'bbbbbbbb']) {
+      const r = await handleVerifyClaim({ directory: root, kind: 'decision-current', subject }) as {
+        verdict: string; reason: string; receipt?: unknown;
+      };
+      expect(r.verdict).toBe('unverifiable');
+      expect(r.reason).toMatch(/supersession cycle.*aaaaaaaa.*bbbbbbbb/i);
+      expect(r.receipt).toBeUndefined();
+    }
+  });
+
   it('refutes a rejected decision', async () => {
     await writeStore([decision({ id: 'deadbeef', title: 'Rejected idea', status: 'rejected' })]);
     const r = await handleVerifyClaim({ directory: root, kind: 'decision-current', subject: 'deadbeef' }) as {

--- a/src/core/services/mcp-handlers/claim-verification.ts
+++ b/src/core/services/mcp-handlers/claim-verification.ts
@@ -422,7 +422,25 @@ async function verifyDecisionCurrent(absDir: string, subject: string): Promise<u
   }
 
   const indexCommit = await readIndexCommit(absDir);
-  const supersededBy = buildRetirementGraph(decisions).supersededBy.get(id);
+  const retirement = buildRetirementGraph(decisions);
+  const cycle = retirement.cycles.find((members) => members.includes(id));
+  if (cycle) {
+    return {
+      claim,
+      verdict: 'unverifiable' as Verdict,
+      reason: `Decision "${id}" belongs to a supersession cycle (${cycle.join(' → ')} → ${cycle[0]}). No member is an authoritative terminal replacement; repair the decision history before citing any member as current.`,
+      confidenceBoundary: cleanBoundary,
+    };
+  }
+  if (retirement.retiredDecisionIds.has(id) && !retirement.supersededBy.has(id)) {
+    return {
+      claim,
+      verdict: 'unverifiable' as Verdict,
+      reason: `Decision "${id}" has a supersession chain that enters a cycle, so no authoritative terminal replacement can be determined. Repair the decision history before citing it as current.`,
+      confidenceBoundary: cleanBoundary,
+    };
+  }
+  const supersededBy = retirement.supersededBy.get(id);
   if (supersededBy) {
     const superseder = decisions.find((d) => d.id === supersededBy);
     const evidence = `decision ${id} ("${shortTitle(target.title)}") was superseded by ${supersededBy}${superseder ? ` ("${shortTitle(superseder.title)}")` : ''}`;

--- a/src/core/services/mcp-handlers/enforcement-policy.test.ts
+++ b/src/core/services/mcp-handlers/enforcement-policy.test.ts
@@ -18,6 +18,19 @@ import {
 const invalidSeverity: GovernanceFinding = { code: 'x', severity: 'warn', source: 'x', subject: 'x', message: 'x' };
 void invalidSeverity;
 
+const CORPUS_DEFAULT_CLASSES = {
+  'corpus-reference-unresolved': 'blocking',
+  'corpus-reference-ambiguous': 'blocking',
+  'corpus-self-reference': 'blocking',
+  'corpus-duplicate-identifier': 'blocking',
+  'corpus-edge-unsupported': 'blocking',
+  'corpus-target-type-mismatch': 'blocking',
+  'corpus-target-retired': 'advisory',
+  'corpus-supersession-cycle': 'blocking',
+  'corpus-anchor-target-missing': 'advisory',
+  'corpus-reference-undeclared': 'advisory',
+} as const;
+
 describe('applyPolicyPrecedence — pure precedence core', () => {
   // Spec: off > blocking > advisory > source default. Exercises the "source default
   // is blocking" branch the registry never uses, proving precedence independently.
@@ -61,9 +74,12 @@ describe('resolveEnforcementClass', () => {
 });
 
 describe('FINDING_CODE_REGISTRY', () => {
-  it('every registered code defaults to advisory (blocking is always opt-in)', () => {
-    for (const spec of Object.values(FINDING_CODE_REGISTRY)) {
-      expect(spec.defaultClass).toBe('advisory');
+  it('keeps every pre-existing source advisory by default and declares complete metadata', () => {
+    for (const [code, spec] of Object.entries(FINDING_CODE_REGISTRY)) {
+      expect(['blocking', 'frozen', 'advisory', 'off'], code).toContain(spec.defaultClass);
+      expect(spec.source, code).not.toBe('');
+      expect(spec.description, code).not.toBe('');
+      if (!(code in CORPUS_DEFAULT_CLASSES)) expect(spec.defaultClass, code).toBe('advisory');
     }
   });
   it('registers the stale-decision-reference code and the lowered surface codes', () => {
@@ -77,6 +93,16 @@ describe('FINDING_CODE_REGISTRY', () => {
     for (const code of ['footprint-escape', 'footprint-escape-new-conflict', 'mis-declared-append']) {
       expect(isKnownFindingCode(code)).toBe(true);
       expect(FINDING_CODE_REGISTRY[code].source).toBe('footprint-escape');
+    }
+  });
+  it('registers every corpus-integrity code with its specified source default', () => {
+    for (const [code, defaultClass] of Object.entries(CORPUS_DEFAULT_CLASSES)) {
+      expect(isKnownFindingCode(code), code).toBe(true);
+      expect(FINDING_CODE_REGISTRY[code]).toMatchObject({
+        source: 'corpus-integrity',
+        defaultClass,
+      });
+      expect(sourceDefaultClass(code)).toBe(defaultClass);
     }
   });
 });

--- a/src/core/services/mcp-handlers/enforcement-policy.ts
+++ b/src/core/services/mcp-handlers/enforcement-policy.ts
@@ -16,9 +16,9 @@
  *
  * Resolution is a pure, order-independent function with a fixed precedence:
  *   an explicit class > source default.
- * `advisory` is the source default for every code, so a repository that declares
- * no policy behaves exactly as it does today. Deterministic, no LLM (north star
- * `c6d1ad07`).
+ * Most sources default to `advisory`; sources may declare stricter defaults when
+ * an invalid artifact would otherwise be trusted. Deterministic, no LLM (north
+ * star `c6d1ad07`).
  */
 
 import type {
@@ -72,9 +72,9 @@ export interface ClassifiedFinding extends GovernanceFinding {
  * class, so (a) a declared policy that names an unknown code can be flagged, and
  * (b) the catalogue is the documented contract for what an operator may govern.
  *
- * `defaultClass` is `advisory` for every code: blocking is always opt-in, per
- * `add-preflight-blast-radius-guard`/AdvisoryByDefault. The field exists so a
- * future source CAN declare a stricter default without changing the resolver.
+ * `defaultClass` is source-owned. Most findings are advisory by default, while
+ * corpus resolution and graph-shape failures are blocking because an invalid
+ * governance graph must not be trusted as authoritative.
  */
 export interface FindingCodeSpec {
   defaultClass: EnforcementClass;
@@ -167,6 +167,57 @@ export const FINDING_CODE_REGISTRY: Record<string, FindingCodeSpec> = {
     defaultClass: 'advisory',
     source: 'doctor',
     description: 'Unreviewed served content lexically resembles an imperative override, message impersonation, or direction away from a recorded decision. The check is incomplete and review-only.',
+  },
+  // ── governance corpus integrity (add-knowledge-corpus-integrity) ──
+  'corpus-reference-unresolved': {
+    defaultClass: 'blocking',
+    source: 'corpus-integrity',
+    description: 'A declared corpus edge names a target that cannot be resolved.',
+  },
+  'corpus-reference-ambiguous': {
+    defaultClass: 'blocking',
+    source: 'corpus-integrity',
+    description: 'A declared corpus edge resolves to more than one target.',
+  },
+  'corpus-self-reference': {
+    defaultClass: 'blocking',
+    source: 'corpus-integrity',
+    description: 'A corpus artifact declares a graph edge to itself where self-reference is invalid.',
+  },
+  'corpus-duplicate-identifier': {
+    defaultClass: 'blocking',
+    source: 'corpus-integrity',
+    description: 'Multiple corpus artifacts declare the same identifier.',
+  },
+  'corpus-edge-unsupported': {
+    defaultClass: 'blocking',
+    source: 'corpus-integrity',
+    description: 'A corpus artifact declares an edge kind that its artifact type does not support.',
+  },
+  'corpus-target-type-mismatch': {
+    defaultClass: 'blocking',
+    source: 'corpus-integrity',
+    description: 'A declared corpus edge resolves to an artifact outside the edge\'s target range.',
+  },
+  'corpus-target-retired': {
+    defaultClass: 'advisory',
+    source: 'corpus-integrity',
+    description: 'A live corpus artifact references a superseded, rejected, or otherwise retired target.',
+  },
+  'corpus-supersession-cycle': {
+    defaultClass: 'blocking',
+    source: 'corpus-integrity',
+    description: 'Decision supersession edges form a cycle, so no member can be treated as authoritative.',
+  },
+  'corpus-anchor-target-missing': {
+    defaultClass: 'advisory',
+    source: 'corpus-integrity',
+    description: 'A corpus artifact anchor names a symbol or file that no longer exists.',
+  },
+  'corpus-reference-undeclared': {
+    defaultClass: 'advisory',
+    source: 'corpus-integrity',
+    description: 'Corpus prose names another artifact without declaring the corresponding graph edge.',
   },
 };
 

--- a/src/core/services/mcp-handlers/stale-decision-reference.test.ts
+++ b/src/core/services/mcp-handlers/stale-decision-reference.test.ts
@@ -199,11 +199,32 @@ describe('findStaleDecisionReferences — adversarial edge cases', () => {
     expect(forA.supersededBy).toBe('c0c0c0c0'); // terminal, not the dead b0b0b0b0
   });
 
-  it('a chain cycle does not hang (cycle-guarded)', () => {
-    // pathological: X supersedes Y and Y supersedes X
-    const x = decision({ id: 'x0x0x0x0', supersedes: 'y0y0y0y0' });
-    const y = decision({ id: 'y0y0y0y0', supersedes: 'x0x0x0x0' });
-    expect(() => buildRetirementGraph([x, y])).not.toThrow();
+  it('discloses deterministic cycle membership without inventing a live superseder', () => {
+    // pathological: A supersedes B and B supersedes A. Neither is an authoritative
+    // terminal replacement, and in particular neither may resolve to itself.
+    const a = decision({ id: 'aaaaaaaa', supersedes: 'bbbbbbbb' });
+    const b = decision({ id: 'bbbbbbbb', supersedes: 'aaaaaaaa' });
+    const forward = buildRetirementGraph([a, b]);
+    const reverse = buildRetirementGraph([b, a]);
+    expect(forward.supersededBy.size).toBe(0);
+    expect(forward.cycles).toEqual([['aaaaaaaa', 'bbbbbbbb']]);
+    expect(reverse.cycles).toEqual(forward.cycles);
+  });
+
+  it('canonicalizes multiple cycles despite competing superseders and shuffled input', () => {
+    const a = decision({ id: 'aaaaaaaa', supersedes: 'bbbbbbbb' });
+    const b = decision({ id: 'bbbbbbbb', supersedes: 'aaaaaaaa' });
+    const c = decision({ id: 'cccccccc', supersedes: 'aaaaaaaa' });
+    const d = decision({ id: 'dddddddd', supersedes: 'eeeeeeee' });
+    const e = decision({ id: 'eeeeeeee', supersedes: 'ffffffff' });
+    const f = decision({ id: 'ffffffff', supersedes: 'dddddddd' });
+    const g = buildRetirementGraph([f, c, d, b, e, a]);
+    expect(g.cycles).toEqual([
+      ['aaaaaaaa', 'bbbbbbbb'],
+      ['dddddddd', 'eeeeeeee', 'ffffffff'],
+    ]);
+    expect(g.supersededBy.has('cccccccc')).toBe(false); // superseder, not retired target
+    expect(g.supersededBy.size).toBe(0);
   });
 
   // H2: a retired id embedded in a longer hex blob (e.g. a 40-char git SHA) has no word

--- a/src/core/services/mcp-handlers/stale-decision-reference.ts
+++ b/src/core/services/mcp-handlers/stale-decision-reference.ts
@@ -58,6 +58,10 @@ export interface StaleDecisionReferenceFinding {
 export interface RetirementGraph {
   /** retiredId → the id of the active decision that superseded it. */
   supersededBy: Map<string, string>;
+  /** Every target of an effective supersession edge, even when no live terminal exists. */
+  retiredDecisionIds: Set<string>;
+  /** Supersession cycles, with both each cycle and the outer list stably sorted. */
+  cycles: string[][];
 }
 
 /**
@@ -77,21 +81,46 @@ export function buildRetirementGraph(decisions: readonly PendingDecision[]): Ret
     const existing = immediate.get(target);
     if (existing === undefined || c.id < existing) immediate.set(target, c.id);
   }
-  // Resolve each retired target to its LIVE terminal superseder: if the immediate
-  // superseder is itself retired (a chain A←B←C), follow to the live end so the
-  // remediation never points the user at a decision that is also dead. Cycle-guarded.
-  const retiredTargets = new Set(immediate.keys());
-  const supersededBy = new Map<string, string>();
-  for (const target of immediate.keys()) {
-    let cur = immediate.get(target)!;
-    const visited = new Set<string>([target]);
-    while (retiredTargets.has(cur) && !visited.has(cur)) {
-      visited.add(cur);
+  const retiredDecisionIds = [...immediate.keys()].sort(stableCompare);
+
+  // Find cycles in the canonical immediate-superseder graph before resolving live
+  // terminals. A cycle has no authoritative terminal decision; reporting one of its
+  // members as the other's live replacement (or, worse, as its own replacement) would
+  // manufacture authority. Canonicalize membership so consumers can emit one stable
+  // finding per cycle regardless of decision-store order or cycle entry point.
+  const cycleByKey = new Map<string, string[]>();
+  for (const target of retiredDecisionIds) {
+    const path: string[] = [];
+    const position = new Map<string, number>();
+    let cur = target;
+    while (immediate.has(cur)) {
+      const at = position.get(cur);
+      if (at !== undefined) {
+        const cycle = path.slice(at).sort(stableCompare);
+        cycleByKey.set(cycle.join('\x00'), cycle);
+        break;
+      }
+      position.set(cur, path.length);
+      path.push(cur);
       cur = immediate.get(cur)!;
     }
-    supersededBy.set(target, cur);
   }
-  return { supersededBy };
+  const cycles = [...cycleByKey.values()].sort((a, b) => stableCompare(a.join('\x00'), b.join('\x00')));
+  const cycleMembers = new Set(cycles.flat());
+
+  // Resolve each retired target to its LIVE terminal superseder: if the immediate
+  // superseder is itself retired (a chain A←B←C), follow to the live end so the
+  // remediation never points the user at a decision that is also dead. Any chain that
+  // enters a cycle is omitted because it has no live terminal replacement.
+  const supersededBy = new Map<string, string>();
+  for (const target of retiredDecisionIds) {
+    let cur = immediate.get(target)!;
+    while (immediate.has(cur) && !cycleMembers.has(cur)) {
+      cur = immediate.get(cur)!;
+    }
+    if (!cycleMembers.has(cur)) supersededBy.set(target, cur);
+  }
+  return { supersededBy, retiredDecisionIds: new Set(retiredDecisionIds), cycles };
 }
 
 /** Map of retired target → the set of its immediate superseders (a target may have >1). */

--- a/src/utils/path-confinement.test.ts
+++ b/src/utils/path-confinement.test.ts
@@ -140,6 +140,11 @@ describe('readFileConfined', () => {
     await expect(readFileConfined(root, 'openspec/specs/core/spec.md')).resolves.toBe('# real spec\n');
   });
 
+  it('rejects an oversized file from descriptor metadata before returning content', async () => {
+    await expect(readFileConfined(root, 'openspec/specs/core/spec.md', 2))
+      .rejects.toThrow(/exceeds byte limit/);
+  });
+
   it('returns UTF-8 content and post-read metadata from the confined descriptor', async () => {
     const result = await readFileConfinedWithStat(root, 'openspec/specs/core/spec.md');
 

--- a/src/utils/path-confinement.ts
+++ b/src/utils/path-confinement.ts
@@ -139,8 +139,8 @@ function sameFile(
  * check closes the `safeJoin` -> `readFile` swap window for artifact-derived paths:
  * replacing the file or one of its parent directories makes the read fail closed.
  */
-export async function readFileConfined(absDir: string, filePath: string): Promise<string> {
-  return (await readFileConfinedWithStat(absDir, filePath)).content;
+export async function readFileConfined(absDir: string, filePath: string, maxBytes?: number): Promise<string> {
+  return (await readFileConfinedWithStat(absDir, filePath, maxBytes)).content;
 }
 
 export interface ConfinedFileRead {
@@ -154,7 +154,11 @@ export interface ConfinedFileRead {
  * from one descriptor, and neither is returned if that file or its name changes
  * during the read.
  */
-export async function readFileConfinedWithStat(absDir: string, filePath: string): Promise<ConfinedFileRead> {
+export async function readFileConfinedWithStat(
+  absDir: string,
+  filePath: string,
+  maxBytes?: number,
+): Promise<ConfinedFileRead> {
   const lexicalPath = safeJoin(absDir, filePath);
   const canonicalRoot = await realpath(absDir);
   const canonicalPath = await realpath(lexicalPath);
@@ -164,6 +168,9 @@ export async function readFileConfinedWithStat(absDir: string, filePath: string)
   try {
     const opened = await handle.stat();
     if (!opened.isFile()) throw new Error(`Confined read requires a regular file: "${filePath}"`);
+    if (maxBytes !== undefined && opened.size > maxBytes) {
+      throw new Error(`Confined read exceeds byte limit (${maxBytes}): "${filePath}"`);
+    }
 
     const verifyIdentity = async (descriptorStat: Stats): Promise<void> => {
       const currentCanonicalPath = await realpath(canonicalPath);


### PR DESCRIPTION
Status: LGTM; CI pending.

## What was missing / the motivation

OpenLore treated specs, decisions, active changes, and memories as a governance graph without validating whether typed references resolved, remained authoritative, or formed cycles. A decision supersession cycle could even make `decision-current` confidently cite a member as its own replacement.

## What it does

- Adds a closed typed corpus-edge registry and deterministic offline resolver with 10 governable finding codes.
- Validates specs, active deltas, proposals, pending and durable decisions, memories, and anchors through confined reads and bounded resource budgets.
- Preserves supersession metadata through decision sync and refuses authoritative verdicts for cycle members.
- Wires one finding engine into `doctor` and `enforce`, including staged-vs-working-tree protection for source-default blocking checks.
- Archives `add-knowledge-corpus-integrity` and syncs its two requirements into the main OpenSpec corpus.

## Proof it works

- Focused corpus, enforcement, and confinement matrix: 99 tests passed.
- Full E2E: 23 files, 189 tests passed; live-data harness: 486 pass, 0 fail, 39 intentional skips.
- Build, typecheck, lint, API consumer smoke, dependency audit, package-list audit, and OpenSpec strict validation (111/111) passed.
- Four independent adversarial review loops covered correctness, contract/coverage, security/performance, and post-fix regression behavior; all actionable findings were fixed.
- Full local unit run: 8,393 passed, 2 skipped; 19 pre-existing Kotlin-native tests cannot load `tree-sitter-kotlin` under local Node 26.7.0. CI uses the supported runtime and is the authoritative full-suite result.

## Notes / nits

No new MCP tool, store, model call, network dependency, or automatic corpus rewrite was added. Existing undeclared exact references are advisory only; resolution and graph-shape failures use source-declared blocking defaults and remain operator-overridable.