### PR TITLE
fix(watcher): stop spending a deterministic-failure budget on a wait

### DIFF
--- a/src/core/services/mcp-watcher-flush-durability.test.ts
+++ b/src/core/services/mcp-watcher-flush-durability.test.ts
@@ -50,7 +50,7 @@ vi.mock('../../utils/path-confinement.js', async (importOriginal) => {
   };
 });
 
-const { McpWatcher } = await import('./mcp-watcher.js');
+const { McpWatcher, WATCH_MAX_EVENT_RETRIES, WATCH_MAX_CONTENTION_RETRIES } = await import('./mcp-watcher.js');
 type Watcher = InstanceType<typeof McpWatcher>;
 
 interface Internals {
@@ -201,7 +201,9 @@ describe('McpWatcher flush durability (issue #451)', () => {
     // Bounded: the queue is empty, so nothing is left spinning.
     await until(() => inside(watcher).pending.size === 0 && !inside(watcher).running, 'the queue to settle');
     const attempts = stderr.filter((line) => /could not read/.test(line)).length;
-    expect(attempts).toBe(4); // 1 initial + WATCH_MAX_EVENT_RETRIES
+    // One initial attempt plus the budget. The unreadable lane is not the contention class,
+    // so it keeps the smaller of the two.
+    expect(attempts).toBe(1 + WATCH_MAX_EVENT_RETRIES);
   });
 
   it('re-queues a batch whose flush failed for an unrecognized reason', async () => {
@@ -295,8 +297,34 @@ describe('McpWatcher flush durability (issue #451)', () => {
 
     await until(() => said(/gave up on 1 change/), 'the watcher to abandon the change');
     await until(() => internals.pending.size === 0 && !internals.running, 'the queue to settle');
-    expect(stderr.filter((line) => /error: EPERM/.test(line)).length).toBe(4); // 1 + 3 retries
+    // One initial attempt plus the budget — DERIVED, because an `EPERM … rename` is the
+    // transient-contention class and spends the larger budget (#457). A literal here would
+    // assert the number this test was written against rather than the property it names.
+    expect(stderr.filter((line) => /error: EPERM/.test(line)).length)
+      .toBe(1 + WATCH_MAX_CONTENTION_RETRIES);
     expect(internals.eventRetries.size).toBe(0);
+  });
+
+  it('outwaits a reader far longer than it retries a failure that may be deterministic', async () => {
+    // The whole of #457: the blocking descriptor on Windows is usually OUR OWN reader, and no
+    // share mode lets it step aside, so waiting is the only way through. Spending the
+    // deterministic-failure budget on that wait is what dropped a change while a reader
+    // happened to be busy. Both budgets stay BOUNDED — a destination held forever still ends
+    // in one loud, stale-recorded drop.
+    expect(WATCH_MAX_CONTENTION_RETRIES).toBeGreaterThan(WATCH_MAX_EVENT_RETRIES);
+
+    const foo = join(root, 'contended.ts');
+    await writeFile(foo, 'export function delta() {}\n', 'utf-8');
+    const watcher = makeWatcher();
+    const internals = inside(watcher);
+    vi.spyOn(internals, 'persistContext').mockRejectedValue(new Error('EIO: i/o error, write'));
+
+    internals.enqueue(foo);
+    await until(() => said(/gave up on 1 change/), 'the watcher to abandon the change');
+    await until(() => internals.pending.size === 0 && !internals.running, 'the queue to settle');
+    // An EIO is NOT the contention class, so it keeps the smaller budget.
+    expect(stderr.filter((line) => /error: EIO/.test(line)).length)
+      .toBe(1 + WATCH_MAX_EVENT_RETRIES);
   });
 
   it('lands the readable half of a mixed batch and still retries the unreadable half', async () => {

--- a/src/core/services/mcp-watcher-flush-durability.test.ts
+++ b/src/core/services/mcp-watcher-flush-durability.test.ts
@@ -240,7 +240,10 @@ describe('McpWatcher flush durability (issue #451)', () => {
 
     await until(() => said(/gave up on 1 change/), 'the watcher to disclose the abandoned batch');
     await until(() => internals.pending.size === 0 && !internals.running, 'the queue to settle');
-    expect(stderr.filter((line) => /error: EIO/.test(line)).length).toBe(4); // 1 + 3 retries
+    // Derived, like the others: EIO is the DETERMINISTIC class, so it draws that budget.
+    // The last literal '4' in this file, and the same trap - correct today, quietly wrong
+    // the day either budget moves, while still reading as a deliberate expectation.
+    expect(stderr.filter((line) => /error: EIO/.test(line)).length).toBe(1 + WATCH_MAX_EVENT_RETRIES);
     // The single-flight guard is released, so the watcher is not wedged.
     expect(internals.running).toBe(false);
   });

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -143,7 +143,7 @@ const SQLITE_BUSY_RETRY_DELAYS_MS = [50, 150, 450] as const;
  * retry loop: after it, the watcher discloses the drop and — where a graph store
  * exists — records the files as stale, so the staleness outlives the log line.
  */
-const WATCH_MAX_EVENT_RETRIES = 3;
+export const WATCH_MAX_EVENT_RETRIES = 3;
 
 /**
  * The budget for a failure that is TRANSIENT BY CONSTRUCTION, rather than possibly
@@ -164,7 +164,7 @@ const WATCH_MAX_EVENT_RETRIES = 3;
  * Still BOUNDED, so the hot-loop protection the smaller budget buys is not given up: a
  * destination held forever still ends in one loud, stale-recorded drop, just later.
  */
-const WATCH_MAX_CONTENTION_RETRIES = 12;
+export const WATCH_MAX_CONTENTION_RETRIES = 12;
 
 /**
  * Does `reason` name the Windows rename-contention class?

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -146,6 +146,39 @@ const SQLITE_BUSY_RETRY_DELAYS_MS = [50, 150, 450] as const;
 const WATCH_MAX_EVENT_RETRIES = 3;
 
 /**
+ * The budget for a failure that is TRANSIENT BY CONSTRUCTION, rather than possibly
+ * deterministic (issue #457).
+ *
+ * The bound above exists to stop a deterministic failure — ENOSPC, a genuine permission
+ * error — becoming a hot retry loop. Windows rename contention is not that. Measured on
+ * Windows: any open descriptor on the destination blocks the atomic replace, share-delete
+ * included, and the holder is usually OUR OWN reader — a tool call serving
+ * `llm-context.json` while the watcher publishes it. That descriptor WILL close. Waiting is
+ * the only way through, because there is no share mode a reader can adopt to step aside.
+ *
+ * Spending the same 3-strike budget on it is what turned a recoverable wait into an
+ * abandoned change: three attempts against a reader that happens to be busy, and the file
+ * was dropped until a full `analyze`. A read-heavy period must cost freshness for a few
+ * debounces, not until someone notices.
+ *
+ * Still BOUNDED, so the hot-loop protection the smaller budget buys is not given up: a
+ * destination held forever still ends in one loud, stale-recorded drop, just later.
+ */
+const WATCH_MAX_CONTENTION_RETRIES = 12;
+
+/**
+ * Does `reason` name the Windows rename-contention class?
+ *
+ * Matched on the error CODE inside the message because that is what the flush lane carries
+ * — the batch handler stringifies before it gets here. Deliberately narrow: these three
+ * codes on a rename are the sharing-violation class, and anything else keeps the smaller
+ * budget.
+ */
+function isTransientContention(reason: string): boolean {
+  return /\b(EPERM|EACCES|EBUSY)\b/.test(reason) && /\brename\b/.test(reason);
+}
+
+/**
  * How long a single flush may run before the watcher says so, once, on stderr.
  *
  * `acquireAnalysisLock` waits without bound by design (a serialization promise
@@ -817,6 +850,7 @@ export class McpWatcher {
     reason: string,
   ): Promise<void> {
     process.stderr.write(`[mcp-watcher] error: ${reason}\n`);
+    const budget = isTransientContention(reason) ? WATCH_MAX_CONTENTION_RETRIES : WATCH_MAX_EVENT_RETRIES;
     const requeued: string[] = [];
     const abandoned: string[] = [];
     const requeue = (paths: readonly string[], into: Set<string>): void => {
@@ -830,7 +864,7 @@ export class McpWatcher {
           continue;
         }
         const attempts = (this.eventRetries.get(path) ?? 0) + 1;
-        if (attempts > WATCH_MAX_EVENT_RETRIES) {
+        if (attempts > budget) {
           this.eventRetries.delete(path);
           abandoned.push(path);
           continue;
@@ -849,7 +883,7 @@ export class McpWatcher {
         `[mcp-watcher] deferred ${requeued.length} change(s) for retry after that error\n`,
       );
     }
-    if (abandoned.length > 0) await this.abandonEvents(abandoned, WATCH_MAX_EVENT_RETRIES, reason);
+    if (abandoned.length > 0) await this.abandonEvents(abandoned, budget, reason);
   }
 
   /**


### PR DESCRIPTION
**Status:** LGTM — closes #457. Builds on #459 (retry ladder) and #460 (harness + evidence).

## What was wrong

The watcher could still lose a change on Windows. The remaining defect is a **classification**
one, not a timing one.

`WATCH_MAX_EVENT_RETRIES = 3` exists, by its own docstring, "to keep a **deterministic** failure
from becoming a hot retry loop" — `ENOSPC`, a genuine permission error. Windows rename contention
is not that class. Per @laurentftech's measurement in #460, any open descriptor on the
destination blocks the atomic replace — share-delete included — and the holder is usually **our
own reader**: a tool call serving `llm-context.json` while the watcher publishes it.

That descriptor *will* close, and no share mode lets a reader step aside, so waiting is the only
way through. Spending three strikes on a wait is what turned a recoverable delay into an
abandoned change: three attempts while a reader happened to be busy, and the file was dropped
until a full `analyze`.

## How it was fixed

The contention class gets its own budget (12), so read pressure costs freshness for a few
debounces instead of a drop. **Still bounded** — the hot-loop protection the smaller budget buys
is not given up: a destination held forever still ends in one loud, stale-recorded drop, just
later.

## Proof

Both budgets are exported and the assertions derive from them, plus a new test that the classes
are actually distinguished (an `EIO` keeps the smaller budget; an `EPERM … rename` gets the
larger). **Mutation-checked:** setting the contention budget back to 3 turns it red.

The existing `bounds a failure that happens AFTER the file was read` mocked exactly
`EPERM … rename` and asserted `toBe(4)` — a literal encoding the old budget rather than the
property it names. That is the **third** instance this week of a test asserting a literal where
it meant a property, after #458's `join()` expectations and #459's `renameCalls === 9`; all three
were invisible on POSIX and only the Windows job caught them. Derived now.

Watcher suites: **100 passing** across the four files. `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)