### PR TITLE
test(security): audit doctor embedding egress

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -809,6 +809,8 @@ async function checkEmbeddingConnection(rootPath: string): Promise<CheckResult |
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DOCTOR_TIMEOUT_MS);
+    // INTENTIONAL EGRESS: doctor sends a constant probe to the operator-selected endpoint or repo-selected loopback.
+    // codeql[js/file-access-to-http]
     const response = await withRelaxedTls(() => fetch(`${url}/embeddings`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },

--- a/src/workflow-security.test.ts
+++ b/src/workflow-security.test.ts
@@ -396,7 +396,7 @@ describe('workflow security: supply-chain automation is wired', () => {
 });
 
 describe('workflow security: reviewed CodeQL egress stays narrow and auditable', () => {
-  it('allows only the fourteen reviewed file-to-HTTP egress sinks', () => {
+  it('allows only the fifteen reviewed file-to-HTTP egress sinks', () => {
     const markers: Record<string, number> = {};
     const unexplained: string[] = [];
 
@@ -418,6 +418,7 @@ describe('workflow security: reviewed CodeQL egress stays narrow and auditable',
       'Every reviewed CodeQL egress marker must name one query and have an immediately preceding rationale.'
     ).toEqual([]);
     expect(markers, 'Changing the reviewed egress set requires explicit security review.').toEqual({
+      'src/cli/commands/doctor.ts': 1,
       'src/cli/commands/serve.ts': 2,
       'src/cli/commands/view.ts': 1,
       'src/core/analyzer/embedding-service.ts': 1,


### PR DESCRIPTION
**Status:** LGTM. Awaiting required GitHub checks.

**What was wrong:** Doctor's embedding probe is an intentional outbound request with existing trust-boundary tests, but it was not included in the repository's count-pinned reviewed-egress inventory. CodeQL alert #537 exposed that auditability gap.

**How it was fixed:** Added the required rationale-bound CodeQL audit marker directly at the doctor embedding sink and increased the exact reviewed-sink inventory from 14 to 15. Runtime behavior is unchanged.

**Replication / proof:** The existing doctor tests prove that repository-selected remote endpoints are refused, environment-selected remote endpoints use only environment model/key values, and the probe body is the constant ping. The focused doctor and workflow-security suites pass (77 tests), as do lint and typecheck.

**Notes / nits:** Alerts #538 and #539 refer to the already-marked core embedding flow, whose feature purpose is to send repository text to an operator-selected endpoint or a repository-selected loopback endpoint. After this PR is green, all 3 reviewed findings can be triaged as intended egress under SECURITY.md.
