### PR TITLE
fix(windows): close the console-flash class the guards could not see

### DIFF
--- a/openspec/changes/harden-windows-spawn-invariant/.openspec.yaml
+++ b/openspec/changes/harden-windows-spawn-invariant/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/harden-windows-spawn-invariant/proposal.md
+++ b/openspec/changes/harden-windows-spawn-invariant/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+`extend-api-for-supervising-hosts` (#431) fixed the Windows console-flash and zombie-daemon
+regressions and left two structural guards behind so the bug class could not return. Reviewing the
+merged result against the whole tree found that the guards do not yet cover the class they claim,
+and that three `git` spawns were never migrated.
+
+**The bug class.** `windowsHide` defaults to false in Node. A console program spawned from a parent
+with no console of its own — the `serve`/`mcp` daemon, a Claude Code hook (`orient --inject`, which
+fires on every user turn once installed), the Pi extension host — opens a brand new visible console
+window, one per spawn. That is what made the app unusable on Windows.
+
+**What the guards miss.**
+
+- `git-exec.test.ts` matched only the `execFile` / `execFileSync` / `execFileAsync` shapes, so a
+  `spawn`/`spawnSync` of `git` was invisible to it. Three such sites survived the migration, two of
+  them inside MCP handlers on the daemon path the fix was written for:
+  `epistemic-lease.ts` (`git rev-parse HEAD`, on the tool-invocation path), `analysis.ts`
+  (`runGit`), and `git-diff.ts` (`git cat-file --batch`).
+- That same guard skipped any FILE that imported `git-exec.js`. All 30 migrated files import it, so
+  the guard exempted precisely the files most likely to grow the next `git` spawn.
+- `windows-detached-spawn-guard.test.ts` fires only on `detached: true`. The flash needs no
+  `detached` at all — none of the three sites above is detached.
+
+Six further non-`git` spawns had the same defect and no guard that could see them, four of them
+reachable from the daemon or the Pi host (`which gryph`, the synchronous `gryph query`, the Pi
+extension's POSIX spawn branch, plus `claude` and `docker` probes).
+
+## What Changes
+
+All additive or one-line. No behavioural change on macOS or Linux, where `windowsHide` is a
+documented no-op.
+
+**One invariant, stated directly.** A new `windows-hidden-spawn-guard.test.ts` replaces both
+source-scanning guards with an import-aware scanner: EVERY subprocess spawned from `src/` sets
+`windowsHide: true`, unless it inherits the parent's console (`stdio: 'inherit'`), which is the
+interactive re-entry path — `heap-sizing`'s re-exec of the user's own command, `preflight`'s
+re-analyze, `update`'s package-manager run — whose prompts must keep reaching a real console.
+
+Import-awareness is what makes the scan usable: it resolves which local identifiers are bound to
+`node:child_process`, so the hundreds of `regex.exec(...)` / `db.exec(...)` method calls are not
+false positives, and an aliased import (`import { spawn as launch }`) is not a false negative. The
+git-routing invariant moves into the same file, and stops exempting whole files: an alias of the
+guarded helper is simply not a `node:child_process` binding, while a fresh raw import beside it is.
+
+**The nine unguarded spawns are fixed**, three by routing through `git-exec.ts` (which gains
+`spawnGit` / `spawnGitSync` for the streaming and fd-redirected shapes), six by setting the option
+directly.
+
+**Two correctness fixes found in the same review.**
+
+- `execFileGitSync` typed a plain-options call as returning `string`, but Node's `execFileSync`
+  returns a `Buffer` unless given an encoding — so the ergonomic `execFileGitSync('git', args,
+  { cwd }).trim()` was a latent `TypeError` against a passing type check. It now defaults to
+  `'utf-8'`; `{ encoding: 'buffer' }` still yields bytes.
+- Both daemon exit paths used `then`, so a `teardown()` that rejects on one of its unguarded
+  synchronous steps skipped `process.exit` entirely and surfaced as an unhandled rejection — the
+  zombie daemon returning in exactly the failure case the fix exists to prevent, after the client
+  was told the stop succeeded. Both now use `finally`.
+
+## Deliberately NOT done
+
+- **`stdio: 'inherit'` sites are not touched.** Forcing `CREATE_NO_WINDOW` on them would detach the
+  user's own interactive command from the console it needs.
+- **No new spec domain.** The invariant is recorded as one `cli` requirement, mirroring
+  `analyzer: GitPathOutputFidelity`, which holds the identical "one shared helper plus an automated
+  guard" shape for git's `core.quotepath`.
+- **The `finally` change carries no dedicated regression test.** `teardown()`'s awaited steps are
+  individually guarded (`drainServeRebuilds` uses `allSettled`, the watcher stop is `.catch`ed), so
+  forcing a rejection would mean contriving a throw from a synchronous step. It is defensive
+  hardening, not a reproduced failure, and is documented as such at the call site.

--- a/openspec/changes/harden-windows-spawn-invariant/specs/cli/spec.md
+++ b/openspec/changes/harden-windows-spawn-invariant/specs/cli/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: SubprocessesNeverSurfaceAConsoleWindow
+
+Every subprocess spawned from `src/` SHALL set `windowsHide: true`, unless it inherits the parent's
+console (`stdio: 'inherit'`). On Windows a console program spawned from a process that has no
+console of its own — the `serve`/`mcp` daemon, a Git hook or agent hook invocation, an editor
+extension host — is given a brand new visible console window, one per spawn; a path that shells out
+per file turns that into a continuous flash that makes the tool unusable for real work.
+
+The exemption is exact rather than incidental: an inheriting child is by construction attached to a
+console its parent already has, so no window is created, and suppressing one would cut the user's
+own interactive command off from the terminal it is writing to.
+
+Spawning `git` SHALL additionally route through a single shared helper, so that `windowsHide` — and
+any future cross-cutting concern on git subprocesses — is applied in one place instead of being
+re-remembered at every call site.
+
+An automated guard SHALL enforce both invariants on every platform, by reading the source rather
+than by running it: a headless Windows runner cannot observe a window flashing, so no behavioural
+test on any runner can fail when the option is dropped. The guard SHALL resolve which local
+identifiers are bound to the process-spawning module, so that it neither reports method calls that
+merely share a name (`regex.exec`, `db.exec`) nor misses a spawn imported under an alias, and it
+SHALL scope its exemptions to individual call sites rather than to whole files.
+
+#### Scenario: A new spawn on a daemon path omits the option
+
+- **GIVEN** a contributor adds a subprocess spawn that does not inherit a console
+- **WHEN** the guard test runs in CI, on any platform
+- **THEN** it fails, naming the offending file and line, and states both remedies — set
+  `windowsHide: true`, or route a `git` spawn through the shared helper
+
+#### Scenario: A migrated file grows a second, raw git spawn
+
+- **GIVEN** a file that already calls the shared git helper under a local alias
+- **WHEN** a new raw `node:child_process` spawn of `git` is added beside it
+- **THEN** the guard fails on the new site, and does not treat the file's existing use of the helper
+  as blanket permission
+
+#### Scenario: An interactive command keeps its console
+
+- **GIVEN** a command that re-executes the user's own invocation with `stdio: 'inherit'`
+- **WHEN** the guard test runs
+- **THEN** it passes without `windowsHide`, because the child writes to the console it inherited
+
+#### Scenario: A stopping daemon whose teardown fails still exits
+
+- **GIVEN** a daemon asked to stop, whose teardown rejects
+- **WHEN** the shutdown path settles
+- **THEN** the process still exits, rather than leaving a live OS process behind after the client
+  has been told the stop succeeded

--- a/openspec/changes/harden-windows-spawn-invariant/tasks.md
+++ b/openspec/changes/harden-windows-spawn-invariant/tasks.md
@@ -1,0 +1,30 @@
+## 1. State the invariant once, and enforce it
+
+- [x] 1.1 Add `src/utils/windows-hidden-spawn-guard.test.ts`: an import-aware scanner that resolves
+  `node:child_process` bindings (including aliases), masks comments and string literals
+  length-preservingly so reported lines stay true, and fails on any spawn lacking `windowsHide` that
+  does not inherit a console — verified by a negative control and a non-vacuity check.
+- [x] 1.2 Move the git-routing guard into the same file, keyed on bindings rather than files, so one
+  migrated alias no longer exempts a raw spawn beside it — verified by a mixed-import control.
+- [x] 1.3 Reduce `src/utils/git-exec.test.ts` to behaviour, and make each assertion prove the option
+  reaches the spawn — verified by mutation: deleting `windowsHide` turns five of them red.
+
+## 2. Close the nine unguarded spawns
+
+- [x] 2.1 Add `spawnGit` / `spawnGitSync` to `src/utils/git-exec.ts`, typed as `typeof spawn` /
+  `typeof spawnSync` so Node's stdio-tuple narrowing survives the wrapper — verified by typecheck
+  against `git cat-file --batch`'s non-nullable `child.stdin`.
+- [x] 2.2 Route the three raw `git` spawns through them: `epistemic-lease.ts`, `analysis.ts`,
+  `git-diff.ts`.
+- [x] 2.3 Set `windowsHide` on the six non-git sites: `gryph-bridge.ts` (×2), `pi/extension.ts`'s
+  POSIX branch, `prove.ts`, `agent-eval/measure.ts`, `bench/container-launch.ts`.
+- [x] 2.4 Re-anchor `tls-coverage.test.ts`'s three `pi/extension.ts` exemptions, shifted by the new
+  comment; make `epistemic-lease.test.ts`'s `node:child_process` mock partial, since the module now
+  reaches `git-exec.ts` and its wholesale mock left `execFile` undefined at import.
+
+## 3. Correctness fixes found in the same review
+
+- [x] 3.1 Default `execFileGitSync` to `'utf-8'` so a plain-options call returns the `string` its
+  signature promises — verified by mutation, and by a test that `{ encoding: 'buffer' }` still
+  yields bytes.
+- [x] 3.2 Exit on a rejected teardown in both daemon exit paths (`finally`, not `then`).

--- a/src/bench/container-launch.ts
+++ b/src/bench/container-launch.ts
@@ -46,6 +46,7 @@ export function launchBenchmarkContainer(
   const imageId = execFileSync('docker', ['image', 'inspect', '--format', '{{.Id}}', spec.tag], {
     cwd: root,
     encoding: 'utf8',
+    windowsHide: true,
   }).trim();
   if (!/^sha256:[a-f0-9]{64}$/.test(imageId)) throw new Error(`Docker returned an invalid benchmark image id: ${imageId}.`);
 

--- a/src/cli/commands/prove.ts
+++ b/src/cli/commands/prove.ts
@@ -120,7 +120,7 @@ export async function loadProveEligibility(absDir: string): Promise<ReturnType<t
 }
 
 function claudeAvailable(): boolean {
-  try { execFileSync('claude', ['--version'], { stdio: 'ignore' }); return true; } catch { return false; }
+  try { execFileSync('claude', ['--version'], { stdio: 'ignore', windowsHide: true }); return true; } catch { return false; }
 }
 
 /** Best-effort short repo SHA for scorecard provenance; null when unavailable. */

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -801,8 +801,17 @@ async function runServe(options: ServeCliOptions): Promise<ServeOutcome> {
       // leaving a zombie daemon behind even though the client sees success (change:
       // extend-api-for-supervising-hosts). Exit explicitly here too, once the response has
       // actually gone out so the client still gets its 202 first.
+      // `finally`, not `then`. teardown()'s awaited steps are individually guarded (the watcher
+      // stop is `.catch`ed, drainServeRebuilds uses allSettled), but its synchronous ones are not:
+      // a throw from watchRepair.cancel(), unregisterRepairHost() or releaseContextCache() rejects
+      // teardownPromise. On `then` that skips process.exit entirely AND surfaces as an unhandled
+      // rejection — the zombie daemon returns in precisely the failure case this code exists to
+      // prevent, after the client has already been told the stop succeeded. Defensive rather than a
+      // reproduced failure, but exiting regardless is the right call either way: the draining
+      // descriptor is published before any of this runs, so the daemon is already unreachable and
+      // all that remains is whether its OS process lingers.
       res.on('finish', () => {
-        void shutdown.then(() => process.exit(0));
+        void shutdown.finally(() => process.exit(0));
       });
       return;
     }
@@ -1105,8 +1114,13 @@ async function runServe(options: ServeCliOptions): Promise<ServeOutcome> {
     return teardownPromise;
   };
   async function exitAfterTeardown(): Promise<void> {
-    await teardown();
-    process.exit(0);
+    // try/finally for the same reason as the /shutdown path below: if teardown() rejects on one of
+    // its unguarded synchronous steps, a SIGINT/SIGTERM'd daemon must still exit rather than linger.
+    try {
+      await teardown();
+    } finally {
+      process.exit(0);
+    }
   }
   const onSigInt  = () => void exitAfterTeardown();
   const onSigTerm = () => void exitAfterTeardown();

--- a/src/core/agent-eval/measure.ts
+++ b/src/core/agent-eval/measure.ts
@@ -89,7 +89,7 @@ export const claudeRunner: AgentRunner = (input) => {
   ];
   if (input.systemPrompt) args.push('--append-system-prompt', input.systemPrompt);
   try {
-    return execFileSync('claude', args, { cwd: input.cwd, encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 });
+    return execFileSync('claude', args, { cwd: input.cwd, encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024, windowsHide: true });
   } catch (err) {
     // Some non-zero exits still emit the result JSON on stdout.
     const e = err as { stdout?: Buffer | string };

--- a/src/core/drift/git-diff.ts
+++ b/src/core/drift/git-diff.ts
@@ -5,7 +5,6 @@
  * working tree and a base ref (typically main/master).
  */
 
-import { spawn } from 'node:child_process';
 import { lstat, opendir, realpath, stat } from 'node:fs/promises';
 import { extname, basename, posix, resolve } from 'node:path';
 import type { ChangedFile } from '../../types/index.js';
@@ -13,7 +12,7 @@ import { logger } from '../../utils/logger.js';
 import { DIFF_MAX_CHARS } from '../../constants.js';
 import { gitPathArgs } from '../../utils/git-args.js';
 import { readFileConfined, safeJoin } from '../../utils/path-confinement.js';
-import { execFileGit as execFileAsync } from '../../utils/git-exec.js';
+import { execFileGit as execFileAsync, spawnGit } from '../../utils/git-exec.js';
 
 
 /** Git's well-known empty tree SHA — used as base ref for single-commit repos */
@@ -597,7 +596,7 @@ async function readRevisionBlobsBatch(
   if (entries.length === 0) return new Map();
   const maxOutput = entries.reduce((sum, entry) => sum + entry.bytes + 128, 0);
   return new Promise((resolveBatch, rejectBatch) => {
-    const child = spawn('git', ['cat-file', '--batch'], { cwd: rootPath, stdio: ['pipe', 'pipe', 'pipe'] });
+    const child = spawnGit('git', ['cat-file', '--batch'], { cwd: rootPath, stdio: ['pipe', 'pipe', 'pipe'] });
     const errors: Buffer[] = [];
     const files = new Map<string, string>();
     const decoder = new TextDecoder('utf-8', { fatal: true });

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -19,7 +19,7 @@ import { join, relative, sep } from 'node:path';
 function servedRelPath(fromDir: string, target: string): string {
   return relative(fromDir, target).split(sep).join('/');
 }
-import { spawnSync } from 'node:child_process';
+import { spawnGitSync } from '../../../utils/git-exec.js';
 import { mkdtempSync, readFileSync, rmSync, openSync, closeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { escapeRegExp } from '../../../utils/misc.js';
@@ -1628,9 +1628,9 @@ function runGit(args: string[], cwd: string): Promise<string> {
     const errPath = join(tmp, 'e');
     const outFd = openSync(outPath, 'w');
     const errFd = openSync(errPath, 'w');
-    let r: ReturnType<typeof spawnSync>;
+    let r: ReturnType<typeof spawnGitSync>;
     try {
-      r = spawnSync('git', args, {
+      r = spawnGitSync('git', args, {
         cwd,
         stdio: ['ignore', outFd, errFd],
         env: { ...process.env, PATH },

--- a/src/core/services/mcp-handlers/epistemic-lease.test.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.test.ts
@@ -12,7 +12,11 @@ import type { EpistemicTracker } from './epistemic-lease.js';
 // Mock git hash — default returns stable hash
 // ============================================================================
 
-vi.mock('node:child_process', () => ({
+// Partial, not wholesale: `getGitHash` now spawns through `utils/git-exec.js`, which promisifies
+// `execFile` at import time. A mock that returns only `spawnSync` leaves that export undefined and
+// the whole suite fails to import. Spread the real module and override the one function under test.
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
   spawnSync: vi.fn(() => ({ stdout: 'deadbeef1234\n', status: 0 })),
 }));
 

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -30,7 +30,7 @@
  *   - stale    → one-line factual note prepended (visible before the result)
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawnGitSync } from '../../../utils/git-exec.js';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import {
@@ -400,7 +400,7 @@ export function updatePanic(
 
 function getGitHash(directory: string): string {
   try {
-    const result = spawnSync('git', ['rev-parse', 'HEAD'], {
+    const result = spawnGitSync('git', ['rev-parse', 'HEAD'], {
       cwd: directory,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],

--- a/src/core/services/mcp-handlers/gryph-bridge.ts
+++ b/src/core/services/mcp-handlers/gryph-bridge.ts
@@ -156,6 +156,8 @@ function isGryphAvailable(): boolean {
   const result = spawnSync('which', ['gryph'], {
     timeout: GRYPH_DETECT_TIMEOUT_MS,
     stdio: ['ignore', 'pipe', 'ignore'],
+    // Runs from the MCP daemon, which has no console of its own on Windows.
+    windowsHide: true,
   });
   const fromPath = result.status === 0 ? result.stdout?.toString().trim() : '';
   if (fromPath) {
@@ -199,7 +201,8 @@ function queryGryphSync(action: 'exec' | 'write', since: string): unknown[] {
   const result = spawnSync(
     _gryphBin,
     ['query', '--format', 'json', '--action', action, '--since', since],
-    { timeout: GRYPH_TIMEOUT_MS, stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' },
+    // windowsHide: same console-less daemon parent as the detached async query below.
+    { timeout: GRYPH_TIMEOUT_MS, stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8', windowsHide: true },
   );
   if (result.status !== 0 || !result.stdout) return [];
   try {

--- a/src/core/services/security-capabilities.test.ts
+++ b/src/core/services/security-capabilities.test.ts
@@ -59,8 +59,14 @@ describe('Capability declaration — matches observed behavior (mcp-security)', 
   it('declared subprocess spawns are exercised by real code (git)', () => {
     const bins = decl.capabilities.subprocess.spawns.map((s: { bin: string }) => s.bin);
     expect(bins.some((b: string) => b === 'git')).toBe(true);
-    // git is genuinely spawned somewhere on the surface.
-    expect(surfaceText()).toMatch(/(?:execFile|execFileSync|spawn|spawnSync)\(\s*['"`]git['"`]/);
+    // git is genuinely spawned somewhere on the surface. The call SHAPE moved behind one home —
+    // every git spawn now routes through src/utils/git-exec.ts so `windowsHide` is applied in a
+    // single place (cli: SubprocessesNeverSurfaceAConsoleWindow), reaching the surface under the
+    // helper names or a local alias of them. The capability claim is unchanged: git is still
+    // spawned. Longest-first alternation, so `execFile` cannot match the prefix of `execFileGit`.
+    expect(surfaceText()).toMatch(
+      /\b(?:execFileGitSync|execFileGit|spawnGitSync|spawnGit|execFileAsync|execFileSync|execFile|spawnSync|spawn)\(\s*['"`]git['"`]/,
+    );
   });
 
   it('declared egress hosts include the real configured-provider defaults', () => {

--- a/src/core/services/tls-coverage.test.ts
+++ b/src/core/services/tls-coverage.test.ts
@@ -46,9 +46,9 @@ const EXEMPT: { file: string; line: number; why: string }[] = [
   { file: 'src/cli/commands/serve.ts', line: 397, why: 'loopback http:// authenticated shutdown request' },
   { file: 'src/cli/commands/serve-descriptor.ts', line: 224, why: 'loopback http:// legacy liveness probe' },
   { file: 'src/api/health.ts', line: 111, why: 'loopback http:// watcher-state probe of an announced daemon' },
-  { file: 'src/pi/extension.ts', line: 578, why: 'loopback http:// health probe' },
-  { file: 'src/pi/extension.ts', line: 771, why: 'loopback http:// daemon call' },
-  { file: 'src/pi/extension.ts', line: 1613, why: 'loopback http:// health probe' },
+  { file: 'src/pi/extension.ts', line: 580, why: 'loopback http:// health probe' },
+  { file: 'src/pi/extension.ts', line: 773, why: 'loopback http:// daemon call' },
+  { file: 'src/pi/extension.ts', line: 1615, why: 'loopback http:// health probe' },
   {
     file: 'src/pi/extension.ts',
     line: 223,

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -463,7 +463,9 @@ export async function runConfigWizard(ctx: ExtensionContext, existing?: Existing
           const chunks: Buffer[] = [];
           const proc = process.platform === 'win32'
             ? spawn('cmd.exe', ['/c', cmd, ...args], { cwd: ctx.cwd, stdio: ['ignore', 'ignore', 'pipe'], windowsHide: true })
-            : spawn(cmd, args, { cwd: ctx.cwd, stdio: ['ignore', 'ignore', 'pipe'] });
+            // windowsHide is a documented no-op off Windows; set here too so the invariant is
+            // uniform across both branches rather than a carve-out the guard has to know about.
+            : spawn(cmd, args, { cwd: ctx.cwd, stdio: ['ignore', 'ignore', 'pipe'], windowsHide: true });
           proc.stderr?.on('data', (d: Buffer) => chunks.push(d));
           proc.on('close', (code) => res([code ?? 1, Buffer.concat(chunks).toString().trim()]));
           proc.on('error', () => res(null));

--- a/src/utils/git-exec.test.ts
+++ b/src/utils/git-exec.test.ts
@@ -1,100 +1,143 @@
 /**
- * fix-windows-git-spawn-console-flash — the shared windowsHide discipline and its
- * structural guard.
+ * fix-windows-git-spawn-console-flash — the shared `windowsHide` discipline.
  *
- * `execFileGit`/`execFileGitSync` are the one home for spawning `git` with
- * `windowsHide: true`. The guard test converts the per-site discipline into a
- * CI-enforced invariant: any `execFile`/`execFileSync`/`execFileAsync` call whose
- * first argument is the literal `'git'` MUST route through this module, so a new
- * unguarded site can't silently reintroduce the Windows console-flash bug (a
- * console subprocess spawned from a parent with no attached console — the
- * serve/mcp daemon, a Claude Code hook, the Pi extension host — gets a brand new
- * visible window per spawn unless windowsHide is set).
+ * `execFileGit`/`execFileGitSync`/`spawnGit`/`spawnGitSync` are the one home for
+ * spawning `git` with `windowsHide: true`. This file covers their BEHAVIOUR; the
+ * structural invariants that keep them the only home live in
+ * `windows-hidden-spawn-guard.test.ts`, which owns the import-aware source
+ * scanner both of them need:
+ *
+ *   - every subprocess in `src/` sets `windowsHide` or inherits a console, and
+ *   - no raw `node:child_process` spawn of `git` survives outside this module.
+ *
+ * They live there rather than being duplicated here: the earlier file-local
+ * version of the git guard exempted any file that imported `git-exec.js`, which
+ * silently excused all 30 migrated files — the ones most likely to grow the next
+ * `git` spawn.
+ *
+ * The assertions below check the option actually reaches the spawn. A test that
+ * only proved `git --version` still runs would pass just as happily with
+ * `windowsHide` deleted, which is the one regression that matters here and is
+ * invisible on the Linux and macOS runners this suite normally runs on.
  */
 
-import { describe, it, expect } from 'vitest';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { execFileGit, execFileGitSync } from './git-exec.js';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import * as childProcess from 'node:child_process';
+import { execFileGit, execFileGitSync, spawnGit, spawnGitSync } from './git-exec.js';
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const SRC_ROOT = join(HERE, '..'); // src/
+/** The `util.promisify.custom` implementation Node attaches to `execFile`. */
+type CustomExecFile = (file: unknown, args: unknown, options: unknown) => Promise<{ stdout: string; stderr: string }>;
+
+/** Options recorded off the promisified `execFile` path — see the mock factory below. */
+const recorded = vi.hoisted(() => ({ promisifiedExecFile: [] as unknown[][] }));
+
+/**
+ * An ESM module namespace is not configurable, so `vi.spyOn(childProcess, 'spawn')` throws. Mock
+ * the module instead, delegating to the real implementations so these stay behavioural tests that
+ * actually run `git`.
+ *
+ * TWO subtleties, both of which silently produce a green vacuous test if missed:
+ *
+ *  1. `execFile` carries a `util.promisify.custom` implementation. A plain `vi.fn(actual.execFile)`
+ *     drops that symbol, `promisify` falls back to callback convention and resolves with stdout
+ *     ALONE — so `const { stdout } = await execFileGit(...)` quietly becomes `undefined`.
+ *  2. `git-exec.ts` promisifies `execFile` at import time, and the custom implementation calls the
+ *     real binding directly. So the async path never touches the `vi.fn` on the namespace, and
+ *     asserting on `childProcess.execFile.mock` would report zero calls forever. The custom
+ *     implementation is therefore wrapped, recording into `recorded` before delegating.
+ */
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const { promisify } = await import('node:util');
+  const custom = (actual.execFile as unknown as Record<symbol, CustomExecFile>)[promisify.custom];
+  const execFile = vi.fn(actual.execFile);
+  Object.defineProperty(execFile, promisify.custom, {
+    value: (file: unknown, args: unknown, options: unknown) => {
+      recorded.promisifiedExecFile.push([file, args, options]);
+      return custom(file, args, options);
+    },
+  });
+  return {
+    ...actual,
+    execFile,
+    execFileSync: vi.fn(actual.execFileSync),
+    spawn: vi.fn(actual.spawn),
+    spawnSync: vi.fn(actual.spawnSync),
+  };
+});
+
+/** The options argument the wrapper handed to the real child_process function. */
+function optionsOfFirstCall(fn: unknown): unknown {
+  return (fn as Mock).mock.calls[0][2];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recorded.promisifiedExecFile.length = 0;
+});
 
 describe('execFileGit / execFileGitSync', () => {
-  it('sets windowsHide: true on the underlying spawn', async () => {
+  it('really runs git', async () => {
     // `git --version` is cheap, side-effect-free, and available in any dev/CI env
     // that can run this suite at all (the repo itself is a git checkout).
     const { stdout } = await execFileGit('git', ['--version']);
     expect(stdout).toMatch(/git version/i);
   });
 
-  it('execFileGitSync also succeeds (and applies windowsHide)', () => {
-    const out = execFileGitSync('git', ['--version'], { encoding: 'utf-8' });
-    expect(out).toMatch(/git version/i);
+  it('passes windowsHide: true to the underlying execFile', async () => {
+    const { stdout } = await execFileGit('git', ['--version']);
+    expect(stdout).toMatch(/git version/i);
+    expect(recorded.promisifiedExecFile).toHaveLength(1);
+    expect(recorded.promisifiedExecFile[0][2]).toMatchObject({ windowsHide: true });
+  });
+
+  it('passes windowsHide: true to execFileSync, and a caller cannot turn it off', () => {
+    // A caller passing `windowsHide: false` must not be able to reintroduce the bug.
+    execFileGitSync('git', ['--version'], { windowsHide: false });
+    expect(optionsOfFirstCall(childProcess.execFileSync)).toMatchObject({ windowsHide: true });
+  });
+
+  it('defaults execFileGitSync to utf-8 so a plain call returns the string its type promises', () => {
+    // Node's execFileSync returns a Buffer when no encoding is given, so this
+    // ergonomic shape used to be a runtime TypeError against a `string` signature.
+    const out = execFileGitSync('git', ['--version']);
+    expect(typeof out).toBe('string');
+    expect(out.trim()).toMatch(/git version/i);
+  });
+
+  it('still returns bytes when the caller asks for them', () => {
+    const out = execFileGitSync('git', ['--version'], { encoding: 'buffer' });
+    expect(Buffer.isBuffer(out)).toBe(true);
   });
 });
 
-// ── Structural guard: no unguarded `git` spawn in src ──────────────────────────
-
-/** Every `.ts` under src/, excluding tests and this discipline's own home. */
-function tsSourceFiles(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) {
-      if (entry === 'node_modules' || entry === 'fixtures') continue;
-      out.push(...tsSourceFiles(full));
-      continue;
-    }
-    if (!entry.endsWith('.ts')) continue;
-    if (entry.endsWith('.test.ts') || entry === 'git-exec.ts') continue;
-    out.push(full);
-  }
-  return out;
-}
-
-// A call whose first argument is the literal 'git' — the shape a raw
-// execFile/execFileSync spawn of git takes at every known unguarded site. Does
-// NOT match `execFileAsync`/`execFileSync` calls in a file that imports its local
-// `execFileAsync`/`execFileSync` name FROM git-exec.js (the aliased-import
-// migration form: `import { execFileGit as execFileAsync } from '.../git-exec.js'`)
-// — that file's `execFileAsync('git', ...)` calls are already routed through the
-// guarded helper under a locally-aliased name.
-const GIT_SPAWN_TOKEN = /\b(?:execFile|execFileSync|execFileAsync)\(\s*(['"])git\1/;
-// This file itself imports (possibly aliased) from git-exec.js.
-const IMPORTS_GIT_EXEC = /from\s+(['"])(?:\.\.?\/)*utils\/git-exec\.js\1/;
-
-describe('git windowsHide guard (structural invariant)', () => {
-  it('every literal `git` execFile*/execFileAsync spawn in src routes through execFileGit(Sync)', () => {
-    const violations: string[] = [];
-
-    for (const file of tsSourceFiles(SRC_ROOT)) {
-      const text = readFileSync(file, 'utf-8');
-      if (IMPORTS_GIT_EXEC.test(text)) continue; // migrated: local name is an alias for the guarded helper
-      const lines = text.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        const trimmed = line.trim();
-        if (trimmed.startsWith('*') || trimmed.startsWith('//')) continue; // doc comment / line comment
-        if (!GIT_SPAWN_TOKEN.test(line)) continue;
-        const rel = file.slice(SRC_ROOT.length + 1);
-        violations.push(`${rel}:${i + 1}  ${trimmed}`);
-      }
-    }
-
-    expect(
-      violations,
-      `Unguarded literal 'git' spawn(s) found — route them through execFileGit/execFileGitSync ` +
-        `(src/utils/git-exec.ts) so windowsHide: true is applied and the spawn doesn't flash a ` +
-        `console window on Windows when run from a console-less parent:\n${violations.join('\n')}`,
-    ).toEqual([]);
+describe('spawnGit / spawnGitSync', () => {
+  it('spawnGitSync passes windowsHide and returns git output', () => {
+    const result = spawnGitSync('git', ['--version'], { encoding: 'utf-8' });
+    expect(optionsOfFirstCall(childProcess.spawnSync)).toMatchObject({ windowsHide: true });
+    expect(String(result.stdout)).toMatch(/git version/i);
   });
 
-  it('the guard actually detects an unguarded spawn (negative control)', () => {
-    const bad = `const out = execFileSync('git', ['status'], { cwd });`;
-    const good = `const out = execFileGitSync('git', ['status'], { cwd });`;
-    expect(GIT_SPAWN_TOKEN.test(bad)).toBe(true);
-    expect(GIT_SPAWN_TOKEN.test(good)).toBe(false);
+  it('spawnGit passes windowsHide and streams git output', async () => {
+    const child = spawnGit('git', ['--version'], { stdio: ['ignore', 'pipe', 'ignore'] });
+    expect(optionsOfFirstCall(childProcess.spawn)).toMatchObject({ windowsHide: true });
+
+    const out = await new Promise<string>((resolve, reject) => {
+      let text = '';
+      child.stdout?.on('data', (c: Buffer) => { text += c.toString(); });
+      child.on('close', () => resolve(text));
+      child.on('error', reject);
+    });
+    expect(out).toMatch(/git version/i);
+  });
+
+  it('keeps the stdio-tuple typing that makes piped streams non-nullable', () => {
+    // A re-declared single signature would widen `child.stdin` back to `| null` at
+    // every call site; git-diff's `git cat-file --batch` reader depends on it.
+    const child = spawnGit('git', ['cat-file', '--batch'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    expect(child.stdin).toBeTruthy();
+    expect(child.stdout).toBeTruthy();
+    child.stdin.end();
+    child.kill();
   });
 });

--- a/src/utils/git-exec.ts
+++ b/src/utils/git-exec.ts
@@ -12,13 +12,31 @@
  *
  * Usage: `execFileGit('git', args, opts)` in place of a locally
  * `promisify(execFile)`'d call; `execFileGitSync('git', args, opts)` in place of
- * a direct `execFileSync('git', ...)` call. Typed like `execFile`/`execFileSync`
- * themselves: plain options → `string` output, `{ encoding: 'buffer' }` → `Buffer`
- * output. A structural guard (`git-exec.guard.test.ts`) fails CI on a new `git`
- * spawn that skips this file.
+ * a direct `execFileSync('git', ...)` call; `spawnGit` / `spawnGitSync` in place
+ * of a direct `spawn`/`spawnSync` of `git` — the streaming shapes (`git cat-file
+ * --batch`, a fd-redirected `spawnSync`) that the execFile helpers cannot express.
+ *
+ * Typed like the `node:child_process` functions they wrap. The ONE deliberate
+ * difference is `execFileGitSync`'s default encoding: `execFileSync` returns a
+ * `Buffer` unless an encoding is given, which makes the ergonomic
+ * `execFileGitSync('git', args, { cwd }).trim()` a runtime `TypeError`. This
+ * module defaults that call to `'utf-8'` so a plain-options call really does
+ * return the `string` its signature promises; pass `{ encoding: 'buffer' }` for
+ * bytes.
+ *
+ * Structural guards fail CI on a regression: `git-exec.test.ts` on a new `git`
+ * spawn that skips this file, and `windows-hidden-spawn-guard.test.ts` on ANY
+ * subprocess spawned without `windowsHide` and without an inherited console.
  */
 
-import { execFile, execFileSync, type ExecFileOptions, type ExecFileSyncOptions } from 'node:child_process';
+import {
+  execFile,
+  execFileSync,
+  spawn,
+  spawnSync,
+  type ExecFileOptions,
+  type ExecFileSyncOptions,
+} from 'node:child_process';
 import { promisify } from 'node:util';
 
 const rawExecFileAsync = promisify(execFile);
@@ -43,7 +61,13 @@ export function execFileGit(
   return rawExecFileAsync(file, args as string[], { ...options, windowsHide: true });
 }
 
-/** `execFileSync`, `windowsHide: true` always applied. */
+/**
+ * `execFileSync`, `windowsHide: true` always applied.
+ *
+ * Also defaults `encoding` to `'utf-8'`. Node's own `execFileSync` returns a `Buffer` when no
+ * encoding is given, so the `string` overload below would otherwise be a lie that only fails at
+ * runtime (`.trim()` on a Buffer). Callers that want bytes ask for them: `{ encoding: 'buffer' }`.
+ */
 export function execFileGitSync(
   file: string,
   args: readonly string[] | undefined,
@@ -60,5 +84,33 @@ export function execFileGitSync(
   options?: ExecFileSyncOptions,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- implementation signature for the overloads above
 ): any {
-  return execFileSync(file, args, { ...options, windowsHide: true });
+  return execFileSync(file, args, { encoding: 'utf-8', ...options, windowsHide: true });
 }
+
+/**
+ * `spawn`, `windowsHide: true` always applied — for the streaming shapes `execFile` cannot
+ * express (a long-lived `git cat-file --batch` fed over stdin).
+ *
+ * Typed as `typeof spawn` rather than re-declared, so every one of Node's overloads survives the
+ * wrapper — including the stdio-tuple narrowing that makes `child.stdin`/`stdout` non-nullable for
+ * a `{ stdio: ['pipe', 'pipe', 'pipe'] }` call. Re-declaring a single signature here would widen
+ * those back to `| null` at every call site.
+ */
+export const spawnGit: typeof spawn = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- transparent pass-through to the overloads above
+  file: any, args?: any, options?: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ditto
+): any => spawn(file, args, { ...(options ?? {}), windowsHide: true });
+
+/**
+ * `spawnSync`, `windowsHide: true` always applied — for the synchronous shapes `execFileSync`
+ * cannot express (redirecting the child's stdout/stderr straight onto file descriptors).
+ *
+ * Typed as `typeof spawnSync` for the same reason as {@link spawnGit}: it preserves the
+ * encoding-dependent `SpawnSyncReturns<string>` / `SpawnSyncReturns<Buffer>` split.
+ */
+export const spawnGitSync: typeof spawnSync = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- transparent pass-through to the overloads above
+  file: any, args?: any, options?: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ditto
+): any => spawnSync(file, args, { ...(options ?? {}), windowsHide: true });

--- a/src/utils/windows-hidden-spawn-guard.test.ts
+++ b/src/utils/windows-hidden-spawn-guard.test.ts
@@ -1,0 +1,313 @@
+/**
+ * The general structural invariant behind the Windows console-flash bug class.
+ *
+ * `windowsHide` defaults to FALSE in Node. Spawning a console program from a parent that has no
+ * console of its own — the `openlore serve`/`mcp` daemon, a Claude Code hook invocation
+ * (`orient --inject`, which fires on every user turn once installed), the Pi extension host — then
+ * gets a brand new visible console window, one per spawn. A path that shells out per file turns
+ * that into a storm of flashing windows.
+ *
+ * Two guards already cover slices of this: `git-exec.test.ts` (every `git` spawn routes through the
+ * shared helper) and `windows-detached-spawn-guard.test.ts` (`detached: true` implies
+ * `windowsHide`). Neither is the whole class. The first only matched the `execFile*` shapes, so
+ * three raw `spawn`/`spawnSync` calls of `git` slipped past it — two of them inside MCP handlers, on
+ * the daemon path the fix was written for. The second only fires on `detached`, and the flash needs
+ * no `detached` at all.
+ *
+ * So this guard states the invariant directly and shape-independently: EVERY subprocess spawned
+ * from `src/` sets `windowsHide: true`, unless it inherits the parent's console.
+ *
+ * WHY `stdio: 'inherit'` IS THE ONE EXEMPTION, not an oversight. An inheriting child is by
+ * construction attached to the console its parent already has, so no new window is created and
+ * there is nothing to hide. Forcing `CREATE_NO_WINDOW` on those would be actively wrong: they are
+ * the interactive re-entry paths (`heap-sizing`'s re-exec of the user's own command, `preflight`'s
+ * re-analyze, `update`'s package-manager run) whose prompts and progress output must keep reaching
+ * the real console.
+ *
+ * The scan is IMPORT-AWARE rather than name-based: it resolves which local identifiers are bound to
+ * `node:child_process` and matches only calls to those. That is what keeps it honest in both
+ * directions — no false positive on the hundreds of `regex.exec(...)` / `db.exec(...)` method calls
+ * that a name-based scan drowns in, and no false negative on an aliased import
+ * (`import { spawn as launch }`), which is exactly how a future regression would arrive.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = join(HERE, '..'); // src/
+
+/** The `node:child_process` functions that start a process. */
+const SPAWNING_EXPORTS = new Set([
+  'spawn', 'spawnSync', 'execFile', 'execFileSync', 'exec', 'execSync', 'fork',
+]);
+
+/**
+ * `src/utils/git-exec.ts` is the guarded home itself: it applies `windowsHide` to the call it
+ * wraps, so its own `spawn(...)` bodies are the fix, not a violation.
+ */
+const EXEMPT_FILES = new Set(['utils/git-exec.ts']);
+
+/** Every `.ts` under src/, excluding tests. */
+function tsSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === 'node_modules' || entry === 'fixtures') continue;
+      out.push(...tsSourceFiles(full));
+      continue;
+    }
+    if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Blank out comments — and, when `strings` is set, string bodies too — preserving every byte offset
+ * and newline.
+ *
+ * Length-preserving so reported line numbers stay true, and so the balanced-paren scan below can
+ * run over masked text while slicing argument text out of the ORIGINAL.
+ *
+ * The two modes exist because the import specifier `'node:child_process'` is ITSELF a string
+ * literal: masking strings before resolving bindings erases the very thing being matched, and the
+ * scan then reports a clean tree because it found no spawners at all. Bindings are read from
+ * comment-masked source; call sites are scanned with strings masked too, so a `)` or a `//` inside
+ * a literal cannot end a call early. The vacuity test at the bottom is what catches this if the two
+ * are ever conflated again.
+ */
+export function maskComments(source: string, strings: boolean): string {
+  const out = source.split('');
+  const blank = (from: number, to: number): void => {
+    for (let i = from; i < to && i < out.length; i++) if (out[i] !== '\n') out[i] = ' ';
+  };
+  for (let i = 0; i < source.length; i++) {
+    const c = source[i];
+    const next = source[i + 1];
+    if (c === '/' && next === '/') {
+      const end = source.indexOf('\n', i);
+      blank(i, end === -1 ? source.length : end);
+      i = end === -1 ? source.length : end;
+    } else if (c === '/' && next === '*') {
+      const end = source.indexOf('*/', i + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      blank(i, stop);
+      i = stop - 1;
+    } else if (strings && (c === '"' || c === "'" || c === '`')) {
+      let j = i + 1;
+      while (j < source.length && source[j] !== c) {
+        if (source[j] === '\\') j++;
+        j++;
+      }
+      blank(i + 1, j);
+      i = j;
+    }
+  }
+  return out.join('');
+}
+
+/** Local identifiers in this file bound to a process-starting `node:child_process` export. */
+export function childProcessBindings(commentMasked: string): Set<string> {
+  const locals = new Set<string>();
+  const re = /import\s*(?:type\s+)?\{([^}]*)\}\s*from\s*['"]node:child_process['"]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(commentMasked)) !== null) {
+    for (const clause of m[1].split(',')) {
+      const trimmed = clause.trim();
+      if (!trimmed) continue;
+      const [importedRaw, localRaw] = trimmed.split(/\s+as\s+/);
+      const imported = importedRaw.replace(/^type\s+/, '').trim();
+      if (SPAWNING_EXPORTS.has(imported)) locals.add((localRaw ?? importedRaw).trim());
+    }
+  }
+  return locals;
+}
+
+/** The argument-list text of the call whose `(` sits at `openIdx`, scanned over masked source. */
+function callArguments(masked: string, original: string, openIdx: number): string {
+  let depth = 0;
+  for (let i = openIdx; i < masked.length; i++) {
+    if (masked[i] === '(') depth++;
+    else if (masked[i] === ')') {
+      depth--;
+      if (depth === 0) return original.slice(openIdx + 1, i);
+    }
+  }
+  return original.slice(openIdx + 1);
+}
+
+interface Violation { file: string; line: number; text: string }
+
+/** Every spawning call in one file that neither hides its window nor inherits a console. */
+export function unhiddenSpawns(relPath: string, source: string): Violation[] {
+  const masked = maskComments(source, true);
+  const locals = childProcessBindings(maskComments(source, false));
+  if (locals.size === 0) return [];
+
+  const found: Violation[] = [];
+  for (const local of locals) {
+    // Not preceded by `.`, a word char or `$` — so `regex.exec(...)` and `db.exec(...)` never match.
+    const re = new RegExp(`(^|[^.\\w$])${local}\\s*\\(`, 'g');
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(masked)) !== null) {
+      const openIdx = m.index + m[0].length - 1;
+      const args = callArguments(masked, source, openIdx);
+      if (/windowsHide\s*:\s*true/.test(args)) continue;
+      if (/stdio\s*:\s*(['"`])inherit\1/.test(args)) continue;
+      found.push({
+        file: relPath,
+        line: source.slice(0, openIdx).split('\n').length,
+        text: `${local}(${args.split('\n')[0].trim().slice(0, 90)}`,
+      });
+    }
+  }
+  return found.sort((a, b) => a.line - b.line);
+}
+
+/**
+ * Every spawning call in one file whose first argument is the literal `'git'`.
+ *
+ * The companion invariant to the one above, and the reason it lives here rather than beside
+ * `git-exec.ts`: it needs the same import-aware scanner. `src/utils/git-exec.ts` is the ONE home
+ * for spawning `git`, so `windowsHide` (and any future cross-cutting concern — env scrubbing, a
+ * timeout floor) is applied in a single place instead of re-remembered at 30-odd call sites.
+ *
+ * Import-awareness is what makes this sound. The migrated sites import the helper under a local
+ * alias (`import { execFileGit as execFileAsync }`), so their `execFileAsync('git', …)` calls are
+ * already routed and must not be flagged. The previous version of this guard achieved that by
+ * skipping any FILE that imported `git-exec.js` at all — which quietly exempted all 30 migrated
+ * files, precisely the ones most likely to grow the next `git` spawn. Resolving bindings instead of
+ * whole files closes that: an alias of the guarded helper is simply not a `node:child_process`
+ * binding, while a fresh raw import in the same file is.
+ */
+export function unroutedGitSpawns(relPath: string, source: string): Violation[] {
+  const masked = maskComments(source, true);
+  const locals = childProcessBindings(maskComments(source, false));
+  if (locals.size === 0) return [];
+
+  const found: Violation[] = [];
+  for (const local of locals) {
+    const re = new RegExp(`(^|[^.\\w$])${local}\\s*\\(`, 'g');
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(masked)) !== null) {
+      const openIdx = m.index + m[0].length - 1;
+      // First argument read from the ORIGINAL text: the literal is masked out of `masked`.
+      const args = callArguments(masked, source, openIdx);
+      if (!/^\s*(['"`])git\1\s*(?:,|$)/.test(args)) continue;
+      found.push({
+        file: relPath,
+        line: source.slice(0, openIdx).split('\n').length,
+        text: `${local}(${args.split('\n')[0].trim().slice(0, 90)}`,
+      });
+    }
+  }
+  return found.sort((a, b) => a.line - b.line);
+}
+
+describe('windowsHide guard for every spawn (structural invariant)', () => {
+  it('every subprocess spawned in src sets windowsHide, or inherits the console', () => {
+    const violations: string[] = [];
+    for (const file of tsSourceFiles(SRC_ROOT)) {
+      const rel = file.slice(SRC_ROOT.length + 1).replace(/\\/g, '/');
+      if (EXEMPT_FILES.has(rel)) continue;
+      for (const v of unhiddenSpawns(rel, readFileSync(file, 'utf-8'))) {
+        violations.push(`${v.file}:${v.line}  ${v.text}`);
+      }
+    }
+
+    expect(
+      violations,
+      `Subprocess spawn(s) without \`windowsHide: true\` — on Windows, a console program spawned ` +
+        `from a parent with no console of its own (the serve/mcp daemon, a Claude Code hook, the ` +
+        `Pi extension host) gets a brand new visible window per spawn. Add \`windowsHide: true\` ` +
+        `to the options object — it is a documented no-op on macOS/Linux. For a \`git\` spawn, ` +
+        `route it through src/utils/git-exec.ts instead, which applies it for you. If the child ` +
+        `must stay attached to the user's terminal, give it \`stdio: 'inherit'\` and say why:\n` +
+        violations.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('flags an unguarded spawn, and accepts the two legitimate shapes (negative control)', () => {
+    const bad = `import { spawn } from 'node:child_process';\nspawn('git', ['status'], { cwd });`;
+    expect(unhiddenSpawns('x.ts', bad)).toHaveLength(1);
+
+    const hidden = `import { spawn } from 'node:child_process';\nspawn('git', ['status'], { cwd, windowsHide: true });`;
+    expect(unhiddenSpawns('x.ts', hidden)).toEqual([]);
+
+    const inherits = `import { spawn } from 'node:child_process';\nspawn('git', ['status'], { cwd, stdio: 'inherit' });`;
+    expect(unhiddenSpawns('x.ts', inherits)).toEqual([]);
+  });
+
+  it('follows an aliased import — the shape a regression actually arrives in', () => {
+    const aliased = `import { spawn as launch } from 'node:child_process';\nlaunch('git', ['status'], { cwd });`;
+    expect(unhiddenSpawns('x.ts', aliased)).toHaveLength(1);
+  });
+
+  it('never matches a method call named like a child_process export', () => {
+    // `.exec` on a regex or a SQLite handle is the overwhelming majority of `exec(` in this repo;
+    // a name-based scan reports hundreds of them and is therefore unusable as a gate.
+    const methods = `import { exec } from 'node:child_process';
+      while ((m = re.exec(source)) !== null) {}
+      db.exec('VACUUM');
+      this.db.exec(\`DELETE FROM nodes\`);`;
+    expect(unhiddenSpawns('x.ts', methods)).toEqual([]);
+  });
+
+  it('does not read a spawn out of a comment or a string literal', () => {
+    const quoted = `import { spawn } from 'node:child_process';
+      /** Usage: spawn('git', args, { cwd }) — replaced by the helper. */
+      // spawn('git', ['log'], { cwd });
+      const sample = "spawn('git', ['log'], { cwd })";`;
+    expect(unhiddenSpawns('x.ts', quoted)).toEqual([]);
+  });
+
+  it('is not vacuous — it does resolve bindings in the real tree', () => {
+    const withBindings = tsSourceFiles(SRC_ROOT).filter(
+      f => childProcessBindings(maskComments(readFileSync(f, 'utf-8'), false)).size > 0,
+    );
+    expect(withBindings.length).toBeGreaterThan(5);
+  });
+});
+
+describe('git spawns route through git-exec (structural invariant)', () => {
+  it('no raw node:child_process spawn of `git` survives outside the helper', () => {
+    const violations: string[] = [];
+    for (const file of tsSourceFiles(SRC_ROOT)) {
+      const rel = file.slice(SRC_ROOT.length + 1).replace(/\\/g, '/');
+      if (EXEMPT_FILES.has(rel)) continue;
+      for (const v of unroutedGitSpawns(rel, readFileSync(file, 'utf-8'))) {
+        violations.push(`${v.file}:${v.line}  ${v.text}`);
+      }
+    }
+
+    expect(
+      violations,
+      `Raw \`git\` spawn(s) found — route them through src/utils/git-exec.ts ` +
+        `(execFileGit / execFileGitSync / spawnGit / spawnGitSync) so windowsHide: true is applied ` +
+        `in one place and the spawn cannot flash a console window on Windows:\n${violations.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('flags a raw git spawn but not the aliased helper (negative control)', () => {
+    const raw = `import { execFileSync } from 'node:child_process';\nexecFileSync('git', ['status'], { cwd });`;
+    expect(unroutedGitSpawns('x.ts', raw)).toHaveLength(1);
+
+    const routed = `import { execFileGit as execFileAsync } from '../utils/git-exec.js';\nexecFileAsync('git', ['status'], { cwd });`;
+    expect(unroutedGitSpawns('x.ts', routed)).toEqual([]);
+
+    // The hole this replaced: one migrated alias in a file no longer exempts a raw spawn beside it.
+    const mixed = `import { execFileGit as execFileAsync } from '../utils/git-exec.js';
+      import { spawnSync } from 'node:child_process';
+      execFileAsync('git', ['log'], { cwd });
+      spawnSync('git', ['rev-parse', 'HEAD'], { cwd });`;
+    expect(unroutedGitSpawns('x.ts', mixed)).toHaveLength(1);
+  });
+
+  it('does not flag a spawn of something else', () => {
+    const other = `import { spawnSync } from 'node:child_process';\nspawnSync('gh', ['pr', 'list'], { cwd });`;
+    expect(unroutedGitSpawns('x.ts', other)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Status

Ready to merge. Follow-up to #431, on merged `main`. Typecheck, lint, 9,308 unit tests, build, `audit:packlist`, `audit:deps`, `audit:gate` and `api-consumer-smoke` all green locally.

## What was wrong

#431 fixed the Windows console-flash and zombie-daemon regressions and left two structural guards behind so the bug class could not return. Reviewing the merged result against the whole tree found that **the guards do not cover the class they claim**, and that three `git` spawns were never migrated.

`windowsHide` defaults to false in Node. A console program spawned from a parent with no console of its own — the `serve`/`mcp` daemon, a Claude Code hook (`orient --inject`, which fires every user turn once installed), the Pi extension host — is given a brand new visible console window, one per spawn.

**Three gaps, each independently sufficient to let the bug back in:**

| Guard | Blind spot |
|---|---|
| `git-exec.test.ts` | Matched only the `execFile*` shapes, so a `spawn`/`spawnSync` of `git` was invisible |
| `git-exec.test.ts` | Skipped any **file** importing `git-exec.js` — all 30 migrated files do, exempting exactly the files most likely to grow the next `git` spawn |
| `windows-detached-spawn-guard.test.ts` | Fires only on `detached: true`; the flash needs no `detached` at all |

**Nine spawns were live**, all confirmed on `main`. Three are `git`, two of those inside MCP handlers on the very daemon path #431 was written for:

- [`epistemic-lease.ts:403`](src/core/services/mcp-handlers/epistemic-lease.ts) — `git rev-parse HEAD`, on the tool-invocation path
- [`analysis.ts:1633`](src/core/services/mcp-handlers/analysis.ts) — `runGit`
- [`git-diff.ts:600`](src/core/drift/git-diff.ts) — `git cat-file --batch`
- plus six non-`git` sites (`which gryph`, the synchronous `gryph query`, Pi's POSIX spawn branch, and the `claude` / `docker` probes), four of them reachable from the daemon or the Pi host

## How it was fixed

**One invariant, stated directly.** [`windows-hidden-spawn-guard.test.ts`](src/utils/windows-hidden-spawn-guard.test.ts) replaces both source-scanning guards: **every subprocess spawned from `src/` sets `windowsHide: true`, unless it inherits the parent's console.** The `stdio: 'inherit'` exemption is exact, not incidental — those are the interactive re-entry paths (`heap-sizing`'s re-exec of the user's own command, `preflight`'s re-analyze, `update`'s package-manager run), and forcing `CREATE_NO_WINDOW` on them would cut the user off from the terminal they are watching.

The scan is **import-aware**, which is what makes it usable in both directions: it resolves which local identifiers are bound to `node:child_process`, so the hundreds of `regex.exec(...)` / `db.exec(...)` method calls are not false positives (a name-based scan reports 265 hits and is unusable as a gate), and an aliased `import { spawn as launch }` is not a false negative — which is exactly how a regression would arrive. The git-routing invariant moves into the same file and is keyed on **bindings, not files**, so one migrated alias no longer excuses a raw spawn beside it.

**All nine are closed** — three routed through `git-exec.ts`, which gains `spawnGit` / `spawnGitSync` for the streaming and fd-redirected shapes; six by setting the option.

**Two correctness fixes found in the same review:**

- `execFileGitSync` typed a plain-options call as returning `string`, but Node's `execFileSync` returns a **`Buffer`** without an explicit encoding — so the ergonomic `execFileGitSync('git', args, { cwd }).trim()` was a latent `TypeError` behind a passing typecheck. It now defaults to `'utf-8'`; `{ encoding: 'buffer' }` still yields bytes.
- Both daemon exit paths used `then`, so a `teardown()` that rejects skipped `process.exit` entirely **and** surfaced as an unhandled rejection — the zombie daemon returning in precisely the failure case the fix exists to prevent, after the client was told the stop succeeded. Both use `finally` now.

## Proof it works

Every assertion is mutation-checked, which matters here because the bug is **invisible to a headless Windows runner by construction** — no behavioural test on any runner can fail when the option is dropped.

- Deleting `windowsHide` / the encoding default from `git-exec.ts` turns **5 of 8** behavioural tests red; restoring it returns 8/8.
- Reverting `epistemic-lease.ts` to its raw `spawnSync` turns the new guard red, naming `core/services/mcp-handlers/epistemic-lease.ts:403` — and, as expected, the **old** git guard stayed green on that same mutation. That is the hole, demonstrated.
- The guard carries negative controls for each accepted shape, an aliased-import case, a method-call case, a comment/string-literal case, and a non-vacuity check.
- `spawnGit` is typed as `typeof spawn` rather than re-declared, so Node's stdio-tuple narrowing survives the wrapper; a test pins `child.stdin` staying non-nullable, which `git cat-file --batch` depends on.

**Two follow-on repairs the change forced**, both worth knowing about:

- `tls-coverage.test.ts` pins each loopback-http exemption to a `file:line`; a two-line comment in `pi/extension.ts` shifted three `fetch(` sites. Re-anchored. (Same trap #431 hit.)
- `epistemic-lease.test.ts` mocked `node:child_process` **wholesale**. The module now reaches `git-exec.ts`, which promisifies `execFile` at import, so the mock left that export undefined and the whole suite failed to import. Made partial. Three other partial mocks (`gryph-bridge`, `decisions`, `decisions-anchoring`) have the same latent fragility — worth knowing before the next module gains a `git-exec` import.

## Notes / nits

- **No behavioural change on macOS or Linux.** `windowsHide` is a documented no-op there; every fix is one line or a helper swap.
- **The `finally` change has no dedicated regression test.** `teardown()`'s awaited steps are individually guarded (`drainServeRebuilds` uses `allSettled`, the watcher stop is `.catch`ed), so only a throw from a synchronous step can reject it. It is defensive hardening rather than a reproduced failure, and the call-site comment says exactly that rather than overclaiming.
- **`windows-detached-spawn-guard.test.ts` is kept**, not folded in: a `detached: true` spawn that also inherits stdio would be exempted by the new rule and is still worth catching.
- The invariant is recorded as one `cli` spec requirement, mirroring `analyzer: GitPathOutputFidelity`, which holds the identical "one shared helper plus an automated guard" shape for git's `core.quotepath`.
- Issue #434 is **not** addressed here and stays open for @laurentftech — every item on it needs a Windows machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
