### PR TITLE
chore(deps): give the parser/vector stack its own Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,18 @@ updates:
     open-pull-requests-limit: 5
     versioning-strategy: increase-if-necessary
     groups:
+      # The ABI-sensitive parser/vector stack, in its own PR. These are NOT ignored
+      # (see the note below) — they are separated, because bundling them with routine
+      # drift is what stalled #429: seven grammar majors broke 34 analyzer tests and
+      # held six harmless bumps hostage for the whole cycle. Grouping only changes
+      # which PR they arrive in, so advisory-driven security updates are unaffected.
+      parser-stack:
+        applies-to: version-updates
+        patterns:
+          - 'tree-sitter'
+          - 'tree-sitter-*'
+          - 'web-tree-sitter'
+          - '@lancedb/lancedb'
       # One PR for routine dev-tooling drift (eslint, vitest, tsx, types).
       dev-dependencies:
         applies-to: version-updates


### PR DESCRIPTION
**Status:** LGTM. Small config change; stops a failure mode we just hit twice.

## What was missing / the motivation

Dependabot #429 bundled 13 production updates. Seven were tree-sitter grammar majors that break **34 analyzer tests** (#438) — including silently dropping Dart and Lua support. The other six were harmless. Because they arrived as one group, the harmless six were stuck behind a parser-compatibility project for the whole cycle, and the PR sat red.

The moment #429 was superseded, Dependabot regenerated the same shape as #440 — same grammar majors, same harmless bumps, same red PR.

## What it does

Adds a `parser-stack` version-update group covering `tree-sitter`, `tree-sitter-*`, `web-tree-sitter`, and `@lancedb/lancedb`, ordered before the other npm groups so it claims those packages first. Routine drift lands on its own; parser work gets reviewed on its own schedule.

**It deliberately does not use `ignore`.** The existing comment in this file is correct that an ignore would also suppress advisory-driven security updates on the highest-risk native input surface. Grouping only changes *which PR* a version update arrives in — security updates are unaffected — so that note is left in place, and I've cross-referenced it from the new group.

## Proof it works

- `.github/dependabot.yml` parses as valid YAML; npm groups resolve to `['parser-stack', 'dev-dependencies', 'production-minor-patch']` in that order.
- `src/workflow-security.test.ts` → 12/12 pass (this is the suite that guards the Dependabot config and action pinning).

## Notes / nits

- Group ordering is what makes this work: Dependabot assigns a dependency to the first matching group, so `parser-stack` must stay above `production-minor-patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)