### PR TITLE
fix(test): stop the durability suite manufacturing the contention it trips over

### DIFF
--- a/src/core/decisions/atomic-store.ts
+++ b/src/core/decisions/atomic-store.ts
@@ -43,12 +43,25 @@ let tmpCounter = 0;
  * Backoff for a rename that lost a race with another handle on the destination.
  *
  * POSIX `rename(2)` replaces the destination unconditionally. Windows does not:
- * `MoveFileExW(REPLACE_EXISTING)` needs DELETE access to the target, so it returns
- * `EPERM`/`EACCES`/`EBUSY` while ANY other handle is open on it without
- * `FILE_SHARE_DELETE` — an antivirus or Search Indexer scanning the file it just
- * saw written, or a reader that opened it a millisecond earlier. The window is
- * milliseconds wide and the operation is idempotent (the temp file is still
- * there, fully fsync'd), so the correct response is to wait and try again.
+ * `MoveFileExW(REPLACE_EXISTING)` returns `EPERM`/`EACCES`/`EBUSY` while ANY other
+ * handle is open on the target. The window is milliseconds wide and the operation is
+ * idempotent (the temp file is still there, fully fsync'd), so the correct response
+ * is to wait and try again.
+ *
+ * WHO holds it is usually US, not an antivirus — measured on Windows 11 / Node 26
+ * while investigating issue #457, after an earlier version of this note guessed at a
+ * scanner and sent the investigation the wrong way:
+ *
+ *   - every open shape blocks it, `O_RDONLY` included (so `readFileConfined`'s
+ *     `O_NOFOLLOW` is not special), and
+ *   - `FILE_SHARE_DELETE` does NOT rescue it. A reader that explicitly grants
+ *     share-delete still blocks the replace, so there is no share mode a reader can
+ *     adopt to make this go away.
+ *
+ * That second point is why this ladder is the ARCHITECTURE and not a workaround: with
+ * nothing to fix on the read side, waiting for our own reader to close its descriptor
+ * is the only way through. Any concurrent read of the artifact — a tool call serving
+ * `llm-context.json` while the watcher publishes it — can cost a publish this way.
  *
  * Observed, not theorised: a Windows CI runner produced
  * `EPERM: operation not permitted, rename '….llm-context.json.tmp-…' -> '…llm-context.json'`

--- a/src/core/decisions/atomic-store.ts
+++ b/src/core/decisions/atomic-store.ts
@@ -58,6 +58,23 @@ let tmpCounter = 0;
  *     share-delete still blocks the replace, so there is no share mode a reader can
  *     adopt to make this go away.
  *
+ * The second point is the load-bearing one, so here is how to re-measure it rather than
+ * take it on trust. Hold the destination open with `CreateFileW` called DIRECTLY — the
+ * share flags then are exactly what Win32 receives — while `node` performs the rename, so
+ * the call under test is the real libuv `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`:
+ *
+ * ```
+ * share READ|WRITE (no delete)  -> node rename FAILED EPERM
+ * share READ|WRITE|DELETE       -> node rename FAILED EPERM
+ * share DELETE only             -> node rename FAILED EPERM
+ * no handle at all              -> node rename SUCCEEDED
+ * ```
+ *
+ * Both halves of that harness matter. A first attempt used .NET's `File.Move(overwrite)`
+ * to do the replacing and reported `ACCESS_DENIED` for every arm including the control —
+ * it is not the same call, and it would have "confirmed" the conclusion for the wrong
+ * reason.
+ *
  * That second point is why this ladder is the ARCHITECTURE and not a workaround: with
  * nothing to fix on the read side, waiting for our own reader to close its descriptor
  * is the only way through. Any concurrent read of the artifact — a tool call serving

--- a/src/core/decisions/atomic-store.ts
+++ b/src/core/decisions/atomic-store.ts
@@ -87,22 +87,28 @@ const RENAME_CONTENTION_DELAYS_MS = [10, 25, 50, 100, 200, 400, 800, 1600] as co
 /**
  * Windows keeps retrying past the shared ladder; every other platform stops at it.
  *
- * MEASURED (issue #457, probe run 34043412177): the same code, the same test, on a clean
- * `windows-latest` CI runner — 10 consecutive runs, and the contention path did not fire
- * ONCE. On the reporting Windows 11 machine it fails about 1 run in 5. Identical code on
- * both, so the handle blocking the rename cannot be one of ours: it is the environment
- * (Defender's first-touch scan, the Search Indexer, a backup agent) opening a
- * just-published artifact. That is the arbitrary-third-party case the shared ladder's own
- * comment says it is NOT sized for, and `llm-context.json` is exactly the kind of file
- * those tools open — a freshly written artifact in a watched tree.
+ * The reason is the one measured above: on Windows ANY open descriptor on the destination
+ * blocks the replace, share-delete included, and the descriptor is usually our own reader.
+ * There is nothing to fix on the read side, so the only way through is to outwait the
+ * reader — which makes the LENGTH of this ladder the whole mitigation, and worth more here
+ * than on a platform where the failure cannot occur at all.
+ *
+ * A CORRECTION, recorded because the wrong version of it was committed here first: an
+ * earlier note claimed this same extension was warranted because a clean `windows-latest`
+ * runner never hit the contention in 10 runs while a real machine failed ~1 in 5, and
+ * concluded from that clean negative that the holder had to be external. That inference
+ * does not hold. The contention is timing-sensitive, so an idle runner simply never lands
+ * in the window; not reproducing says nothing about WHO holds the handle. The direct
+ * measurement — the holding pid read straight off the temp file name — says it is us.
  *
  * Extended to ~6.4s rather than `graceful-fs`'s 60s: the ceiling that matters is the commit
- * lock's, not the scanner's. 10s is when a lock becomes a stale candidate and 30s is when a
- * waiter gives up, so a writer that spends its whole budget must still finish well inside
- * both. This doubles the tolerated hold while keeping that property.
+ * lock's. 10s is when a lock becomes a stale candidate and 30s is when a waiter gives up,
+ * so a writer that spends its whole budget must still finish well inside both. This doubles
+ * the tolerated hold while keeping that property.
  *
- * POSIX is unchanged: there is no share-mode conflict there, so an `EPERM` on rename is a
- * genuine permission error, and spending seconds retrying it only delays a real failure.
+ * POSIX is unchanged: a rename there replaces the destination whatever has it open, so an
+ * `EPERM` is a genuine permission error and retrying it for seconds only delays a real
+ * failure.
  */
 const WINDOWS_EXTRA_RENAME_DELAYS_MS = [3200] as const;
 

--- a/src/core/services/mcp-watcher-flush-durability.test.ts
+++ b/src/core/services/mcp-watcher-flush-durability.test.ts
@@ -25,7 +25,7 @@
  * closed) is not reproducible here — the DURABILITY contract is.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -96,15 +96,53 @@ function makeWatcher(options: Record<string, unknown> = {}): Watcher {
 const UNTIL_BUDGET_MS = process.platform === 'win32' ? 20_000 : 10_000;
 
 /** Poll for an observable outcome; on timeout, say so AND show the watcher's own diagnostics. */
-async function until(done: () => boolean | Promise<boolean>, what: string, budget = UNTIL_BUDGET_MS): Promise<void> {
+async function until(
+  done: () => boolean | Promise<boolean>,
+  what: string,
+  budget = UNTIL_BUDGET_MS,
+  intervalMs = 10,
+): Promise<void> {
   const deadline = Date.now() + budget;
   for (;;) {
     if (await done()) return;
     if (Date.now() >= deadline) {
       throw new Error(`Timed out after ${budget}ms waiting for ${what}.\nWatcher said:\n${stderr.join('') || '(nothing)'}`);
     }
-    await new Promise((r) => setTimeout(r, 10));
+    await new Promise((r) => setTimeout(r, intervalMs));
   }
+}
+
+/**
+ * Poll llm-context.json for `needle` — WITHOUT standing on the writer's foot.
+ *
+ * On Windows an open handle on a file blocks `MoveFileEx(MOVEFILE_REPLACE_EXISTING)` onto
+ * it, whatever share mode the reader asked for. That is measured, not assumed: granting a
+ * reader FILE_SHARE_DELETE explicitly does not let the replace through (issue #457).
+ *
+ * The watcher publishes this exact file by temp+fsync+rename, so polling it with `readFile`
+ * every 10ms keeps a descriptor open across most of the publish window — and the test then
+ * manufactures the contention it trips over. Measured here: the rename ladder in
+ * atomicWriteFile exhausted roughly 1 run in 4, the watcher abandoned the change, and the
+ * assertion failed for a reason that has nothing to do with flush durability.
+ *
+ * Polling every 100ms and reading only when the mtime has moved cuts that duty cycle by more
+ * than an order of magnitude. The assertion is unchanged — the content still has to land.
+ *
+ * NOTE the product behaviour is real and stays open in #457: a concurrent reader CAN still
+ * cost a publish. This only stops the harness from being that reader.
+ */
+async function untilContext(needle: string, what: string): Promise<void> {
+  let lastMtimeMs = -1;
+  let cached = '';
+  await until(async () => {
+    let mtimeMs: number;
+    try { mtimeMs = (await stat(contextPath)).mtimeMs; } catch { return false; }
+    if (mtimeMs !== lastMtimeMs) {
+      lastMtimeMs = mtimeMs;
+      try { cached = await readFile(contextPath, 'utf-8'); } catch { return false; }
+    }
+    return cached.includes(needle);
+  }, what, UNTIL_BUDGET_MS, 100);
 }
 
 const said = (pattern: RegExp): boolean => stderr.some((line) => pattern.test(line));
@@ -143,10 +181,7 @@ describe('McpWatcher flush durability (issue #451)', () => {
 
     inside(makeWatcher()).enqueue(foo);
 
-    await until(
-      async () => (await readFile(contextPath, 'utf-8')).includes('delta'),
-      'the retried flush to reach disk',
-    );
+    await untilContext('delta', 'the retried flush to reach disk');
     // Before the fix this batch produced no output at all — the drop was invisible.
     expect(said(/could not read 1 changed file/)).toBe(true);
     expect(said(/deferred 1 unreadable change/)).toBe(true);
@@ -186,10 +221,7 @@ describe('McpWatcher flush durability (issue #451)', () => {
 
     // The change survives the failure and lands on the retry. Before the fix the
     // drained batch existed only in a local array and was garbage-collected.
-    await until(
-      async () => (await readFile(contextPath, 'utf-8')).includes('gamma'),
-      'the re-queued batch to land',
-    );
+    await untilContext('gamma', 'the re-queued batch to land');
     expect(said(/error: ENOSPC/)).toBe(true);
     expect(said(/deferred 1 change\(s\) for retry/)).toBe(true);
   });
@@ -279,9 +311,9 @@ describe('McpWatcher flush durability (issue #451)', () => {
     internals.enqueue(bad);
 
     // The readable file is not held hostage by its neighbour...
-    await until(async () => (await readFile(contextPath, 'utf-8')).includes('alpha'), 'the readable half to land');
+    await untilContext('alpha', 'the readable half to land');
     // ...and the unreadable one comes back on the retry rather than leaving with it.
-    await until(async () => (await readFile(contextPath, 'utf-8')).includes('beta'), 'the retried half to land');
+    await untilContext('beta', 'the retried half to land');
     expect(said(/could not read 1 changed file/)).toBe(true);
     expect(said(/gave up/)).toBe(false);
   });
@@ -316,7 +348,7 @@ describe('McpWatcher flush durability (issue #451)', () => {
     // fsync'd temp+rename on a runner where those are slow.
     readFailures.set('foo.ts', 1);
     internals.enqueue(foo);
-    await until(async () => (await readFile(contextPath, 'utf-8')).includes('alpha'), 'the first round to land');
+    await untilContext('alpha', 'the first round to land');
     await until(() => internals.eventRetries.size === 0, 'the retry ledger to clear');
 
     // Three more failures. With round 1's entry still in the ledger this is the
@@ -324,7 +356,7 @@ describe('McpWatcher flush durability (issue #451)', () => {
     await writeFile(foo, 'export function omega() {}\n', 'utf-8');
     readFailures.set('foo.ts', 3);
     internals.enqueue(foo);
-    await until(async () => (await readFile(contextPath, 'utf-8')).includes('omega'), 'the second round to land');
+    await untilContext('omega', 'the second round to land');
     expect(said(/gave up/)).toBe(false);
     await until(() => internals.eventRetries.size === 0, 'the retry ledger to clear again');
   });


### PR DESCRIPTION
Follow-up to #457, from a Windows box — which is what that issue was waiting for.

`mcp-watcher-flush-durability.test.ts` failed about **1 run in 4** on Windows, always the same
way: the watcher's artifact publish lost its rename to `EPERM`, gave up after 3 attempts, and the
assertion failed for a reason unrelated to flush durability. The file is **not** on the Windows
deny-list, so it was queued to redden a `windows-unit` run.

## Evidence

Measured with a Restart Manager probe fired at the moment the retry ladder in `atomicWriteFile`
exhausts (no Sysinternals on the machine; the probe was validated against a known lock first).
Three findings, in the order they changed the conclusion:

1. **The holder is our own process** — the same pid that wrote the temp file, readable straight
   off `…llm-context.json.tmp-<pid>-<n>`. Not Defender, not the Search Indexer.
2. **Every open shape blocks the replace**, `O_RDONLY` included — so `readFileConfined`'s
   `O_NOFOLLOW` is not special:
   ```
   O_RDONLY                                   -> rename FAILED EPERM
   O_RDONLY | O_NOFOLLOW  (readFileConfined)  -> rename FAILED EPERM
   O_RDWR                                     -> rename FAILED EPERM
   no handle at all                           -> rename SUCCEEDED
   ```
3. **`FILE_SHARE_DELETE` does not rescue it.** PowerShell holds the destination under an explicit
   share mode while **Node** performs the rename, so the call under test is the real
   libuv `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` rather than a .NET approximation:
   ```
   reader WITHOUT share-delete -> node rename FAILED EPERM
   reader WITH    share-delete -> node rename FAILED EPERM
   ```

(3) refutes the premise recorded in #457 — that Node's share flags mean our own reads cannot
block the rename — and collapses that issue's fork. There is no share mode a reader can adopt, so
**retrying is the architecture, not a workaround**.

## The change

**`mcp-watcher-flush-durability.test.ts`** — `until()` polled `readFile(contextPath)` every 10ms.
The watcher publishes that exact file by temp+fsync+rename, so the harness held a descriptor
across most of the publish window and manufactured the contention it then tripped over. The new
`untilContext()` polls every 100ms and reads only when the mtime has moved: more than an order of
magnitude less duty cycle, same assertion — the content still has to land.

**`atomic-store.ts`** — comment only. `RENAME_CONTENTION_DELAYS_MS` attributed the hold to "an
antivirus or Search Indexer", with our own reader as an afterthought. The evidence inverts that,
and the earlier text sent this investigation looking for Defender. Corrected, with the
share-delete result recorded so the next reader does not have to re-derive it.

## Verification

- **0 failures in 15 runs**, from a ~1-in-4 baseline.
- Clean under a short (8.3) `TEMP` too — the shape a Windows runner hands out.
- The 4 failing files under `src/core/decisions` are pre-existing Windows deny-list entries;
  `atomic-store.test.ts` fails the same 2 tests with this change stashed.

## What this deliberately does NOT do

**It does not close #457.** The product behaviour is real: a concurrent reader can still cost a
publish, and on a long-lived server that reader is a tool call serving `llm-context.json` while the
watcher writes it. Production read pressure is far below this harness's — which is why the 1-in-4
rate was never representative — but the mechanism stands, and the issue keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY7qhboMVqELNAMESEZSks
