### PR TITLE
fix(watcher): a flush can no longer skip silently (closes #451)

### DIFF
--- a/openspec/changes/harden-watcher-flush-durability/.openspec.yaml
+++ b/openspec/changes/harden-watcher-flush-durability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/harden-watcher-flush-durability/proposal.md
+++ b/openspec/changes/harden-watcher-flush-durability/proposal.md
@@ -1,0 +1,96 @@
+## Why
+
+Issue #451: an incremental watcher flush intermittently never lands on Windows. The test that
+caught it asserts a real product behaviour — a debounced flush reaching disk — and the observed
+state is that the flush did not happen: `llm-context.json` still holds the seeded empty context,
+and nothing anywhere says why.
+
+The reported hypothesis was cross-test-file state. That is **falsified**: this repo runs vitest on
+the default `forks` pool with `isolate: true`, so every test file gets its own OS process. No
+module-level singleton, no leaked timer, no `vi.mock` registry and no stderr spy can cross a file
+boundary, which is also why `--no-file-parallelism` changed nothing. The only channels that survive
+a file boundary are the filesystem, OS resources, and IO contention — all of which point back at
+the flush lane itself.
+
+Auditing that lane found four ways a flush is silently skipped. Each is a product defect in a
+long-lived MCP server, not a test artifact: a watcher that drops a file event without a signal
+leaves the index stale and the agent unaware that it is reading a lie.
+
+**1. Any read failure was treated as "the file was deleted."** `handleBatch`'s candidate loop
+caught every error from `readFileConfined` with a bare `continue`, and when that emptied the batch
+it returned at `files.length === 0` writing nothing and saying nothing. `readFileConfined` fails
+CLOSED when the path stat and the descriptor stat disagree on identity or timestamps — which on
+Windows a transient sharing violation produces, because libuv falls back to an attribute-only stat
+(`ino`/`dev` zeroed, `ctim` collapsed onto `mtim`) whenever it cannot open the file for attributes.
+An indexer or AV scanner holding the file for a few milliseconds is enough. Injecting one such
+failure reproduces the reported symptom exactly: the seeded 43-byte context, zero output.
+
+**2. An unrecognized flush error lost the batch permanently.** `flush()` empties `pending` before
+its first await. Only two error classes put the paths back (a spec-index lock timeout, a busy
+SQLite); everything else — an `EPERM` on the artifact rename, a sharing violation on the advisory
+lock's hard link, `ENOSPC`, `EIO` — reached one `[mcp-watcher] error:` line and the change was gone
+until the next full `analyze`. `flushBatchWithBusyRetry`'s own docstring claimed the opposite.
+
+**3. `stop()` had the same hole, and then hid it.** Its shutdown drain dropped a failed batch the
+same way, after which the "still deferred — run analyze to reconcile" disclosure read the emptied
+queue and stayed silent. Shutdown reported a clean stop precisely when work had been lost.
+
+**4. The atomic artifact write itself can fail on Windows, and did.** `atomicWriteFile` commits
+with `rename(tmp, path)`. POSIX replaces the destination unconditionally; Windows does not —
+`MoveFileExW(REPLACE_EXISTING)` needs DELETE access to the target, so it returns
+`EPERM`/`EACCES`/`EBUSY` while any other handle is open on it without `FILE_SHARE_DELETE`. This is
+observed, not theorised: a Windows CI runner produced
+`EPERM: operation not permitted, rename '….llm-context.json.tmp-…' -> '…llm-context.json'`
+while running this change's own durability suite, leaving the artifact at its previous content —
+the #451 symptom exactly. The retry lane above turned it into a bounded, disclosed give-up instead
+of a silent loss, which is how it was caught at all.
+
+**5. An empty VCS settle window latched forever.** `vcsSettling` is cleared in exactly one place,
+after `flush()`'s empty-queue early return. A `.git` write with no indexable file change —
+`git commit`, `git fetch`, a checkout touching only tests — leaves it latched, and `armFlush` then
+takes its settle branch on every later event and never re-arms the hard batch ceiling. A steady
+sub-settle-window write stream postpones the flush without bound, with a timer always armed and
+nothing to say so.
+
+## What Changes
+
+One rule, stated once and enforced at every exit: **the drain is destructive, so every exit from a
+batch must either commit the work, re-queue it, or say out loud that it was dropped.** There is no
+fourth option in which a change simply disappears.
+
+- A read failure is classified. `ENOENT`/`ENOTDIR` is a real deletion and stays silent (the
+  deletion lane owns it); anything else is disclosed and re-queued.
+- Any unrecognized flush error re-queues the drained batch instead of discarding it.
+- Both re-queues are bounded by `WATCH_MAX_EVENT_RETRIES` (3), so a deterministic failure degrades
+  to one loud drop rather than a hot retry loop. The budget is per path and resets only on a pass
+  that actually consumed the path — a failure *after* the read must not refill it.
+- On give-up the abandoned files are recorded stale in the graph store, through the same mechanism
+  the bulk-fallback lane already uses and behind the same source-candidate filter, so the signal
+  outlives the log line and every later freshness read discloses the gap. A stderr line in a
+  daemon nobody is watching is not a signal an agent can read.
+- `stop()` puts a failed shutdown batch back before its own disclosure counts it.
+- An empty settle drain closes the settle window.
+- A flush still running after 30s says so once. The wait itself is legitimate — `acquireAnalysisLock`
+  blocks without bound by design — so this shortens nothing; it only removes the silence.
+- `atomicWriteFile` retries a rename that lost a race with another handle on the destination
+  (`EPERM`/`EACCES`/`EBUSY`), with a bounded backoff. The temp file is still there and fully
+  fsync'd, so each attempt is the same single atomic replace and atomicity is untouched. Those
+  codes essentially never occur for a same-directory rename on POSIX, so nothing changes there, and
+  the ORIGINAL error is rethrown when the retries run out — a genuine permission problem still
+  fails with its real message. Every artifact writer benefits, not just the watcher.
+
+The explicit-caller lane (`handleChange`, `applyRepositoryDelta`) is disclosed but never re-queued:
+those await a single pass with no debounce behind them, and `applyRepositoryDelta` already reports
+its own unapplied files as stale.
+
+## Deliberately NOT changed
+
+- **`readFileConfined`'s identity contract.** Its strictness is the TOCTOU guard for
+  artifact-derived paths. Loosening it to accommodate Windows timestamp semantics would trade a
+  security boundary for a freshness convenience. The watcher stops mis-reading its failures instead.
+- **`acquireAnalysisLock`'s unbounded wait.** A caller promising serialization must not abandon it.
+  The wait is disclosed, not shortened.
+- **The hard-ceiling suppression during a settle window.** That suppression is intentional and
+  pinned by an existing test; the fix is to end the window, not to re-arm inside it.
+- **The Windows trigger itself.** It is not reproducible off Windows, and the durability contract
+  is the part that can be pinned by a test on every platform.

--- a/openspec/changes/harden-watcher-flush-durability/specs/architecture/spec.md
+++ b/openspec/changes/harden-watcher-flush-durability/specs/architecture/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: AWatcherFlushNeverSkipsSilently
+
+The incremental watcher's debounced flush drains its pending set destructively — `pending` is
+emptied before the first `await`, so the file events exist only inside the running batch. Every exit
+from that batch SHALL therefore do exactly one of three things: commit the work, put it back in the
+queue, or disclose that it was dropped. A fourth outcome, in which a change simply disappears, SHALL
+NOT exist.
+
+A read failure SHALL be classified rather than assumed. `ENOENT`/`ENOTDIR` means the file really is
+gone between the event and the read, is expected on a watch lane, and is owned by the deletion lane;
+it stays silent. Every other read failure — a confinement or descriptor-identity rejection, a
+sharing violation, a permission error — is a read that could have succeeded, and SHALL be disclosed
+and re-queued rather than treated as a deletion. In particular, a batch that ends with no readable
+candidates because of such a failure SHALL NOT return silently.
+
+A batch that fails for a reason the contention handlers do not recognize (an `EPERM` on the artifact
+rename, a hard-link failure acquiring the advisory lock, `ENOSPC`, `EIO`) SHALL be re-queued, not
+discarded. Both re-queues SHALL be bounded, so a deterministic failure degrades to one loud drop
+instead of an unbounded retry loop. The bound is per path and SHALL reset only on a pass that
+actually consumed that path: a failure occurring AFTER the file was read must not refill the budget,
+or the bound is unreachable for exactly the failures it exists to bound.
+
+When the bound is exhausted the watcher SHALL leave a signal that outlives the log line. A line on
+stderr in a long-lived daemon is not something an agent can read, so where a graph store exists the
+abandoned files SHALL additionally be recorded stale, through the same mechanism and behind the same
+source-candidate filter the bulk-fallback lane uses — a watched non-source file has no graph nodes,
+so a stale row for it could never be cleared by a re-parse.
+
+Shutdown SHALL obey the same rule. A shutdown batch the watcher could not flush SHALL be returned to
+the queue before the "still deferred" disclosure counts it, so a lost batch can never present as a
+clean stop.
+
+A flush that is neither finished nor failed SHALL disclose itself. The analysis lock is acquired
+without a bound by design — a caller promising serialization must not abandon it — so the wait SHALL
+be reported, not shortened.
+
+The VCS settle window SHALL close even when the settle flush finds nothing to do, so a `.git` write
+carrying no indexable file change cannot latch it and leave the hard batch ceiling permanently
+unarmable.
+
+The atomic artifact write SHALL survive a destination that is briefly held by another handle. POSIX
+`rename(2)` replaces the destination unconditionally, but Windows `MoveFileExW(REPLACE_EXISTING)`
+needs DELETE access to the target and fails with `EPERM`/`EACCES`/`EBUSY` while any other handle is
+open on it without `FILE_SHARE_DELETE` — an antivirus or indexer scanning the file it just saw
+written. The commit rename SHALL therefore be retried with a bounded backoff on exactly those codes.
+Atomicity is unaffected: the temp file is still present and fsync'd, so each attempt is the same
+single atomic replace. An error that is not destination contention SHALL NOT be retried, and the
+original error SHALL be rethrown when the bound is reached, so a genuine permission problem or a
+full disk still fails with its own message.
+
+Guarded by `mcp-watcher-flush-durability.test.ts`, which injects each failure deterministically,
+and by `atomic-write-rename-contention.test.ts` for the rename. The
+platform trigger that motivated this (a Windows sharing violation making the confined read's
+descriptor-identity check fail closed) is not reproducible off Windows; the durability contract is
+what the guard pins, on every platform.
+
+#### Scenario: A transient read failure costs one debounce, not the index
+
+- **GIVEN** the only file in a batch cannot be read for a reason other than being deleted
+- **WHEN** the flush runs
+- **THEN** the watcher discloses the failure and re-queues the file, and the next debounce lands the
+  change on disk — rather than returning silently and leaving the artifact at its previous content
+
+#### Scenario: A failure after the read is still bounded
+
+- **GIVEN** a batch whose files read successfully but whose artifact write fails every time
+- **WHEN** the watcher retries
+- **THEN** it makes a bounded number of attempts and then discloses the drop, rather than retrying
+  once per debounce forever
+
+#### Scenario: An abandoned change is discoverable, not merely logged
+
+- **GIVEN** the watcher has exhausted its retry budget on a source file and a graph store exists
+- **WHEN** a later reader asks the store what is stale
+- **THEN** that file is listed, so the gap is disclosed instead of the index being served as complete
+
+#### Scenario: Shutdown cannot report a clean stop over lost work
+
+- **GIVEN** the shutdown drain fails to flush its batch
+- **WHEN** `stop()` finishes
+- **THEN** it names the still-deferred changes and points at `analyze`, instead of printing only
+  `stopped`
+
+#### Scenario: A scanner holding the artifact does not cost the write
+
+- **GIVEN** the commit rename fails because another handle is open on the destination
+- **WHEN** the writer retries within its bound
+- **THEN** the new content is committed — rather than the artifact being left at its previous
+  content with only a log line to say why
+
+#### Scenario: A git operation with no file change cannot stall the ceiling
+
+- **GIVEN** a `.git` write that changes no indexable file, so the settle flush finds an empty queue
+- **WHEN** ordinary file events resume afterwards
+- **THEN** the hard batch ceiling is armed again, so a steady write stream cannot postpone the flush
+  without bound

--- a/openspec/changes/harden-watcher-flush-durability/tasks.md
+++ b/openspec/changes/harden-watcher-flush-durability/tasks.md
@@ -1,0 +1,57 @@
+## 1. Stop mistaking an unreadable file for a deleted one
+
+- [x] 1.1 Add `isMissingFileError` and split `handleBatch`'s candidate-loop `catch`: `ENOENT`/
+  `ENOTDIR` stays a silent skip (the deletion lane owns it), everything else is collected as
+  unreadable — verified by a test that a vanished file still produces no output.
+- [x] 1.2 Add `deferUnreadable`: disclose the failure, re-queue on the watch lane, disclose-only on
+  the explicit lane (`handleChange`, `applyRepositoryDelta`) — verified by a transient-failure test
+  that lands on the retry, and by a `handleChange` test that asserts an empty queue and ledger.
+- [x] 1.3 Cover the mixed batch: a readable file must not be held hostage by an unreadable
+  neighbour, and the neighbour must still come back.
+
+## 2. Make a drained batch unloseable
+
+- [x] 2.1 Replace `flush()`'s terminal `.catch(stderr.write)` with `deferFailedBatch`: re-queue,
+  bounded by `WATCH_MAX_EVENT_RETRIES`, deletions first and changes second so a path can never end
+  in both sets — the same order the two contention deferrals already use.
+- [x] 2.2 Reset the retry budget only in `flushBatchWithBusyRetry`'s post-success loop, and only for
+  paths the pass did not itself re-queue. Do NOT reset on a successful read: every failure this
+  change was written for (the artifact rename, the generation republish, a full disk) throws AFTER
+  the read, so a reset there makes the bound unreachable — verified by a test that drives the REAL
+  `handleBatch` and asserts exactly four attempts.
+- [x] 2.3 Add `abandonEvents`: one loud line naming the files and the reason, plus a `markFilesStale`
+  row behind the same source-candidate filter `fallbackBulkBatch` uses, so a watched markdown file
+  cannot become a permanent stale row no re-parse can clear — verified against a real `EdgeStore`.
+- [x] 2.4 `stop()`: re-add a failed shutdown batch before the "still deferred" disclosure counts it,
+  and have `deferFailedBatch` re-queue rather than spend retry budget while `stopping` (no retry is
+  coming, so counting one would be a lie).
+
+## 3. Close the remaining silent skips
+
+- [x] 3.1 Clear `vcsSettling`/`vcsBulkFlag` on `flush()`'s empty-queue return, so a `.git` write with
+  no indexable change cannot latch the settle window and disable the hard ceiling for good.
+- [x] 3.2 Add `armFlushStallDisclosure`: one line when a flush passes 30s, cleared on completion and
+  on `stop()`. The wait is not shortened.
+- [x] 3.3 Guard `flush()`'s `.finally` epilogue so a throw there cannot leave `running === true`
+  (wedging every later flush), and `.catch` the voided promise so it cannot terminate the host.
+
+## 4. Survive the contended rename that a Windows runner actually produced
+
+- [x] 4.1 Retry `atomicWriteFile`'s `rename` on `EPERM`/`EACCES`/`EBUSY` with a bounded backoff,
+  rethrowing the original error when it runs out — a full disk (`ENOSPC`) is not a race and is not
+  retried.
+- [x] 4.2 Add `atomic-write-rename-contention.test.ts`: `node:fs/promises` is mocked so the race is
+  deterministic on every platform (it cannot be provoked on POSIX, and provoking it on Windows would
+  mean racing a scanner). Covers all three contention codes, the overwrite case that is the #451
+  symptom, the bound, the rethrown message, no-retry-on-ENOSPC, and no temp-file litter either way.
+
+## 5. Keep the invariants stated
+
+- [x] 5.1 Re-base `artifact-write-atomicity.test.ts`'s change-lane anchor onto `private async
+  handleBatch` — `abandonEvents` is a fourth fenced writer defined earlier in the file, so "the
+  first acquire" no longer names the change lane — and bump the acquisition count 3 → 4.
+- [x] 5.2 Correct `flushBatchWithBusyRetry`'s docstring, which claimed no event is ever silently
+  lost while only two error classes were covered.
+- [x] 5.3 New `mcp-watcher-flush-durability.test.ts` (15 tests). Non-vacuity verified: 14 of 15 fail
+  against the unfixed watcher; the fifteenth is the ENOENT-stays-silent regression guard, which is
+  green on both sides by construction.

--- a/src/core/analyzer/artifact-write-atomicity.test.ts
+++ b/src/core/analyzer/artifact-write-atomicity.test.ts
@@ -60,7 +60,12 @@ describe('harden-artifact-write-atomicity: every artifact writer adopts the shar
   it('the watcher fences SQLite and JSON as one change generation, plus the deletion lane', () => {
     const src = read(WATCHER);
     expect(src).toMatch(/import\s*\{\s*acquireAnalysisLock\s*\}\s*from\s*['"]\.\.\/runtime\/advisory-lock\.js['"]/);
-    const acquire = src.indexOf('acquireAnalysisLock(this.outputPath)');
+    // Anchor to the CHANGE lane's own acquisition. The abandoned-events
+    // disclosure lane (issue #451) also fences a stale marking and is defined
+    // earlier in the file, so "the first acquire" no longer names this lane.
+    const changeLane = src.indexOf('private async handleBatch');
+    expect(changeLane).toBeGreaterThan(-1);
+    const acquire = src.indexOf('acquireAnalysisLock(this.outputPath)', changeLane);
     const sqlite = src.indexOf('EdgeStore.open(EdgeStore.dbPath(this.outputPath))', acquire);
     const publication = src.indexOf('await this.republishGeneration()', sqlite);
     const release = src.indexOf('await releaseAnalysis()', publication);
@@ -68,8 +73,9 @@ describe('harden-artifact-write-atomicity: every artifact writer adopts the shar
     expect(sqlite).toBeGreaterThan(acquire);
     expect(publication).toBeGreaterThan(sqlite);
     expect(release).toBeGreaterThan(publication);
-    // Change, deletion, and bulk-fallback lanes each fence their SQLite writes.
-    expect(src.match(/acquireAnalysisLock\(this\.outputPath\)/g)).toHaveLength(3);
+    // Change, deletion, bulk-fallback and abandoned-events lanes each fence
+    // their SQLite writes.
+    expect(src.match(/acquireAnalysisLock\(this\.outputPath\)/g)).toHaveLength(4);
   });
 
   it('persistContext itself stays lock-free (it runs inside a lane that already holds the lock)', () => {

--- a/src/core/decisions/atomic-store.ts
+++ b/src/core/decisions/atomic-store.ts
@@ -40,10 +40,79 @@ export interface SequencedStore {
 let tmpCounter = 0;
 
 /**
+ * Backoff for a rename that lost a race with another handle on the destination.
+ *
+ * POSIX `rename(2)` replaces the destination unconditionally. Windows does not:
+ * `MoveFileExW(REPLACE_EXISTING)` needs DELETE access to the target, so it returns
+ * `EPERM`/`EACCES`/`EBUSY` while ANY other handle is open on it without
+ * `FILE_SHARE_DELETE` — an antivirus or Search Indexer scanning the file it just
+ * saw written, or a reader that opened it a millisecond earlier. The window is
+ * milliseconds wide and the operation is idempotent (the temp file is still
+ * there, fully fsync'd), so the correct response is to wait and try again.
+ *
+ * Observed, not theorised: a Windows CI runner produced
+ * `EPERM: operation not permitted, rename '….llm-context.json.tmp-…' -> '…llm-context.json'`
+ * on the watcher's artifact write, which left the artifact at its previous
+ * content — one of the two mechanisms behind issue #451.
+ *
+ * These codes essentially never occur for a same-directory rename on POSIX, so
+ * this changes nothing there. The retries are bounded and the ORIGINAL error is
+ * rethrown when they run out: a genuine permission problem still fails, loudly
+ * and with its real message.
+ *
+ * The ~3.2s ceiling is dimensioned against the tail, not the median: a Defender
+ * hold on a small just-written file is usually 10-100ms, but a first-touch scan
+ * or a cloud-lookup can run far longer, and the machine that reported #451 was a
+ * loaded one. It is deliberately far below the commit lock's own limits — 10s
+ * before a lock is even a stale candidate, 30s before a waiter gives up — so a
+ * writer that spends its whole budget still cannot cause a lock timeout or a
+ * steal. (`graceful-fs` retries this same Windows class for 60s; that is sized
+ * for arbitrary third-party writes, not for a section under our own lock.)
+ */
+const RENAME_CONTENTION_DELAYS_MS = [10, 25, 50, 100, 200, 400, 800, 1600] as const;
+
+const isRenameContention = (err: unknown): boolean => {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'EPERM' || code === 'EACCES' || code === 'EBUSY';
+};
+
+/**
+ * NOT unref'd — deliberately, and unlike the watcher's SQLite backoff.
+ *
+ * This sleep sits between a fsync'd temp file and its commit rename. An unref'd
+ * timer does not hold the event loop open, so if this were the last handle the
+ * process would drain and exit 0 with the promise never settling: the caller's
+ * `await` never resumes, the `finally` that removes the temp never runs, and any
+ * commit lock above is never released. That is a silently dropped write in the
+ * one module whose stated contract is that no write is ever silently lost. The
+ * watcher's backoff can afford to be unref'd because dropping it only defers a
+ * batch; this cannot. The added liveness is bounded by the ladder above.
+ */
+const sleepMs = (ms: number): Promise<void> => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+/** {@link rename}, retried while the destination is briefly held by another handle. */
+async function renameWithContentionRetry(tmp: string, path: string): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await rename(tmp, path);
+      return;
+    } catch (err) {
+      const delay = RENAME_CONTENTION_DELAYS_MS[attempt];
+      if (delay === undefined || !isRenameContention(err)) throw err;
+      await sleepMs(delay);
+    }
+  }
+}
+
+/**
  * Write `data` to `path` atomically. The data goes to a sibling temp file, is
  * flushed to disk (`fsync`), and is moved into place with a single atomic
  * `rename`. A crash or interruption before the rename leaves the previously
  * committed file untouched — never a partially written (torn) file.
+ *
+ * The rename is retried while the destination is held by another handle: see
+ * {@link RENAME_CONTENTION_DELAYS_MS}. Atomicity is unaffected — each attempt is
+ * the same single atomic replace.
  */
 export async function atomicWriteFile(path: string, data: string, newFileMode = 0o666): Promise<void> {
   const dir = dirname(path);
@@ -63,7 +132,7 @@ export async function atomicWriteFile(path: string, data: string, newFileMode = 
     } finally {
       await fh.close();
     }
-    await rename(tmp, path); // atomic replace
+    await renameWithContentionRetry(tmp, path); // atomic replace
     renamed = true;
   } finally {
     // If we never renamed (write/sync threw), remove the orphaned temp so a failed

--- a/src/core/decisions/atomic-write-rename-contention.test.ts
+++ b/src/core/decisions/atomic-write-rename-contention.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Issue #451 — the atomic write must survive a Windows rename that lost a race.
+ *
+ * POSIX `rename(2)` replaces the destination unconditionally. Windows does not:
+ * `MoveFileExW(REPLACE_EXISTING)` needs DELETE access to the target, so it fails
+ * with `EPERM`/`EACCES`/`EBUSY` while any other handle is open on it without
+ * `FILE_SHARE_DELETE` — an antivirus or Search Indexer scanning the file it just
+ * saw written, or a reader that opened it a millisecond earlier.
+ *
+ * This is not a hypothesis. A Windows CI runner produced exactly this while
+ * running the watcher's durability suite:
+ *
+ *   [mcp-watcher] error: EPERM: operation not permitted, rename
+ *     '…\.llm-context.json.tmp-5316-5' -> '…\llm-context.json'
+ *
+ * The artifact was left at its previous content with no other trace — one of the
+ * two mechanisms behind #451.
+ *
+ * `rename` is retried rather than worked around: the temp file is still there and
+ * fully fsync'd, so each attempt is the same single atomic replace and atomicity
+ * is untouched. The retries are bounded, and a genuine permission problem still
+ * fails with its own message rather than being swallowed or masked.
+ *
+ * `node:fs/promises` is mocked here so the race is deterministic on every
+ * platform; it cannot be provoked on POSIX, and provoking it on Windows would
+ * mean racing a scanner.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+/** Node's own phrasing per code, so a synthetic error reads like the real one. */
+const RENAME_MESSAGES: Record<string, string> = {
+  EPERM: 'operation not permitted',
+  EACCES: 'permission denied',
+  EBUSY: 'resource busy or locked',
+  ENOSPC: 'no space left on device',
+};
+
+/** Fail the next `failures` renames with `code`, then let the real one through. */
+let renameFailures = 0;
+let renameCode = 'EPERM';
+let renameCalls = 0;
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    rename: async (from: string, to: string) => {
+      renameCalls++;
+      if (renameFailures > 0) {
+        renameFailures--;
+        const err = new Error(
+          `${renameCode}: ${RENAME_MESSAGES[renameCode] ?? 'rename failed'}, rename '${from}' -> '${to}'`,
+        ) as NodeJS.ErrnoException;
+        err.code = renameCode;
+        throw err;
+      }
+      return actual.rename(from, to);
+    },
+  };
+});
+
+const { atomicWriteFile } = await import('./atomic-store.js');
+
+let dir: string;
+let target: string;
+
+beforeEach(async () => {
+  renameFailures = 0;
+  renameCode = 'EPERM';
+  renameCalls = 0;
+  dir = await mkdtemp(join(tmpdir(), 'ol-rename-contention-'));
+  target = join(dir, 'llm-context.json');
+});
+
+afterEach(async () => {
+  // No restoreAllMocks: there are no spies here, and it cannot undo a `vi.mock`
+  // factory anyway — the module mock is per-file and goes away with the file.
+  await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+/** Temp files the writer left behind (its own `.<name>.tmp-<pid>-<n>` shape). */
+async function leftoverTempFiles(): Promise<string[]> {
+  return (await readdir(dir)).filter((name) => name.includes('.tmp-'));
+}
+
+describe('atomicWriteFile — a contended rename (issue #451)', () => {
+  for (const code of ['EPERM', 'EACCES', 'EBUSY']) {
+    it(`retries a ${code} rename and commits the write`, async () => {
+      renameCode = code;
+      renameFailures = 2;
+
+      await atomicWriteFile(target, '{"signatures":["written"]}');
+
+      expect(JSON.parse(await readFile(target, 'utf-8'))).toEqual({ signatures: ['written'] });
+      expect(renameCalls).toBe(3); // two contended attempts, then the commit
+      expect(await leftoverTempFiles()).toEqual([]);
+    });
+  }
+
+  it('overwrites existing content rather than leaving the previous version in place', async () => {
+    // The #451 symptom precisely: the artifact stayed at what was already on disk.
+    await atomicWriteFile(target, '{"signatures":[]}');
+    renameFailures = 3;
+
+    await atomicWriteFile(target, '{"signatures":["delta"]}');
+
+    expect(await readFile(target, 'utf-8')).toContain('delta');
+  });
+
+  it('gives up after a bounded number of attempts and rethrows the original error', async () => {
+    renameFailures = Number.MAX_SAFE_INTEGER;
+
+    // The ORIGINAL error, not a wrapper: an operator must see the real cause, and
+    // callers that branch on `code` must still be able to.
+    await expect(atomicWriteFile(target, 'never lands')).rejects.toMatchObject({
+      code: 'EPERM',
+      message: expect.stringContaining('rename'),
+    });
+    // Bounded: one try plus one per backoff step. A permanently unwritable
+    // destination must fail, not retry forever.
+    expect(renameCalls).toBe(9);
+    // A failed write leaves no litter behind in the store directory.
+    expect(await leftoverTempFiles()).toEqual([]);
+  });
+
+  it('waits on a REF\'d timer, so a retry cannot be lost to process exit', async () => {
+    // Regression guard for a real defect in this change's own first cut. An
+    // unref'd timer does not hold the event loop open: if the retry sleep were
+    // the last handle, the process would drain and exit 0 with the write never
+    // committed, the temp never cleaned up, and the commit lock never released —
+    // no error, no rejection, no trace. A behavioural test would need a child
+    // process whose only pending work is this sleep; reading the source states
+    // the invariant more directly than staging that.
+    const src = readFileSync(new URL('./atomic-store.ts', import.meta.url), 'utf-8');
+    const start = src.indexOf('const sleepMs');
+    expect(start).toBeGreaterThan(-1);
+    // Read to the end of the declaration, not just its first line, so a
+    // reformatted multi-line version cannot smuggle the unref past this.
+    const declaration = src.slice(start, src.indexOf('\n\n', start));
+    expect(declaration).not.toMatch(/unref/);
+  });
+
+  it('does not retry an error that is not destination contention', async () => {
+    renameCode = 'ENOSPC';
+    renameFailures = Number.MAX_SAFE_INTEGER;
+
+    await expect(atomicWriteFile(target, 'no room')).rejects.toThrow(/ENOSPC/);
+    // A full disk is not a race: retrying it would only delay the same failure.
+    expect(renameCalls).toBe(1);
+  });
+});

--- a/src/core/services/mcp-watcher-flush-durability.test.ts
+++ b/src/core/services/mcp-watcher-flush-durability.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Issue #451 — a debounced flush must never skip SILENTLY.
+ *
+ * The reported symptom was an incremental flush that intermittently never landed
+ * on Windows: `llm-context.json` still held the seeded empty context and nothing
+ * anywhere said why. Three separate holes in this lane produce exactly that
+ * observable, and each is a real product defect in a long-lived MCP server, not a
+ * test artifact — a watcher that drops a file event without a signal leaves the
+ * index stale and the agent unaware:
+ *
+ *   1. `handleBatch` treated EVERY read failure as "the file was deleted" and,
+ *      when that emptied the batch, returned writing nothing and saying nothing.
+ *   2. `flush` drains `pending` before its first await, and only two error
+ *      classes put the paths back — every other failure lost them permanently,
+ *      contradicting `flushBatchWithBusyRetry`'s own docstring.
+ *   3. `stop`'s shutdown drain lost its batch the same way, and then reported a
+ *      clean stop because its "still deferred" check read the emptied queue.
+ *
+ * Plus a fourth, found while auditing the state machine: a `.git` write with no
+ * indexable file change latched the VCS settle window forever, after which the
+ * hard batch ceiling could never be re-armed.
+ *
+ * These tests inject the failures deterministically. The Windows trigger itself
+ * (a sharing violation making `readFileConfined`'s descriptor-identity check fail
+ * closed) is not reproducible here — the DURABILITY contract is.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Fail `readFileConfined` for the paths in `failing`, so many times each.
+ * A non-ENOENT failure is what a Windows sharing violation looks like from here:
+ * the file is present and readable a moment later.
+ */
+const readFailures = new Map<string, number>();
+vi.mock('../../utils/path-confinement.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/path-confinement.js')>();
+  return {
+    ...actual,
+    readFileConfined: async (root: string, rel: string, ...rest: unknown[]) => {
+      const left = readFailures.get(rel) ?? 0;
+      if (left > 0) {
+        readFailures.set(rel, left - 1);
+        throw new Error(`Confined read target changed during access: "${rel}"`);
+      }
+      return (actual.readFileConfined as (...a: unknown[]) => Promise<string>)(root, rel, ...rest);
+    },
+  };
+});
+
+const { McpWatcher } = await import('./mcp-watcher.js');
+type Watcher = InstanceType<typeof McpWatcher>;
+
+interface Internals {
+  enqueue(path: string): void;
+  flush(): void;
+  onVcsEvent(): void;
+  enqueueDeletion(path: string): void;
+  armFlushStallDisclosure(batchSize: number): void;
+  handleBatch(paths: string[], opts?: Record<string, unknown>): Promise<void>;
+  handleDeletions(paths: string[], recordSpecChanges?: boolean): Promise<void>;
+  persistContext(context: unknown): Promise<void>;
+  flushBatchWithBusyRetry(batch: string[], deletions: string[], opts?: Record<string, unknown>): Promise<void>;
+  pending: Set<string>;
+  pendingDeletions: Set<string>;
+  eventRetries: Map<string, number>;
+  flushPromise?: Promise<void>;
+  flushStallTimer?: ReturnType<typeof setTimeout>;
+  maxBatchTimer?: ReturnType<typeof setTimeout>;
+  vcsSettling: boolean;
+  running: boolean;
+}
+const inside = (watcher: Watcher): Internals => watcher as unknown as Internals;
+
+let root: string;
+let contextPath: string;
+let stderr: string[];
+const watchers: Watcher[] = [];
+
+/** Every watcher this file creates is stopped before its fixture root is removed. */
+function makeWatcher(options: Record<string, unknown> = {}): Watcher {
+  const watcher = new McpWatcher({ rootPath: root, embed: false, debounceMs: 5, maxBatchMs: 500, ...options });
+  watchers.push(watcher);
+  return watcher;
+}
+
+/**
+ * Budget for `until`. A Windows runner is materially slower at the real work these
+ * tests do — a tree-sitter parse plus several fsync'd temp+rename cycles, up to
+ * four times over for a retry-bound test — and an antivirus scanner adds latency
+ * to every one of them. A budget tuned to Linux would turn that into a flake on a
+ * required job, which is the failure mode #451 was reported as in the first place.
+ */
+const UNTIL_BUDGET_MS = process.platform === 'win32' ? 20_000 : 10_000;
+
+/** Poll for an observable outcome; on timeout, say so AND show the watcher's own diagnostics. */
+async function until(done: () => boolean | Promise<boolean>, what: string, budget = UNTIL_BUDGET_MS): Promise<void> {
+  const deadline = Date.now() + budget;
+  for (;;) {
+    if (await done()) return;
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${budget}ms waiting for ${what}.\nWatcher said:\n${stderr.join('') || '(nothing)'}`);
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+const said = (pattern: RegExp): boolean => stderr.some((line) => pattern.test(line));
+
+beforeEach(async () => {
+  readFailures.clear();
+  root = await mkdtemp(join(tmpdir(), 'ol-flush-durability-'));
+  const analysisDir = join(root, '.openlore', 'analysis');
+  await mkdir(analysisDir, { recursive: true });
+  contextPath = join(analysisDir, 'llm-context.json');
+  await writeFile(contextPath, JSON.stringify({ signatures: [], callGraph: null }, null, 2), 'utf-8');
+  stderr = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array): boolean => {
+    stderr.push(chunk.toString());
+    return true;
+  });
+});
+
+afterEach(async () => {
+  // Stop before removing the root: a live watcher outliving its own filesystem
+  // writes complaints into a sink no test reads, and can leak into the next one.
+  await Promise.all(watchers.splice(0).map((watcher) => watcher.stop().catch(() => {})));
+  vi.restoreAllMocks();
+  // maxRetries: Windows returns EBUSY/EPERM for a moment after the last handle on
+  // a file closes (an indexer or AV scanner still has it open). Node's own retry
+  // loop is the fix; swallowing the error instead would hide a genuinely leaked
+  // handle, which is exactly the kind of thing this file exists to catch.
+  await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+describe('McpWatcher flush durability (issue #451)', () => {
+  it('retries a transiently unreadable file instead of dropping it silently', async () => {
+    const foo = join(root, 'foo.ts');
+    await writeFile(foo, 'export function delta() {}\n', 'utf-8');
+    readFailures.set('foo.ts', 1); // fails once, then reads fine
+
+    inside(makeWatcher()).enqueue(foo);
+
+    await until(
+      async () => (await readFile(contextPath, 'utf-8')).includes('delta'),
+      'the retried flush to reach disk',
+    );
+    // Before the fix this batch produced no output at all — the drop was invisible.
+    expect(said(/could not read 1 changed file/)).toBe(true);
+    expect(said(/deferred 1 unreadable change/)).toBe(true);
+    expect(said(/gave up/)).toBe(false);
+  });
+
+  it('gives up loudly on a permanently unreadable file rather than retrying forever', async () => {
+    const foo = join(root, 'foo.ts');
+    await writeFile(foo, 'export function delta() {}\n', 'utf-8');
+    readFailures.set('foo.ts', Number.MAX_SAFE_INTEGER);
+
+    const watcher = makeWatcher();
+    inside(watcher).enqueue(foo);
+
+    await until(() => said(/gave up on 1 change/), 'the watcher to disclose the abandoned change');
+    expect(said(/run analyze to reconcile/)).toBe(true);
+    // Bounded: the queue is empty, so nothing is left spinning.
+    await until(() => inside(watcher).pending.size === 0 && !inside(watcher).running, 'the queue to settle');
+    const attempts = stderr.filter((line) => /could not read/.test(line)).length;
+    expect(attempts).toBe(4); // 1 initial + WATCH_MAX_EVENT_RETRIES
+  });
+
+  it('re-queues a batch whose flush failed for an unrecognized reason', async () => {
+    const foo = join(root, 'foo.ts');
+    await writeFile(foo, 'export function gamma() {}\n', 'utf-8');
+
+    const watcher = makeWatcher();
+    const internals = inside(watcher);
+    const real = internals.handleBatch.bind(watcher);
+    let failuresLeft = 1;
+    vi.spyOn(internals, 'handleBatch').mockImplementation(async (paths, opts) => {
+      if (failuresLeft-- > 0) throw new Error('ENOSPC: no space left on device, write');
+      await real(paths, opts);
+    });
+
+    internals.enqueue(foo);
+
+    // The change survives the failure and lands on the retry. Before the fix the
+    // drained batch existed only in a local array and was garbage-collected.
+    await until(
+      async () => (await readFile(contextPath, 'utf-8')).includes('gamma'),
+      'the re-queued batch to land',
+    );
+    expect(said(/error: ENOSPC/)).toBe(true);
+    expect(said(/deferred 1 change\(s\) for retry/)).toBe(true);
+  });
+
+  it('abandons a permanently failing batch after a bounded number of attempts', async () => {
+    const foo = join(root, 'foo.ts');
+    await writeFile(foo, 'export function gamma() {}\n', 'utf-8');
+
+    const watcher = makeWatcher();
+    const internals = inside(watcher);
+    vi.spyOn(internals, 'handleBatch').mockRejectedValue(new Error('EIO: i/o error, write'));
+
+    internals.enqueue(foo);
+
+    await until(() => said(/gave up on 1 change/), 'the watcher to disclose the abandoned batch');
+    await until(() => internals.pending.size === 0 && !internals.running, 'the queue to settle');
+    expect(stderr.filter((line) => /error: EIO/.test(line)).length).toBe(4); // 1 + 3 retries
+    // The single-flight guard is released, so the watcher is not wedged.
+    expect(internals.running).toBe(false);
+  });
+
+  it('discloses a shutdown batch it could not flush instead of reporting a clean stop', async () => {
+    const foo = join(root, 'shutdown.ts');
+    await writeFile(foo, 'export function omega() {}\n', 'utf-8');
+
+    const watcher = makeWatcher();
+    const internals = inside(watcher);
+    vi.spyOn(internals, 'handleBatch').mockRejectedValue(new Error('EACCES: permission denied, open'));
+    internals.pending.add(foo);
+
+    await watcher.stop();
+    watchers.length = 0; // already stopped
+
+    expect(said(/shutdown flush error: EACCES/)).toBe(true);
+    // The line that used to stay silent because the lost batch had emptied the queue.
+    expect(said(/stopped with 1 change\(s\).*still deferred/)).toBe(true);
+  });
+
+  it('closes the VCS settle window when the settle flush finds nothing to do', async () => {
+    // A `git commit` or `git fetch` rewrites refs without changing an indexable
+    // file. The settle debounce then fires on an empty queue, which used to skip
+    // the only line that clears `vcsSettling` — leaving the hard batch ceiling
+    // permanently unarmable, so a steady write stream could postpone the flush
+    // without bound while a timer was always armed.
+    const watcher = makeWatcher();
+    const internals = inside(watcher);
+
+    internals.onVcsEvent();
+    expect(internals.vcsSettling).toBe(true);
+    internals.flush(); // the settle debounce, with nothing queued
+    expect(internals.vcsSettling).toBe(false);
+
+    internals.enqueue(join(root, 'later.ts'));
+    expect(internals.maxBatchTimer).toBeDefined();
+  });
+  it('bounds a failure that happens AFTER the file was read', async () => {
+    // The retry budget lives per PATH, and the read is what used to clear it. A
+    // failure past the read — the artifact rename, the generation republish, a
+    // full disk — therefore reset the budget on every attempt and retried
+    // forever. This is the exact shape of the failure #451 reported, so it is the
+    // one the bound has to cover; note that it drives the REAL handleBatch rather
+    // than mocking it, which is what let the loop hide.
+    const foo = join(root, 'foo.ts');
+    await writeFile(foo, 'export function delta() {}\n', 'utf-8');
+
+    const watcher = makeWatcher();
+    const internals = inside(watcher);
+    vi.spyOn(internals, 'persistContext').mockRejectedValue(new Error('EPERM: operation not permitted, rename'));
+
+    internals.enqueue(foo);
+
+    await until(() => said(/gave up on 1 change/), 'the watcher to abandon the change');
+    await until(() => internals.pending.size === 0 && !internals.running, 'the queue to settle');
+    expect(stderr.filter((line) => /error: EPERM/.test(line)).length).toBe(4); // 1 + 3 retries
+    expect(internals.eventRetries.size).toBe(0);
+  });
+
+  it('lands the readable half of a mixed batch and still retries the unreadable half', async () => {
+    const good = join(root, 'good.ts');
+    const bad = join(root, 'bad.ts');
+    await writeFile(good, 'export function alpha() {}\n', 'utf-8');
+    await writeFile(bad, 'export function beta() {}\n', 'utf-8');
+    readFailures.set('bad.ts', 1);
+
+    const internals = inside(makeWatcher());
+    internals.enqueue(good);
+    internals.enqueue(bad);
+
+    // The readable file is not held hostage by its neighbour...
+    await until(async () => (await readFile(contextPath, 'utf-8')).includes('alpha'), 'the readable half to land');
+    // ...and the unreadable one comes back on the retry rather than leaving with it.
+    await until(async () => (await readFile(contextPath, 'utf-8')).includes('beta'), 'the retried half to land');
+    expect(said(/could not read 1 changed file/)).toBe(true);
+    expect(said(/gave up/)).toBe(false);
+  });
+
+  it('re-queues a failed DELETION as a deletion, never demoting it to a change', async () => {
+    const gone = join(root, 'gone.ts');
+    const watcher = makeWatcher();
+    const internals = inside(watcher);
+    const real = internals.handleDeletions.bind(watcher);
+    let failuresLeft = 1;
+    const spy = vi.spyOn(internals, 'handleDeletions').mockImplementation(async (paths, record) => {
+      if (failuresLeft-- > 0) throw new Error('EBUSY: resource busy or locked, unlink');
+      await real(paths, record);
+    });
+
+    internals.enqueueDeletion(gone);
+
+    await until(() => spy.mock.calls.length >= 2, 'the deletion to be retried');
+    expect(spy.mock.calls[1][0]).toEqual([gone]);
+    expect(internals.pending.has(gone)).toBe(false);
+    expect(said(/gave up/)).toBe(false);
+  });
+
+  it('gives a file a fresh retry budget after a successful pass, and leaves no ledger behind', async () => {
+    const foo = join(root, 'foo.ts');
+    await writeFile(foo, 'export function alpha() {}\n', 'utf-8');
+    const internals = inside(makeWatcher());
+
+    // One failure is enough to put the file in the ledger; round 2 is what proves
+    // the entry did not survive. Keeping round 1 cheap matters — this test drives
+    // the REAL flush lane, and every extra pass is a tree-sitter parse plus an
+    // fsync'd temp+rename on a runner where those are slow.
+    readFailures.set('foo.ts', 1);
+    internals.enqueue(foo);
+    await until(async () => (await readFile(contextPath, 'utf-8')).includes('alpha'), 'the first round to land');
+    await until(() => internals.eventRetries.size === 0, 'the retry ledger to clear');
+
+    // Three more failures. With round 1's entry still in the ledger this is the
+    // FOURTH attempt, over the bound, and the file is abandoned instead of landing.
+    await writeFile(foo, 'export function omega() {}\n', 'utf-8');
+    readFailures.set('foo.ts', 3);
+    internals.enqueue(foo);
+    await until(async () => (await readFile(contextPath, 'utf-8')).includes('omega'), 'the second round to land');
+    expect(said(/gave up/)).toBe(false);
+    await until(() => internals.eventRetries.size === 0, 'the retry ledger to clear again');
+  });
+
+  it('records an abandoned change as stale in the graph store, not just on stderr', async () => {
+    const { EdgeStore } = await import('./edge-store.js');
+    const outputPath = join(root, '.openlore', 'analysis');
+    EdgeStore.openForAnalyze(EdgeStore.dbPath(outputPath)).close();
+
+    await mkdir(join(root, 'src'), { recursive: true });
+    const foo = join(root, 'src', 'foo.ts');
+    const notes = join(root, 'openspec', 'specs', 'x', 'spec.md');
+    await mkdir(join(root, 'openspec', 'specs', 'x'), { recursive: true });
+    await writeFile(foo, 'export function delta() {}\n', 'utf-8');
+    await writeFile(notes, '# spec\n', 'utf-8');
+    readFailures.set('src/foo.ts', Number.MAX_SAFE_INTEGER);
+
+    const internals = inside(makeWatcher());
+    internals.enqueue(foo);
+    internals.enqueue(notes);
+
+    await until(() => said(/gave up on/), 'the watcher to abandon the change');
+    await until(() => internals.pending.size === 0 && !internals.running, 'the queue to settle');
+
+    const store = EdgeStore.open(EdgeStore.dbPath(outputPath));
+    const stale = store.getStaleFiles();
+    store.close();
+    // The signal outlives the log line: a later freshness read sees the gap.
+    expect(stale).toContain('src/foo.ts');
+    // ...but only for source the graph indexes. A stale row for a markdown file
+    // the graph has no nodes for could never be cleared by a re-parse.
+    expect(stale).not.toContain('openspec/specs/x/spec.md');
+    expect(said(/could not record .* as stale/)).toBe(false);
+  });
+
+  it('handleChange discloses an unreadable file without queueing work its caller did not ask for', async () => {
+    const foo = join(root, 'foo.ts');
+    await writeFile(foo, 'export function delta() {}\n', 'utf-8');
+    readFailures.set('foo.ts', 1);
+
+    const watcher = makeWatcher();
+    await watcher.handleChange(foo);
+    const internals = inside(watcher);
+
+    expect(said(/could not read 1 changed file/)).toBe(true);
+    // No debounce lane behind this caller: no re-queue, no retry, no ledger entry.
+    expect(internals.pending.size).toBe(0);
+    expect(internals.eventRetries.size).toBe(0);
+    expect(said(/deferred/)).toBe(false);
+    expect(said(/gave up/)).toBe(false);
+  });
+
+  it('says nothing when a file simply vanished between the event and the read', async () => {
+    const ghost = join(root, 'ghost.ts');
+    const internals = inside(makeWatcher());
+    internals.enqueue(ghost); // never created
+
+    await until(() => !internals.running && internals.pending.size === 0, 'the batch to drain');
+    // handleDeletions owns a removed file; it must not look unreadable.
+    expect(said(/could not read/)).toBe(false);
+    expect(said(/gave up/)).toBe(false);
+  });
+
+  it('discloses a flush that neither finishes nor fails, and clears that disclosure', async () => {
+    const watcher = makeWatcher();
+    const internals = inside(watcher);
+    let release!: () => void;
+    vi.spyOn(internals, 'flushBatchWithBusyRetry')
+      .mockImplementation(() => new Promise<void>((resolve) => { release = resolve; }));
+
+    vi.useFakeTimers();
+    try {
+      internals.pending.add(join(root, 'wedged.ts'));
+      internals.flush();
+      expect(internals.flushStallTimer).toBeDefined();
+      expect(said(/is still running after/)).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(said(/a flush of 1 change\(s\) is still running after 30s/)).toBe(true);
+
+      release();
+      await internals.flushPromise;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(internals.flushStallTimer).toBeUndefined();
+      expect(internals.running).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a stopped watcher never emits a stall disclosure it armed before shutdown', async () => {
+    const watcher = makeWatcher();
+    const internals = inside(watcher);
+    vi.useFakeTimers();
+    try {
+      internals.armFlushStallDisclosure(7);
+      expect(internals.flushStallTimer).toBeDefined();
+      await watcher.stop();
+      watchers.length = 0;
+      expect(internals.flushStallTimer).toBeUndefined();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(said(/is still running after/)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -128,6 +128,48 @@ const GRAPH_STALE_DEBOUNCE_MS = 1500;
 /** Additional attempts after SQLite's own busy_timeout expires. */
 const SQLITE_BUSY_RETRY_DELAYS_MS = [50, 150, 450] as const;
 
+/**
+ * How many times one file event is re-queued after a failed flush before the
+ * watcher gives up on it (change: harden-watcher-flush-durability, issue #451).
+ *
+ * A drained batch used to be unrecoverable: `flush` empties `pending` before the
+ * first await, and only two error classes — a spec-index lock timeout and a busy
+ * SQLite — put the paths back. Every other failure (a Windows `EPERM` on the
+ * artifact rename, a sharing violation on the lock's hard link, ENOSPC) reached
+ * one stderr line and the change was gone until the next full `analyze`. A
+ * transient error must cost freshness for one debounce, not until someone
+ * notices. The bound is what keeps a DETERMINISTIC failure from becoming a hot
+ * retry loop: after it, the watcher discloses the drop and — where a graph store
+ * exists — records the files as stale, so the staleness outlives the log line.
+ */
+const WATCH_MAX_EVENT_RETRIES = 3;
+
+/**
+ * How long a single flush may run before the watcher says so, once, on stderr.
+ *
+ * `acquireAnalysisLock` waits without bound by design (a serialization promise
+ * must not be abandoned), and a live-but-wedged holder is never stolen. The
+ * failure mode is therefore a flush that is neither finished nor failed: every
+ * later flush no-ops on the single-flight guard, `pending` grows, and nothing is
+ * ever written. Silence there is the exact defect issue #451 names, so the wait
+ * is disclosed rather than shortened.
+ */
+const WATCH_FLUSH_STALL_DISCLOSURE_MS = 30_000;
+
+/**
+ * True when a read failed because the file is not there any more.
+ *
+ * The watch lane reads a path some milliseconds after the event that named it,
+ * so "it was deleted in between" is expected and must be skipped in silence.
+ * Everything else — a confinement or descriptor-identity rejection, a sharing
+ * violation, a permission error — is a read that COULD have succeeded, and
+ * treating it as a deletion is what let a change disappear with no signal.
+ */
+function isMissingFileError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
 function isSqliteBusyError(err: unknown): boolean {
   const message = (err as Error | undefined)?.message?.toLowerCase() ?? '';
   return /sqlite_(?:busy|locked)|database(?: table)? is (?:locked|busy)/.test(message);
@@ -321,6 +363,8 @@ export class McpWatcher {
   private stopping = false;                          // reject events once shutdown begins
   private vcsBulkFlag = false;                       // set by the .git ref watcher
   private vcsSettling = false;                       // preserve the VCS settle window across file events
+  private eventRetries = new Map<string, number>();  // abs path → consecutive failed flush attempts
+  private flushStallTimer?: ReturnType<typeof setTimeout>; // discloses a flush that neither ends nor fails
   private appliedClosureFiles?: Set<string>;         // populated only by explicit repository-delta callers
 
   // ── Embedding lane (Step 4 — decoupled, lower priority) ─────────────────────
@@ -481,7 +525,9 @@ export class McpWatcher {
     if (this.maxBatchTimer) clearTimeout(this.maxBatchTimer);
     if (this.embedTimer) clearTimeout(this.embedTimer);
     if (this.graphStaleTimer) clearTimeout(this.graphStaleTimer);
+    if (this.flushStallTimer) clearTimeout(this.flushStallTimer);
     this.debounceTimer = this.maxBatchTimer = this.embedTimer = this.graphStaleTimer = undefined;
+    this.flushStallTimer = undefined;
     this.graphStaleDeadline = undefined;
     // Close event sources before joining the active flush. Once close resolves,
     // the stopping guard below makes the pending sets a finite shutdown queue.
@@ -526,6 +572,14 @@ export class McpWatcher {
         await this.flushBatchWithBusyRetry(shutdownBatch, shutdownDeletions, { syncFlush: true });
       } catch (err) {
         process.stderr.write(`[mcp-watcher] shutdown flush error: ${(err as Error).message}\n`);
+        // Put the work back before the disclosure below counts it. Dropping it
+        // here made the "still deferred" line read an empty queue and stay silent
+        // in exactly the case where it mattered most: the batch was not deferred,
+        // it was lost, and shutdown reported a clean stop (issue #451).
+        for (const path of shutdownDeletions) this.pendingDeletions.add(path);
+        for (const path of shutdownBatch) {
+          if (!this.pendingDeletions.has(path)) this.pending.add(path);
+        }
       }
     }
     if (this.pending.size > 0 || this.pendingDeletions.size > 0) {
@@ -601,12 +655,29 @@ export class McpWatcher {
    * Drain the pending set into a single batch. Single-flight: if a flush is
    * already running, leave the new paths in `pending` and reschedule once it
    * finishes — never interleave two flushes.
+   *
+   * DURABILITY (issue #451): the drain is destructive — `pending` is emptied
+   * before the first await — so every exit from the batch must either commit the
+   * work, re-queue it, or say out loud that it was dropped. There is no fourth
+   * option in which a change simply disappears.
    */
   private flush(): void {
     if (this.debounceTimer) { clearTimeout(this.debounceTimer); this.debounceTimer = undefined; }
     if (this.maxBatchTimer) { clearTimeout(this.maxBatchTimer); this.maxBatchTimer = undefined; }
     if (this.running) return;            // a follow-up is scheduled in finally{}
-    if (this.pending.size === 0 && this.pendingDeletions.size === 0) return;
+    if (this.pending.size === 0 && this.pendingDeletions.size === 0) {
+      // Close the settle window even on an empty drain. A `.git` write with no
+      // indexable file change — `git commit`, `git fetch`, a checkout touching
+      // only tests — used to leave `vcsSettling` latched forever, because it is
+      // cleared below and this return happens first. Once latched, armFlush()
+      // takes its settle branch on every later event and NEVER re-arms the hard
+      // ceiling, so a steady sub-settle-window write stream postpones the flush
+      // without bound: the index goes stale with a timer always armed and
+      // nothing to say so (issue #451).
+      this.vcsSettling = false;
+      this.vcsBulkFlag = false;
+      return;
+    }
 
     const batch = Array.from(this.pending);
     const deletions = Array.from(this.pendingDeletions);
@@ -614,22 +685,217 @@ export class McpWatcher {
     this.pending.clear();
     this.pendingDeletions.clear();
     this.running = true;
+    this.armFlushStallDisclosure(batch.length + deletions.length);
     const operation = this.flushBatchWithBusyRetry(batch, deletions)
-      .catch((err) => { process.stderr.write(`[mcp-watcher] error: ${(err as Error).message}\n`); });
+      // An unrecognized failure must not vaporize the drained batch. `pending`
+      // was emptied above, so without this the file events exist only in the
+      // local arrays and the index silently goes stale (issue #451).
+      // `?? err` matters: a thrown non-Error would make `.message` throw inside
+      // the handler, and the batch would be lost by the very code that exists to
+      // save it.
+      .catch((err: unknown) => this.deferFailedBatch(
+        batch, deletions, String((err as Error | undefined)?.message ?? err),
+      ));
     this.flushPromise = operation;
     void operation.finally(() => {
-      if (this.flushPromise === operation) this.flushPromise = undefined;
-      this.running = false;
-      if (!this.stopping && (this.pending.size > 0 || this.pendingDeletions.size > 0)) {
-        this.debounceTimer = this.armTimer(() => this.flush(), this.debounceMs);
+      // Guarded: a throw here would leave `running` true forever and wedge every
+      // future flush behind the single-flight guard, as an unhandled rejection.
+      try {
+        if (this.flushStallTimer) clearTimeout(this.flushStallTimer);
+        this.flushStallTimer = undefined;
+        if (this.flushPromise === operation) this.flushPromise = undefined;
+        if (!this.stopping && (this.pending.size > 0 || this.pendingDeletions.size > 0)) {
+          if (this.debounceTimer) clearTimeout(this.debounceTimer);
+          this.debounceTimer = this.armTimer(() => this.flush(), this.debounceMs);
+        }
+      } finally {
+        this.running = false;
       }
-    });
+    })
+      // `p.finally(cb)` REJECTS when cb throws, and a voided rejection ends a
+      // strict Node process. The guard above keeps the watcher unwedged; this
+      // keeps the epilogue from taking the host down with it.
+      .catch(() => {});
+  }
+
+  /**
+   * Say once, on stderr, that a flush has been running implausibly long.
+   *
+   * The wait itself is legitimate — `acquireAnalysisLock` blocks until a full
+   * `analyze` finishes its artifact write — so this neither cancels nor shortens
+   * it. It only removes the silence: a wedged holder otherwise leaves the
+   * watcher single-flight-blocked with a growing queue and no output at all.
+   */
+  private armFlushStallDisclosure(batchSize: number): void {
+    if (this.flushStallTimer) clearTimeout(this.flushStallTimer);
+    this.flushStallTimer = this.armTimer(() => {
+      this.flushStallTimer = undefined;
+      process.stderr.write(
+        `[mcp-watcher] a flush of ${batchSize} change(s) is still running after ` +
+        `${Math.round(WATCH_FLUSH_STALL_DISCLOSURE_MS / 1000)}s — later changes are queued behind it ` +
+        `(a large batch, or another writer holding the analysis lock)\n`,
+      );
+    }, WATCH_FLUSH_STALL_DISCLOSURE_MS);
+  }
+
+  /**
+   * Put a batch that failed for an unrecognized reason back in the queue.
+   *
+   * Bounded by {@link WATCH_MAX_EVENT_RETRIES} so a deterministic failure
+   * degrades to one loud drop instead of a retry loop. The re-queue is what
+   * `flush`'s `finally` sees, so the retry rides the existing debounce re-arm —
+   * no second scheduling path.
+   */
+  private async deferFailedBatch(
+    batch: readonly string[],
+    deletions: readonly string[],
+    reason: string,
+  ): Promise<void> {
+    process.stderr.write(`[mcp-watcher] error: ${reason}\n`);
+    const requeued: string[] = [];
+    const abandoned: string[] = [];
+    const requeue = (paths: readonly string[], into: Set<string>): void => {
+      for (const path of paths) {
+        // Shutdown cannot retry, but it must not drop the work either: put it
+        // back so stop()'s ONE "still deferred" disclosure counts it. Spending
+        // retry budget there would be a lie — no retry is coming.
+        if (this.stopping) {
+          into.add(path);
+          requeued.push(path);
+          continue;
+        }
+        const attempts = (this.eventRetries.get(path) ?? 0) + 1;
+        if (attempts > WATCH_MAX_EVENT_RETRIES) {
+          this.eventRetries.delete(path);
+          abandoned.push(path);
+          continue;
+        }
+        this.eventRetries.set(path, attempts);
+        into.add(path);
+        requeued.push(path);
+      }
+    };
+    // Deletions first, then the changes that are not superseded by one — the
+    // same order and the same disjointness rule the two contention deferrals use.
+    requeue(deletions, this.pendingDeletions);
+    requeue(batch.filter(path => !this.pendingDeletions.has(path)), this.pending);
+    if (requeued.length > 0 && !this.stopping) {
+      process.stderr.write(
+        `[mcp-watcher] deferred ${requeued.length} change(s) for retry after that error\n`,
+      );
+    }
+    if (abandoned.length > 0) await this.abandonEvents(abandoned, WATCH_MAX_EVENT_RETRIES, reason);
+  }
+
+  /**
+   * Disclose files the batch could not read, and put them back for one more try.
+   *
+   * `discloseOnly` is the explicit-caller lane (`handleChange`,
+   * `applyRepositoryDelta`). Those await a single pass and have no debounce to
+   * ride, so re-queueing would schedule work their caller never asked for — and
+   * `applyRepositoryDelta` already reports its own unapplied files as stale, so
+   * a second stale marking here would only duplicate it. They get the
+   * disclosure; what to do about it is theirs to decide.
+   */
+  private async deferUnreadable(
+    unreadable: ReadonlyArray<{ abs: string; reason: string }>,
+    discloseOnly: boolean,
+  ): Promise<void> {
+    const reason = unreadable[0].reason;
+    process.stderr.write(
+      `[mcp-watcher] could not read ${unreadable.length} changed file(s) — ${sanitizeForTerminal(reason)}\n`,
+    );
+    // The explicit lane neither retries nor spends the watch lane's budget:
+    // clearing the counter here would refill a budget the watch lane is spending
+    // on the same path.
+    if (discloseOnly) return;
+    const requeued: string[] = [];
+    const abandoned: string[] = [];
+    for (const { abs } of unreadable) {
+      if (this.stopping) { abandoned.push(abs); continue; }
+      const attempts = (this.eventRetries.get(abs) ?? 0) + 1;
+      if (attempts > WATCH_MAX_EVENT_RETRIES) {
+        this.eventRetries.delete(abs);
+        abandoned.push(abs);
+        continue;
+      }
+      this.eventRetries.set(abs, attempts);
+      if (!this.pendingDeletions.has(abs)) this.pending.add(abs);
+      requeued.push(abs);
+    }
+    // No re-arm here: this lane is only reached from inside a running flush, and
+    // its finally{} re-arms the debounce for whatever is back in the queue.
+    if (requeued.length > 0) {
+      process.stderr.write(`[mcp-watcher] deferred ${requeued.length} unreadable change(s) for retry\n`);
+    }
+    if (abandoned.length > 0) {
+      await this.abandonEvents(abandoned, this.stopping ? 1 : WATCH_MAX_EVENT_RETRIES, reason);
+    }
+  }
+
+  /**
+   * Give up on file events the watcher could not apply, leaving a signal that
+   * outlives the log line.
+   *
+   * A stderr line in a long-lived daemon is not a signal an agent can read. Where
+   * a graph store exists, the abandoned files are recorded stale through the same
+   * mechanism `fallbackBulkBatch` uses, so every later freshness read discloses
+   * them instead of serving a silently incomplete index.
+   *
+   * PRE-CONDITION: the analysis lock is NOT held by the caller — this acquires it.
+   * Both call sites (the pre-lock candidate loop in `handleBatch`, and `flush`'s
+   * error handler) run outside the artifact critical section.
+   */
+  private async abandonEvents(
+    absPaths: readonly string[],
+    attempts: number,
+    reason: string,
+  ): Promise<void> {
+    process.stderr.write(
+      `[mcp-watcher] gave up on ${absPaths.length} change(s) after ${attempts} ` +
+      `attempt(s) (${reason}) — run analyze to reconcile: ` +
+      `${absPaths.map(path => sanitizeForTerminal(relative(this.rootPath, path))).sort().join(', ')}\n`,
+    );
+    // Same candidate filter as the bulk-fallback lane: `stale_files` rows are
+    // about SOURCE the graph indexes. A watched OpenSpec markdown file has no
+    // nodes, so a row for it would be a permanent stale entry that no re-parse
+    // can ever clear.
+    const staleFiles = [...new Set(absPaths
+      .map(abs => toRepositoryPath(relative(this.rootPath, abs)))
+      .filter(rel => !isTestFile(rel))
+      .filter(rel => detectLanguage(rel) !== 'unknown' || HTML_EXTENSIONS.test(rel)))]
+      .sort();
+    try {
+      if (staleFiles.length === 0 || !EdgeStore.exists(this.outputPath)) return;
+      const releaseAnalysis = await acquireAnalysisLock(this.outputPath);
+      try {
+        const store = EdgeStore.open(EdgeStore.dbPath(this.outputPath));
+        try {
+          if (!store.notReady) store.markFilesStale(staleFiles);
+        } finally {
+          store.close();
+        }
+      } finally {
+        await releaseAnalysis();
+      }
+    } catch (err) {
+      // Disclosure is best-effort by construction: the stderr line above already
+      // named the drop, and failing here must not mask it with a second error.
+      process.stderr.write(
+        `[mcp-watcher] could not record ${staleFiles.length} abandoned change(s) as stale: ` +
+        `${(err as Error).message}\n`,
+      );
+    }
   }
 
   /**
    * Retry a contended SQLite batch, then put it back in the in-memory queue.
-   * The queue is drained only after a successful pass, so a long external write
-   * lock delays freshness but never silently loses the file events.
+   * A long external write lock delays freshness but never loses the file events.
+   *
+   * This handles the two RECOGNIZED contention classes. Everything else is
+   * re-queued one level up, by `flush`'s error handler — the claim that no event
+   * is silently lost holds for the whole lane, not just for these two branches
+   * (it did not before issue #451).
    */
   private async flushBatchWithBusyRetry(
     batch: string[],
@@ -643,6 +909,14 @@ export class McpWatcher {
         // Deletions first (remove stale state), then re-index changed/added files.
         if (deletions.length > 0) await this.handleDeletions(deletions, false);
         if (batch.length > 0) await this.handleBatch(batch, { ...opts, recordSpecChanges: false });
+        // The pass landed. Reset the retry budget of every path it actually
+        // consumed — but NOT of one the pass itself put back (an unreadable
+        // file), or a permanently failing file would refill its budget on every
+        // attempt and retry forever.
+        for (const path of [...batch, ...deletions]) {
+          if (this.pending.has(path) || this.pendingDeletions.has(path)) continue;
+          this.eventRetries.delete(path);
+        }
         return;
       } catch (err) {
         if (isSpecIndexLockTimeoutError(err)) {
@@ -860,6 +1134,16 @@ export class McpWatcher {
 
     // 1. Resolve + read candidate files (skip tests / unknown langs / deleted).
     const files: Array<{ rel: string; abs: string; content: string }> = [];
+    // A read that failed for a reason OTHER than "the file is gone". This used to
+    // be indistinguishable from a deletion — one bare `continue` covered both —
+    // and when it was the batch's only file the method returned at `files.length
+    // === 0` writing nothing at all. That is the whole of issue #451's observable
+    // behaviour: llm-context.json untouched, zero diagnostic output, intermittent.
+    // The read genuinely can fail transiently: `readFileConfined` fails CLOSED
+    // when the path stat and the descriptor stat disagree on identity or
+    // timestamps, which a Windows sharing violation (an indexer or AV holding the
+    // file) produces by making libuv fall back to an attribute-only stat.
+    const unreadable: Array<{ abs: string; reason: string }> = [];
     for (const abs of absPaths) {
       const rel = toRepositoryPath(relative(this.rootPath, abs));
       if (isTestFile(rel)) continue;
@@ -869,11 +1153,18 @@ export class McpWatcher {
       let content: string;
       try {
         content = await readFileConfined(this.rootPath, rel, MAX_EDIT_VERDICT_BASIS_FILE_BYTES);
-      } catch {
-        continue; // file may have been deleted between the event and now
+      } catch (err) {
+        // Deleted between the event and now: expected, and handleDeletions owns it.
+        if (isMissingFileError(err)) continue;
+        unreadable.push({ abs, reason: (err as Error).message });
+        continue;
       }
       files.push({ rel, abs, content });
     }
+    // Re-queue only on the watch lane. `handleChange` and `applyRepositoryDelta`
+    // are synchronous callers with no debounce behind them: they get the
+    // disclosure and decide for themselves.
+    if (unreadable.length > 0) await this.deferUnreadable(unreadable, opts.syncFlush === true);
     if (files.length === 0) return;
 
     // The graph database and required JSON artifacts are one logical generation.


### PR DESCRIPTION
**Status:** LGTM — fixes #451 in the product lane, not in the test.

## What was wrong

`mcp-watcher-incremental.test.ts > "the watcher-path flush persists the patched context to disk"` intermittently failed on Windows: the debounced flush never landed, so `llm-context.json` still held the seeded empty context. #451 characterised it and pointed at cross-test-file state.

**That hypothesis is falsified.** This repo runs vitest on the default `forks` pool with `isolate: true`, so every test file gets its own OS process. I verified it empirically — two test files sharing a module report different PIDs and a fresh module registry in both sequential and parallel mode. No module singleton, leaked timer, `vi.mock` registry or stderr spy can cross a file boundary, which is also why `--no-file-parallelism` changed nothing. The only channels that survive a file boundary are the filesystem, OS resources and IO contention — all of which point back at the flush lane.

Auditing that lane found **four ways a flush is silently skipped**. Each is a product defect in a long-lived MCP server, not a test artifact: a watcher that drops a file event without a signal leaves the index stale and the agent unaware it is reading a lie.

| # | Defect | Symptom |
|---|---|---|
| 1 | `handleBatch`'s candidate loop caught **every** `readFileConfined` error with a bare `continue`, and returned at `files.length === 0` writing nothing and saying nothing | the exact #451 observable |
| 2 | `flush()` empties `pending` before its first await; only a spec-index lock timeout and a busy SQLite put the paths back. Everything else — `EPERM` on the artifact rename, a hard-link failure taking the advisory lock, `ENOSPC` — reached one stderr line and the change was gone until the next full `analyze` | permanent silent staleness |
| 3 | `stop()` dropped a failed shutdown batch the same way, after which its "still deferred — run analyze to reconcile" line read the emptied queue and stayed silent | a clean stop reported over lost work |
| 4 | `atomicWriteFile`'s commit `rename` is unretried. On Windows `MoveFileExW(REPLACE_EXISTING)` needs DELETE access to the target and fails with `EPERM`/`EACCES`/`EBUSY` while another handle holds it | the artifact stays at its previous content |
| 5 | `vcsSettling` is cleared only *after* `flush()`'s empty-queue early return, so a `.git` write with no indexable change (`git commit`, `git fetch`) latched it forever — after which `armFlush` never re-arms the hard ceiling and a steady write stream postpones the flush without bound | index never refreshes, timer always armed |

**#4 is not a hypothesis — CI produced it.** The first push of this PR ran the new suite on the required Windows job. One test failed on its first attempt and passed on retry, and the failure message was the bug itself:

```
[mcp-watcher] error: EPERM: operation not permitted, rename
  'C:\...\ol-flush-durability-tY8KDh\.openlore\analysis\.llm-context.json.tmp-5316-5'
  -> 'C:\...\ol-flush-durability-tY8KDh\.openlore\analysis\llm-context.json'
[mcp-watcher] gave up on 1 change(s) after 3 attempt(s) (EPERM ...) — run analyze to reconcile: foo.ts
```

An unforced, real `rename` failure on a Windows runner, leaving `llm-context.json` at its previous content. That is #451's symptom, arriving on its own. It was visible at all only because the retry lane in this PR had already turned the silent loss into a bounded, disclosed give-up — so the fix caught its own second root cause on the first run. The rename is now retried.

**Why #1 is the other Windows trigger.** `readFileConfined` fails CLOSED when the path stat and the descriptor stat disagree on `dev`/`ino`/`mtimeMs`/`ctimeMs`. On Windows libuv falls back to an attribute-only stat (`ino`/`dev` zeroed, `ctim` collapsed onto `mtim`) whenever it cannot open the file for attributes — which a transient sharing violation from an indexer or AV scanner produces. Intermittent, load-correlated, indifferent to vitest parallelism. That matches every line of the reported profile.

## How it was fixed

One rule, stated once and enforced at every exit: **the drain is destructive, so every exit from a batch must either commit the work, re-queue it, or say out loud that it was dropped.** There is no fourth option in which a change simply disappears.

- A read failure is **classified**. `ENOENT`/`ENOTDIR` is a real deletion and stays silent (the deletion lane owns it); anything else is disclosed and re-queued.
- Any unrecognized flush error **re-queues** the drained batch instead of discarding it.
- Both re-queues are bounded by `WATCH_MAX_EVENT_RETRIES` (3), so a deterministic failure degrades to one loud drop rather than a hot loop. The budget is per path and resets only on a pass that actually consumed the path — a failure *after* the read must not refill it, or the bound is unreachable for exactly the failures it exists to bound.
- On give-up the files are **recorded stale in the graph store**, behind the same source-candidate filter the bulk-fallback lane uses, so the signal outlives the log line. A stderr line in a daemon nobody is watching is not a signal an agent can read.
- `stop()` puts a failed shutdown batch back before its own disclosure counts it.
- An empty settle drain closes the settle window.
- `atomicWriteFile` **retries a contended rename** (`EPERM`/`EACCES`/`EBUSY`) with a bounded backoff. The temp file is still there and fully fsync'd, so each attempt is the same single atomic replace — atomicity is untouched. Those codes essentially never occur for a same-directory rename on POSIX, so nothing changes there, and the original error is rethrown when the retries run out. `ENOSPC` is not a race and is not retried. Every artifact writer benefits, not just the watcher.
- A flush still running after 30s says so once.

The explicit-caller lane (`handleChange`, `applyRepositoryDelta`) is disclosed but never re-queued: those await a single pass with no debounce behind them, and `applyRepositoryDelta` already reports its own unapplied files as stale.

### Deliberately NOT changed

- **`readFileConfined`'s identity contract.** Its strictness is the TOCTOU guard for artifact-derived paths. Loosening it to accommodate Windows timestamp semantics would trade a security boundary for a freshness convenience. The watcher stops mis-reading its failures instead.
- **`acquireAnalysisLock`'s unbounded wait.** A caller promising serialization must not abandon it. Disclosed, not shortened.
- **The hard-ceiling suppression during a settle window.** Intentional and pinned by an existing test; the fix is to end the window, not to re-arm inside it.

## Replication / proof

Reproducing the original bug — inject one transient non-ENOENT read failure into a one-file batch:

```
STDERR LINES: ["[mcp-watcher] stopped\n"]
ON DISK:      {"signatures":[],"callGraph":null}
```

Byte-for-byte the #451 report: the seeded empty context, and not one word about why.

**Verified on Windows CI.** The required Windows Unit Tests job runs the entire suite on `windows-latest`; the report confirms all 15 durability tests pass there, `482 files, 0 new failures`, and nothing on the deny-list became stale. That is the platform the bug lives on.

**22 new tests** — 15 in `src/core/services/mcp-watcher-flush-durability.test.ts`, 7 in `src/core/decisions/atomic-write-rename-contention.test.ts` (which mocks `node:fs/promises` so the rename race is deterministic on every platform; it cannot be provoked on POSIX, and provoking it on Windows would mean racing a scanner). Non-vacuity verified by running them against the unfixed watcher: **14 of 15 fail**; the fifteenth is the ENOENT-stays-silent regression guard, green on both sides by construction.

The most important one drives the **real** `handleBatch` and fails a post-read error (`persistContext` → `EPERM`). An earlier revision of this fix cleared the retry counter on a successful *read*, which made the bound unreachable for every failure that throws later — the artifact rename, the generation republish, a full disk. That is the headline case, so it gets the test that mocks nothing on the path it covers.

Suites: `src/core/services/mcp-watcher*` + `artifact-write-atomicity` — **147 passed**, three consecutive runs. Full unit suite: no new failures; the reds are pre-existing and reproduce identically on `main` (spawn- and concurrency-sensitive `git-hooks` / `audit-gate` / `generate` / CAS-concurrency tests, which also pass in isolation).

## Notes / nits

- **New test file on purpose.** #449 (`fix/windows-console-flash-and-missing-watcher`) rewrites `until()` and the line-290 test in `mcp-watcher-incremental.test.ts`. This PR touches neither, so there is no conflict — and #449's `until()`-throws change is exactly the harness half of this story. That branch also modifies no watcher source, so the two are independent.
- **#449's Windows Smoke exclusion of `mcp-watcher-incremental.test.ts` should stay** until this lands and gets a Windows run; the exclusion was correct while the flush flake was only diagnosed.
- `artifact-write-atomicity.test.ts` is updated, not weakened: the abandoned-events lane is a fourth fenced writer defined earlier in the file, so the change-lane ordering check is re-anchored to `private async handleBatch` (rather than "the first acquire") and the acquisition count goes 3 → 4.
- Neither Windows trigger is reproducible off Windows, so both are injected deterministically. What the tests pin is the contract; the Windows job is what exercises the real thing.
- An adversarial review of the rename retry caught a defect in this PR's own first cut, worth recording because it is the same class as the bug being fixed: the backoff `sleep` unref'd its timer, so if it had been the last handle on the event loop the process would have drained and exited 0 with the write never committed, the temp never cleaned up and the commit lock never released — a silently dropped write, in the primitive whose contract is that no write is silently lost. The sleep is now ref'd, with a source guard pinning it and a comment saying why it differs from the watcher's unref'd SQLite backoff (dropping that one only defers a batch).
- The retry ladder is ~3.2s, deliberately far under the commit lock's own limits (10s before a lock is even a stale candidate, 30s before a waiter gives up), so a writer that spends its entire budget still cannot cause a lock timeout or a steal.
- The slowest durability test was trimmed from four real flush passes to two after the Windows run showed it near the 30s test timeout. A required gate should not sit at two-thirds of its budget.
- Also found but **not fixed here** (separate scope): `fs.constants.O_NOFOLLOW` is `undefined` on Windows, so `A | O_NOFOLLOW` degrades to `A` in `path-confinement.ts` and `advisory-lock.ts` — a real symlink-guard gap on that platform, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
