### PR TITLE
chore(release): prepare v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@
 All notable changes to OpenLore are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-08-30
+
+**The release where OpenLore learns the shape and vocabulary of a whole workspace.**
+
+- **Analyze large workspaces by shard.** OpenLore detects package boundaries, supports explicit
+  `workspace.shards` configuration and targeted `analyze --shard` runs, then assembles bounded,
+  attributable workspace results without making a monorepo behave like one giant package.
+- **Catch imported bundles up instead of starting over.** A clean bundle from an ancestor commit
+  now applies the exact repository delta through the watcher's bounded converge-or-flag path;
+  unverifiable, diverged, or oversized gaps still rebuild and disclose why.
+- **Find code using the repository's own language.** Keyword search now expands queries through a
+  bounded repository vocabulary, semantic results disclose score meaning and index freshness, and
+  stale regions retain enough structural context to explain what needs rebuilding.
+- **Understand more real-world source files.** Vue, Svelte, and Astro script containers participate
+  in structural analysis, while the digest distinguishes languages with structural backing from
+  files that are only counted.
+- **Keep the agent loop honest.** New Claude Code and Codex enforcement hooks run repository policy
+  checks during agent work, preserve concurrent settings edits, and fail safely at trust boundaries.
+  Generate and Repair also disclose when OpenSpec validation did not run instead of presenting
+  unvalidated prose as a completed specification.
+- **Treat Pi as a first-class install target.** `install`, `connect`, dry-run, force, and uninstall
+  flows now detect and configure Pi. The generated extension shim fixes the previously broken copied
+  artifact while refusing to overwrite user-owned extensions by default.
+- **Harden network, path, and architecture boundaries.** TLS verification opt-outs are scoped to one
+  outbound surface at a time; configured spec roots and architecture-layer patterns are confined;
+  incremental watcher work is bounded and preserves explicit freshness receipts under races.
+- Adds a reproducible default-surface benchmark protocol and refreshes `web-tree-sitter` to 0.25.10.
+
+This release is backward-compatible with 3.0.x. The programmatic API adds optional workspace,
+retrieval, and stale-region receipt types; configuration schema 1.2.0 adds only optional sections.
+
+**Upgrade:** `npm i -g openlore@3.1.0` — or `openlore update`.
+
+**Full Changelog**: https://github.com/clay-good/OpenLore/compare/v3.0.1...v3.1.0
+
 ## [3.0.1] - 2026-08-23
 
 - Release validation now builds the trusted OpenLore launcher before exercising hook

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         {
           default = pkgs.buildNpmPackage {
             pname = "openlore";
-            version = "3.0.1";
+            version = "3.1.0";
 
             src = ./.;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Persistent architectural memory and structural cognition for AI coding agents.",
   "type": "module",
   "main": "dist/api/index.js",

--- a/src/core/services/fixtures/configs/3.1.0-default.json
+++ b/src/core/services/fixtures/configs/3.1.0-default.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.2.0",
+  "projectType": "nodejs",
+  "openspecPath": "./openspec",
+  "analysis": {
+    "maxFiles": 100000,
+    "includePatterns": [],
+    "excludePatterns": []
+  },
+  "generation": {
+    "model": "claude-sonnet-4-6",
+    "domains": "auto"
+  },
+  "panicResponse": {
+    "mode": "off"
+  },
+  "createdAt": "2026-08-30T00:00:00.000Z",
+  "lastRun": null
+}

--- a/src/core/services/fixtures/configs/3.1.0-workspace.json
+++ b/src/core/services/fixtures/configs/3.1.0-workspace.json
@@ -1,0 +1,36 @@
+{
+  "version": "1.2.0",
+  "projectType": "nodejs",
+  "openspecPath": "./openspec",
+  "analysis": {
+    "maxFiles": 100000,
+    "includePatterns": [],
+    "excludePatterns": [
+      "**/generated/**"
+    ]
+  },
+  "generation": {
+    "model": "claude-sonnet-4-6",
+    "domains": "auto"
+  },
+  "retrieval": {
+    "vocabularyExpansion": true
+  },
+  "workspace": {
+    "shards": [
+      {
+        "name": "api",
+        "root": "packages/api"
+      },
+      {
+        "name": "web",
+        "root": "packages/web"
+      }
+    ]
+  },
+  "panicResponse": {
+    "mode": "off"
+  },
+  "createdAt": "2026-08-30T00:00:00.000Z",
+  "lastRun": null
+}

--- a/src/core/services/fixtures/configs/README.md
+++ b/src/core/services/fixtures/configs/README.md
@@ -10,6 +10,9 @@ They intentionally do not move with the current schema.
 - `3.0.0-default.json` captures the configuration factory shape for the v3 release candidate.
 - `3.0.1-default.json` captures the unchanged configuration factory shape for the v3.0.1
   release-pipeline patch.
+- `3.1.0-default.json` captures the default configuration factory shape for v3.1.0 and schema 1.2.0.
+- `3.1.0-workspace.json` captures the optional workspace-shard and retrieval settings introduced in
+  v3.1.0.
 
 For each release, add at least one `<package-version>-*.json` fixture before changing the package
 version. Include both a factory-default shape and a realistic customized shape when the release


### PR DESCRIPTION
## Status

LGTM.

## What was missing / the motivation

The backward-compatible features merged since v3.0.1 need a SemVer release boundary and user-facing upgrade notes. A patch would understate the added functionality, so 3.1.0 is the smallest correct version.

## What it does

- Bumps the npm package, lockfile, and Nix package metadata to 3.1.0.
- Adds release notes covering workspace shards, incremental bundle catch-up, repository-vocabulary search, SFC analysis, agent enforcement hooks, first-class Pi installation, and security hardening.
- Adds frozen default and workspace-specific fixtures for configuration schema 1.2.0.

## Proof it works

- Protected main checks are green for the complete source boundary: unit tests, integration tests, Node 22.19, Windows, build, lint/typecheck, CodeQL, and the aggregate CI gate.
- Combined release commit: lint, typecheck, and build pass.
- Focused release/import coverage: 225/225 tests pass.
- Deterministic integration suite: 35/35 tests pass.
- Public API consumer smoke test, dependency audit, and 1,827-file npm packlist audit pass.
- The atomic-store stress suite passes 24/24 in isolation. Under two local full-suite runs, one of its high-contention cases exceeded the 30-second test budget while 9,198/9,199 tests passed; the same complete source boundary passes protected CI, and the release workflow will rerun the full gate before publishing.

## Notes / nits

The tag-driven release workflow creates the GitHub release from CHANGELOG.md and publishes one validated immutable tarball to npm with provenance. No public exports, commands, required API fields, supported runtimes, or existing configuration fields are removed.