### PR TITLE
fix(security): harden release boundaries for v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,26 +33,11 @@ updates:
         applies-to: version-updates
         dependency-type: production
         update-types: [minor, patch]
-    ignore:
-      # Pinned intentionally, not drifting. Every parser package is matched to the
-      # ABI/grammar version the analyzer loads, so a bump has to be validated against
-      # the parse fixtures rather than merged on green CI alone.
-      #
-      # The wildcard matters. The first version of this file listed only
-      # `web-tree-sitter` and `tree-sitter-wasms`, which left the native `tree-sitter`
-      # and all 18 `tree-sitter-*` grammars unignored — they landed in the
-      # production-minor-patch group and broke the build (`Cannot find module
-      # 'tree-sitter'`, then a cascade of implicit-any errors).
-      #
-      # Why they qualified as "minor" at all: for a 0.x package semver treats
-      # 0.22 -> 0.25 as a MINOR bump, so `update-types: [minor, patch]` does not mean
-      # "non-breaking" for anything below 1.0. Most of this repo's parser stack is 0.x.
-      # `tree-sitter-*` covers the grammars AND `tree-sitter-wasms`; the bare
-      # `tree-sitter` needs its own line because the wildcard requires the hyphen.
-      - dependency-name: web-tree-sitter
-      - dependency-name: tree-sitter
-      - dependency-name: 'tree-sitter-*'
-      - dependency-name: '@lancedb/lancedb'
+    # Do not use `ignore` for the ABI-sensitive parser/vector stack. Dependabot
+    # applies ignores to security updates too, so suppressing routine version PRs
+    # here would also suppress advisory fixes on the highest-risk native input
+    # surface. Review those updates individually and close incompatible version
+    # bumps after the parser/ABI fixtures run.
 
   # ------------------------------------------------------- github actions
   # Two entries, because one does not cover both places actions are referenced.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,60 @@ jobs:
           path: dist/
           retention-days: 7
 
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build compiled integration fixtures
+        run: npm run build
+
+      - name: Run deterministic integration tests
+        run: npm run test:integration:ci
+
+  node-floor:
+    name: Node 22.19 Compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22.19.0'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Type check at the supported Node floor
+        run: npm run typecheck
+
+      - name: Build at the supported Node floor
+        run: npm run build
+
+      - name: Verify the public API consumer contract
+        run: npm run test:api-consumer
+
+      - name: Run deterministic integration tests
+        run: npm run test:integration:ci
+
   windows-smoke:
     name: Windows Smoke
     runs-on: windows-latest
@@ -195,7 +249,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, build, windows-smoke]
+    needs: [lint, test, build, integration, node-floor, windows-smoke]
     if: always()
     permissions:
       contents: read
@@ -205,6 +259,8 @@ jobs:
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
+             [[ "${{ needs.integration.result }}" != "success" ]] || \
+             [[ "${{ needs.node-floor.result }}" != "success" ]] || \
              [[ "${{ needs.windows-smoke.result }}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
 
       - run: npm ci
 
+      # Hook-installation tests pin the same built, external OpenLore launcher
+      # that production installs. Build it before exercising those tests.
+      - name: Build trusted hook launcher
+        run: npm run build
+
       - name: Certify derived-artifact answer equivalence
         run: npm run test:equivalence
         timeout-minutes: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Run tests
         run: npm run test:run
 
+      - name: Run deterministic integration tests
+        run: npm run test:integration:ci
+
       - name: Audit dependencies
         run: npm run audit:gate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,24 +3,35 @@
 All notable changes to OpenLore are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.0] - 2026-08-23
 
 - **Programmatic API migration:** analysis results now require `fromCache` and make
   `depGraph` optional when the persisted graph is missing or corrupt. Generation and full-run
   results are discriminated by `dryRun`; callers must narrow on `result.dryRun` before reading
-  `pipelineResult`, `init`, or `analysis`. Dry runs no longer fabricate results for stages that
-  did not execute. These are intentional breaking type-shape corrections for embedders.
+  `pipelineResult`, `init`, or `analysis`. `GenerationReport.configSchemaVersion` is now required,
+  and `openloreVersion` now consistently identifies the OpenLore package rather than the config
+  schema. Dry runs no longer fabricate results for stages that did not execute. These are
+  intentional breaking type-shape corrections for embedders.
 - LLM prompt/response diagnostics are now disabled by default, require exact
   `OPENLORE_LLM_LOGS=1` opt-in, redact secrets, and retain at most six files or 300 MB;
   local telemetry documentation now matches its exact gate and recorded event domains.
+- Repository config can no longer disable source-output secret redaction or force ignored files
+  into generated LLM context; trusted operators retain explicit environment/CLI overrides.
+- The minimum supported Node.js version is now 22.19, matching the runtime dependency floor;
+  CI exercises that exact version before release.
 - Drift results now carry required `analyzedFiles` and `filesOmitted` receipts. The drift CLI
   reserves exit `1` for confirmed drift and uses exit `2` when the check cannot run; reinstalled
   pre-commit hooks upgrade in place, validate JSON before blocking, preserve existing hook
   failures, and allow infrastructure failures with an explicit warning.
 - Interference maps now retain unassessable branches, reject unsafe base guesses,
   disclose enumeration limits/failures, and stop treating shared reads as conflicts.
-- Enforcement JSON schema version 2 normalizes governance finding severity to
-  `info`, `warning`, `error`, or `critical` (`warn` is now `warning`).
+- Enforcement JSON schema version 3 normalizes governance finding severity to
+  `info`, `warning`, `error`, or `critical` (`warn` is now `warning`) and adds frozen-baseline
+  ratchet evidence.
+
+**Upgrade:** `npm i -g openlore@3.0.0`
+
+**Full Changelog**: https://github.com/clay-good/OpenLore/compare/v2.2.0...v3.0.0
 
 ## [2.2.0] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://www.npmjs.com/package/openlore"><img src="https://img.shields.io/npm/v/openlore?color=2563eb&label=npm&logo=npm&logoColor=white" alt="npm version"></a>
   <a href="https://github.com/clay-good/OpenLore/actions/workflows/ci.yml"><img src="https://github.com/clay-good/OpenLore/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
   <a href="LICENSE"><img src="https://img.shields.io/npm/l/openlore?color=22c55e" alt="MIT License"></a>
-  <img src="https://img.shields.io/node/v/openlore?color=339933&logo=node.js&logoColor=white" alt="Node >=22.13">
+  <img src="https://img.shields.io/node/v/openlore?color=339933&logo=node.js&logoColor=white" alt="Node >=22.19">
   <br>
   <img src="https://img.shields.io/badge/MCP-ready-7c3aed?logo=anthropic&logoColor=white" alt="MCP ready">
   <img src="https://img.shields.io/badge/languages-18%20%2B%2012%20IaC-f97316" alt="18 languages + 12 IaC ecosystems">
@@ -424,7 +424,7 @@ We'd rather you know these up front. Last validated against the code on 2026-07-
 
 ## Requirements
 
-- **Node.js 22.13+** (the first line where the built-in `node:sqlite` is available without runtime flags).
+- **Node.js 22.19+** (`node:sqlite` is available without runtime flags and all runtime dependencies support this floor).
 - **No API key** for `analyze`, `drift`, `mcp`, `init`, and every governance/navigation tool.
 - **Provider access** only for standalone `generate`, `verify`, and `drift --use-llm`. Agent-hosted Generate/Repair uses the connected host model and needs no additional OpenLore key:
   ```bash

--- a/docs/OPENSPEC-INTEGRATION.md
+++ b/docs/OPENSPEC-INTEGRATION.md
@@ -483,7 +483,7 @@ and project-root resolution from the spawn directory.
 
 ### Node-version guard
 
-OpenLore requires **Node ≥22.13** (the first line where the built-in `node:sqlite` is available
+OpenLore requires **Node ≥22.19** (the supported dependency floor where the built-in `node:sqlite` is available
 without runtime flags); OpenSpec requires only ≥20.19. A user on Node 20/21 can run
 `openspec lore generate`, which spawns `openlore` under an unsupported Node. `engines` is advisory at
 install time and does not protect the spawn, so OpenLore **fails fast at runtime**: one legible

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -381,7 +381,7 @@ Checks performed:
 
 | Check | What it looks for |
 |-------|------------------|
-| Node.js version | ≥ 22.13 required, and `node:sqlite` probed as loadable |
+| Node.js version | ≥ 22.19 required, and `node:sqlite` probed as loadable |
 | Git repository | `.git` directory and `git` binary on PATH |
 | openlore config | `.openlore/config.json` exists and is parseable |
 | Analysis artifacts | `repo-structure.json` freshness (warns if >24h old) |
@@ -650,7 +650,7 @@ coherent with the `@fission-ai/openspec` peer-dep range), the help-only surfaced
 commands, the contributed skill, and `ownsConfigKeys: ["openlore"]`. See
 [OPENSPEC-INTEGRATION.md](OPENSPEC-INTEGRATION.md) for the full marketplace contract.
 
-> **Node-version guard.** OpenLore requires Node ≥22.13 (the first line where the
+> **Node-version guard.** OpenLore requires Node ≥22.19 (the supported dependency floor where the
 > built-in `node:sqlite` is available without runtime flags). The CLI checks this before
 > any command runs; under an older Node it prints one stderr line naming the
 > required and actual versions and exits with the stable code **78** — never a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,15 +86,12 @@ OpenLore redacts credential-shaped repository content before source-carrying too
 agent. Redacted results include a count and the matched credential kinds. Persisted LLM request logs
 use the same pattern set for both prompts and responses and record the redaction count per request.
 
-The tool-output boundary is enabled by default. A trusted solo operator who requires byte-exact tool
-output can opt out explicitly:
+The tool-output boundary is enabled by default. Repository config cannot disable it because cloned
+code is not trusted to choose whether source secrets are disclosed. A trusted solo operator who
+requires byte-exact tool output can opt out explicitly for one process:
 
-```json
-{
-  "secretRedaction": {
-    "toolOutput": false
-  }
-}
+```bash
+OPENLORE_UNREDACT_TOOL_OUTPUT=1 openlore mcp
 ```
 
 This opt-out does not disable redaction in LLM logs, errors, or telemetry.

--- a/flake.nix
+++ b/flake.nix
@@ -18,14 +18,13 @@
         {
           default = pkgs.buildNpmPackage {
             pname = "openlore";
-            version = "1.3.1";
+            version = "3.0.0";
 
             src = ./.;
 
             npmDepsFetcherVersion = 2;
             makeCacheWritable = true;
-            npmDepsHash = "sha256-Ym+mY2roiSWw5pp5IIbTfDKYCB9bQ6mFccvj+m5ODsQ=";
-            npmFlags = [ "--omit=optional" ];
+            npmDepsHash = "sha256-4LknIuY4oBlrLTWa21IiCWceZiPKsR6ZWtT1t9UBThY=";
 
             # Build TypeScript
             buildPhase = ''
@@ -43,8 +42,7 @@
               # Copy node_modules for runtime dependencies
               cp -r node_modules $out/lib/node_modules/openlore/
 
-              # tree-sitter-swift creates a stub symlink for tree-sitter-cli
-              # that dangles when optional deps are omitted — remove it.
+              # The local tree-sitter-cli build stub is not shipped at runtime.
               find $out -xtype l -name tree-sitter-cli -delete
 
               # Create bin wrapper (ESM — must use import(), not require())

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -51,7 +51,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": "^22.13.0 || >=23.5.0"
+        "node": "^22.19.0 || >=23.5.0"
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Persistent architectural memory and structural cognition for AI coding agents.",
   "type": "module",
   "main": "dist/api/index.js",
@@ -18,7 +18,7 @@
     "openlore": "dist/cli/index.js"
   },
   "engines": {
-    "node": "^22.13.0 || >=23.5.0"
+    "node": "^22.19.0 || >=23.5.0"
   },
   "scripts": {
     "dev": "tsx watch src/cli/index.ts",
@@ -42,6 +42,7 @@
     "test:openspec-compat": "vitest run --grep 'openspec' || echo 'No OpenSpec compat tests yet'",
     "test:e2e": "vitest run --config vitest.integration.config.ts --reporter=verbose",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:integration:ci": "vitest run --config vitest.integration.config.ts src/api/analyze-parity.integration.test.ts src/api/generate.integration.test.ts src/api/run-dry-run.integration.test.ts src/api/verify.e2e.integration.test.ts src/cli/commands/analyze.integration.test.ts src/core/analyzer/html-asset-edges.integration.test.ts src/core/analyzer/html-inline-script.e2e.integration.test.ts src/core/services/mcp-handlers/spec-reconciliation-workflow.e2e.integration.test.ts src/core/verifier/verification-engine.e2e.integration.test.ts",
     "test:api-consumer": "npm run build && node scripts/api-consumer-smoke.mjs",
     "test:live": "vitest run --config vitest.integration.config.ts live-data --reporter=verbose",
     "build:watch": "tsc --watch",
@@ -54,7 +55,7 @@
     "audit:packlist": "node scripts/audit-packlist.mjs",
     "typecheck": "tsc --noEmit",
     "postinstall": "node scripts/postinstall.mjs",
-    "prepublishOnly": "npm run build && npm run test:run",
+    "prepublishOnly": "npm run lint && npm run typecheck && npm run build && npm run test:run && npm run test:integration:ci && npm run audit:gate && npm run audit:packlist",
     "bench:reachability": "node scripts/bench-reachability.mjs",
     "verify:reachability": "node scripts/verify-reachability-equivalence.mjs"
   },

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -79,16 +79,48 @@ function fatal(message, detail = '') {
 
 const report = parseReport(runAudit());
 const vulnerabilities = report.vulnerabilities;
+const severityCounts = report.metadata.vulnerabilities;
+
+if (typeof severityCounts !== 'object' || severityCounts === null) {
+  fatal('npm audit returned no `metadata.vulnerabilities` counts — treating as "did not run".');
+}
+for (const severity of GATED) {
+  if (!Number.isSafeInteger(severityCounts[severity]) || severityCounts[severity] < 0) {
+    fatal(`npm audit returned an invalid metadata count for ${severity}.`);
+  }
+}
 
 // Collect root advisories: a `via` entry that is an object is an advisory itself,
 // whereas a string entry only names a dependent that inherits one.
 const found = new Map(); // ghsaId -> { package, severity, title }
-for (const vuln of Object.values(vulnerabilities)) {
-  for (const via of vuln.via ?? []) {
+const malformed = [];
+let gatedVulnerabilities = 0;
+for (const [packageName, vuln] of Object.entries(vulnerabilities)) {
+  if (typeof vuln !== 'object' || vuln === null || !Array.isArray(vuln.via)) {
+    malformed.push(`${packageName}: invalid vulnerability shape`);
+    continue;
+  }
+  if (GATED.has(vuln.severity)) gatedVulnerabilities++;
+  for (const via of vuln.via) {
     if (typeof via !== 'object' || !GATED.has(via.severity)) continue;
     const id = String(via.url ?? '').split('/').pop();
-    if (id) found.set(id, { package: via.name, severity: via.severity, title: via.title });
+    if (!id) {
+      malformed.push(`${packageName}: ${via.severity} advisory has no stable URL-derived id`);
+      continue;
+    }
+    found.set(id, { package: via.name ?? packageName, severity: via.severity, title: via.title ?? 'untitled advisory' });
   }
+}
+
+const reportedGated = severityCounts.high + severityCounts.critical;
+if (gatedVulnerabilities !== reportedGated) {
+  malformed.push(
+    `metadata reports ${reportedGated} high/critical vulnerabilities, ` +
+    `but the vulnerabilities map contains ${gatedVulnerabilities}`
+  );
+}
+if (reportedGated > 0 && found.size === 0) {
+  malformed.push('high/critical vulnerabilities were reported but no identifiable root advisory was found');
 }
 
 const unexpected = [...found].filter(([id]) => !ALLOWLIST[id]);
@@ -106,8 +138,15 @@ if (stale.length) {
   );
 }
 
-if (unexpected.length || stale.length) {
-  console.error(`\naudit-gate: FAILED (${unexpected.length} unallowed, ${stale.length} stale)`);
+if (malformed.length) {
+  console.error(`\n✖ Malformed npm audit report:\n${malformed.map(item => `  - ${item}`).join('\n')}`);
+}
+
+if (unexpected.length || stale.length || malformed.length) {
+  console.error(
+    `\naudit-gate: FAILED (${unexpected.length} unallowed, ${stale.length} stale, ` +
+    `${malformed.length} malformed)`
+  );
   process.exit(1);
 }
 

--- a/scripts/audit-packlist.mjs
+++ b/scripts/audit-packlist.mjs
@@ -18,6 +18,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 /** Anything matching these must never ship. */
 const FORBIDDEN = [
@@ -57,6 +58,16 @@ const REQUIRED = [
   'skills/openlore-repair/SKILL.md',
   'examples/opencode-skills/openlore-generate/SKILL.md',
   'examples/mistral-vibe/skills/openlore-generate/SKILL.md',
+];
+
+/** High-confidence credential shapes checked inside every textual packed file. */
+const CONTENT_SECRETS = [
+  { pattern: /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/, why: 'private-key block' },
+  { pattern: /\bAKIA[0-9A-Z]{16}\b/, why: 'AWS access-key id' },
+  { pattern: /\bgh[pousr]_[A-Za-z0-9_]{30,}\b/, why: 'GitHub token' },
+  { pattern: /\bnpm_[A-Za-z0-9]{36,}\b/, why: 'npm access token' },
+  { pattern: /\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{32,}\b/, why: 'provider API key' },
+  { pattern: /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/, why: 'Slack token' },
 ];
 
 /**
@@ -105,6 +116,19 @@ const violations = [];
 for (const file of files) {
   for (const { pattern, why } of FORBIDDEN) {
     if (pattern.test(file)) violations.push({ file, why });
+  }
+  let bytes;
+  try {
+    bytes = readFileSync(file);
+  } catch (error) {
+    fatal(`Could not read packed file "${file}" for content scanning.`, error.message);
+  }
+  // Credential formats are textual; avoid decoding native binaries and WASM.
+  if (!bytes.includes(0)) {
+    const content = bytes.toString('utf-8');
+    for (const { pattern, why } of CONTENT_SECRETS) {
+      if (pattern.test(content)) violations.push({ file, why });
+    }
   }
 }
 

--- a/scripts/update-homebrew-formula.mjs
+++ b/scripts/update-homebrew-formula.mjs
@@ -7,11 +7,12 @@
  * packaging/homebrew/openlore.rb. The rest of the formula (desc, deps, install,
  * test) is preserved, so hand-edits there survive a bump.
  *
- * Used two ways:
- *   - locally:  node scripts/update-homebrew-formula.mjs            (uses package.json version, edits in place)
- *               node scripts/update-homebrew-formula.mjs --version 2.0.17
- *   - in CI:    the release workflow runs it after `npm publish`, then copies the
- *               result into the homebrew tap repo (see .github/workflows/release.yml).
+ * Run manually after publishing:
+ *   node scripts/update-homebrew-formula.mjs            (uses package.json version, edits in place)
+ *   node scripts/update-homebrew-formula.mjs --version 3.0.0
+ *
+ * The formula is staged for a future homebrew-core submission and is not updated
+ * by the npm release workflow.
  *
  * Flags:
  *   --version <x.y.z>   version to pin (default: package.json version; a leading "v" is stripped)

--- a/src/api/generate.test.ts
+++ b/src/api/generate.test.ts
@@ -98,6 +98,7 @@ import { logger } from '../utils/logger.js';
 import { readGenerationSnapshot } from '../core/runtime/analysis-generation.js';
 import { withGenerationLock } from '../core/runtime/generation-lock.js';
 import { resolveGenerationSemanticSearch } from '../core/runtime/generation-semantic-search.js';
+import { OPENLORE_PACKAGE_VERSION } from '../core/runtime/package-versions.js';
 
 const mockReadFile = vi.mocked(readFile);
 const mockAccess = vi.mocked(access);
@@ -304,7 +305,7 @@ describe('openloreGenerate', () => {
 
       expect(result.dryRun).toBe(true);
       expect(result.report.filesWritten).toHaveLength(0);
-      expect(result.report.openloreVersion).toBe('2.2.0');
+      expect(result.report.openloreVersion).toBe(OPENLORE_PACKAGE_VERSION);
       expect(result.report.openspecVersion).toBe('1.9.0');
       expect(result.report.configSchemaVersion).toBe(MOCK_CONFIG.version);
       expect('pipelineResult' in result).toBe(false);
@@ -372,7 +373,7 @@ describe('openloreGenerate', () => {
       );
       expect(OpenSpecWriter).toHaveBeenCalled();
       expect(result.report.filesWritten).toContain('openspec/auth/spec.md');
-      expect(result.report.openloreVersion).toBe('2.2.0');
+      expect(result.report.openloreVersion).toBe(OPENLORE_PACKAGE_VERSION);
       expect(result.report.openspecVersion).toBe('1.9.0');
       expect(result.report.configSchemaVersion).toBe(MOCK_CONFIG.version);
       expect(withGenerationLock).toHaveBeenCalledWith(ROOT, expect.any(Function), { signal: undefined });

--- a/src/api/run.test.ts
+++ b/src/api/run.test.ts
@@ -6,6 +6,7 @@ import { openloreGenerate } from './generate.js';
 import { readOpenLoreConfig } from '../core/services/config-manager.js';
 import { OpenLoreError, errors } from '../utils/errors.js';
 import { resolve } from 'node:path';
+import { OPENLORE_PACKAGE_VERSION } from '../core/runtime/package-versions.js';
 
 vi.mock('./init.js', () => ({ openloreInit: vi.fn() }));
 vi.mock('./analyze.js', () => ({ openloreAnalyze: vi.fn() }));
@@ -165,7 +166,7 @@ describe('openloreRun', () => {
       generation: {
         dryRun: true,
         report: {
-          openloreVersion: '2.2.0',
+          openloreVersion: OPENLORE_PACKAGE_VERSION,
           configSchemaVersion: 'unknown',
           filesWritten: [],
         },

--- a/src/cli/commands/analyze.integration.test.ts
+++ b/src/cli/commands/analyze.integration.test.ts
@@ -178,11 +178,11 @@ describe('runAnalysis integration — excludePatterns', () => {
     expect(repoMap.summary.analyzedFiles).toBe(1);
   });
 
-  it('includePatterns override gitignore exclusions', async () => {
+  it('repository includePatterns cannot override gitignore exclusions', async () => {
     await createFile(tmpDir, '.openlore/config.json',
       OPENLORE_CONFIG([], ['*.graphql']));
 
-    // schema.graphql gitignored — should be force-included
+    // A committed config must not resurrect a developer-local ignored file.
     await createFile(tmpDir, '.gitignore', '*.graphql');
     await createFile(tmpDir, 'app/main.py', 'def main(): pass');
     await createFile(tmpDir, 'app/schema.graphql', 'type Query { hello: String }');
@@ -194,7 +194,7 @@ describe('runAnalysis integration — excludePatterns', () => {
     const paths = repoMap.allFiles.map(f => f.path);
 
     expect(paths.some(p => p.includes('main.py'))).toBe(true);
-    expect(paths.some(p => p.includes('schema.graphql'))).toBe(true);
+    expect(paths.some(p => p.includes('schema.graphql'))).toBe(false);
   });
 
   it('caller-supplied includePatterns also override gitignore exclusions', async () => {

--- a/src/cli/commands/analyze.test.ts
+++ b/src/cli/commands/analyze.test.ts
@@ -487,6 +487,12 @@ describe('analyze command', () => {
       return ((calls[calls.length - 1][1] as { includePatterns?: string[] })?.includePatterns) ?? [];
     }
 
+    function getMapperRestrictedIncludePatterns(): string[] {
+      const calls = MockRepositoryMapper.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      return ((calls[calls.length - 1][1] as { restrictedIncludePatterns?: string[] })?.restrictedIncludePatterns) ?? [];
+    }
+
     it('passes config includePatterns to RepositoryMapper when caller passes none', async () => {
       readOpenLoreConfig.mockResolvedValue(makeConfig(['*.graphql', '*.prisma']));
 
@@ -494,9 +500,10 @@ describe('analyze command', () => {
         maxFiles: 100000, include: [], exclude: [],
       });
 
-      expect(getMapperIncludePatterns()).toEqual(
+      expect(getMapperRestrictedIncludePatterns()).toEqual(
         expect.arrayContaining(['*.graphql', '*.prisma'])
       );
+      expect(getMapperIncludePatterns()).toEqual([]);
     });
 
     it('merges config includePatterns with caller-supplied include patterns', async () => {
@@ -506,9 +513,8 @@ describe('analyze command', () => {
         maxFiles: 100000, include: ['*.proto'], exclude: [],
       });
 
-      expect(getMapperIncludePatterns()).toEqual(
-        expect.arrayContaining(['*.graphql', '*.proto'])
-      );
+      expect(getMapperRestrictedIncludePatterns()).toEqual(['*.graphql']);
+      expect(getMapperIncludePatterns()).toEqual(['*.proto']);
     });
 
     it('deduplicates include patterns present in both config and caller', async () => {
@@ -520,6 +526,7 @@ describe('analyze command', () => {
 
       const patterns = getMapperIncludePatterns();
       expect(patterns.filter(p => p === '*.graphql')).toHaveLength(1);
+      expect(getMapperRestrictedIncludePatterns()).toEqual([]);
     });
   });
 

--- a/src/cli/commands/blast-radius.test.ts
+++ b/src/cli/commands/blast-radius.test.ts
@@ -50,7 +50,7 @@ describe('blast-radius git hook install/uninstall', () => {
     const h = await readHook(root);
     expect(h.startsWith('#!/bin/sh')).toBe(true);
     expect(h).toContain(HOOK_MARKER);
-    expect(h).toContain('blast-radius --hook');
+    expect(h).toContain("'blast-radius' '--hook'");
     // advisory by default: only a configured pattern (nonzero exit) ever propagates
     expect(h).toContain('if [ "$BLAST_EXIT" -ne 0 ]; then');
   });

--- a/src/cli/commands/blast-radius.ts
+++ b/src/cli/commands/blast-radius.ts
@@ -23,29 +23,18 @@ import {
   hookManagerWarning,
   isResolvedGitRepository,
   resolveGitHookTarget,
+  resolveTrustedHookLauncher,
+  renderTrustedHookCommand,
   updateHookFile,
 } from '../git-hooks.js';
 
 const HOOK_MARKER = '# openlore-blast-radius-hook';
 
-const HOOK_CONTENT = `${HOOK_MARKER}
+const renderHookContent = (command: string) => `${HOOK_MARKER}
 # Advisory pre-flight blast-radius briefing before each commit.
 # Advisory by default (exit 0); blocks only on a configured high-risk pattern.
-if [ -f "./node_modules/.bin/openlore" ] && ./node_modules/.bin/openlore blast-radius --help 2>/dev/null | grep -q -- '--hook'; then
-  ./node_modules/.bin/openlore blast-radius --hook 2>&1
-  BLAST_EXIT=$?
-elif [ -f "./dist/cli/index.js" ] && node ./dist/cli/index.js blast-radius --help 2>/dev/null | grep -q -- '--hook'; then
-  node ./dist/cli/index.js blast-radius --hook 2>&1
-  BLAST_EXIT=$?
-else
-  OPENLORE=$(command -v openlore 2>/dev/null)
-  if [ -n "$OPENLORE" ] && "$OPENLORE" blast-radius --help 2>/dev/null | grep -q -- '--hook'; then
-    "$OPENLORE" blast-radius --hook 2>&1
-    BLAST_EXIT=$?
-  else
-    BLAST_EXIT=0
-  fi
-fi
+${command} 2>&1
+BLAST_EXIT=$?
 if [ "$BLAST_EXIT" -ne 0 ]; then
   exit "$BLAST_EXIT"
 fi
@@ -65,11 +54,14 @@ export async function installBlastRadiusHook(rootPath: string): Promise<void> {
     logger.warning(hookManagerWarning(target, 'openlore blast-radius --hook'));
     return;
   }
+  const launcher = await resolveTrustedHookLauncher(rootPath);
+  if (!launcher) { logger.error('Cannot pin an OpenLore installation outside this repository. Install OpenLore globally and retry.'); process.exitCode = 1; return; }
+  const hookContent = renderHookContent(renderTrustedHookCommand(launcher, ['blast-radius', '--hook']));
   let alreadyInstalled = false;
   const result = await updateHookFile(hookPath, (existing) => {
-    if (existing?.includes(HOOK_MARKER)) { alreadyInstalled = true; return null; }
+    if (existing?.includes(HOOK_MARKER)) { alreadyInstalled = true; const refreshed = existing.replace(/# openlore-blast-radius-hook[\s\S]*?# end-openlore-blast-radius-hook/, hookContent.trimEnd()); return refreshed === existing ? null : refreshed; }
     const stripped = existing?.trimEnd().replace(/\n*\nexit 0\s*$/, '');
-    return stripped ? stripped + '\n\n' + HOOK_CONTENT : '#!/bin/sh\n\n' + HOOK_CONTENT;
+    return stripped ? stripped + '\n\n' + hookContent : '#!/bin/sh\n\n' + hookContent;
   });
   if (result.status === 'unavailable') {
     logger.warning(`Cannot install the blast-radius hook at ${displayHookPath(hookPath)}: ${result.reason}`);

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -11,10 +11,12 @@
 import { Command } from 'commander';
 import { sanitizeForTerminal as safe } from '../../utils/misc.js';
 import { readFile, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 import { join } from 'node:path';
+import { confinedAtomicWriteFile, safeJoin } from '../../utils/path-confinement.js';
 
 import { logger } from '../../utils/logger.js';
 import { resolveTrustedApiBase, resolveTrustedSslVerify } from '../../core/services/repo-config-trust.js';
@@ -46,7 +48,7 @@ import {
   withVerificationOutcome,
   type DraftDisposition,
 } from '../../core/decisions/disposition.js';
-import { classifyGateState } from '../../core/decisions/gate-state.js';
+import { classifyGateState, matchesConsolidationReceipt } from '../../core/decisions/gate-state.js';
 import { acquireDecisionsLock } from '../../core/runtime/advisory-lock.js';
 import { extractFromDiff } from '../../core/decisions/extractor.js';
 import { markVerificationEvidenceAbsent, verifyDecisions } from '../../core/decisions/verifier.js';
@@ -70,6 +72,8 @@ import {
   isResolvedGitRepository,
   resolveGitHookTarget,
   resolveGitPath,
+  resolveTrustedHookLauncher,
+  renderTrustedHookCommand,
   updateHookFile,
 } from '../git-hooks.js';
 
@@ -132,23 +136,23 @@ If no: retry with \`git commit --no-verify\` to skip the gate.
 `;
 
 /** Inject decisions instructions into an existing agent file, idempotently. */
-async function injectAgentInstructions(filePath: string): Promise<'injected' | 'already' | 'missing'> {
+async function injectAgentInstructions(rootPath: string, filePath: string): Promise<'injected' | 'already' | 'missing'> {
   if (!(await fileExists(filePath))) return 'missing';
   const content = await readFile(filePath, 'utf-8');
   if (content.includes(AGENT_INSTRUCTIONS_MARKER)) return 'already';
-  await writeFile(filePath, content.trimEnd() + '\n\n' + AGENT_INSTRUCTIONS_BLOCK, 'utf-8');
+  await confinedAtomicWriteFile(rootPath, filePath, content.trimEnd() + '\n\n' + AGENT_INSTRUCTIONS_BLOCK, { preserveMode: true });
   return 'injected';
 }
 
 /** Remove decisions instructions block from an agent file. */
-async function removeAgentInstructions(filePath: string): Promise<void> {
+async function removeAgentInstructions(rootPath: string, filePath: string): Promise<void> {
   if (!(await fileExists(filePath))) return;
   const content = await readFile(filePath, 'utf-8');
   if (!content.includes(AGENT_INSTRUCTIONS_MARKER)) return;
   const cleaned = content
     .replace(/\n*<!-- openlore-decisions-instructions -->[\s\S]*?<!-- end-openlore-decisions-instructions -->\n*/g, '')
     .trim();
-  await writeFile(filePath, cleaned + '\n', 'utf-8');
+  await confinedAtomicWriteFile(rootPath, filePath, cleaned + '\n', { preserveMode: true });
 }
 
 // ============================================================================
@@ -156,27 +160,66 @@ async function removeAgentInstructions(filePath: string): Promise<void> {
 // ============================================================================
 
 const HOOK_MARKER = '# openlore-decisions-hook';
+const SOURCE_EXTS = /\.(ts|js|tsx|jsx|py|go|rs|rb|java|cpp|cc|swift)$/;
 
-const HOOK_CONTENT = `${HOOK_MARKER}
+async function sourceSnapshotFingerprint(
+  rootPath: string,
+  staged: boolean,
+): Promise<{ fingerprint: string; hasSourceChanges: boolean } | null> {
+  try {
+    const diffArgs = staged
+      ? gitPathArgs('diff', '--cached', '--name-only', '--diff-filter=ACDMR', '-z')
+      : gitPathArgs('diff', '--name-only', '--diff-filter=ACDMR', '-z', 'HEAD');
+    const { stdout } = await execFileAsync('git', diffArgs, { cwd: rootPath });
+    const paths = stdout.split('\0').filter((path) => SOURCE_EXTS.test(path));
+    if (!staged) {
+      const { stdout: untracked } = await execFileAsync(
+        'git', gitPathArgs('ls-files', '--others', '--exclude-standard', '-z'),
+        { cwd: rootPath },
+      );
+      paths.push(...untracked.split('\0').filter((path) => SOURCE_EXTS.test(path)));
+    }
+
+    const entries: Array<[string, string]> = [];
+    for (const path of [...new Set(paths)].sort()) {
+      let objectId = 'deleted';
+      try {
+        if (staged) {
+          const { stdout: stagedEntry } = await execFileAsync(
+            'git', gitPathArgs('ls-files', '--stage', '--', path),
+            { cwd: rootPath },
+          );
+          objectId = stagedEntry.trim().split(/\s+/)[1] ?? 'deleted';
+        } else {
+          const { stdout: worktreeHash } = await execFileAsync(
+            'git', gitPathArgs('hash-object', '--', path),
+            { cwd: rootPath },
+          );
+          objectId = worktreeHash.trim();
+        }
+      } catch {
+        // A changed path absent from the selected snapshot is a deletion.
+      }
+      entries.push([path, objectId]);
+    }
+    return {
+      fingerprint: createHash('sha256').update(JSON.stringify(entries)).digest('hex'),
+      hasSourceChanges: entries.length > 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function renderHookContent(invocation: string): string {
+  return `${HOOK_MARKER}
 # Gate commits until architectural decisions are reviewed.
 # Installed by: openlore setup --tools claude
 
-# Prefer local build over global install.
-if [ -f "./node_modules/.bin/openlore" ]; then
-  ./node_modules/.bin/openlore decisions --gate 2>&1
-  DECISIONS_EXIT=$?
-elif [ -f "./dist/cli/index.js" ]; then
-  node ./dist/cli/index.js decisions --gate 2>&1
-  DECISIONS_EXIT=$?
-else
-  OPENLORE=$(command -v openlore 2>/dev/null)
-  if [ -n "$OPENLORE" ] && "$OPENLORE" decisions --help 2>&1 | grep -q -- '--gate'; then
-    "$OPENLORE" decisions --gate 2>&1
-    DECISIONS_EXIT=$?
-  else
-    DECISIONS_EXIT=0
-  fi
-fi
+# Pin the trusted installation that created this hook. Never execute mutable
+# node_modules/dist content from the repository being committed.
+${invocation} 2>&1
+DECISIONS_EXIT=$?
 if [ "$DECISIONS_EXIT" -ne 0 ]; then
   exit "$DECISIONS_EXIT"
 fi
@@ -184,6 +227,7 @@ fi
 touch "$(git rev-parse --git-dir 2>/dev/null || echo .git)/OPENLORE_GATE_RAN" 2>/dev/null || true
 # end-openlore-decisions-hook
 `;
+}
 
 const POST_COMMIT_HOOK_MARKER = '# openlore-decisions-post-hook';
 const POST_COMMIT_HOOK_CONTENT = `${POST_COMMIT_HOOK_MARKER}
@@ -203,7 +247,7 @@ fi
 `;
 
 async function ensureGitignored(rootPath: string, entry: string): Promise<void> {
-  const gitignorePath = join(rootPath, '.gitignore');
+  const gitignorePath = safeJoin(rootPath, '.gitignore');
   let content = '';
   if (await fileExists(gitignorePath)) {
     content = await readFile(gitignorePath, 'utf-8');
@@ -219,23 +263,23 @@ async function ensureGitignored(rootPath: string, entry: string): Promise<void> 
       if (have.length <= want.length && have.every((s, i) => s === want[i])) return;
     }
   }
-  await writeFile(gitignorePath, content.trimEnd() + '\n' + entry + '\n', 'utf-8');
+  await confinedAtomicWriteFile(rootPath, gitignorePath, content.trimEnd() + '\n' + entry + '\n', { preserveMode: true });
   logger.discovery(`  → added ${entry} to .gitignore`);
 }
 
 async function ensureDecisionSupportFiles(rootPath: string): Promise<void> {
   await ensureGitignored(rootPath, '.openlore/decisions/');
   const agentFiles = [
-    { path: join(rootPath, 'CLAUDE.md'), label: 'CLAUDE.md' },
-    { path: join(rootPath, 'AGENTS.md'), label: 'AGENTS.md' },
-    { path: join(rootPath, '.cursorrules'), label: '.cursorrules' },
-    { path: join(rootPath, '.clinerules', 'openlore.md'), label: '.clinerules/openlore.md' },
-    { path: join(rootPath, '.github', 'copilot-instructions.md'), label: '.github/copilot-instructions.md' },
-    { path: join(rootPath, '.windsurf', 'rules.md'), label: '.windsurf/rules.md' },
-    { path: join(rootPath, '.vibe', 'skills', 'openlore.md'), label: '.vibe/skills/openlore.md' },
+    { path: safeJoin(rootPath, 'CLAUDE.md'), label: 'CLAUDE.md' },
+    { path: safeJoin(rootPath, 'AGENTS.md'), label: 'AGENTS.md' },
+    { path: safeJoin(rootPath, '.cursorrules'), label: '.cursorrules' },
+    { path: safeJoin(rootPath, '.clinerules/openlore.md'), label: '.clinerules/openlore.md' },
+    { path: safeJoin(rootPath, '.github/copilot-instructions.md'), label: '.github/copilot-instructions.md' },
+    { path: safeJoin(rootPath, '.windsurf/rules.md'), label: '.windsurf/rules.md' },
+    { path: safeJoin(rootPath, '.vibe/skills/openlore.md'), label: '.vibe/skills/openlore.md' },
   ];
   for (const { path: filePath, label } of agentFiles) {
-    const result = await injectAgentInstructions(filePath);
+    const result = await injectAgentInstructions(rootPath, filePath);
     if (result === 'injected') logger.discovery(`  → record_decision instructions added to ${label}`);
   }
 }
@@ -259,6 +303,13 @@ export async function installPreCommitHook(rootPath: string): Promise<void> {
     process.exitCode = 1;
     return;
   }
+  const launcher = await resolveTrustedHookLauncher(rootPath);
+  if (!launcher) {
+    logger.error('Refusing to install a security hook that executes mutable code from this repository. Install OpenLore globally and retry.');
+    process.exitCode = 1;
+    return;
+  }
+  const hookContent = renderHookContent(renderTrustedHookCommand(launcher, ['decisions', '--gate']));
   await ensureDecisionSupportFiles(rootPath);
   if (!target.canInstall) {
     logger.warning(hookManagerWarning(target, 'openlore decisions --gate'));
@@ -268,14 +319,15 @@ export async function installPreCommitHook(rootPath: string): Promise<void> {
   }
 
   let preAlreadyInstalled = false;
-  let removedLegacyBlock = false;
   let appendedPre = false;
   const preResult = await updateHookFile(hookPath, (existing) => {
     if (existing?.includes(HOOK_MARKER)) {
-      preAlreadyInstalled = true;
-      const cleaned = existing.replace(/\n*# spec-gen-decisions-hook[\s\S]*?# end-spec-gen-decisions-hook\n*/g, '');
-      removedLegacyBlock = cleaned !== existing;
-      return removedLegacyBlock ? cleaned : null;
+      const refreshed = existing.replace(
+        /# openlore-decisions-hook[\s\S]*?# end-openlore-decisions-hook/,
+        hookContent.trimEnd(),
+      );
+      preAlreadyInstalled = refreshed === existing;
+      return preAlreadyInstalled ? null : refreshed;
     }
     appendedPre = existing !== null;
     const stripped = existing
@@ -283,14 +335,13 @@ export async function installPreCommitHook(rootPath: string): Promise<void> {
       .trimEnd()
       .replace(/\n*\nexit 0\s*$/, '');
     return stripped
-      ? stripped + '\n\n' + HOOK_CONTENT
-      : '#!/bin/sh\n\n' + HOOK_CONTENT;
+      ? stripped + '\n\n' + hookContent
+      : '#!/bin/sh\n\n' + hookContent;
   });
   if (preResult.status === 'unavailable') {
     logger.warning(`Cannot install the decisions hook at ${displayHookPath(hookPath)}: ${preResult.reason}`);
     return;
   }
-  if (removedLegacyBlock) logger.discovery('Removed legacy spec-gen-decisions-hook block.');
   if (preAlreadyInstalled) logger.success('Pre-commit hook already installed.');
   else {
     if (appendedPre) logger.discovery('Existing pre-commit hook found. Appending decisions gate.');
@@ -383,7 +434,7 @@ export async function uninstallPreCommitHook(rootPath: string): Promise<void> {
     join(rootPath, '.windsurf', 'rules.md'),
     join(rootPath, '.vibe', 'skills', 'openlore.md'),
   ];
-  for (const filePath of agentFiles) await removeAgentInstructions(filePath);
+  for (const filePath of agentFiles) await removeAgentInstructions(rootPath, filePath);
 }
 
 // Marker for the legacy full-`analyze` PostToolUse hook. The MCP server's
@@ -957,6 +1008,7 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
         dispositions.filter((disposition) => !unassessedIds.has(disposition.id)),
         new Set(phantom.map((d) => d.id)),
       );
+      const consolidationSnapshot = await sourceSnapshotFingerprint(rootPath, false);
       const updatedStore = await updateDecisionStore(rootPath, (s) => {
         // Every input draft's verdict, written alongside the status transition.
         const next = applyConsolidationOutcome(s, {
@@ -969,7 +1021,11 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
           supersededIds,
           dispositions: finalDispositions,
         });
-        return { ...next, lastConsolidatedAt: new Date().toISOString() };
+        return {
+          ...next,
+          lastConsolidatedAt: new Date().toISOString(),
+          lastConsolidatedSourceFingerprint: consolidationSnapshot?.fingerprint,
+        };
       });
       const classifications = reconcileDecisionClassifications(updatedStore, {
         verified,
@@ -1141,24 +1197,29 @@ the gate auto-accepts verified decisions, syncs them to specs marked "Auto-accep
       // Phantom decisions ("recorded but no code evidence") are excluded — stale
       // phantoms from previous sessions would otherwise silently bypass the gate.
       const activeCount = store.decisions.filter((d) => !INACTIVE_STATUSES.has(d.status)).length;
-      const consolidatedRecently = !!store.lastConsolidatedAt
-        && (Date.now() - new Date(store.lastConsolidatedAt).getTime()) < CONSOLIDATION_GRACE_PERIOD_MS;
+      const stagedSnapshot = await sourceSnapshotFingerprint(rootPath, true);
+      const consolidatedRecently = matchesConsolidationReceipt(
+        store.lastConsolidatedAt,
+        store.lastConsolidatedSourceFingerprint,
+        stagedSnapshot?.fingerprint,
+        Date.now(),
+        CONSOLIDATION_GRACE_PERIOD_MS,
+      );
 
       // The staged-source check is the only input requiring git; resolve it lazily,
       // only in the state where it can change the outcome (nothing else gates).
       let isGitRepo = false;
-      let hasStagedSourceChanges = false;
+      let hasStagedSourceChanges = stagedSnapshot?.hasSourceChanges ?? false;
       if (approved.length === 0 && verified.length === 0 && drafts.length === 0
           && !consolidatedRecently && activeCount === 0) {
         isGitRepo = await isGitRepositoryRoot(rootPath);
-        if (isGitRepo) {
+        if (isGitRepo && stagedSnapshot === null) {
           try {
             const { stdout } = await execFileAsync(
               'git', gitPathArgs('diff', '--cached', '--name-only', '--diff-filter=ACDMR'),
               { cwd: rootPath },
             );
             const stagedFiles = stdout.trim().split('\n').filter(Boolean);
-            const SOURCE_EXTS = /\.(ts|js|tsx|jsx|py|go|rs|rb|java|cpp|cc|swift)$/;
             hasStagedSourceChanges = stagedFiles.some((f) => SOURCE_EXTS.test(f));
           } catch { /* git unavailable — skip */ }
         }

--- a/src/cli/commands/drift.ts
+++ b/src/cli/commands/drift.ts
@@ -42,6 +42,8 @@ import {
   hookManagerWarning,
   isResolvedGitRepository,
   resolveGitHookTarget,
+  resolveTrustedHookLauncher,
+  shellQuote,
   updateHookFile,
 } from '../git-hooks.js';
 
@@ -188,33 +190,19 @@ function usesShellInterpreter(shebang: string): boolean {
   return SHELL_INTERPRETERS.has(interpreter);
 }
 
-const HOOK_CONTENT = `
+const renderHookContent = (nodePath: string, cliPath: string) => `
 ${HOOK_MARKER}
 OPENLORE_DRIFT_PREVIOUS_EXIT=$?
 # Automatically check for spec drift before committing
 # Installed by: openlore drift --install-hook
 
-# Run openlore drift in static mode (fast, no LLM)
-# Prefer the repository-local binary so the hook checks with the same OpenLore
-# version as the repository. Fall back to the published package via npx only
-# when no local binary is installed; npx may download or use another version.
-if [ -x "./node_modules/.bin/openlore" ]; then
-  OPENLORE_DRIFT_COMMAND=./node_modules/.bin/openlore
-else
-  OPENLORE_DRIFT_COMMAND=npx
-fi
-
 # Bound both runtime and captured output. A broken/skewed launcher is an
 # infrastructure failure, never evidence of drift and never an unbounded commit hang.
-if OPENLORE_DRIFT_OUTPUT=$(node -e '
+if OPENLORE_DRIFT_OUTPUT=$(${shellQuote(nodePath)} -e '
 const { spawn, spawnSync } = require("node:child_process");
 const requestedCommand = process.argv[1];
-const command = process.platform === "win32"
-  ? (requestedCommand === "npx" ? "npx.cmd" : requestedCommand + ".cmd")
-  : requestedCommand;
-const args = requestedCommand === "npx"
-  ? ["--yes", "openlore", "drift", "--fail-on", "warning", "--json"]
-  : ["drift", "--fail-on", "warning", "--json"];
+const command = process.execPath;
+const args = [requestedCommand, "drift", "--fail-on", "warning", "--json"];
 const cap = 1024 * 1024;
 const stdoutChunks = [];
 const stderrChunks = [];
@@ -275,13 +263,13 @@ child.on("close", code => {
   if (launchError) console.error("openlore: drift launcher failed: " + launchError.message);
   process.exitCode = forcedReason || launchError ? 2 : (Number.isInteger(code) ? code : 2);
 });
-' "$OPENLORE_DRIFT_COMMAND"); then
+' ${shellQuote(cliPath)}); then
   OPENLORE_DRIFT_EXIT=0
 else
   OPENLORE_DRIFT_EXIT=$?
 fi
 
-if OPENLORE_DRIFT_VERDICT=$(printf '%s\n' "$OPENLORE_DRIFT_OUTPUT" | node -e '
+if OPENLORE_DRIFT_VERDICT=$(printf '%s\n' "$OPENLORE_DRIFT_OUTPUT" | ${shellQuote(nodePath)} -e '
 let input = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", chunk => { input += chunk; });
@@ -310,7 +298,7 @@ if [ "$OPENLORE_DRIFT_EXIT" -eq 1 ] && [ "$OPENLORE_DRIFT_VERDICT" = "drift" ]; 
   echo ""
   # Node is guaranteed by OpenLore. Sanitize repository-controlled strings
   # before printing them to a terminal and keep the summary bounded.
-  printf '%s\n' "$OPENLORE_DRIFT_OUTPUT" | node -e '
+  printf '%s\n' "$OPENLORE_DRIFT_OUTPUT" | ${shellQuote(nodePath)} -e '
 let input = "";
 const safe = value => Array.from(String(value ?? ""))
   .map(ch => { const code = ch.charCodeAt(0); return code < 32 || (code >= 127 && code <= 159) ? " " : ch; })
@@ -376,6 +364,9 @@ export async function installPreCommitHook(rootPath: string): Promise<void> {
     logger.warning(hookManagerWarning(target, 'openlore drift --fail-on warning --quiet'));
     return;
   }
+  const launcher = await resolveTrustedHookLauncher(rootPath);
+  if (!launcher) { logger.error('Cannot pin an OpenLore installation outside this repository. Install OpenLore globally and retry.'); process.exitCode = 2; return; }
+  const hookContent = renderHookContent(launcher.node, launcher.cli);
 
   let updated = false;
   let appended = false;
@@ -396,7 +387,7 @@ export async function installPreCommitHook(rootPath: string): Promise<void> {
       }
       if (block) {
         updated = true;
-        return existing.slice(0, block.start) + HOOK_CONTENT.trimEnd() + existing.slice(block.end);
+        return existing.slice(0, block.start) + hookContent.trimEnd() + existing.slice(block.end);
       }
     }
     appended = existing !== null;
@@ -406,8 +397,8 @@ export async function installPreCommitHook(rootPath: string): Promise<void> {
       return null;
     }
     return existing
-      ? existing.trimEnd() + '\n\n' + HOOK_CONTENT
-      : '#!/bin/sh\n\n' + HOOK_CONTENT;
+      ? existing.trimEnd() + '\n\n' + hookContent
+      : '#!/bin/sh\n\n' + hookContent;
   });
   if (result.status === 'unavailable') {
     logger.warning(`Cannot install the drift hook at ${displayHookPath(hookPath)}: ${result.reason}`);

--- a/src/cli/commands/enforce.test.ts
+++ b/src/cli/commands/enforce.test.ts
@@ -202,23 +202,19 @@ describe('enforce git hook install/uninstall', () => {
     const h = await readHook(root);
     expect(h.startsWith('#!/bin/sh')).toBe(true);
     expect(h).toContain('# openlore-enforcement-hook');
-    expect(h).toContain('enforce --hook');
-    expect(h).toContain('openlore enforce hook unavailable');
-    expect(h).toContain('ENFORCE_EXIT=1');
+    expect(h).toContain("'enforce' '--hook'");
+    expect(h).not.toContain('node_modules/.bin/openlore');
+    expect(h).not.toContain('command -v openlore');
   });
 
-  it('installed hook fails actionably when no compatible CLI can run', async () => {
+  it('pins an absolute launcher instead of relying on PATH', async () => {
     const root = await mkRepo();
     await mkdir(join(root, '.git'), { recursive: true });
     await installEnforcementHook(root);
 
-    await expect(execFileAsync('/bin/sh', [join(root, '.git', 'hooks', 'pre-commit')], {
-      cwd: root,
-      env: { ...process.env, PATH: '' },
-    })).rejects.toMatchObject({
-      code: 1,
-      stderr: expect.stringMatching(/hook unavailable.*install a compatible OpenLore CLI/i),
-    });
+    const h = await readHook(root);
+    expect(h).toContain(process.execPath);
+    expect(h).not.toContain('npx');
   });
 
   it('appends after an existing decisions-gate hook, stripping a trailing `exit 0`', async () => {
@@ -272,7 +268,7 @@ describe('enforce git hook install/uninstall', () => {
       cwd: root,
       env: { ...process.env, PATH: `${join(root, 'test-bin')}${delimiter}${process.env.PATH ?? ''}` },
     });
-    expect(await readFile(join(root, 'openlore-hook-ran'), 'utf-8')).toBe('ran');
+    await expect(readFile(join(root, 'openlore-hook-ran'), 'utf-8')).rejects.toThrow();
   });
 });
 

--- a/src/cli/commands/enforce.ts
+++ b/src/cli/commands/enforce.ts
@@ -70,6 +70,8 @@ import {
   hookManagerWarning,
   isResolvedGitRepository,
   resolveGitHookTarget,
+  resolveTrustedHookLauncher,
+  renderTrustedHookCommand,
   updateHookFile,
 } from '../git-hooks.js';
 
@@ -77,25 +79,11 @@ const HOOK_MARKER = '# openlore-enforcement-hook';
 const execFileAsync = promisify(execFile);
 const ENFORCEMENT_BASELINE_REPO_PATH = '.openlore/enforcement-baseline.jsonl';
 
-const HOOK_CONTENT = `${HOOK_MARKER}
+const renderHookContent = (command: string) => `${HOOK_MARKER}
 # Unified finding-enforcement gate before each commit.
 # Advisory by default; fails closed for configured blocking/frozen policy and unverifiable execution.
-if [ -f "./node_modules/.bin/openlore" ] && ./node_modules/.bin/openlore enforce --help 2>/dev/null | grep -q -- '--hook'; then
-  ./node_modules/.bin/openlore enforce --hook 2>&1
-  ENFORCE_EXIT=$?
-elif [ -f "./dist/cli/index.js" ] && node ./dist/cli/index.js enforce --help 2>/dev/null | grep -q -- '--hook'; then
-  node ./dist/cli/index.js enforce --hook 2>&1
-  ENFORCE_EXIT=$?
-else
-  OPENLORE=$(command -v openlore 2>/dev/null)
-  if [ -n "$OPENLORE" ] && "$OPENLORE" enforce --help 2>/dev/null | grep -q -- '--hook'; then
-    "$OPENLORE" enforce --hook 2>&1
-    ENFORCE_EXIT=$?
-  else
-    echo "openlore enforce hook unavailable: install a compatible OpenLore CLI or rebuild this checkout before committing." >&2
-    ENFORCE_EXIT=1
-  fi
-fi
+${command} 2>&1
+ENFORCE_EXIT=$?
 if [ "$ENFORCE_EXIT" -ne 0 ]; then
   exit "$ENFORCE_EXIT"
 fi
@@ -115,16 +103,24 @@ export async function installEnforcementHook(rootPath: string): Promise<void> {
     logger.warning(hookManagerWarning(target, 'openlore enforce --hook'));
     return;
   }
+  const launcher = await resolveTrustedHookLauncher(rootPath);
+  if (!launcher) {
+    logger.error('Cannot pin an OpenLore installation outside this repository. Install OpenLore globally and retry.');
+    process.exitCode = 1;
+    return;
+  }
+  const hookContent = renderHookContent(renderTrustedHookCommand(launcher, ['enforce', '--hook']));
   let alreadyInstalled = false;
   const result = await updateHookFile(hookPath, (existing) => {
     if (existing?.includes(HOOK_MARKER)) {
       alreadyInstalled = true;
-      return null;
+      const refreshed = existing.replace(/# openlore-enforcement-hook[\s\S]*?# end-openlore-enforcement-hook/, hookContent.trimEnd());
+      return refreshed === existing ? null : refreshed;
     }
     const stripped = existing?.trimEnd().replace(/\n*\nexit 0\s*$/, '');
     return stripped
-      ? stripped + '\n\n' + HOOK_CONTENT
-      : '#!/bin/sh\n\n' + HOOK_CONTENT;
+      ? stripped + '\n\n' + hookContent
+      : '#!/bin/sh\n\n' + hookContent;
   });
   if (result.status === 'unavailable') {
     logger.warning(`Cannot install the enforcement hook at ${displayHookPath(hookPath)}: ${result.reason}`);

--- a/src/cli/commands/impact-certificate.test.ts
+++ b/src/cli/commands/impact-certificate.test.ts
@@ -51,7 +51,7 @@ describe('impact-certificate git hook install/uninstall', () => {
     const h = await readHook(root);
     expect(h.startsWith('#!/bin/sh')).toBe(true);
     expect(h).toContain(HOOK_MARKER);
-    expect(h).toContain('impact-certificate --hook');
+    expect(h).toContain("'impact-certificate' '--hook'");
     expect(h).toContain('if [ "$CERT_EXIT" -ne 0 ]; then'); // advisory: only a configured severity propagates
   });
 

--- a/src/cli/commands/impact-certificate.ts
+++ b/src/cli/commands/impact-certificate.ts
@@ -25,29 +25,18 @@ import {
   hookManagerWarning,
   isResolvedGitRepository,
   resolveGitHookTarget,
+  resolveTrustedHookLauncher,
+  renderTrustedHookCommand,
   updateHookFile,
 } from '../git-hooks.js';
 
 const HOOK_MARKER = '# openlore-impact-certificate-hook';
 
-const HOOK_CONTENT = `${HOOK_MARKER}
+const renderHookContent = (command: string) => `${HOOK_MARKER}
 # Advisory change-impact certificate before each commit.
 # Advisory by default (exit 0); blocks only on a configured surface severity.
-if [ -f "./node_modules/.bin/openlore" ] && ./node_modules/.bin/openlore impact-certificate --help 2>/dev/null | grep -q -- '--hook'; then
-  ./node_modules/.bin/openlore impact-certificate --hook 2>&1
-  CERT_EXIT=$?
-elif [ -f "./dist/cli/index.js" ] && node ./dist/cli/index.js impact-certificate --help 2>/dev/null | grep -q -- '--hook'; then
-  node ./dist/cli/index.js impact-certificate --hook 2>&1
-  CERT_EXIT=$?
-else
-  OPENLORE=$(command -v openlore 2>/dev/null)
-  if [ -n "$OPENLORE" ] && "$OPENLORE" impact-certificate --help 2>/dev/null | grep -q -- '--hook'; then
-    "$OPENLORE" impact-certificate --hook 2>&1
-    CERT_EXIT=$?
-  else
-    CERT_EXIT=0
-  fi
-fi
+${command} 2>&1
+CERT_EXIT=$?
 if [ "$CERT_EXIT" -ne 0 ]; then
   exit "$CERT_EXIT"
 fi
@@ -67,11 +56,14 @@ export async function installImpactCertificateHook(rootPath: string): Promise<vo
     logger.warning(hookManagerWarning(target, 'openlore impact-certificate --hook'));
     return;
   }
+  const launcher = await resolveTrustedHookLauncher(rootPath);
+  if (!launcher) { logger.error('Cannot pin an OpenLore installation outside this repository. Install OpenLore globally and retry.'); process.exitCode = 1; return; }
+  const hookContent = renderHookContent(renderTrustedHookCommand(launcher, ['impact-certificate', '--hook']));
   let alreadyInstalled = false;
   const result = await updateHookFile(hookPath, (existing) => {
-    if (existing?.includes(HOOK_MARKER)) { alreadyInstalled = true; return null; }
+    if (existing?.includes(HOOK_MARKER)) { alreadyInstalled = true; const refreshed = existing.replace(/# openlore-impact-certificate-hook[\s\S]*?# end-openlore-impact-certificate-hook/, hookContent.trimEnd()); return refreshed === existing ? null : refreshed; }
     const stripped = existing?.trimEnd().replace(/\n*\nexit 0\s*$/, '');
-    return stripped ? stripped + '\n\n' + HOOK_CONTENT : '#!/bin/sh\n\n' + HOOK_CONTENT;
+    return stripped ? stripped + '\n\n' + hookContent : '#!/bin/sh\n\n' + hookContent;
   });
   if (result.status === 'unavailable') {
     logger.warning(`Cannot install the impact-certificate hook at ${displayHookPath(hookPath)}: ${result.reason}`);

--- a/src/cli/commands/local-http-guard.test.ts
+++ b/src/cli/commands/local-http-guard.test.ts
@@ -8,6 +8,9 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
   isLoopbackHost,
@@ -20,7 +23,26 @@ import {
   createBrowserSessionGuard,
   readCookie,
   parseAuthority,
+  writeInstanceDescriptor,
 } from './local-http-guard.js';
+
+describe('writeInstanceDescriptor', () => {
+  it('rejects an outbound descriptor symlink without modifying its target', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openlore-descriptor-root-'));
+    const outside = await mkdtemp(join(tmpdir(), 'openlore-descriptor-outside-'));
+    try {
+      await mkdir(join(root, '.openlore'));
+      const target = join(outside, 'target.json');
+      await writeFile(target, 'preserve');
+      await symlink(target, join(root, '.openlore', 'serve.json'));
+      await expect(writeInstanceDescriptor(root, join(root, '.openlore', 'serve.json'), { token: 'secret' })).rejects.toThrow(/blocked|symbolic/i);
+      expect(await readFile(target, 'utf-8')).toBe('preserve');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+});
 
 /** Minimal IncomingMessage stand-in — only headers/url are read by the guard. */
 function fakeReq(headers: Record<string, string | undefined>, url = '/'): IncomingMessage {

--- a/src/cli/commands/local-http-guard.ts
+++ b/src/cli/commands/local-http-guard.ts
@@ -19,9 +19,8 @@
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { timingSafeEqual } from 'node:crypto';
-import { mkdir, writeFile, chmod } from 'node:fs/promises';
-import { dirname } from 'node:path';
 import { LOOPBACK_HOSTNAMES, isLoopbackHost } from '../../utils/loopback.js';
+import { confinedAtomicWriteFile } from '../../utils/path-confinement.js';
 
 /** Header a client presents to authenticate to a local OpenLore HTTP surface. */
 export const OPENLORE_TOKEN_HEADER = 'x-openlore-token';
@@ -121,15 +120,16 @@ export function constantTimeEqual(a: string, b: string): boolean {
  * pre-created by another local user) would otherwise keep its permissive mode.
  */
 export async function writeInstanceDescriptor(
+  rootPath: string,
   descriptorPath: string,
   value: unknown,
 ): Promise<void> {
-  await mkdir(dirname(descriptorPath), { recursive: true, mode: 0o700 });
-  await writeFile(descriptorPath, JSON.stringify(value, null, 2) + '\n', {
-    encoding: 'utf-8',
-    mode: 0o600,
-  });
-  await chmod(descriptorPath, 0o600);
+  await confinedAtomicWriteFile(
+    rootPath,
+    descriptorPath,
+    JSON.stringify(value, null, 2) + '\n',
+    { mode: 0o600 },
+  );
 }
 
 /**

--- a/src/cli/commands/mcp.conformance.integration.test.ts
+++ b/src/cli/commands/mcp.conformance.integration.test.ts
@@ -24,6 +24,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { ErrorCode, SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/sdk/types.js';
 import { TOOL_DEFINITIONS, TOOL_PRESETS } from './mcp.js';
 import { startServe } from './serve.js';
+import { SERVE_PROTOCOL_VERSION } from './serve-descriptor.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../');
 const MCP_BIN = join(REPO_ROOT, 'dist/cli/index.js');
@@ -401,6 +402,7 @@ describe('spec — lean default surface + breadth pointer (via SDK Client over s
         res.writeHead(200, { 'content-type': 'application/json' });
         res.end(JSON.stringify({
           ok: true,
+          protocolVersion: SERVE_PROTOCOL_VERSION,
           presetDispatchEnforced: true,
           root: dir,
           pid: process.pid,
@@ -429,6 +431,7 @@ describe('spec — lean default surface + breadth pointer (via SDK Client over s
       port: address.port,
       pid: process.pid,
       host: '127.0.0.1',
+      protocolVersion: SERVE_PROTOCOL_VERSION,
       startedAt: new Date().toISOString(),
       version: 'test',
     }));

--- a/src/cli/commands/refresh-stories.ts
+++ b/src/cli/commands/refresh-stories.ts
@@ -19,6 +19,8 @@ import {
   hookManagerWarning,
   isResolvedGitRepository,
   resolveGitHookTarget,
+  resolveTrustedHookLauncher,
+  renderTrustedHookCommand,
   updateHookFile,
 } from '../git-hooks.js';
 
@@ -28,12 +30,12 @@ import {
 
 const HOOK_MARKER = '# openlore-refresh-hook';
 
-const HOOK_CONTENT = `
+const renderHookContent = (command: string) => `
 ${HOOK_MARKER}
 # Automatically refresh stale risk_context in story files after structural changes.
 # Installed by: openlore refresh-stories --install-hook
 
-npx --yes openlore refresh-stories 2>/dev/null || true
+${command} 2>/dev/null || true
 # end-openlore-refresh-hook
 `.trimStart();
 
@@ -50,12 +52,15 @@ export async function installPostCommitHook(rootPath: string): Promise<void> {
     logger.warning(hookManagerWarning(target, 'openlore refresh-stories'));
     return;
   }
+  const launcher = await resolveTrustedHookLauncher(rootPath);
+  if (!launcher) { logger.error('Cannot pin an OpenLore installation outside this repository. Install OpenLore globally and retry.'); process.exitCode = 1; return; }
+  const hookContent = renderHookContent(renderTrustedHookCommand(launcher, ['refresh-stories']));
   let alreadyInstalled = false;
   let appended = false;
   const result = await updateHookFile(hookPath, (existing) => {
-    if (existing?.includes(HOOK_MARKER)) { alreadyInstalled = true; return null; }
+    if (existing?.includes(HOOK_MARKER)) { alreadyInstalled = true; const refreshed = existing.replace(/# openlore-refresh-hook[\s\S]*?# end-openlore-refresh-hook/, hookContent.trimEnd()); return refreshed === existing ? null : refreshed; }
     appended = existing !== null;
-    return existing ? existing.trimEnd() + '\n\n' + HOOK_CONTENT : '#!/bin/sh\n\n' + HOOK_CONTENT;
+    return existing ? existing.trimEnd() + '\n\n' + hookContent : '#!/bin/sh\n\n' + hookContent;
   });
   if (result.status === 'unavailable') {
     logger.warning(`Cannot install the refresh-stories hook at ${displayHookPath(hookPath)}: ${result.reason}`);

--- a/src/cli/commands/serve-descriptor.test.ts
+++ b/src/cli/commands/serve-descriptor.test.ts
@@ -22,11 +22,13 @@ import {
   validateServeHealth,
   readServeDescriptor,
   serveHttpBaseUrl,
+  SERVE_PROTOCOL_VERSION,
 } from './serve-descriptor.js';
 
-const HEALTHY = { port: 8080, pid: 4242, host: '127.0.0.1', token: 't', startedAt: 's', version: 'v' };
+const HEALTHY = { port: 8080, pid: 4242, host: '127.0.0.1', token: 't', protocolVersion: SERVE_PROTOCOL_VERSION, startedAt: 's', version: 'v' } as const;
 const HEALTH = {
   ok: true,
+  protocolVersion: SERVE_PROTOCOL_VERSION,
   presetDispatchEnforced: true,
   root: '/tmp/project',
   pid: 4242,
@@ -97,13 +99,19 @@ describe('validateServeDescriptor', () => {
   });
 
   it('normalizes missing/ill-typed startedAt and version to empty strings', () => {
-    const d = validateServeDescriptor({ port: 8080, pid: 1, host: '127.0.0.1' });
-    expect(d).toEqual({ port: 8080, pid: 1, host: '127.0.0.1', token: undefined, startedAt: '', version: '' });
+    const d = validateServeDescriptor({ port: 8080, pid: 1, host: '127.0.0.1', protocolVersion: SERVE_PROTOCOL_VERSION });
+    expect(d).toEqual({ port: 8080, pid: 1, host: '127.0.0.1', token: undefined, protocolVersion: SERVE_PROTOCOL_VERSION, startedAt: '', version: '' });
   });
 
   it('accepts an absent token but rejects a non-string one', () => {
-    expect(validateServeDescriptor({ port: 8080, pid: 1, host: '127.0.0.1' })).not.toBeNull();
-    expect(validateServeDescriptor({ port: 8080, pid: 1, host: '127.0.0.1', token: 5 })).toBeNull();
+    expect(validateServeDescriptor({ port: 8080, pid: 1, host: '127.0.0.1', protocolVersion: SERVE_PROTOCOL_VERSION })).not.toBeNull();
+    expect(validateServeDescriptor({ port: 8080, pid: 1, host: '127.0.0.1', protocolVersion: SERVE_PROTOCOL_VERSION, token: 5 })).toBeNull();
+  });
+
+  it('rejects legacy or incompatible daemon protocols', () => {
+    expect(validateServeDescriptor({ ...HEALTHY, protocolVersion: undefined })).toBeNull();
+    expect(validateServeDescriptor({ ...HEALTHY, protocolVersion: SERVE_PROTOCOL_VERSION + 1 })).toBeNull();
+    expect(validateServeHealth({ ...HEALTH, protocolVersion: SERVE_PROTOCOL_VERSION + 1 }, '/tmp/project', HEALTHY)).toBeNull();
   });
 
   it('accepts only the ready/draining lifecycle states', () => {

--- a/src/cli/commands/serve-descriptor.ts
+++ b/src/cli/commands/serve-descriptor.ts
@@ -30,6 +30,9 @@ import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { isLoopbackHost } from './local-http-guard.js';
 
+/** Increment only when the daemon HTTP tool/health contract becomes incompatible. */
+export const SERVE_PROTOCOL_VERSION = 1;
+
 /**
  * The validated daemon-discovery descriptor. `startedAt` / `version` are
  * advisory metadata (normalized to '' when absent or ill-typed); the other four
@@ -41,6 +44,7 @@ export interface ServeDescriptor {
   pid: number;
   host: string;
   token?: string;
+  protocolVersion: typeof SERVE_PROTOCOL_VERSION;
   startedAt: string;
   version: string;
   state?: 'ready' | 'draining';
@@ -48,6 +52,7 @@ export interface ServeDescriptor {
 
 export interface ServeHealth {
   ok: true;
+  protocolVersion: typeof SERVE_PROTOCOL_VERSION;
   presetDispatchEnforced: true;
   root: string;
   pid: number;
@@ -57,6 +62,11 @@ export interface ServeHealth {
   tokenAuthenticated: boolean;
   draining: boolean;
 }
+
+export type ServeDescriptorRead =
+  | { kind: 'compatible'; descriptor: ServeDescriptor }
+  | { kind: 'incompatible'; descriptor: { port: number; pid: number; host: string; token?: string } }
+  | { kind: 'absent' };
 
 /** Build the loopback HTTP origin, including the brackets required by IPv6 URLs. */
 export function serveHttpBaseUrl(host: string, port: number): string {
@@ -79,12 +89,13 @@ export function canonicalServeRoot(root: string): string {
 export function validateServeHealth(
   parsed: unknown,
   expectedRoot: string,
-  descriptor?: Pick<ServeDescriptor, 'pid' | 'token'>,
+  descriptor?: Pick<ServeDescriptor, 'pid' | 'token' | 'protocolVersion'>,
 ): ServeHealth | null {
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
   const h = parsed as Record<string, unknown>;
   if (
     h.ok !== true
+    || h.protocolVersion !== SERVE_PROTOCOL_VERSION
     || h.presetDispatchEnforced !== true
     || typeof h.root !== 'string'
     || canonicalServeRoot(h.root) !== canonicalServeRoot(expectedRoot)
@@ -98,10 +109,12 @@ export function validateServeHealth(
     || h.tokenAuthenticated !== true
     || typeof h.draining !== 'boolean'
     || (descriptor !== undefined && h.pid !== descriptor.pid)
+    || (descriptor !== undefined && descriptor.protocolVersion !== h.protocolVersion)
     || (descriptor !== undefined && h.tokenProtected !== Boolean(descriptor.token))
   ) return null;
   return {
     ok: true,
+    protocolVersion: SERVE_PROTOCOL_VERSION,
     presetDispatchEnforced: true,
     root: canonicalServeRoot(h.root),
     pid: h.pid,
@@ -128,14 +141,16 @@ export function validateServeDescriptor(parsed: unknown): ServeDescriptor | null
   // outbound fetch target during liveness probing (egress / SSRF).
   const hostOk = typeof d.host === 'string' && isLoopbackHost(d.host);
   const tokenOk = d.token === undefined || typeof d.token === 'string';
+  const protocolOk = d.protocolVersion === SERVE_PROTOCOL_VERSION;
   const stateOk = d.state === undefined || d.state === 'ready' || d.state === 'draining';
-  if (!portOk || !pidOk || !hostOk || !tokenOk || !stateOk) return null;
+  if (!portOk || !pidOk || !hostOk || !tokenOk || !protocolOk || !stateOk) return null;
   const state = d.state === 'ready' || d.state === 'draining' ? d.state : undefined;
   return {
     port: d.port as number,
     pid: d.pid as number,
     host: d.host as string,
     token: d.token as string | undefined,
+    protocolVersion: SERVE_PROTOCOL_VERSION,
     startedAt: typeof d.startedAt === 'string' ? d.startedAt : '',
     version: typeof d.version === 'string' ? d.version : '',
     ...(state === undefined ? {} : { state }),
@@ -160,4 +175,52 @@ export async function readServeDescriptor(
   }
   const descriptor = validateServeDescriptor(parsed);
   return descriptor?.state === 'draining' && !options.includeDraining ? null : descriptor;
+}
+
+/** Distinguish a narrowly safe legacy/incompatible announcement from absence. */
+export async function readServeDescriptorState(
+  descriptorPath: string,
+  options: { includeDraining?: boolean } = {},
+): Promise<ServeDescriptorRead> {
+  let parsed: unknown;
+  try { parsed = JSON.parse(await readFile(descriptorPath, 'utf-8')); } catch { return { kind: 'absent' }; }
+  const descriptor = validateServeDescriptor(parsed);
+  if (descriptor) {
+    if (descriptor.state === 'draining' && !options.includeDraining) return { kind: 'absent' };
+    return { kind: 'compatible', descriptor };
+  }
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    const d = parsed as Record<string, unknown>;
+    const safe = typeof d.port === 'number' && Number.isInteger(d.port) && d.port >= 1 && d.port <= 65535
+      && typeof d.pid === 'number' && Number.isInteger(d.pid) && d.pid > 0
+      && typeof d.host === 'string' && isLoopbackHost(d.host)
+      && (d.token === undefined || typeof d.token === 'string');
+    if (safe && d.protocolVersion !== SERVE_PROTOCOL_VERSION) return {
+      kind: 'incompatible',
+      descriptor: { port: d.port as number, pid: d.pid as number, host: d.host as string, ...(typeof d.token === 'string' ? { token: d.token } : {}) },
+    };
+  }
+  return { kind: 'absent' };
+}
+
+/** A stale legacy file must not become a permanent repository-local denial of service. */
+export async function incompatibleServeDescriptorIsLive(
+  descriptor: { port: number; pid: number; host: string; token?: string },
+  expectedRoot: string,
+): Promise<boolean> {
+  try {
+    const response = await fetch(`${serveHttpBaseUrl(descriptor.host, descriptor.port)}/health`, {
+      headers: descriptor.token ? { 'x-openlore-token': descriptor.token } : undefined,
+      signal: AbortSignal.timeout(500),
+      redirect: 'error',
+    });
+    if (!response.ok) return false;
+    const health = await response.json().catch(() => null) as Record<string, unknown> | null;
+    return health?.ok === true
+      && health.pid === descriptor.pid
+      && typeof health.root === 'string'
+      && canonicalServeRoot(health.root) === canonicalServeRoot(expectedRoot);
+  } catch {
+    return false;
+  }
 }

--- a/src/cli/commands/serve.test.ts
+++ b/src/cli/commands/serve.test.ts
@@ -15,6 +15,7 @@ import { createServer, request as httpRequest } from 'node:http';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { DatabaseSync } from 'node:sqlite';
 import { startServe, readDescriptor, idleTimeoutMs, drainServeRebuilds, type ServeHandle } from './serve.js';
+import { SERVE_PROTOCOL_VERSION } from './serve-descriptor.js';
 import { TOOL_PRESETS } from './mcp.js';
 import { EdgeStore } from '../../core/services/edge-store.js';
 import * as analyzeApi from '../../api/analyze.js';
@@ -82,7 +83,13 @@ describe('host-scoped cold-read repair', () => {
 async function boot(opts: { token?: string; preset?: string } = {}): Promise<ServeHandle> {
   root = await mkdtemp(join(tmpdir(), 'openlore-serve-'));
   // watch:false — these are transport tests; the watcher has its own coverage.
-  const h = await startServe({ directory: root, port: '0', watch: false, ...opts });
+  const h = await startServe({
+    directory: root,
+    port: '0',
+    watch: false,
+    allowUnauthenticatedForTesting: opts.token === undefined,
+    ...opts,
+  });
   if (!h) throw new Error('startServe returned no handle');
   handle = h;
   return h;
@@ -249,6 +256,7 @@ describe('idle self-shutdown', () => {
         directory: dir,
         port: '0',
         watch: false,
+        allowUnauthenticatedForTesting: true,
         preset: 'navigation',
         idleTimeout: '0.01',
       });
@@ -274,7 +282,7 @@ describe('idle self-shutdown', () => {
     const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
     const dir = await mkdtemp(join(tmpdir(), 'openlore-idle-'));
     try {
-      const h = await startServe({ directory: dir, port: '0', watch: false, idleTimeout: '0' });
+      const h = await startServe({ directory: dir, port: '0', watch: false, idleTimeout: '0', allowUnauthenticatedForTesting: true });
       await sleep(700);
       expect(exit).not.toHaveBeenCalled();
       expect(await readDescriptor(dir)).not.toBeNull(); // still serving
@@ -308,6 +316,18 @@ describe('openlore serve', () => {
     // A governance read that IS in substrate but NOT in navigation — proves the
     // default is the both-faces surface, not the navigate-only escape.
     expect(body.tools).toContain('recall');
+  });
+
+  it('protects a default daemon with a generated descriptor token', async () => {
+    root = await mkdtemp(join(tmpdir(), 'openlore-serve-protected-default-'));
+    const h = await startServe({ directory: root, port: '0', watch: false });
+    expect(h?.token).toMatch(/^[0-9a-f]{48}$/);
+    handle = h;
+    expect(await jsonOf(await fetch(`${h!.baseUrl}/health`))).toEqual({ ok: true, tokenProtected: true });
+    const authenticated = await jsonOf(await fetch(`${h!.baseUrl}/health`, {
+      headers: { 'x-openlore-token': h!.token! },
+    }));
+    expect(authenticated).toMatchObject({ root: await realpath(root), tokenAuthenticated: true });
   });
 
   it('writes serve.json on start and removes it on close', async () => {
@@ -513,8 +533,7 @@ describe('openlore serve', () => {
     // /health stays public for liveness but reports whether the candidate token
     // actually authenticated, so descriptor consumers can fail closed.
     const publicHealth = await jsonOf(await fetch(`${h.baseUrl}/health`));
-    expect(publicHealth.tokenProtected).toBe(true);
-    expect(publicHealth.tokenAuthenticated).toBe(false);
+    expect(publicHealth).toEqual({ ok: true, tokenProtected: true });
     const authenticatedHealth = await jsonOf(await fetch(`${h.baseUrl}/health`, {
       headers: { 'x-openlore-token': 'sekret' },
     }));
@@ -544,7 +563,7 @@ describe('openlore serve', () => {
     // (pid 1). The health probe must fail → file removed, no shutdown request.
     await writeFile(
       descPath,
-      JSON.stringify({ port: 1, pid: 1, host: '127.0.0.1', version: 'x', startedAt: '' }),
+      JSON.stringify({ port: 1, pid: 1, host: '127.0.0.1', protocolVersion: SERVE_PROTOCOL_VERSION, version: 'x', startedAt: '' }),
       'utf-8',
     );
     const h = await startServe({ directory: root, stop: true });
@@ -608,7 +627,7 @@ describe('openlore serve', () => {
     }
 
     // A well-formed loopback descriptor is accepted.
-    await write({ port: 8080, pid: 1, host: '127.0.0.1', version: 'x', startedAt: '', token: 't' });
+    await write({ port: 8080, pid: 1, host: '127.0.0.1', protocolVersion: SERVE_PROTOCOL_VERSION, version: 'x', startedAt: '', token: 't' });
     const ok = await readDescriptor(root);
     expect(ok).not.toBeNull();
     expect(ok!.host).toBe('127.0.0.1');
@@ -619,7 +638,7 @@ describe('openlore serve', () => {
     const h1 = await boot();
     // Second start for the same root must detect the live daemon and return its
     // endpoint (same port), not bind a new server.
-    const h2 = await startServe({ directory: root, port: '0', watch: false });
+    const h2 = await startServe({ directory: root, port: '0', watch: false, allowUnauthenticatedForTesting: true });
     expect(h2).toBeDefined();
     expect(h2!.port).toBe(h1.port);
     // close() on the reused handle is a no-op — must not tear down h1.
@@ -672,7 +691,7 @@ describe('openlore serve', () => {
     const descriptor = await readDescriptor(root);
     await writeFile(path, JSON.stringify({ ...descriptor!, state: 'draining' }));
 
-    const reused = await startServe({ directory: root, port: '0', watch: false });
+    const reused = await startServe({ directory: root, port: '0', watch: false, allowUnauthenticatedForTesting: true });
     expect(reused?.port).toBe(first.port);
     expect((await readDescriptor(root))?.state).toBe('ready');
     await reused!.close();
@@ -774,7 +793,10 @@ describe('openlore serve', () => {
         expect(output.join('')).toContain('reusing');
       }, { timeout: 15_000, interval: 50 });
 
-      await fetch(`http://${descriptor!.host}:${descriptor!.port}/shutdown`, { method: 'POST' });
+      await fetch(`http://${descriptor!.host}:${descriptor!.port}/shutdown`, {
+        method: 'POST',
+        headers: { 'x-openlore-token': descriptor!.token! },
+      });
       await vi.waitFor(() => expect(winner.exitCode).not.toBeNull(), { timeout: 15_000, interval: 50 });
     } finally {
       await Promise.all(children.map(terminateChild));
@@ -841,7 +863,7 @@ describe('openlore serve', () => {
 
   it('treats all and full as the same security surface when reusing a daemon', async () => {
     const h1 = await boot({ preset: 'full' });
-    const h2 = await startServe({ directory: root, port: '0', watch: false, preset: 'all' });
+    const h2 = await startServe({ directory: root, port: '0', watch: false, preset: 'all', allowUnauthenticatedForTesting: true });
     expect(h2).toBeDefined();
     expect(h2!.port).toBe(h1.port);
   });
@@ -910,6 +932,7 @@ describe('openlore serve', () => {
       pid: process.pid,
       host: '127.0.0.1',
       token: 'descriptor-token',
+      protocolVersion: SERVE_PROTOCOL_VERSION,
       startedAt: '',
       version: 'test',
     }));
@@ -968,6 +991,7 @@ describe('openlore serve', () => {
       port: address.port,
       pid: process.pid,
       host: '127.0.0.1',
+      protocolVersion: SERVE_PROTOCOL_VERSION,
       startedAt: '',
       version: '2.1.6',
     }));
@@ -978,6 +1002,7 @@ describe('openlore serve', () => {
         port: '0',
         watch: false,
         preset: 'navigation',
+        allowUnauthenticatedForTesting: true,
       });
       expect(reused).toBeUndefined();
       expect(process.exitCode).toBe(1);
@@ -1107,7 +1132,13 @@ describe('openlore serve', () => {
   it('refuses a non-loopback bind without a token', async () => {
     root = await mkdtemp(join(tmpdir(), 'openlore-serve-'));
     const prev = process.exitCode;
-    const h = await startServe({ directory: root, port: '0', watch: false, host: '0.0.0.0' });
+    const h = await startServe({
+      directory: root,
+      port: '0',
+      watch: false,
+      host: '0.0.0.0',
+      allowUnauthenticatedForTesting: true,
+    });
     expect(h).toBeUndefined();
     expect(process.exitCode).toBe(1);
     expect(await fileExists(join(root, OPENLORE_DIR))).toBe(false);
@@ -1192,7 +1223,7 @@ describe('openlore serve', () => {
     expect(health1.ok).toBe(true);
 
     // Second startServe → reuse path, no second server bound.
-    const h2 = await startServe({ directory: root, port: '0', watch: false });
+    const h2 = await startServe({ directory: root, port: '0', watch: false, allowUnauthenticatedForTesting: true });
     expect(h2!.port).toBe(h1.port); // same port = same server
 
     // Original server still alive after h2.close()

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -36,6 +36,7 @@
 import { Command } from 'commander';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createRequire } from 'node:module';
+import { randomBytes } from 'node:crypto';
 import { access, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { logger } from '../../utils/logger.js';
@@ -59,9 +60,12 @@ import {
 } from './local-http-guard.js';
 import {
   readServeDescriptor,
+  readServeDescriptorState,
+  incompatibleServeDescriptorIsLive,
   canonicalServeRoot,
   serveHttpBaseUrl,
   validateServeHealth,
+  SERVE_PROTOCOL_VERSION,
   type ServeDescriptor,
   type ServeHealth,
 } from './serve-descriptor.js';
@@ -184,6 +188,8 @@ interface ServeCliOptions {
   idleTimeout?: string;
   /** Internal test seam; the CLI always uses the production startup-lock bound. */
   startupLockWaitMs?: number;
+  /** Internal test seam for legacy unauthenticated transport cases. */
+  allowUnauthenticatedForTesting?: boolean;
 }
 
 /** Live daemon handle. Returned by {@link startServe} so callers (tests) can
@@ -295,6 +301,17 @@ async function probeDaemon(
 /** Stop the verified daemon and wait until its listener has actually closed. */
 async function stopDaemon(root: string): Promise<boolean> {
   const path = serveFilePath(root);
+  const announced = await readServeDescriptorState(path, { includeDraining: true });
+  if (announced.kind === 'incompatible') {
+    if (await incompatibleServeDescriptorIsLive(announced.descriptor, root)) {
+      logger.error('A legacy or incompatible OpenLore daemon is announced for this repository. Stop it with the matching OpenLore version before upgrading.');
+      process.exitCode = 1;
+      return false;
+    }
+    await unlink(path).catch(() => {});
+    logger.warning(`Removed stale incompatible ${SERVE_FILE}.`);
+    return true;
+  }
   const desc = await readDescriptor(root);
   if (!desc) {
     logger.warning(`No running openlore serve daemon found for ${root}.`);
@@ -306,7 +323,7 @@ async function stopDaemon(root: string): Promise<boolean> {
       // A stopper can die after publishing draining but before POST /shutdown.
       // The verified daemon says no teardown began, so resume the stop safely.
       desc.state = 'ready';
-      await writeInstanceDescriptor(path, desc);
+      await writeInstanceDescriptor(root, path, desc);
     } else {
     const deadline = Date.now() + SERVE_STOP_WAIT_MS;
     while (Date.now() < deadline) {
@@ -333,7 +350,7 @@ async function stopDaemon(root: string): Promise<boolean> {
   }
   try {
     const headers = desc.token ? { [OPENLORE_TOKEN_HEADER]: desc.token } : undefined;
-    await writeInstanceDescriptor(path, { ...desc, state: 'draining' });
+    await writeInstanceDescriptor(root, path, { ...desc, state: 'draining' });
     // INTENTIONAL EGRESS: the authenticated health probe bound this loopback descriptor to this repo.
     // codeql[js/file-access-to-http]
     const res = await fetch(`${serveHttpBaseUrl(desc.host, desc.port)}/shutdown`, {
@@ -358,7 +375,7 @@ async function stopDaemon(root: string): Promise<boolean> {
     process.exitCode = 1;
     return false;
   } catch {
-    await writeInstanceDescriptor(path, { ...desc, state: 'ready' }).catch(() => {});
+    await writeInstanceDescriptor(root, path, { ...desc, state: 'ready' }).catch(() => {});
     logger.warning('The verified daemon did not accept the shutdown request.');
     return false;
   }
@@ -367,7 +384,10 @@ async function stopDaemon(root: string): Promise<boolean> {
 export async function startServe(options: ServeCliOptions): Promise<ServeHandle | undefined> {
   const root = canonicalServeRoot(options.directory ?? process.cwd());
   const host = options.host ?? '127.0.0.1';
-  const token = options.token ?? (process.env.OPENLORE_SERVE_TOKEN || undefined);
+  const configuredToken = options.token ?? process.env.OPENLORE_SERVE_TOKEN;
+  let token = options.allowUnauthenticatedForTesting
+    ? undefined
+    : configuredToken || randomBytes(24).toString('hex');
   const discoveryHost = discoveryHostForBind(host);
   const presetName = options.preset ?? LEAN_DEFAULT_PRESET;
   const isFullSurface = presetName === FULL_PRESET_ALIAS || presetName === FULL_PRESET;
@@ -505,14 +525,29 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
   // Don't start a second daemon for a root already served by a healthy one —
   // a concurrent spawn (two MCP clients, or pi + MCP) would otherwise leave two
   // watchers racing on the same .openlore/analysis. Reuse the live one instead.
+  const announcedDescriptor = await readServeDescriptorState(serveFilePath(root), { includeDraining: true });
+  if (announcedDescriptor.kind === 'incompatible') {
+    if (await incompatibleServeDescriptorIsLive(announcedDescriptor.descriptor, root)) {
+      logger.error('A legacy or incompatible OpenLore daemon is already announced for this repository. Stop it with the matching OpenLore version before starting this release.');
+      process.exitCode = 1;
+      return;
+    }
+    await unlink(serveFilePath(root)).catch(() => {});
+  }
   let existing = await readDescriptor(root);
+  if (!options.allowUnauthenticatedForTesting && !configuredToken && existing?.token) {
+    // A generated token is instance state, not launch configuration. Reuse the
+    // descriptor's owner-only token instead of generating a different one and
+    // falsely reporting a posture mismatch on every default invocation.
+    token = existing.token;
+  }
   if (existing?.state === 'draining') {
     const drainingProbe = await probeDaemon(existing, root);
     if (drainingProbe.health && !drainingProbe.health.draining) {
       // Recover a stopper that crashed between publishing draining and sending
       // the shutdown request. Identity/token/root were proved by the probe.
       existing.state = 'ready';
-      await writeInstanceDescriptor(serveFilePath(root), existing);
+      await writeInstanceDescriptor(root, serveFilePath(root), existing);
     } else {
     const deadline = Date.now() + SERVE_STOP_WAIT_MS;
     while (Date.now() < deadline && existing?.state === 'draining') {
@@ -690,12 +725,13 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
       // the repository path, PID, version, preset, or tool surface to a remote caller
       // that merely supplies the allowed wildcard Host header. Authenticated clients
       // still receive the full root-bound identity proof used by descriptor validation.
-      if (!isLoopbackHost(host) && token && !tokenAuthenticated) {
+      if (token && !tokenAuthenticated) {
         sendJson(res, 200, { ok: true, tokenProtected: true });
         return;
       }
       sendJson(res, 200, {
         ok: true,
+        protocolVersion: SERVE_PROTOCOL_VERSION,
         presetDispatchEnforced: true,
         version: _pkgVersion,
         root,
@@ -976,7 +1012,7 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
       const announced = await readDescriptor(root);
       if (announced?.state === 'draining') return true;
       try {
-        await writeInstanceDescriptor(serveFilePath(root), { ...descriptor, state: 'draining' });
+        await writeInstanceDescriptor(root, serveFilePath(root), { ...descriptor, state: 'draining' });
         return true;
       } catch (err) {
         logger.warning(
@@ -1027,12 +1063,13 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
     pid: process.pid,
     host: discoveryHost,
     token,
+    protocolVersion: SERVE_PROTOCOL_VERSION,
     startedAt,
     version: _pkgVersion,
     state: 'ready',
   };
   try {
-    await writeInstanceDescriptor(serveFilePath(root), descriptor);
+    await writeInstanceDescriptor(root, serveFilePath(root), descriptor);
   } catch (err) {
     await releaseStartupLock();
     await teardown();
@@ -1075,7 +1112,7 @@ export const serveCommand = new Command('serve')
     `Callable tool surface enforced at dispatch (navigation, substrate, minimal, or all/full). Default: ${LEAN_DEFAULT_PRESET}`,
     LEAN_DEFAULT_PRESET,
   )
-  .option('--token <token>', 'Require this token as the x-openlore-token header (default: $OPENLORE_SERVE_TOKEN)')
+  .option('--token <token>', 'Require this token as the x-openlore-token header (default: $OPENLORE_SERVE_TOKEN or a generated per-daemon token)')
   .option('--no-watch', 'Disable the freshness watcher + debounced call-graph re-analyze')
   .option('--idle-timeout <minutes>', `Self-terminate after this many minutes with no requests, so orphaned daemons can't pile up in RAM (0 disables). Default: ${DEFAULT_IDLE_TIMEOUT_MIN}`)
   .option('--stop', 'Stop a running daemon for --directory and exit')

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -28,6 +28,7 @@ import { validatePanicSignal, readPanicTelemetry } from '../../core/services/mcp
 import type { PanicGateReport } from '../../core/services/mcp-handlers/panic-validation.js';
 import type { PanicResponseMode } from '../../types/index.js';
 import { atomicWriteFile } from '../../core/decisions/atomic-store.js';
+import { confinedAtomicWriteFile, safeJoin } from '../../utils/path-confinement.js';
 
 // ============================================================================
 // TYPES
@@ -108,15 +109,18 @@ async function detectOmoa(projectRoot: string): Promise<boolean> {
 async function copyFile(
   src: string,
   dest: string,
+  confinementRoot: string,
   force: boolean,
   transform?: (content: string) => string,
 ): Promise<'created' | 'updated' | 'skipped'> {
-  const exists = await fileExists(dest);
+  const confinedDest = safeJoin(confinementRoot, relative(confinementRoot, dest));
+  const exists = await fileExists(confinedDest);
   if (exists && !force) return 'skipped';
   const raw = await readFile(src, 'utf-8');
   const content = transform ? transform(raw) : raw;
-  await mkdir(dirname(dest), { recursive: true });
-  await writeFile(dest, content, 'utf-8');
+  await mkdir(dirname(confinedDest), { recursive: true });
+  const verifiedDest = safeJoin(confinementRoot, relative(confinementRoot, confinedDest));
+  await confinedAtomicWriteFile(confinementRoot, verifiedDest, content, { preserveMode: true });
   return exists ? 'updated' : 'created';
 }
 
@@ -277,16 +281,19 @@ async function runSetup(
         logger.warning(`setup: source not found — ${entry.src} (re-install openlore to fix)`);
         continue;
       }
+      const confinementRoot = tool === 'pi' && piGlobal ? homedir() : projectRoot;
+      const confinedDest = safeJoin(confinementRoot, relative(confinementRoot, entry.dest));
       // Remove the old .ts counterpart when installing the .js Pi extension.
       // Prior versions of setup distributed openlore.ts; Pi loads all files in the
       // extensions dir, so both registering the same tools causes a conflict.
-      if (tool === 'pi' && entry.dest.endsWith('.js')) {
-        const oldTs = entry.dest.slice(0, -3) + '.ts';
+      if (tool === 'pi' && confinedDest.endsWith('.js')) {
+        const oldTs = safeJoin(confinementRoot, relative(confinementRoot, confinedDest.slice(0, -3) + '.ts'));
         if (await fileExists(oldTs)) await unlink(oldTs);
       }
       const status = await copyFile(
         entry.src,
-        entry.dest,
+        confinedDest,
+        confinementRoot,
         force,
         /[/\\]SKILL\.md$/.test(entry.dest) ? content => adaptSkillForHost(content, tool) : undefined,
       );
@@ -514,7 +521,8 @@ async function readClaudeSettings(settingsPath: string): Promise<ClaudeHookSetti
 
 /** Install `openlore panic-check` as a PreToolUse hook (idempotent). */
 export async function installPanicCheckHook(rootPath: string, format: string = 'claude'): Promise<void> {
-  const settingsPath = join(rootPath, '.claude', 'settings.json');
+  const settingsPath = await verifiedCheckEditSettingsPath(rootPath, true);
+  if (!settingsPath) return;
   let settings: ClaudeHookSettings;
   try { settings = await readClaudeSettings(settingsPath); }
   catch (e) { logger.error((e as Error).message); return; }
@@ -537,21 +545,20 @@ export async function installPanicCheckHook(rootPath: string, format: string = '
     updated[existingIdx] = hookEntry;
     settings.hooks ??= {};
     settings.hooks.PreToolUse = updated;
-    await mkdir(join(rootPath, '.claude'), { recursive: true });
-    await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+    await confinedAtomicWriteFile(rootPath, settingsPath, JSON.stringify(settings, null, 2) + '\n', { preserveMode: true });
     logger.success(`panic-check PreToolUse hook updated to format: ${format}`);
     return;
   }
   settings.hooks ??= {};
   settings.hooks.PreToolUse = [...hooks, hookEntry];
-  await mkdir(join(rootPath, '.claude'), { recursive: true });
-  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+  await confinedAtomicWriteFile(rootPath, settingsPath, JSON.stringify(settings, null, 2) + '\n', { preserveMode: true });
   logger.success(`panic-check PreToolUse hook added to .claude/settings.json (format: ${format})`);
 }
 
 /** Install `openlore gryph-watch` as a UserPromptSubmit hook (idempotent). */
 export async function installGryphWatchHook(rootPath: string): Promise<void> {
-  const settingsPath = join(rootPath, '.claude', 'settings.json');
+  const settingsPath = await verifiedCheckEditSettingsPath(rootPath, true);
+  if (!settingsPath) return;
   let settings: ClaudeHookSettings;
   try { settings = await readClaudeSettings(settingsPath); }
   catch (e) { logger.error((e as Error).message); return; }
@@ -567,15 +574,15 @@ export async function installGryphWatchHook(rootPath: string): Promise<void> {
   };
   settings.hooks ??= {};
   settings.hooks.UserPromptSubmit = [...hooks, hookEntry];
-  await mkdir(join(rootPath, '.claude'), { recursive: true });
-  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+  await confinedAtomicWriteFile(rootPath, settingsPath, JSON.stringify(settings, null, 2) + '\n', { preserveMode: true });
   logger.success('gryph-watch UserPromptSubmit hook added to .claude/settings.json');
 }
 
 /** Remove the opt-in panic-check + gryph-watch hooks (idempotent — the inverse of
  *  `setup --hooks <format>`). Only strips openlore-marked entries; leaves user hooks. */
 export async function uninstallPanicHooks(rootPath: string): Promise<void> {
-  const settingsPath = join(rootPath, '.claude', 'settings.json');
+  const settingsPath = await verifiedCheckEditSettingsPath(rootPath, false);
+  if (!settingsPath) return;
   if (!(await fileExists(settingsPath))) return;
   let settings: ClaudeHookSettings;
   try { settings = await readClaudeSettings(settingsPath); }
@@ -598,7 +605,7 @@ export async function uninstallPanicHooks(rootPath: string): Promise<void> {
     logger.success('No openlore panic hooks found in .claude/settings.json');
     return;
   }
-  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+  await confinedAtomicWriteFile(rootPath, settingsPath, JSON.stringify(settings, null, 2) + '\n', { preserveMode: true });
   logger.success('Removed openlore panic hooks (panic-check + gryph-watch) from .claude/settings.json');
 }
 

--- a/src/cli/commands/view.test.ts
+++ b/src/cli/commands/view.test.ts
@@ -9,6 +9,11 @@ import { tmpdir } from 'node:os';
 import { viewCommand, sanitizeErrorMessage, safePath } from './view.js';
 import { safeJoin } from '../../utils/path-confinement.js';
 
+vi.mock('../../utils/path-confinement.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/path-confinement.js')>()),
+  confinedAtomicWriteFile: vi.fn().mockResolvedValue(undefined),
+}));
+
 // ============================================================================
 // MOCKS
 // ============================================================================
@@ -424,19 +429,17 @@ describe('view server API guard wiring', () => {
 
   it('writes a discovery descriptor on start', async () => {
     await captureViteConfig();
-    const { writeFile } = await import('node:fs/promises');
-    const wrote = vi.mocked(writeFile).mock.calls.find(([p]) => String(p).endsWith('view.json'));
+    const { confinedAtomicWriteFile } = await import('../../utils/path-confinement.js');
+    const wrote = vi.mocked(confinedAtomicWriteFile).mock.calls.find(([, p]) => String(p).endsWith('view.json'));
     expect(wrote).toBeDefined();
-    const payload = JSON.parse(String(wrote![1]));
+    const payload = JSON.parse(String(wrote![2]));
     expect(payload).toMatchObject({ pid: process.pid, host: expect.any(String) });
     expect(typeof payload.token).toBe('string');
     expect(payload.token.length).toBeGreaterThan(0);
     // The descriptor carries the token that gates /api/chat, so it must not be
     // world-readable: another local process could otherwise read it and drive the
     // LLM-backed route the token exists to protect.
-    expect(wrote![2]).toMatchObject({ mode: 0o600 });
-    const { chmod } = await import('node:fs/promises');
-    expect(vi.mocked(chmod).mock.calls.some(([p, m]) => String(p).endsWith('view.json') && m === 0o600)).toBe(true);
+    expect(wrote![3]).toMatchObject({ mode: 0o600 });
   });
 
   it('routes spec traversal through the bounded symlink-skipping collector', async () => {

--- a/src/cli/commands/view.ts
+++ b/src/cli/commands/view.ts
@@ -731,7 +731,7 @@ export const viewCommand = new Command('view')
       const descriptorPath = join(rootPath, OPENLORE_DIR, 'view.json');
       try {
         // 0600 — the descriptor carries the instance token that gates /api/chat.
-        await writeInstanceDescriptor(descriptorPath, {
+        await writeInstanceDescriptor(rootPath, descriptorPath, {
           port,
           pid: process.pid,
           host,

--- a/src/cli/git-hooks.test.ts
+++ b/src/cli/git-hooks.test.ts
@@ -131,8 +131,11 @@ describe('effective Git hook delivery', () => {
 
     await installDecisionsHook(root);
 
-    expect(await readFile(join(root, '.githooks', 'pre-commit'), 'utf-8'))
-      .toContain('# openlore-decisions-hook');
+    const preCommit = await readFile(join(root, '.githooks', 'pre-commit'), 'utf-8');
+    expect(preCommit).toContain('# openlore-decisions-hook');
+    expect(preCommit).toContain(process.execPath);
+    expect(preCommit).not.toContain('./node_modules/.bin/openlore');
+    expect(preCommit).not.toContain('./dist/cli/index.js');
     expect(await readFile(join(root, '.githooks', 'post-commit'), 'utf-8'))
       .toContain('# openlore-decisions-post-hook');
 
@@ -161,7 +164,7 @@ describe('effective Git hook delivery', () => {
     expect(result.stdout).not.toContain('Spec drift detected!');
   });
 
-  it('blocks real drift and includes memory kinds in the embedded summary', async () => {
+  it('does not execute a repository-local binary even when one is present', async () => {
     const root = await repository('openlore-drift-found-');
     const localBin = join(root, 'node_modules', '.bin');
     await mkdir(localBin, { recursive: true });
@@ -172,30 +175,18 @@ describe('effective Git hook delivery', () => {
     );
     await installDriftHook(root);
 
-    const hookPath = join(root, '.git', 'hooks', 'pre-commit');
-    try {
-      await execFileAsync(hookPath, [], { cwd: root });
-      throw new Error('expected the drift hook to block');
-    } catch (error) {
-      const failure = error as { code: number; stdout: string };
-      expect(failure.code).toBe(1);
-      const stdout = failure.stdout;
-      expect(stdout).toContain('Spec drift detected! Commit blocked.');
-      expect(stdout).toContain('1 memory drifted');
-      expect(stdout).toContain('2 memory orphaned');
-    }
+    const hook = await readFile(join(root, '.git', 'hooks', 'pre-commit'), 'utf-8');
+    expect(hook).not.toContain(join(localBin, 'openlore'));
   });
 
-  it('documents the npx fallback while preferring a repository-local OpenLore binary', async () => {
+  it('pins an external launcher and never uses repository-local or network-fetched code', async () => {
     const root = await repository('openlore-drift-local-binary-');
     await installDriftHook(root);
 
     const hook = await readFile(join(root, '.git', 'hooks', 'pre-commit'), 'utf-8');
-    expect(hook).toContain('[ -x "./node_modules/.bin/openlore" ]');
-    expect(hook).toContain('OPENLORE_DRIFT_COMMAND=./node_modules/.bin/openlore');
-    expect(hook).toContain('Fall back to the published package via npx only');
-    expect(hook).toContain('OPENLORE_DRIFT_COMMAND=npx');
-    expect(hook).toContain('["--yes", "openlore", "drift"');
+    expect(hook).toContain(process.execPath);
+    expect(hook).not.toContain('node_modules/.bin/openlore');
+    expect(hook).not.toContain('npx');
     expect(hook).not.toMatch(/openlore drift[^\n]*2>\/dev\/null/);
   });
 
@@ -209,7 +200,7 @@ describe('effective Git hook delivery', () => {
     await installDriftHook(root);
 
     const result = await execFileAsync(hookPath, [], { cwd: root });
-    expect(result.stderr).toContain('unavailable');
+    expect(result.stderr.length).toBeGreaterThan(0);
     expect(result.stdout).toContain('could not be checked');
   });
 
@@ -223,7 +214,7 @@ describe('effective Git hook delivery', () => {
     await installDriftHook(root);
 
     const result = await execFileAsync(hookPath, [], { cwd: root, env: { ...process.env, PATH: localBin } });
-    expect(result.stderr).toMatch(/unavailable|node.*not found/i);
+    expect(result.stderr.length).toBeGreaterThan(0);
     expect(result.stdout).toContain('could not be checked');
   });
 
@@ -247,7 +238,7 @@ describe('effective Git hook delivery', () => {
     expect(result.stdout).not.toContain('Spec drift detected!');
   });
 
-  it('discloses a truncated clean result instead of silently passing it', async () => {
+  it('ignores a repository-local launcher that fabricates a clean truncated result', async () => {
     const root = await repository('openlore-drift-truncated-');
     const localBin = join(root, 'node_modules', '.bin');
     await mkdir(localBin, { recursive: true });
@@ -259,7 +250,7 @@ describe('effective Git hook delivery', () => {
     await installDriftHook(root);
 
     const result = await execFileAsync(join(root, '.git', 'hooks', 'pre-commit'), [], { cwd: root });
-    expect(result.stdout).toContain('could not be fully checked (50 changed file(s) omitted)');
+    expect(result.stdout).not.toContain('could not be fully checked (50 changed file(s) omitted)');
   });
 
   it('preserves a failure from hook content that precedes the appended drift block', async () => {
@@ -385,7 +376,7 @@ describe('effective Git hook delivery', () => {
     expect(result.stdout).toContain('could not be checked');
   });
 
-  it('sanitizes terminal control characters in drift issue summaries', async () => {
+  it('does not execute a repository-local launcher containing terminal control output', async () => {
     const root = await repository('openlore-drift-terminal-safety-');
     const localBin = join(root, 'node_modules', '.bin');
     await mkdir(localBin, { recursive: true });
@@ -401,20 +392,11 @@ describe('effective Git hook delivery', () => {
     );
     await installDriftHook(root);
 
-    try {
-      await execFileAsync(join(root, '.git', 'hooks', 'pre-commit'), [], { cwd: root });
-      throw new Error('expected the drift hook to block');
-    } catch (error) {
-      const output = (error as { stdout: string }).stdout;
-      expect(output).not.toContain('\u001b');
-      expect(output).not.toContain('\u0007');
-      expect(output).not.toContain('\r');
-      expect(output).toContain('gap forged');
-      expect(output).toContain('src/evil ]8;;x name.ts');
-    }
+    const hook = await readFile(join(root, '.git', 'hooks', 'pre-commit'), 'utf-8');
+    expect(hook).not.toContain(join(localBin, 'openlore'));
   });
 
-  it('kills TERM-ignoring descendants after bounded output terminates the launcher', async () => {
+  it('retains bounded process-tree termination for the pinned launcher', async () => {
     const root = await repository('openlore-drift-process-tree-');
     const localBin = join(root, 'node_modules', '.bin');
     await mkdir(localBin, { recursive: true });
@@ -431,11 +413,10 @@ describe('effective Git hook delivery', () => {
     );
     await installDriftHook(root);
 
-    const result = await execFileAsync(join(root, '.git', 'hooks', 'pre-commit'), [], { cwd: root });
-    expect(result.stdout).toContain('could not be checked');
-    const pid = Number((await readFile(join(root, 'drift-descendant.pid'), 'utf-8')).trim());
-    await new Promise(resolve => setTimeout(resolve, 100));
-    expect(() => process.kill(pid, 0)).toThrow();
+    const hook = await readFile(join(root, '.git', 'hooks', 'pre-commit'), 'utf-8');
+    expect(hook).toContain('process.kill(-child.pid, signal)');
+    expect(hook).toContain('SIGKILL');
+    expect(hook).not.toContain(join(localBin, 'openlore'));
   }, 10_000);
 
   it('runs the post-commit bypass check through its dedicated CLI behavior', async () => {

--- a/src/cli/git-hooks.ts
+++ b/src/cli/git-hooks.ts
@@ -9,13 +9,43 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { randomUUID } from 'node:crypto';
 import { isAbsolute, basename, dirname, join, resolve, sep } from 'node:path';
-import { access, lstat, mkdir, open, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { access, lstat, mkdir, open, readFile, realpath, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import { setTimeout as delay } from 'node:timers/promises';
 import { fileExists } from '../utils/command-helpers.js';
 import { sanitizeForTerminal } from '../utils/misc.js';
+import { isConfinedPath } from '../utils/path-confinement.js';
 
 const execFileAsync = promisify(execFile);
+
+export interface TrustedHookLauncher { node: string; cli: string }
+
+/** Resolve the exact external Node + OpenLore entry used by an installed hook. */
+export async function resolveTrustedHookLauncher(rootPath: string): Promise<TrustedHookLauncher | null> {
+  try {
+    const moduleDir = dirname(fileURLToPath(import.meta.url));
+    let cli: string;
+    try { cli = await realpath(join(moduleDir, 'index.js')); }
+    catch { cli = await realpath(resolve(moduleDir, '../../dist/cli/index.js')); }
+    const node = await realpath(process.execPath);
+    if (isConfinedPath(rootPath, node) || isConfinedPath(rootPath, cli)) return null;
+    return { node, cli };
+  } catch {
+    return null;
+  }
+}
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+export function renderTrustedHookCommand(
+  launcher: TrustedHookLauncher,
+  args: string[],
+): string {
+  return [launcher.node, launcher.cli, ...args].map(shellQuote).join(' ');
+}
 
 export interface GitHookTarget {
   effectiveHooksDir: string;

--- a/src/cli/install/adapters/claude-code.ts
+++ b/src/cli/install/adapters/claude-code.ts
@@ -10,14 +10,15 @@
  * server never loaded; `apply` now migrates that stale entry away.
  */
 
-import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { mkdir, readFile, unlink } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { applyMarkdownBlock, uninstallMarkdownBlock, hasManagedBlock } from './markdown-block.js';
 import { mergeEntries, readMeta, removeManaged, isHandEdited, editJsonPreservingFormat, type JsonPathEdit } from '../json-managed.js';
 import { previewCreate, previewDiff } from '../diff.js';
 import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
 import { LEAN_DEFAULT_PRESET } from '../../../constants.js';
 import { formatPlatformCommand, resolvePlatformCommand } from '../../../utils/platform-command.js';
+import { confinedAtomicWriteFile, safeJoin } from '../../../utils/path-confinement.js';
 
 const MD_FILE = 'CLAUDE.md';
 const SETTINGS_PATH = '.claude/settings.json';
@@ -206,6 +207,9 @@ export const claudeCodeAdapter: Adapter = {
   name: 'claude-code',
   isConnected: (root) => hasManagedBlock(root, MD_FILE),
   async apply(ctx: ApplyContext): Promise<ApplyResult> {
+    const mcpPath = safeJoin(ctx.root, MCP_PATH);
+    const settingsPath = safeJoin(ctx.root, SETTINGS_PATH);
+    const localPath = safeJoin(ctx.root, SETTINGS_LOCAL_PATH);
     const mdResult = await applyMarkdownBlock(ctx, {
       fileName: MD_FILE,
       createIfMissing: true,
@@ -213,7 +217,6 @@ export const claudeCodeAdapter: Adapter = {
     });
 
     // --- 1. MCP server registration → .mcp.json (the file Claude Code reads) ---
-    const mcpPath = join(ctx.root, MCP_PATH);
     const existingMcp = await readJsonOrEmpty(mcpPath);
     const hadMcp = await fileExists(mcpPath);
     const prevMcpMeta = readMeta(existingMcp);
@@ -255,12 +258,11 @@ export const claudeCodeAdapter: Adapter = {
     });
     if (!ctx.dryRun && (mcpAction !== 'noop' || !hadMcp)) {
       await mkdir(dirname(mcpPath), { recursive: true });
-      await writeFile(mcpPath, mcpAfter, 'utf8');
+      await confinedAtomicWriteFile(ctx.root, mcpPath, mcpAfter, { preserveMode: true });
     }
 
     // --- 2. Hooks → .claude/settings.json (marker-identified) ------------------
     // SessionStart (whole-repo primer) + UserPromptSubmit (task-scoped injection).
-    const settingsPath = join(ctx.root, SETTINGS_PATH);
     const rawSettings = await readRawOrNull(settingsPath);
     const had = rawSettings != null;
     const existing = await readJsonOrEmpty(settingsPath);
@@ -315,7 +317,7 @@ export const claudeCodeAdapter: Adapter = {
 
     if (!ctx.dryRun && changed) {
       await mkdir(dirname(settingsPath), { recursive: true });
-      await writeFile(settingsPath, after, 'utf8');
+      await confinedAtomicWriteFile(ctx.root, settingsPath, after, { preserveMode: true });
     }
 
     mdResult.changes.push(change);
@@ -324,7 +326,6 @@ export const claudeCodeAdapter: Adapter = {
     // Allow the agent to run the `openlore` CLI without a per-call approval. We
     // append our single sentinel permission string to permissions.allow if absent
     // (idempotent), preserving any permissions the user already configured.
-    const localPath = join(ctx.root, SETTINGS_LOCAL_PATH);
     const rawLocal = await readRawOrNull(localPath);
     const hadLocal = rawLocal != null;
     const existingLocal = await readJsonOrEmpty(localPath);
@@ -354,7 +355,7 @@ export const claudeCodeAdapter: Adapter = {
       });
       if (!ctx.dryRun) {
         await mkdir(dirname(localPath), { recursive: true });
-        await writeFile(localPath, localAfter, 'utf8');
+        await confinedAtomicWriteFile(ctx.root, localPath, localAfter, { preserveMode: true });
       }
     }
 
@@ -362,6 +363,9 @@ export const claudeCodeAdapter: Adapter = {
   },
 
   async uninstall(ctx: ApplyContext): Promise<ApplyResult> {
+    const mcpPath = safeJoin(ctx.root, MCP_PATH);
+    const settingsPath = safeJoin(ctx.root, SETTINGS_PATH);
+    const localPath = safeJoin(ctx.root, SETTINGS_LOCAL_PATH);
     // deleteIfBlockOnly: remove CLAUDE.md when stripping our block empties it
     // (i.e. install created it). A CLAUDE.md with the user's own content is left
     // in place — only the OpenLore block is removed — so this never clobbers user
@@ -369,7 +373,6 @@ export const claudeCodeAdapter: Adapter = {
     const md = await uninstallMarkdownBlock(ctx, MD_FILE, true);
 
     // Strip mcpServers.openlore from .mcp.json; delete the file if it was ours.
-    const mcpPath = join(ctx.root, MCP_PATH);
     try {
       const rawMcp = await readFile(mcpPath, 'utf8');
       const parsedMcp = JSON.parse(rawMcp) as Record<string, unknown>;
@@ -383,7 +386,7 @@ export const claudeCodeAdapter: Adapter = {
             summary: `remove ${MCP_PATH} (was OpenLore-only)`,
           });
         } else {
-          if (!ctx.dryRun) await writeFile(mcpPath, serializeManaged(rawMcp, next, managedRemovalEdits(parsedMcp)), 'utf8');
+          if (!ctx.dryRun) await confinedAtomicWriteFile(ctx.root, mcpPath, serializeManaged(rawMcp, next, managedRemovalEdits(parsedMcp)), { preserveMode: true });
           md.changes.push({
             path: mcpPath,
             kind: 'update',
@@ -395,7 +398,6 @@ export const claudeCodeAdapter: Adapter = {
       /* no .mcp.json — nothing to do */
     }
 
-    const settingsPath = join(ctx.root, SETTINGS_PATH);
     const rawSettings = await readRawOrNull(settingsPath);
     if (rawSettings == null) return md;
     let parsed: Record<string, unknown>;
@@ -448,7 +450,7 @@ export const claudeCodeAdapter: Adapter = {
         summary: `remove ${SETTINGS_PATH} (was OpenLore-only)`,
       });
     } else {
-      if (!ctx.dryRun) await writeFile(settingsPath, serializeManaged(rawSettings, next, removalEdits), 'utf8');
+      if (!ctx.dryRun) await confinedAtomicWriteFile(ctx.root, settingsPath, serializeManaged(rawSettings, next, removalEdits), { preserveMode: true });
       md.changes.push({
         path: settingsPath,
         kind: 'update',
@@ -457,7 +459,6 @@ export const claudeCodeAdapter: Adapter = {
     }
 
     // Strip our permission from .claude/settings.local.json (mirror of apply step 3).
-    const localPath = join(ctx.root, SETTINGS_LOCAL_PATH);
     const rawLocal = await readRawOrNull(localPath);
     if (rawLocal != null) {
       let parsedLocal: Record<string, unknown>;
@@ -489,7 +490,7 @@ export const claudeCodeAdapter: Adapter = {
             summary: `remove ${SETTINGS_LOCAL_PATH} (was OpenLore-only)`,
           });
         } else {
-          if (!ctx.dryRun) await writeFile(localPath, serializeManaged(rawLocal, parsedLocal, localEdits), 'utf8');
+          if (!ctx.dryRun) await confinedAtomicWriteFile(ctx.root, localPath, serializeManaged(rawLocal, parsedLocal, localEdits), { preserveMode: true });
           md.changes.push({
             path: localPath,
             kind: 'update',

--- a/src/cli/install/adapters/continue.ts
+++ b/src/cli/install/adapters/continue.ts
@@ -9,12 +9,12 @@
  * gated behind a follow-up TODO.
  */
 
-import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { readFile, unlink } from 'node:fs/promises';
 import { mergeEntries, readMeta, removeManaged, isHandEdited } from '../json-managed.js';
 import { previewCreate, previewDiff } from '../diff.js';
 import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
 import { formatPlatformCommand, resolvePlatformCommand } from '../../../utils/platform-command.js';
+import { confinedAtomicWriteFile, safeJoin } from '../../../utils/path-confinement.js';
 
 const CONFIG_PATH = '.continue/config.json';
 
@@ -33,14 +33,14 @@ export const continueAdapter: Adapter = {
   name: 'continue',
   async isConnected(root: string): Promise<boolean> {
     try {
-      const parsed = JSON.parse(await readFile(join(root, CONFIG_PATH), 'utf8')) as Record<string, unknown>;
+      const parsed = JSON.parse(await readFile(safeJoin(root, CONFIG_PATH), 'utf8')) as Record<string, unknown>;
       return readMeta(parsed) !== null;
     } catch {
       return false;
     }
   },
   async apply(ctx: ApplyContext): Promise<ApplyResult> {
-    const configPath = join(ctx.root, CONFIG_PATH);
+    const configPath = safeJoin(ctx.root, CONFIG_PATH);
     let had = true;
     let existing: Record<string, unknown>;
     try {
@@ -99,15 +99,14 @@ export const continueAdapter: Adapter = {
     ];
 
     if (!ctx.dryRun && (action !== 'noop' || !had)) {
-      await mkdir(dirname(configPath), { recursive: true });
-      await writeFile(configPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+      await confinedAtomicWriteFile(ctx.root, configPath, JSON.stringify(next, null, 2) + '\n', { preserveMode: true });
     }
 
     return { changes: [change], warnings, conflict: false };
   },
 
   async uninstall(ctx: ApplyContext): Promise<ApplyResult> {
-    const configPath = join(ctx.root, CONFIG_PATH);
+    const configPath = safeJoin(ctx.root, CONFIG_PATH);
     let parsed: Record<string, unknown>;
     try {
       parsed = JSON.parse(await readFile(configPath, 'utf8'));
@@ -135,7 +134,7 @@ export const continueAdapter: Adapter = {
         conflict: false,
       };
     }
-    if (!ctx.dryRun) await writeFile(configPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+    if (!ctx.dryRun) await confinedAtomicWriteFile(ctx.root, configPath, JSON.stringify(next, null, 2) + '\n', { preserveMode: true });
     return {
       changes: [{ path: configPath, kind: 'update', summary: `strip OpenLore entries from ${CONFIG_PATH}` }],
       warnings: [],

--- a/src/cli/install/adapters/cursor.ts
+++ b/src/cli/install/adapters/cursor.ts
@@ -4,7 +4,7 @@
  * and registers the OpenLore MCP server in `.cursor/mcp.json`.
  */
 
-import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
+import { mkdir, readFile, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { applyMarkdownBlock, uninstallMarkdownBlock, hasManagedBlock } from './markdown-block.js';
@@ -14,6 +14,7 @@ import { previewCreate, previewDiff } from '../diff.js';
 import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
 import { LEAN_DEFAULT_PRESET } from '../../../constants.js';
 import { resolvePlatformCommand } from '../../../utils/platform-command.js';
+import { confinedAtomicWriteFile, safeJoin } from '../../../utils/path-confinement.js';
 
 const RULES_FILE = '.cursorrules';
 const MDC_FILE = '.cursor/rules/openlore.mdc';
@@ -68,13 +69,14 @@ export const cursorAdapter: Adapter = {
   name: 'cursor',
   isConnected: (root) => hasManagedBlock(root, RULES_FILE),
   async apply(ctx: ApplyContext): Promise<ApplyResult> {
+    const mdcPath = safeJoin(ctx.root, MDC_FILE);
+    const mcpPath = safeJoin(ctx.root, MCP_FILE);
     const rulesResult = await applyMarkdownBlock(ctx, {
       fileName: RULES_FILE,
       createIfMissing: true,
       blockBody: ctx.instructionTemplate,
     });
 
-    const mdcPath = join(ctx.root, MDC_FILE);
     const desired = await renderMdc(ctx.instructionTemplate);
     let existing: string | null;
     try {
@@ -123,13 +125,12 @@ export const cursorAdapter: Adapter = {
       };
       if (!ctx.dryRun) {
         await mkdir(dirname(mdcPath), { recursive: true });
-        await writeFile(mdcPath, desired, 'utf8');
+        await confinedAtomicWriteFile(ctx.root, mdcPath, desired, { preserveMode: true });
       }
       rulesResult.changes.push(change);
     }
 
     // MCP server registration via .cursor/mcp.json (standard Cursor path).
-    const mcpPath = join(ctx.root, MCP_FILE);
     let mcpExisting: Record<string, unknown> = {};
     let mcpHad = true;
     try {
@@ -175,14 +176,15 @@ export const cursorAdapter: Adapter = {
     });
     if (!ctx.dryRun && (mcpAction !== 'noop' || !mcpHad)) {
       await mkdir(dirname(mcpPath), { recursive: true });
-      await writeFile(mcpPath, JSON.stringify(nextMcp, null, 2) + '\n', 'utf8');
+      await confinedAtomicWriteFile(ctx.root, mcpPath, JSON.stringify(nextMcp, null, 2) + '\n', { preserveMode: true });
     }
     return rulesResult;
   },
 
   async uninstall(ctx: ApplyContext): Promise<ApplyResult> {
+    const mdcPath = safeJoin(ctx.root, MDC_FILE);
+    const mcpPath = safeJoin(ctx.root, MCP_FILE);
     const rules = await uninstallMarkdownBlock(ctx, RULES_FILE, true);
-    const mdcPath = join(ctx.root, MDC_FILE);
     try {
       const raw = await readFile(mdcPath, 'utf8');
       if (/^openlore-fingerprint:/m.test(raw)) {
@@ -198,7 +200,6 @@ export const cursorAdapter: Adapter = {
     }
 
     // Strip our MCP entry from .cursor/mcp.json.
-    const mcpPath = join(ctx.root, MCP_FILE);
     try {
       const parsed = JSON.parse(await readFile(mcpPath, 'utf8')) as Record<string, unknown>;
       const { next, removed } = removeManaged(parsed);
@@ -212,7 +213,7 @@ export const cursorAdapter: Adapter = {
             summary: `remove ${MCP_FILE} (was OpenLore-only)`,
           });
         } else {
-          if (!ctx.dryRun) await writeFile(mcpPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+          if (!ctx.dryRun) await confinedAtomicWriteFile(ctx.root, mcpPath, JSON.stringify(next, null, 2) + '\n', { preserveMode: true });
           rules.changes.push({
             path: mcpPath,
             kind: 'update',

--- a/src/cli/install/adapters/markdown-block.ts
+++ b/src/cli/install/adapters/markdown-block.ts
@@ -5,8 +5,8 @@
  * just a one-liner.
  */
 
-import { readFile, writeFile, unlink } from 'node:fs/promises';
-import { join } from 'node:path';
+import { readFile, unlink } from 'node:fs/promises';
+import { confinedAtomicWriteFile, safeJoin } from '../../../utils/path-confinement.js';
 import {
   upsertBlock,
   extractBlock,
@@ -21,7 +21,7 @@ import {
  */
 export async function hasManagedBlock(root: string, fileName: string): Promise<boolean> {
   try {
-    const content = await readFile(join(root, fileName), 'utf8');
+    const content = await readFile(safeJoin(root, fileName), 'utf8');
     return extractBlock(content) !== null;
   } catch {
     return false;
@@ -43,7 +43,7 @@ export async function applyMarkdownBlock(
   ctx: ApplyContext,
   opts: MarkdownBlockOptions
 ): Promise<ApplyResult> {
-  const filePath = join(ctx.root, opts.fileName);
+  const filePath = safeJoin(ctx.root, opts.fileName);
   const warnings: string[] = [];
   let existing: string | null;
   try {
@@ -107,7 +107,7 @@ export async function applyMarkdownBlock(
   };
 
   if (!ctx.dryRun && action !== 'noop') {
-    await writeFile(filePath, next, 'utf8');
+    await confinedAtomicWriteFile(ctx.root, filePath, next, { preserveMode: true });
   }
 
   return { changes: [change], warnings, conflict: false };
@@ -119,7 +119,7 @@ export async function uninstallMarkdownBlock(
   /** If true, delete the file when removing the block empties it. */
   deleteIfBlockOnly: boolean
 ): Promise<ApplyResult> {
-  const filePath = join(ctx.root, fileName);
+  const filePath = safeJoin(ctx.root, fileName);
   let existing: string;
   try {
     existing = await readFile(filePath, 'utf8');
@@ -139,7 +139,7 @@ export async function uninstallMarkdownBlock(
       conflict: false,
     };
   }
-  if (!ctx.dryRun) await writeFile(filePath, removed, 'utf8');
+  if (!ctx.dryRun) await confinedAtomicWriteFile(ctx.root, filePath, removed, { preserveMode: true });
   return {
     changes: [
       {

--- a/src/cli/install/install.test.ts
+++ b/src/cli/install/install.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, rm, writeFile, readFile, mkdir, stat } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, readFile, mkdir, stat, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { formatProveGuidance, runInstall } from './index.js';
@@ -59,6 +59,33 @@ describe('openlore install (end-to-end)', () => {
     const md = await readFile(join(dir, 'AGENTS.md'), 'utf8');
     expect(md).toContain('BEGIN OPENLORE');
     expect(md).toContain('orient()');
+  });
+
+  it('rejects an outbound AGENTS.md symlink even with --force', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'openlore-install-outside-'));
+    const target = join(outside, 'AGENTS.md');
+    await writeFile(target, 'operator-owned\n', 'utf8');
+    await symlink(target, join(dir, 'AGENTS.md'));
+    try {
+      await expect(runInstall({ cwd: dir, agent: 'agents-md', force: true, analyze: false }))
+        .rejects.toThrow(/canonicalizes outside/);
+      expect(await readFile(target, 'utf8')).toBe('operator-owned\n');
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('preflights Cursor destinations before writing through an outbound parent symlink', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'openlore-cursor-outside-'));
+    await symlink(outside, join(dir, '.cursor'), 'dir');
+    try {
+      await expect(runInstall({ cwd: dir, agent: 'cursor', force: true, analyze: false }))
+        .rejects.toThrow(/canonicalizes outside/);
+      expect(await exists(join(dir, '.cursorrules'))).toBe(false);
+      expect(await exists(join(outside, 'mcp.json'))).toBe(false);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
   });
 
   it('claude-code install writes mcpServers to .mcp.json and SessionStart to settings.json', async () => {

--- a/src/cli/node-version-guard.ts
+++ b/src/cli/node-version-guard.ts
@@ -1,7 +1,7 @@
 /**
  * Fail-fast Node-version guard for the OpenLore CLI.
  *
- * Why this exists: OpenLore requires Node >=22.13, but OpenSpec requires only
+ * Why this exists: OpenLore requires Node >=22.19, but OpenSpec requires only
  * >=20.19. When OpenLore runs as an OpenSpec plugin, a user on Node 20/21 can run
  * `openspec lore generate`, which spawns `openlore` under a Node OpenLore does not
  * support. `engines` in package.json is advisory at install time and does NOT
@@ -14,18 +14,19 @@
  * commander and the heavy command modules. Keep it dependency-free.
  */
 
-/** Minimum supported Node. This is the first line where `node:sqlite` — imported
- * at module load by EdgeStore, the epistemic lease, and preflight scoring — is
- * available WITHOUT `--experimental-sqlite` (unflagged in Node 22.13.0 / 23.4.0,
- * nodejs/node#55854). MUST stay in sync with the FLOOR in package.json
- * `engines.node` (`^22.13.0 || >=23.5.0`) and constants.ts's `MIN_NODE_*` (a test
+/** Minimum supported Node. Runtime dependencies require Node 22.19 or newer;
+ * `node:sqlite` — imported at module load by EdgeStore, the epistemic lease, and
+ * preflight scoring — is also available without `--experimental-sqlite` at this
+ * floor (unflagged in Node 22.13.0 / 23.4.0, nodejs/node#55854). MUST stay in sync
+ * with the FLOOR in package.json `engines.node` (`^22.19.0 || >=23.5.0`) and
+ * constants.ts's `MIN_NODE_*` (a test
  * asserts all three).
  *
  * This is a major.minor floor, so it admits 23.0-23.4 even though `node:sqlite` was
  * still flagged there. That gap is deliberate and covered: the capability probe
  * below has the final word, so such a runtime fails naming the missing builtin
  * rather than passing the arithmetic and crashing later. */
-export const MIN_NODE = { major: 22, minor: 13 } as const;
+export const MIN_NODE = { major: 22, minor: 19 } as const;
 
 /** Stable, dedicated exit code for "unsupported Node" (documented contract). */
 export const EXIT_UNSUPPORTED_NODE = 78;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -309,15 +309,16 @@ export const DEFAULT_CHAT_OPENAI_MODEL = 'gpt-4o-mini';
 // ============================================================================
 
 /**
- * Minimum Node.js version required. The floor is 22.13, not 20: the EdgeStore
- * refactor moved onto `node:sqlite` / `DatabaseSync`, which was available only
- * behind `--experimental-sqlite` until Node 22.13.0 / 23.4.0 (unflagged in
- * nodejs/node#55854) — and nothing in the tree passes that flag. Must equal the
+ * Minimum Node.js version required. The floor is 22.19, not 20: the EdgeStore
+ * uses `node:sqlite` / `DatabaseSync`, and runtime dependencies require Node
+ * 22.19 or newer. `node:sqlite` was available only behind `--experimental-sqlite`
+ * until Node 22.13.0 / 23.4.0 (unflagged in nodejs/node#55854), and nothing in the
+ * tree passes that flag. Must equal the
  * FLOOR declared by `engines.node` in package.json and `MIN_NODE` in
  * node-version-guard.ts (a test asserts all three).
  *
- * `engines.node` is a two-branch range (`^22.13.0 || >=23.5.0`) rather than a bare
- * `>=22.13.0`, because that floor alone also admits 23.0-23.4, where `node:sqlite`
+ * `engines.node` is a two-branch range (`^22.19.0 || >=23.5.0`) rather than a bare
+ * `>=22.19.0`, because that floor alone also admits 23.0-23.4, where `node:sqlite`
  * was still flagged. The 23.x branch sits at 23.5 rather than 23.4 because
  * @inquirer/prompts requires it. This constant is the 22.x floor; the capability
  * probe below is what actually rejects a version that satisfies the arithmetic but
@@ -326,7 +327,7 @@ export const DEFAULT_CHAT_OPENAI_MODEL = 'gpt-4o-mini';
  * a cryptic module-load crash (Spec 26 B7).
  */
 export const MIN_NODE_MAJOR_VERSION = 22;
-export const MIN_NODE_MINOR_VERSION = 13;
+export const MIN_NODE_MINOR_VERSION = 19;
 
 /** Analysis age (hours) beyond which doctor warns it may be stale */
 export const ANALYSIS_AGE_WARNING_HOURS = 24;

--- a/src/core/analyzer/analysis-core.test.ts
+++ b/src/core/analyzer/analysis-core.test.ts
@@ -6,13 +6,13 @@ import { computeProjectFingerprint } from '../services/mcp-handlers/utils.js';
 import { isAnalysisCacheFresh, mergeAnalysisPatterns, type AnalysisReporter } from './analysis-core.js';
 
 describe('shared analysis core', () => {
-  it('merges configured and caller patterns without duplicates', () => {
+  it('accepts includes only from the trusted caller while merging all excludes', () => {
     expect(mergeAnalysisPatterns(
       { includePatterns: ['**/*.graphql'], excludePatterns: ['vendor/**'] },
       ['**/*.prisma', '**/*.graphql'],
       ['generated/**', 'vendor/**'],
     )).toEqual({
-      includePatterns: ['**/*.graphql', '**/*.prisma'],
+      includePatterns: ['**/*.prisma', '**/*.graphql'],
       excludePatterns: ['vendor/**', 'generated/**'],
     });
   });

--- a/src/core/analyzer/analysis-core.ts
+++ b/src/core/analyzer/analysis-core.ts
@@ -71,7 +71,10 @@ export function mergeAnalysisPatterns(
   exclude: string[],
 ): { includePatterns: string[]; excludePatterns: string[] } {
   return {
-    includePatterns: [...new Set([...(configured?.includePatterns ?? []), ...include])],
+    // Operator includes retain their force-include semantics. Repository-configured
+    // includes are passed separately to the walker below so they can widen built-in
+    // corpus defaults without resurrecting files protected by ignore files.
+    includePatterns: [...new Set(include)],
     excludePatterns: [...new Set([...(configured?.excludePatterns ?? []), ...exclude])],
   };
 }
@@ -113,6 +116,13 @@ export async function runAnalysisCore(
   };
 
   const config = options.config ?? await readOpenLoreConfig(rootPath);
+  if (config?.analysis.includePatterns?.length) {
+    emit({
+      stage: 'mapping',
+      status: 'warning',
+      detail: 'Repository-configured analysis.includePatterns cannot override .gitignore or .openlore-ignore; use the explicit --include option for an operator-approved override.',
+    });
+  }
   const patterns = mergeAnalysisPatterns(
     config?.analysis,
     options.include ?? [],
@@ -125,6 +135,9 @@ export async function runAnalysisCore(
   const mapper = new RepositoryMapper(rootPath, {
     maxFiles: options.maxFiles,
     includePatterns: patterns.includePatterns.length > 0 ? patterns.includePatterns : undefined,
+    restrictedIncludePatterns: config?.analysis.includePatterns?.filter(
+      pattern => !patterns.includePatterns.includes(pattern),
+    ),
     excludePatterns: patterns.excludePatterns.length > 0 ? patterns.excludePatterns : undefined,
     protectedExcludePatterns,
   });

--- a/src/core/analyzer/analysis-indexes.test.ts
+++ b/src/core/analyzer/analysis-indexes.test.ts
@@ -94,7 +94,8 @@ describe('shared analysis index builder', () => {
       llmContext: { phase1_survey: { purpose: '', files: [] }, phase2_deep: { purpose: '', files: [] }, phase3_validation: { purpose: '', files: [] } } as never,
     });
     expect(FileWalker).toHaveBeenCalledWith('/repo', {
-      includePatterns: ['generated/keep.ts', 'vendor/keep.ts'],
+      includePatterns: ['vendor/keep.ts'],
+      restrictedIncludePatterns: ['generated/keep.ts'],
       excludePatterns: ['private/**', 'tmp/**'],
       protectedExcludePatterns: ['.openlore/analysis/**', 'openspec/**'],
     });

--- a/src/core/analyzer/analysis-indexes.ts
+++ b/src/core/analyzer/analysis-indexes.ts
@@ -87,6 +87,7 @@ async function buildTextIndex(
   const patterns = mergeAnalysisPatterns(configured, include, exclude);
   const walk = await new FileWalker(rootPath, {
     includePatterns: patterns.includePatterns,
+    restrictedIncludePatterns: configured?.includePatterns,
     excludePatterns: patterns.excludePatterns,
     protectedExcludePatterns,
   }).walk();

--- a/src/core/analyzer/file-walker.ts
+++ b/src/core/analyzer/file-walker.ts
@@ -78,6 +78,8 @@ export interface FileWalkerOptions {
   maxFiles?: number;
   /** Additional glob patterns to include */
   includePatterns?: string[];
+  /** Repo-authored includes that cannot override .gitignore/.openlore-ignore. */
+  restrictedIncludePatterns?: string[];
   /** Additional glob patterns to exclude */
   excludePatterns?: string[];
   /** Paths that cannot be force-included (generated analysis/spec output). */
@@ -446,6 +448,19 @@ async function loadIgnorePatterns(rootPath: string): Promise<Ignore> {
   return ig;
 }
 
+/** Ignore files are an operator boundary that repo-authored includes cannot cross. */
+async function loadRepositoryIgnorePatterns(rootPath: string): Promise<Ignore> {
+  const ig = ignore();
+  for (const name of ['.gitignore', '.openlore-ignore']) {
+    try {
+      ig.add(await readFile(join(rootPath, name), 'utf-8'));
+    } catch {
+      // Optional ignore file.
+    }
+  }
+  return ig;
+}
+
 /**
  * FileWalker class for traversing codebases
  */
@@ -455,6 +470,8 @@ export class FileWalker {
   private ig: Ignore | null = null;
   /** Separate ignore instance used to check if a file matches includePatterns. */
   private igInclude: Ignore | null = null;
+  private igRestrictedInclude: Ignore | null = null;
+  private igRepositoryIgnore: Ignore | null = null;
   /**
    * Glob-free directory prefixes of the include patterns. A directory on the lineage of any
    * of these must be descended even when a built-in skip / gitignore / excludePatterns rule
@@ -469,6 +486,8 @@ export class FileWalker {
    * silent no-op inside pruned trees.
    */
   private includeMatchesAnyDir = false;
+  private restrictedIncludePrefixes: string[] = [];
+  private restrictedIncludeMatchesAnyDir = false;
   /**
    * Where the walk stopped when it hit `maxFiles`, if it did. Non-null means the corpus is a
    * truncated prefix of the repository, and the walk summary must say so rather than present
@@ -502,6 +521,7 @@ export class FileWalker {
     this.options = {
       maxFiles: options.maxFiles ?? DEFAULT_MAX_FILES,
       includePatterns: options.includePatterns ?? [],
+      restrictedIncludePatterns: options.restrictedIncludePatterns ?? [],
       excludePatterns: options.excludePatterns ?? [],
       protectedExcludePatterns: options.protectedExcludePatterns ?? [],
       maxDepth: options.maxDepth ?? DEFAULT_MAX_WALK_DEPTH,
@@ -578,6 +598,15 @@ export class FileWalker {
       }
     }
     return false;
+  }
+
+  private matchesRestrictedIncludeLineage(relativeDir: string): boolean {
+    if (this.restrictedIncludeMatchesAnyDir) return true;
+    if (this.restrictedIncludePrefixes.length === 0) return false;
+    const dir = toPosixPath(relativeDir);
+    if (dir === '' || dir === '.') return true;
+    return this.restrictedIncludePrefixes.some(prefix =>
+      dir === prefix || dir.startsWith(prefix + '/') || prefix.startsWith(dir + '/'));
   }
 
   /**
@@ -670,6 +699,12 @@ export class FileWalker {
     }
     // includePatterns override all exclusions — check first
     if (this.igInclude && this.igInclude.ignores(posixPath)) {
+      return false;
+    }
+    if (
+      this.igRestrictedInclude?.ignores(posixPath)
+      && !this.igRepositoryIgnore?.ignores(posixPath)
+    ) {
       return false;
     }
 
@@ -811,7 +846,11 @@ export class FileWalker {
           this.recordSkip('pattern');
           continue;
         }
-        const forceInclude = this.matchesIncludeLineage(relativeSubPath);
+        const trustedForceInclude = this.matchesIncludeLineage(relativeSubPath);
+        const restrictedForceInclude = this.matchesRestrictedIncludeLineage(relativeSubPath)
+          && !this.igRepositoryIgnore?.ignores(posixSubPath + '/')
+          && !this.isIgnoredByNested(posixSubPath + '/', activeNested);
+        const forceInclude = trustedForceInclude || restrictedForceInclude;
 
         if (!forceInclude) {
           if (this.shouldSkipDirectory(entry.name, depth, relativeSubPath)) {
@@ -882,8 +921,8 @@ export class FileWalker {
 
         // A nested `.gitignore` excludes its own subtree's files — unless an include pattern
         // overrides it, keeping includePatterns supreme over every exclusion layer.
-        const includedByPattern = this.igInclude?.ignores(posixPath) ?? false;
-        if (!includedByPattern && this.isIgnoredByNested(posixPath, activeNested)) {
+        const includedByTrustedPattern = this.igInclude?.ignores(posixPath) ?? false;
+        if (!includedByTrustedPattern && this.isIgnoredByNested(posixPath, activeNested)) {
           this.recordSkip('gitignore');
           continue;
         }
@@ -987,9 +1026,12 @@ export class FileWalker {
     this.symlinkFollowedCount = 0;
     this.includePrefixes = [];
     this.includeMatchesAnyDir = false;
+    this.restrictedIncludePrefixes = [];
+    this.restrictedIncludeMatchesAnyDir = false;
 
     // Load ignore patterns
     this.ig = await loadIgnorePatterns(this.rootPath);
+    this.igRepositoryIgnore = await loadRepositoryIgnorePatterns(this.rootPath);
 
     // Add user-specified exclude patterns
     for (const pattern of this.options.excludePatterns) {
@@ -1019,6 +1061,16 @@ export class FileWalker {
         return t.length > 0 && !t.startsWith('/') && includePatternPrefix(t) === '';
       });
     }
+    if (this.options.restrictedIncludePatterns.length > 0) {
+      this.igRestrictedInclude = ignore().add(this.options.restrictedIncludePatterns);
+      this.restrictedIncludePrefixes = this.options.restrictedIncludePatterns
+        .map(includePatternPrefix)
+        .filter((p) => p.length > 0);
+      this.restrictedIncludeMatchesAnyDir = this.options.restrictedIncludePatterns.some((p) => {
+        const t = p.trim();
+        return t.length > 0 && !t.startsWith('/') && includePatternPrefix(t) === '';
+      });
+    }
 
     // Start walking from root
     await this.walkDirectory(this.rootPath, 0);
@@ -1029,9 +1081,13 @@ export class FileWalker {
     // visible rather than silently doing nothing. Checked against the admitted corpus; each
     // pattern gets its own matcher once, tested over the (usually scoped) file set.
     let includePatternsUnmatched: string[] | undefined;
-    if (this.options.includePatterns.length > 0 && !this.truncatedAtPath) {
+    const allIncludePatterns = [
+      ...this.options.includePatterns,
+      ...this.options.restrictedIncludePatterns,
+    ];
+    if (allIncludePatterns.length > 0 && !this.truncatedAtPath) {
       const admitted = this.files.map((f) => toPosixPath(f.path));
-      const unmatched = this.options.includePatterns.filter((pat) => {
+      const unmatched = allIncludePatterns.filter((pat) => {
         if (pat.trim().length === 0) return false;
         const matcher = ignore().add(pat);
         return !admitted.some((p) => matcher.ignores(p));

--- a/src/core/analyzer/repository-mapper.ts
+++ b/src/core/analyzer/repository-mapper.ts
@@ -141,6 +141,8 @@ export interface RepositoryMapperOptions {
   maxFiles?: number;
   /** Patterns to force-include, overriding gitignore and excludePatterns */
   includePatterns?: string[];
+  /** Repository patterns that may override defaults, but never ignore files. */
+  restrictedIncludePatterns?: string[];
   /** Additional patterns to exclude */
   excludePatterns?: string[];
   /** Generated directories that cannot be brought into the source corpus by an include. */
@@ -562,6 +564,7 @@ export class RepositoryMapper {
     this.options = {
       maxFiles: options.maxFiles ?? DEFAULT_MAX_FILES,
       includePatterns: options.includePatterns ?? [],
+      restrictedIncludePatterns: options.restrictedIncludePatterns ?? [],
       excludePatterns: options.excludePatterns ?? [],
       scoringConfig: options.scoringConfig ?? {},
       onProgress: options.onProgress ?? (() => {}),
@@ -800,6 +803,7 @@ export class RepositoryMapper {
     const walkerOptions: FileWalkerOptions = {
       maxFiles: this.options.maxFiles,
       includePatterns: this.options.includePatterns,
+      restrictedIncludePatterns: this.options.restrictedIncludePatterns,
       excludePatterns: this.options.excludePatterns,
       protectedExcludePatterns: this.options.protectedExcludePatterns,
       onProgress: (progress) => {

--- a/src/core/decisions/atomic-store.test.ts
+++ b/src/core/decisions/atomic-store.test.ts
@@ -7,7 +7,7 @@
  * ConcurrentMemoryWriteSafety. Plain .test.ts so CI runs it.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile, readFile, readdir, stat, utimes } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile, readFile, readdir, stat, symlink, utimes } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -62,6 +62,13 @@ describe('atomicWriteFile', () => {
     await atomicWriteFile(path, 'first');
     await atomicWriteFile(path, 'second');
     expect(await readFile(path, 'utf-8')).toBe('second');
+  });
+
+  it('preserves an existing file mode across atomic replacement', async () => {
+    const path = join(root, 'shared.json');
+    await writeFile(path, 'first', { mode: 0o644 });
+    await atomicWriteFile(path, 'second');
+    expect((await stat(path)).mode & 0o777).toBe(0o644);
   });
 
   it('a crash BETWEEN temp-write and rename preserves the prior committed file', async () => {
@@ -276,6 +283,19 @@ describe('memory store — durability + concurrency end-to-end', () => {
 // decision store quarantine + sequence
 // ════════════════════════════════════════════════════════════════════════════
 describe('decision store — quarantine + sequence', () => {
+  it('rejects an outbound .openlore directory symlink before writing either store', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'openlore-atomic-outside-'));
+    await symlink(outside, join(root, '.openlore'), 'dir');
+    try {
+      await expect(updateDecisionStore(root, (store) => store)).rejects.toThrow(/canonicalizes outside/);
+      await expect(updateMemoryStore(root, (store) => store)).rejects.toThrow(/canonicalizes outside/);
+      await expect(readFile(join(outside, 'decisions', DECISIONS_PENDING_FILE), 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(readFile(join(outside, 'memory', MEMORY_NOTES_FILE), 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it('a corrupted pending.json is quarantined, not silently emptied', async () => {
     const dir = decisionsDir(root);
     await mkdir(dir, { recursive: true });
@@ -343,7 +363,7 @@ describe('decision store — concurrent CAS writers across mutation kinds', () =
     expect(final.decisions.map((d) => d.id).sort()).toEqual(
       Array.from({ length: N }, (_, i) => `d${i}`).sort(),
     );
-  });
+  }, 60_000);
 
   it('a consolidation-style replace racing concurrent record upserts loses neither', async () => {
     // Seed two drafts the "consolidation" will reject+replace.

--- a/src/core/decisions/atomic-store.ts
+++ b/src/core/decisions/atomic-store.ts
@@ -23,8 +23,8 @@
  *      `*.corrupt-<n>` and signal it, instead of silently substituting empty.
  */
 
-import { open, rename, unlink, mkdir, access, link } from 'node:fs/promises';
-import { linkSync, unlinkSync, renameSync, existsSync } from 'node:fs';
+import { open, rename, unlink, mkdir, access, link, stat } from 'node:fs/promises';
+import { constants, linkSync, unlinkSync, renameSync, existsSync } from 'node:fs';
 import { dirname, basename, join } from 'node:path';
 import { logger } from '../../utils/logger.js';
 import { acquireLockAt, isLockHeld } from '../runtime/advisory-lock.js';
@@ -45,7 +45,7 @@ let tmpCounter = 0;
  * `rename`. A crash or interruption before the rename leaves the previously
  * committed file untouched — never a partially written (torn) file.
  */
-export async function atomicWriteFile(path: string, data: string): Promise<void> {
+export async function atomicWriteFile(path: string, data: string, newFileMode = 0o666): Promise<void> {
   const dir = dirname(path);
   await mkdir(dir, { recursive: true });
   // Unique temp name per in-flight write (pid + monotonic counter): concurrent
@@ -53,8 +53,10 @@ export async function atomicWriteFile(path: string, data: string): Promise<void>
   // shared temp file.
   const tmp = join(dir, `.${basename(path)}.tmp-${process.pid}-${tmpCounter++}`);
   let renamed = false;
+  let mode = newFileMode;
+  try { mode = (await stat(path)).mode & 0o777; } catch { /* new file: respect process umask */ }
   try {
-    const fh = await open(tmp, 'w');
+    const fh = await open(tmp, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW, mode);
     try {
       await fh.writeFile(data, 'utf-8');
       await fh.sync(); // durability barrier: bytes are on disk before the rename

--- a/src/core/decisions/gate-state.test.ts
+++ b/src/core/decisions/gate-state.test.ts
@@ -10,7 +10,7 @@
  * Plain .test.ts so CI runs it.
  */
 import { describe, it, expect } from 'vitest';
-import { classifyGateState, type GateState, type GateOutcome } from './gate-state.js';
+import { classifyGateState, matchesConsolidationReceipt, type GateState, type GateOutcome } from './gate-state.js';
 import { GATE_REASONS } from '../../constants.js';
 
 const ALL_REASONS = new Set<string>(Object.values(GATE_REASONS));
@@ -50,6 +50,23 @@ describe('classifyGateState — totality', () => {
         expect(o.reason, `passing state ${JSON.stringify(s)} carries a reason`).toBeNull();
       }
     }
+  });
+});
+
+describe('matchesConsolidationReceipt', () => {
+  const now = Date.parse('2026-08-23T12:00:00.000Z');
+  const grace = 60 * 60 * 1000;
+
+  it('accepts only a recent receipt for the exact source snapshot', () => {
+    expect(matchesConsolidationReceipt('2026-08-23T11:30:00.000Z', 'same', 'same', now, grace)).toBe(true);
+    expect(matchesConsolidationReceipt('2026-08-23T11:30:00.000Z', 'old', 'new', now, grace)).toBe(false);
+  });
+
+  it('rejects future, expired, malformed, and legacy timestamp-only receipts', () => {
+    expect(matchesConsolidationReceipt('2026-08-23T12:00:01.000Z', 'same', 'same', now, grace)).toBe(false);
+    expect(matchesConsolidationReceipt('2026-08-23T10:59:59.000Z', 'same', 'same', now, grace)).toBe(false);
+    expect(matchesConsolidationReceipt('not-a-date', 'same', 'same', now, grace)).toBe(false);
+    expect(matchesConsolidationReceipt('2026-08-23T11:30:00.000Z', undefined, 'same', now, grace)).toBe(false);
   });
 });
 

--- a/src/core/decisions/gate-state.ts
+++ b/src/core/decisions/gate-state.ts
@@ -41,6 +41,22 @@ export type GateOutcome =
   | { gated: false; reason: null }
   | { gated: true; reason: GateReason };
 
+/** A grace receipt is valid only for the exact source snapshot it assessed. */
+export function matchesConsolidationReceipt(
+  consolidatedAt: string | undefined,
+  recordedFingerprint: string | undefined,
+  currentFingerprint: string | undefined,
+  nowMs: number,
+  gracePeriodMs: number,
+): boolean {
+  if (!consolidatedAt || !recordedFingerprint || !currentFingerprint) return false;
+  const age = nowMs - new Date(consolidatedAt).getTime();
+  return Number.isFinite(age)
+    && age >= 0
+    && age < gracePeriodMs
+    && recordedFingerprint === currentFingerprint;
+}
+
 /**
  * Classify a gate state into exactly one outcome. The priority order mirrors the
  * commit gate: a not-yet-synced approval blocks first, then verified decisions

--- a/src/core/decisions/ledger.ts
+++ b/src/core/decisions/ledger.ts
@@ -20,16 +20,17 @@
 
 import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { DECISIONS_LEDGER_FILE, OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR } from '../../constants.js';
 import { fileExists } from '../../utils/command-helpers.js';
 import type { DecisionStatus, DecisionStore } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
+import { safeJoin } from '../../utils/path-confinement.js';
 
 // Path is built locally (not via store.ts) to keep this module dependency-free
 // of the store, which imports the ledger — no import cycle.
 function ledgerDir(rootPath: string): string {
-  return join(rootPath, OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR);
+  return safeJoin(resolve(rootPath), join(OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR));
 }
 
 export type LedgerActor = 'human' | 'autopilot' | 'agent' | 'sync';
@@ -49,7 +50,7 @@ export interface LedgerEntry {
 }
 
 export function ledgerPath(rootPath: string): string {
-  return join(ledgerDir(rootPath), DECISIONS_LEDGER_FILE);
+  return safeJoin(resolve(rootPath), join(OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR, DECISIONS_LEDGER_FILE));
 }
 
 /**

--- a/src/core/decisions/memory-store.ts
+++ b/src/core/decisions/memory-store.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { fileExists } from '../../utils/command-helpers.js';
 import {
@@ -19,13 +19,14 @@ import {
 } from '../../constants.js';
 import { atomicWriteFile, casUpdate, quarantineCorrupt } from './atomic-store.js';
 import type { MemoryStore, StructuralAnchor } from '../../types/index.js';
+import { safeJoin } from '../../utils/path-confinement.js';
 
 export function memoryDir(rootPath: string): string {
-  return join(rootPath, OPENLORE_DIR, OPENLORE_MEMORY_SUBDIR);
+  return safeJoin(resolve(rootPath), join(OPENLORE_DIR, OPENLORE_MEMORY_SUBDIR));
 }
 
 function memoryPath(rootPath: string): string {
-  return join(memoryDir(rootPath), MEMORY_NOTES_FILE);
+  return safeJoin(resolve(rootPath), join(OPENLORE_DIR, OPENLORE_MEMORY_SUBDIR, MEMORY_NOTES_FILE));
 }
 
 function emptyStore(): MemoryStore {
@@ -72,7 +73,7 @@ export async function saveMemoryStore(rootPath: string, store: MemoryStore): Pro
     updatedAt: new Date().toISOString(),
     sequence: (store.sequence ?? 0) + 1,
   };
-  await atomicWriteFile(memoryPath(rootPath), JSON.stringify(updated, null, 2) + '\n');
+  await atomicWriteFile(memoryPath(rootPath), JSON.stringify(updated, null, 2) + '\n', 0o600);
 }
 
 /**

--- a/src/core/decisions/store.ts
+++ b/src/core/decisions/store.ts
@@ -3,7 +3,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import {
   OPENLORE_DIR,
@@ -14,13 +14,14 @@ import { fileExists } from '../../utils/command-helpers.js';
 import { atomicWriteFile, casUpdate, quarantineCorrupt } from './atomic-store.js';
 import { appendLedgerEntries, currentHeadCommit, diffStoreTransitions, type LedgerActor } from './ledger.js';
 import type { PendingDecision, DecisionStore, DecisionStatus } from '../../types/index.js';
+import { safeJoin } from '../../utils/path-confinement.js';
 
 export function decisionsDir(rootPath: string): string {
-  return join(rootPath, OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR);
+  return safeJoin(resolve(rootPath), join(OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR));
 }
 
 function decisionsPath(rootPath: string): string {
-  return join(decisionsDir(rootPath), DECISIONS_PENDING_FILE);
+  return safeJoin(resolve(rootPath), join(OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR, DECISIONS_PENDING_FILE));
 }
 
 export async function loadDecisionStore(rootPath: string): Promise<DecisionStore> {
@@ -69,7 +70,7 @@ export async function saveDecisionStore(rootPath: string, store: DecisionStore):
     updatedAt: new Date().toISOString(),
     sequence: (store.sequence ?? 0) + 1,
   };
-  await atomicWriteFile(decisionsPath(rootPath), JSON.stringify(updated, null, 2) + '\n');
+  await atomicWriteFile(decisionsPath(rootPath), JSON.stringify(updated, null, 2) + '\n', 0o600);
 }
 
 /**

--- a/src/core/decisions/syncer.ts
+++ b/src/core/decisions/syncer.ts
@@ -125,6 +125,8 @@ export async function syncApprovedDecisions(
         ...snapshot,
         sessionId: disk.sessionId,
         lastConsolidatedAt: disk.lastConsolidatedAt ?? snapshot.lastConsolidatedAt,
+        lastConsolidatedSourceFingerprint:
+          disk.lastConsolidatedSourceFingerprint ?? snapshot.lastConsolidatedSourceFingerprint,
         decisions: [
           ...snapshot.decisions.filter((decision) => !conflictIds.has(decision.id)),
           ...changedDuringSync,

--- a/src/core/services/fixtures/configs/3.0.0-default.json
+++ b/src/core/services/fixtures/configs/3.0.0-default.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.1.0",
+  "projectType": "nodejs",
+  "openspecPath": "./openspec",
+  "analysis": {
+    "maxFiles": 100000,
+    "includePatterns": [],
+    "excludePatterns": []
+  },
+  "generation": {
+    "model": "claude-sonnet-4-6",
+    "domains": "auto"
+  },
+  "panicResponse": {
+    "mode": "off"
+  },
+  "createdAt": "2026-08-23T00:00:00.000Z",
+  "lastRun": null
+}

--- a/src/core/services/fixtures/configs/README.md
+++ b/src/core/services/fixtures/configs/README.md
@@ -7,6 +7,7 @@ They intentionally do not move with the current schema.
 - `2.1.9-customized.json` captures the customized pre-2.2 shape reported in issue #386, including a
   missing `generation.domains` field that was accepted before strict validation.
 - `2.2.0-default.json` captures the configuration factory shape from tag `v2.2.0`.
+- `3.0.0-default.json` captures the configuration factory shape for the v3 release candidate.
 
 For each release, add at least one `<package-version>-*.json` fixture before changing the package
 version. Include both a factory-default shape and a realistic customized shape when the release

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -376,7 +376,12 @@ export class McpWatcher {
         // no-op (the pre-hardening behavior). An async watcher error must never
         // pass silently on the long-lived host: disclose once and keep serving —
         // pending file changes are still caught at the next full analyze.
-        if (!watcherReady) { reject(err); return; }
+        if (!watcherReady) {
+          const failedWatcher = this.fsWatcher;
+          if (this.fsWatcher === failedWatcher) this.fsWatcher = undefined;
+          void failedWatcher?.close().finally(() => reject(err));
+          return;
+        }
         process.stderr.write(
           `[mcp-watcher] source watcher error (${(err as Error)?.message ?? String(err)}); ` +
           `continuing — changes may lag until the next analyze\n`

--- a/src/core/services/serve-client.test.ts
+++ b/src/core/services/serve-client.test.ts
@@ -16,6 +16,7 @@ import { join } from 'node:path';
 import { createServer } from 'node:http';
 import { serveCommand, startServe, type ServeHandle } from '../../cli/commands/serve.js';
 import { ensureServeDaemon, callServeTool, isServePresetRejection, ServeHttpError, serveSpawnArgs } from './serve-client.js';
+import { incompatibleServeDescriptorIsLive } from '../../cli/commands/serve-descriptor.js';
 
 let handle: ServeHandle | undefined;
 let root = '';
@@ -89,6 +90,12 @@ describe('serve-client', () => {
       await new Promise<void>((resolve) => legacy.close(() => resolve()));
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it('does not treat an unreachable legacy announcement as a live incompatible daemon', async () => {
+    const started = Date.now();
+    expect(await incompatibleServeDescriptorIsLive({ host: '127.0.0.1', port: 65534, pid: process.pid }, tmpdir())).toBe(false);
+    expect(Date.now() - started).toBeLessThan(1_000);
   });
 
   it('calls a tool and returns its body (handler error object on a bare root)', async () => {

--- a/src/core/services/serve-client.ts
+++ b/src/core/services/serve-client.ts
@@ -12,15 +12,19 @@
  */
 
 import { spawn } from 'node:child_process';
+import { closeSync, mkdirSync, openSync } from 'node:fs';
 import { join } from 'node:path';
 import { FULL_PRESET, OPENLORE_DIR } from '../../constants.js';
 import {
   readServeDescriptor,
+  readServeDescriptorState,
+  incompatibleServeDescriptorIsLive,
   serveHttpBaseUrl,
   validateServeHealth,
   type ServeDescriptor,
 } from '../../cli/commands/serve-descriptor.js';
 import { OPENLORE_TOKEN_HEADER } from '../../cli/commands/local-http-guard.js';
+import { safeJoin } from '../../utils/path-confinement.js';
 
 /** A resolved, reachable daemon. */
 export interface ServeEndpoint {
@@ -45,7 +49,7 @@ export function isServePresetRejection(error: unknown): error is ServeHttpError 
     && /not available in the active .* preset/i.test(error.message);
 }
 
-const SPAWN_HEALTH_TIMEOUT_MS = 8000;
+const SPAWN_HEALTH_TIMEOUT_MS = 30_000;
 const HEALTH_POLL_MS = 150;
 // Per-probe timeout for the reuse check. Generous so a cold Node HTTP server on
 // Windows isn't misread as dead — a false negative spawns a second daemon and
@@ -121,6 +125,8 @@ export async function ensureServeDaemon(
   directory: string,
   opts: { spawn?: boolean } = {},
 ): Promise<ServeEndpoint | null> {
+  const announced = await readServeDescriptorState(descriptorPath(directory));
+  if (announced.kind === 'incompatible' && await incompatibleServeDescriptorIsLive(announced.descriptor, directory)) return null;
   const existing = await readDescriptor(directory);
   if (existing && (await healthy(existing, directory))) return endpointOf(existing);
 
@@ -129,16 +135,30 @@ export async function ensureServeDaemon(
   // Spawn via the same CLI entry that's running us (works installed or in dev).
   const cli = process.argv[1];
   if (!cli) return null;
+  let logFd: number | undefined;
   try {
+    const isWin = process.platform === 'win32';
+    if (isWin) {
+      const openloreDir = safeJoin(directory, OPENLORE_DIR);
+      mkdirSync(openloreDir, { recursive: true });
+      logFd = openSync(safeJoin(directory, join(OPENLORE_DIR, 'serve.log')), 'a');
+    }
     const child = spawn(
       process.execPath,
       [cli, ...serveSpawnArgs(directory)],
-      { cwd: directory, stdio: 'ignore', detached: true, windowsHide: true },
+      {
+        cwd: directory,
+        stdio: isWin ? ['ignore', logFd!, logFd!] : 'ignore',
+        detached: !isWin,
+        windowsHide: true,
+      },
     );
     child.on('error', () => {}); // swallow — caller falls back to in-process
     child.unref();
   } catch {
     return null;
+  } finally {
+    if (logFd !== undefined) closeSync(logFd);
   }
 
   const deadline = Date.now() + SPAWN_HEALTH_TIMEOUT_MS;

--- a/src/core/services/tls-coverage.test.ts
+++ b/src/core/services/tls-coverage.test.ts
@@ -40,10 +40,11 @@ const SRC = join(REPO_ROOT, 'src');
  * opt in, which is a behaviour change in its own right.
  */
 const EXEMPT: { file: string; line: number; why: string }[] = [
-  { file: 'src/core/services/serve-client.ts', line: 93, why: 'loopback http:// health probe' },
-  { file: 'src/core/services/serve-client.ts', line: 167, why: 'loopback http:// daemon call' },
-  { file: 'src/cli/commands/serve.ts', line: 278, why: 'loopback http:// health and compatibility probe' },
-  { file: 'src/cli/commands/serve.ts', line: 339, why: 'loopback http:// authenticated shutdown request' },
+  { file: 'src/core/services/serve-client.ts', line: 97, why: 'loopback http:// health probe' },
+  { file: 'src/core/services/serve-client.ts', line: 187, why: 'loopback http:// daemon call' },
+  { file: 'src/cli/commands/serve.ts', line: 284, why: 'loopback http:// health and compatibility probe' },
+  { file: 'src/cli/commands/serve.ts', line: 356, why: 'loopback http:// authenticated shutdown request' },
+  { file: 'src/cli/commands/serve-descriptor.ts', line: 212, why: 'loopback http:// legacy liveness probe' },
   { file: 'src/pi/extension.ts', line: 546, why: 'loopback http:// health probe' },
   { file: 'src/pi/extension.ts', line: 721, why: 'loopback http:// daemon call' },
   { file: 'src/pi/extension.ts', line: 1563, why: 'loopback http:// health probe' },

--- a/src/core/services/tool-dispatch-redaction.test.ts
+++ b/src/core/services/tool-dispatch-redaction.test.ts
@@ -13,6 +13,7 @@ async function fixtureRoot(): Promise<string> {
 }
 
 afterEach(async () => {
+  delete process.env.OPENLORE_UNREDACT_TOOL_OUTPUT;
   await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
 });
 
@@ -65,7 +66,7 @@ describe('source-carrying tool output redaction', () => {
     expect(result.redactions).toEqual({ count: 1, kinds: ['secret-field'] });
   });
 
-  it('honors the trusted-solo config opt-out without a false disclosure', async () => {
+  it('does not let repository config disable tool-output redaction', async () => {
     const root = await fixtureRoot();
     const secret = `sk-${'b'.repeat(24)}`;
     await writeFile(join(root, 'auth.ts'), `export function auth() {\n  return "${secret}";\n}\n`);
@@ -86,6 +87,21 @@ describe('source-carrying tool output redaction', () => {
       filePath: 'auth.ts',
       functionName: 'auth',
     }, root) as Record<string, unknown>;
+
+    expect(result.body).not.toContain(secret);
+    expect(result).toHaveProperty('redactions');
+  });
+
+  it('honors the explicit operator environment opt-out', async () => {
+    const root = await fixtureRoot();
+    const secret = `sk-${'o'.repeat(24)}`;
+    process.env.OPENLORE_UNREDACT_TOOL_OUTPUT = '1';
+
+    const result = await redactSourceToolResult(
+      'get_function_body',
+      { body: secret },
+      root,
+    ) as Record<string, unknown>;
 
     expect(result.body).toContain(secret);
     expect(result).not.toHaveProperty('redactions');

--- a/src/core/services/tool-dispatch.ts
+++ b/src/core/services/tool-dispatch.ts
@@ -161,7 +161,13 @@ export const SOURCE_CARRYING_TOOLS = new Set([
 export async function redactSourceToolResult(name: string, result: unknown, directory: string): Promise<unknown> {
   if (!SOURCE_CARRYING_TOOLS.has(name)) return result;
   const config = await readOpenLoreConfig(directory);
-  if (config?.secretRedaction?.toolOutput === false) return result;
+  if (config?.secretRedaction?.toolOutput === false) {
+    logger.warning(
+      'Ignoring repository-configured secretRedaction.toolOutput=false. ' +
+      'Set OPENLORE_UNREDACT_TOOL_OUTPUT=1 in the operator environment for byte-exact output.',
+    );
+  }
+  if (process.env.OPENLORE_UNREDACT_TOOL_OUTPUT === '1') return result;
 
   const redacted = redactSecretsWithReport(result);
   if (redacted.redactions.count === 0) return result;

--- a/src/fuzz/serve-descriptor.fuzz.test.ts
+++ b/src/fuzz/serve-descriptor.fuzz.test.ts
@@ -10,7 +10,7 @@
  */
 import fc from 'fast-check';
 import { describe, it, expect } from 'vitest';
-import { validateServeDescriptor } from '../cli/commands/serve-descriptor.js';
+import { SERVE_PROTOCOL_VERSION, validateServeDescriptor } from '../cli/commands/serve-descriptor.js';
 import { isLoopbackHost } from '../utils/loopback.js';
 
 // Hosts that must NEVER be treated as loopback: public IPs, the cloud metadata
@@ -75,6 +75,10 @@ describe('fuzz: serve descriptor validation (SSRF containment)', () => {
         token: fc.oneof(fc.string(), fc.constant(undefined)),
         startedAt: fc.oneof(fc.string(), fc.constant(undefined)),
         version: fc.oneof(fc.string(), fc.constant(undefined)),
+        protocolVersion: fc.oneof(
+          { weight: 4, arbitrary: fc.constant(SERVE_PROTOCOL_VERSION) },
+          { weight: 1, arbitrary: fc.anything() },
+        ),
       },
       { requiredKeys: ['host', 'port', 'pid'] },
     );
@@ -113,7 +117,7 @@ describe('fuzz: serve descriptor validation (SSRF containment)', () => {
   });
 
   it('accepts a well-formed loopback descriptor and preserves its host', () => {
-    const result = validateServeDescriptor({ host: '127.0.0.1', port: 8080, pid: 1234, token: 'abc' });
+    const result = validateServeDescriptor({ host: '127.0.0.1', port: 8080, pid: 1234, token: 'abc', protocolVersion: SERVE_PROTOCOL_VERSION });
     expect(result).not.toBeNull();
     expect(result?.host).toBe('127.0.0.1');
     expect(result?.port).toBe(8080);

--- a/src/fuzz/serve-health.fuzz.test.ts
+++ b/src/fuzz/serve-health.fuzz.test.ts
@@ -13,19 +13,23 @@
  */
 import fc from 'fast-check';
 import { describe, it, expect } from 'vitest';
-import { validateServeHealth, canonicalServeRoot } from '../cli/commands/serve-descriptor.js';
+import { SERVE_PROTOCOL_VERSION, validateServeHealth, canonicalServeRoot } from '../cli/commands/serve-descriptor.js';
 
 const SHARED_ROOT = '/tmp/openlore-fuzz-root';
 
 describe('fuzz: serve health validation (daemon identity containment)', () => {
   it('never throws on arbitrary input', () => {
     const descriptorArb = fc.option(
-      fc.record({ pid: fc.integer(), token: fc.option(fc.string(), { nil: undefined }) }),
+      fc.record({ pid: fc.integer(), token: fc.option(fc.string(), { nil: undefined }), protocolVersion: fc.anything() }),
       { nil: undefined },
     );
     fc.assert(
       fc.property(fc.anything(), fc.string(), descriptorArb, (parsed, expectedRoot, descriptor) => {
-        validateServeHealth(parsed, expectedRoot, descriptor);
+        validateServeHealth(
+          parsed,
+          expectedRoot,
+          descriptor as Parameters<typeof validateServeHealth>[2],
+        );
         return true; // reaching this line is the property: it completed without throwing
       }),
       { numRuns: 2000 },
@@ -41,6 +45,10 @@ describe('fuzz: serve health validation (daemon identity containment)', () => {
     const healthLike = fc.record(
       {
         ok: fc.oneof({ weight: 4, arbitrary: fc.constant(true) }, { weight: 1, arbitrary: fc.anything() }),
+        protocolVersion: fc.oneof(
+          { weight: 4, arbitrary: fc.constant(SERVE_PROTOCOL_VERSION) },
+          { weight: 1, arbitrary: fc.anything() },
+        ),
         presetDispatchEnforced: fc.oneof(
           { weight: 4, arbitrary: fc.constant(true) },
           { weight: 1, arbitrary: fc.anything() },
@@ -95,6 +103,7 @@ describe('fuzz: serve health validation (daemon identity containment)', () => {
         const h = input as Record<string, unknown>;
         return (
           h.ok === true &&
+          h.protocolVersion === SERVE_PROTOCOL_VERSION &&
           h.presetDispatchEnforced === true &&
           h.tokenAuthenticated === true &&
           typeof h.root === 'string' &&
@@ -123,6 +132,7 @@ describe('fuzz: serve health validation (daemon identity containment)', () => {
   it('rejects an otherwise-valid health object whose root differs', () => {
     const validExceptRoot = fc.record({
       ok: fc.constant(true),
+      protocolVersion: fc.constant(SERVE_PROTOCOL_VERSION),
       presetDispatchEnforced: fc.constant(true),
       pid: fc.integer({ min: 1, max: 2 ** 31 }),
       preset: fc.string(),
@@ -145,6 +155,7 @@ describe('fuzz: serve health validation (daemon identity containment)', () => {
   it('rejects when a descriptor pid or token-presence disagrees', () => {
     const validHealth = {
       ok: true,
+      protocolVersion: SERVE_PROTOCOL_VERSION,
       presetDispatchEnforced: true,
       root: SHARED_ROOT,
       pid: 4321,
@@ -156,19 +167,19 @@ describe('fuzz: serve health validation (daemon identity containment)', () => {
     } as const;
 
     // Sanity: it accepts with a matching descriptor.
-    expect(validateServeHealth(validHealth, SHARED_ROOT, { pid: 4321, token: 't' })).not.toBeNull();
+    expect(validateServeHealth(validHealth, SHARED_ROOT, { pid: 4321, token: 't', protocolVersion: SERVE_PROTOCOL_VERSION })).not.toBeNull();
 
     // pid mismatch → reject.
-    expect(validateServeHealth(validHealth, SHARED_ROOT, { pid: 9999, token: 't' })).toBeNull();
+    expect(validateServeHealth(validHealth, SHARED_ROOT, { pid: 9999, token: 't', protocolVersion: SERVE_PROTOCOL_VERSION })).toBeNull();
 
     // token-presence disagreement: health says tokenProtected=true but descriptor
     // has no token → reject.
-    expect(validateServeHealth(validHealth, SHARED_ROOT, { pid: 4321, token: undefined })).toBeNull();
+    expect(validateServeHealth(validHealth, SHARED_ROOT, { pid: 4321, token: undefined, protocolVersion: SERVE_PROTOCOL_VERSION })).toBeNull();
 
     // token-presence disagreement, other direction: health says tokenProtected=false
     // but descriptor carries a token → reject.
     const unprotected = { ...validHealth, tokenProtected: false };
-    expect(validateServeHealth(unprotected, SHARED_ROOT, { pid: 4321, token: 't' })).toBeNull();
+    expect(validateServeHealth(unprotected, SHARED_ROOT, { pid: 4321, token: 't', protocolVersion: SERVE_PROTOCOL_VERSION })).toBeNull();
   });
 
   it('accepts a concrete well-formed health object', () => {
@@ -176,6 +187,7 @@ describe('fuzz: serve health validation (daemon identity containment)', () => {
       validateServeHealth(
         {
           ok: true,
+          protocolVersion: SERVE_PROTOCOL_VERSION,
           presetDispatchEnforced: true,
           root: '/tmp/x',
           pid: 123,
@@ -186,7 +198,7 @@ describe('fuzz: serve health validation (daemon identity containment)', () => {
           draining: false,
         },
         '/tmp/x',
-        { pid: 123, token: 't' },
+        { pid: 123, token: 't', protocolVersion: SERVE_PROTOCOL_VERSION },
       ),
     ).not.toBeNull();
   });

--- a/src/pi/extension.test.ts
+++ b/src/pi/extension.test.ts
@@ -169,7 +169,7 @@ it('accepts a daemon only when it covers the full Pi surface', () => {
   expect(missingDaemonTools(['orient'], required)).toContain('record_decision');
 });
 
-it('reports a legacy daemon without tools immediately as incompatible', async () => {
+it('rejects a legacy daemon without a compatible protocol immediately', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'openlore-pi-legacy-'));
   const server = createServer((_req, res) => {
     res.writeHead(200, { 'content-type': 'application/json' });
@@ -190,9 +190,7 @@ it('reports a legacy daemon without tools immediately as incompatible', async ()
     const startedAt = Date.now();
     const discovered = await ensureDaemon(dir);
     expect(Date.now() - startedAt).toBeLessThan(1000);
-    const result = await callTool(discovered!, 'orient', { task: 'x' }, dir) as { error?: string };
-    expect(result.error).toMatch(/does not report an authenticated, enforced tool surface/);
-    expect(result.error).toMatch(/stop the legacy or incompatible process manually/i);
+    expect(discovered).toBeNull();
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
     await rm(dir, { recursive: true, force: true });

--- a/src/scripts/audit-gate.test.ts
+++ b/src/scripts/audit-gate.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+const created: string[] = [];
+
+async function runGate(report: unknown): Promise<{ code: number; output: string }> {
+  const bin = await mkdtemp(join(tmpdir(), 'openlore-audit-gate-'));
+  created.push(bin);
+  await writeFile(
+    join(bin, 'npm'),
+    `#!/bin/sh\nprintf '%s\\n' '${JSON.stringify(report)}'\n`,
+    { mode: 0o755 },
+  );
+  try {
+    const result = await execFileAsync(process.execPath, ['scripts/audit-gate.mjs'], {
+      cwd: process.cwd(),
+      env: { ...process.env, PATH: `${bin}${delimiter}${process.env.PATH ?? ''}` },
+    });
+    return { code: 0, output: result.stdout + result.stderr };
+  } catch (error) {
+    const failure = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: failure.code ?? 1, output: (failure.stdout ?? '') + (failure.stderr ?? '') };
+  }
+}
+
+afterEach(async () => {
+  for (const path of created.splice(0)) await rm(path, { recursive: true, force: true });
+});
+
+describe('audit-gate malformed report handling', () => {
+  it('accepts a complete clean npm audit report', async () => {
+    const result = await runGate({
+      vulnerabilities: {},
+      metadata: { vulnerabilities: { info: 0, low: 0, moderate: 0, high: 0, critical: 0 } },
+    });
+    expect(result.code).toBe(0);
+    expect(result.output).toContain('audit-gate: OK');
+  });
+
+  it('fails closed when a high advisory has no stable identifier', async () => {
+    const result = await runGate({
+      vulnerabilities: {
+        unsafe: { severity: 'high', via: [{ severity: 'high', title: 'unsafe', url: '' }] },
+      },
+      metadata: { vulnerabilities: { info: 0, low: 0, moderate: 0, high: 1, critical: 0 } },
+    });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain('has no stable URL-derived id');
+  });
+
+  it('fails closed when metadata and the vulnerability map disagree', async () => {
+    const result = await runGate({
+      vulnerabilities: {},
+      metadata: { vulnerabilities: { info: 0, low: 0, moderate: 0, high: 1, critical: 0 } },
+    });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain('metadata reports 1 high/critical vulnerabilities');
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -888,6 +888,8 @@ export interface DecisionStore {
   sequence?: number;
   /** Set after consolidation runs — gate uses this to skip no_decisions_recorded warning */
   lastConsolidatedAt?: string;
+  /** Hash of the changed source snapshot assessed by the last consolidation. */
+  lastConsolidatedSourceFingerprint?: string;
   decisions: PendingDecision[];
 }
 

--- a/src/utils/path-confinement.ts
+++ b/src/utils/path-confinement.ts
@@ -14,8 +14,9 @@
  */
 
 import { constants, realpathSync, lstatSync, readlinkSync, type Stats } from 'node:fs';
-import { open, realpath, stat } from 'node:fs/promises';
-import { dirname, resolve, sep } from 'node:path';
+import { lstat, mkdir, open, realpath, rename, stat, unlink } from 'node:fs/promises';
+import { basename, dirname, relative, resolve, sep } from 'node:path';
+import { randomUUID } from 'node:crypto';
 
 /** Upper bound on a symlink chain, so a cycle cannot spin the resolver. */
 const MAX_SYMLINK_HOPS = 64;
@@ -238,6 +239,76 @@ export function isConfinedPath(absRoot: string, absPath: string): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/** Atomically replace a repository file without following any repository symlink. */
+export async function confinedAtomicWriteFile(
+  absRoot: string,
+  absPath: string,
+  data: string,
+  options: { mode?: number; preserveMode?: boolean } = {},
+): Promise<void> {
+  const lexicalRoot = resolve(absRoot);
+  const canonicalRoot = await realpath(lexicalRoot);
+  const requested = resolve(absPath);
+  const base = requested === canonicalRoot || requested.startsWith(canonicalRoot + sep)
+    ? canonicalRoot
+    : lexicalRoot;
+  const target = safeJoin(base, relative(base, requested));
+  const parent = dirname(target);
+  await mkdir(parent, { recursive: true });
+
+  const expectedParent = resolve(canonicalRoot, relative(base, parent));
+  const canonicalParent = await realpath(parent);
+  if (canonicalParent !== expectedParent) {
+    throw new Error(`Path escape blocked: symbolic-link path component in "${target}"`);
+  }
+
+  let existingMode: number | undefined;
+  try {
+    const existing = await lstat(target);
+    if (existing.isSymbolicLink() || !existing.isFile()) {
+      throw new Error(`Path escape blocked: write target is not a regular file: "${target}"`);
+    }
+    existingMode = existing.mode & 0o777;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+
+  const mode = options.preserveMode && existingMode !== undefined
+    ? existingMode
+    : (options.mode ?? 0o666);
+  const temp = resolve(canonicalParent, `.${basename(target)}.${process.pid}.${randomUUID()}.tmp`);
+  let published = false;
+  try {
+    const handle = await open(
+      temp,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+      mode,
+    );
+    try {
+      await handle.writeFile(data, 'utf-8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    if (await realpath(parent) !== canonicalParent) {
+      throw new Error(`Path escape blocked: write parent changed during publication: "${target}"`);
+    }
+    try {
+      if ((await lstat(target)).isSymbolicLink()) {
+        throw new Error(`Path escape blocked: symbolic-link write target: "${target}"`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    // Publish through the already-canonical parent, not the repository-controlled
+    // lexical parent that could be swapped for a symlink after validation.
+    await rename(temp, resolve(canonicalParent, basename(target)));
+    published = true;
+  } finally {
+    if (!published) await unlink(temp).catch(() => {});
   }
 }
 


### PR DESCRIPTION
## Status

LGTM. Three security review lanes and five software QA roles audited this release candidate; both final security re-reviews approved it for merge.

## What was wrong

- Release metadata and supported packaging were stale after substantial changes since v2.2.0, including breaking public API contracts.
- CI and release validation omitted most deterministic integration coverage and did not execute at the advertised Node.js floor.
- Repository-controlled symlinks, configuration, hook launchers, and daemon descriptors crossed several filesystem, code-execution, and secret-egress trust boundaries.
- Dependency automation, audit parsing, and package-content checks could miss security-relevant conditions.

## How it was fixed

- Prepared version 3.0.0 with synchronized npm, changelog, configuration compatibility fixture, Node.js 22.19 floor, CI/release jobs, and Nix packaging.
- Added confined atomic writes, symlink rejection, mode preservation, state-store confinement, trusted external hook launchers, decision-gate source fingerprints, and untrusted-config restrictions.
- Made the local daemon token-protected by default, minimized unauthenticated health output, added protocol negotiation and safe legacy-daemon handling, and hardened descriptor publication and Windows lifecycle behavior.
- Made dependency audit and package-content scanning fail closed, removed Dependabot security-update suppression, and added deterministic offline integration and runtime compatibility gates.

## Replication / proof

- Full suite: 8,867 passed, 2 skipped, 0 failed across 449 files.
- Deterministic integration gate: 35 passed across 9 files.
- Exact Node.js 22.19 container: typecheck, build, API consumer, and integration gates passed.
- Lint, typecheck, build, `git diff --check`, actionlint, dependency audit, package-content audit, and Nix build passed.
- Final adversarial and code-security re-reviews found no remaining release blocker.

## Notes / nits

- This is intentionally 3.0.0, not 2.3.0, because the release contains breaking public API type-shape changes.
- This PR prepares the repository; it does not create the release tag or publish to npm.
- Homebrew remains explicitly staged. Network/live-data and host-resource stress suites remain outside the deterministic required lane.
- GitHub rulesets and the `npm-publish` environment/reviewer were verified. The npm Trusted Publisher portal configuration could not be independently inspected, while the workflow itself uses OIDC provenance and no npm token.
