### PR TITLE
fix(serving): an unservable index says WHY, instead of reporting absence

### DIFF
--- a/openspec/specs/mcp-handlers/spec.md
+++ b/openspec/specs/mcp-handlers/spec.md
@@ -1519,6 +1519,55 @@ an agent can decide to proceed on the disclosed-stale answer or retry.
 - **THEN** the responses respectively carry `reason: index-absent`, the staleness verdict
   with a repair-in-progress marker and reason, and no freshness caveat at all
 
+### Requirement: AnUnservableIndexNamesWhyRatherThanReportingAbsence
+
+A tool that cannot serve an index SHALL report WHY in the same machine-readable not-ready
+shape and the same `reason` taxonomy as `ReadyOrHonestFirstUse` — never a second, parallel
+vocabulary — and SHALL NOT report a present-but-refused index as an absent one. Beyond
+`index-absent` and `graph-unavailable`, the taxonomy SHALL distinguish at least: an artifact
+the reader refused as not a regular file, a generation manifest present and refused, a
+publish currently in flight, and artifacts that no longer match their published generation.
+
+The verdict SHALL be derived from what was OBSERVED, not from what a path-following read
+would infer:
+
+- The artifact's kind SHALL be determined without following links, because the production
+  reader refuses a symlinked artifact outright. A symlinked or dangling-symlinked artifact is
+  therefore refused, never reported as a generation mismatch or as an absent index.
+- The deliberate in-flight-publish manifest sentinel — the well-formed
+  `{version, state:'publishing'}` a writer commits before its first artifact replacement, for
+  which the manifest reader answers "unavailable" BY DESIGN — SHALL be reported as a transient
+  publish in progress whose remedy is to retry, never as a damaged publish.
+- An artifact/generation mismatch SHALL NOT be asserted as a lost publish while a writer is
+  observed inside the artifact-write critical section, because a writer rewrites artifacts in
+  place and publishes the manifest last, making a mismatch the EXPECTED state for the duration
+  of any concurrent write. The incident claim SHALL be conditional on no such writer being
+  observed.
+
+#### Scenario: A refused symlinked artifact is not reported as a mismatch or as absence
+
+- **GIVEN** an analysis whose `llm-context.json` is a symbolic link, whether to a valid
+  generation-matching artifact or to nothing at all
+- **WHEN** a tool that cannot serve it reports why
+- **THEN** the verdict names the artifact as not a regular file, and is neither
+  `index-absent` nor `index-generation-mismatch`
+
+#### Scenario: A publish in flight is transient, not damage
+
+- **GIVEN** a writer that has committed the in-flight-publish manifest sentinel and not yet
+  published the new generation
+- **WHEN** a tool that cannot serve the index reports why
+- **THEN** the verdict names a publish in progress, its remedy is to retry rather than to
+  rebuild, and it does not claim the publish is damaged
+
+#### Scenario: A mismatch is an incident only when no writer is running
+
+- **GIVEN** two repositories with byte-identical rewritten-but-unrepublished artifacts, one
+  with the artifact-write lock held by a live writer and one with no writer at all
+- **WHEN** each reports why the index is unservable
+- **THEN** the first names the expected mid-write window and asks the caller to retry, and
+  only the second claims a publish was lost
+
 ### Requirement: PriorChurnIsMeasuredBeforeTheBriefedRange
 
 The system SHALL compute `briefing_since`'s prior-churn evidence — `priorChurn`, its

--- a/src/core/runtime/advisory-lock.ts
+++ b/src/core/runtime/advisory-lock.ts
@@ -521,7 +521,25 @@ export async function withAnalysisLock<T>(analysisDir: string, fn: () => Promise
  * `record_decision` spawns against the run already underway.
  */
 export async function isDecisionsLockHeld(rootPath: string): Promise<boolean> {
-  const lockPath = join(decisionsDir(rootPath), DECISIONS_LOCK_FILE);
+  return isLockHeldAt(decisionsDir(rootPath), DECISIONS_LOCK_FILE);
+}
+
+/**
+ * Non-blocking check: is a writer currently inside the artifact-write critical section
+ * for this analysis directory?
+ *
+ * The one honest way to tell an ORDINARY mid-write window apart from a genuine incident.
+ * A writer rewrites artifacts in place and publishes the manifest LAST, so an
+ * artifact/manifest mismatch is the EXPECTED state while `analyze` or a watcher persist is
+ * running — and an incident only when nobody is writing. Never acquires, steals, or waits.
+ */
+export async function isAnalysisLockHeld(analysisDir: string): Promise<boolean> {
+  return isLockHeldAt(analysisDir, ANALYSIS_LOCK_FILE);
+}
+
+/** Shared body of the non-blocking lock peeks: present, a regular file, and not stale. */
+async function isLockHeldAt(dir: string, lockFile: string): Promise<boolean> {
+  const lockPath = join(dir, lockFile);
   try {
     const handle = await open(lockPath, constants.O_RDONLY | constants.O_NOFOLLOW);
     try {

--- a/src/core/runtime/analysis-generation.ts
+++ b/src/core/runtime/analysis-generation.ts
@@ -335,6 +335,29 @@ export async function discardGeneration(analysisDir: string): Promise<void> {
 export async function markGenerationUnavailable(analysisDir: string): Promise<void> {
   await atomicWriteFile(
     manifestPathOf(analysisDir),
-    JSON.stringify({ version: GENERATION_MANIFEST_VERSION, state: 'publishing' }),
+    JSON.stringify({ version: GENERATION_MANIFEST_VERSION, state: PUBLISHING_SENTINEL_STATE }),
   );
+}
+
+/** The `state` value {@link markGenerationUnavailable} writes. */
+const PUBLISHING_SENTINEL_STATE = 'publishing';
+
+/**
+ * Is the present manifest the deliberate in-flight-publish sentinel?
+ *
+ * {@link readCurrentGeneration} answers `null` for it BY DESIGN, and callers that only
+ * see that null cannot tell a healthy publish in progress from a damaged manifest. This
+ * is the narrow read that recovers the distinction: it returns true only for the exact
+ * well-formed sentinel {@link markGenerationUnavailable} writes, and false for an absent,
+ * refused, malformed, or ordinary manifest. Diagnostic only — never a permission to serve.
+ */
+export async function generationPublishInProgress(analysisDir: string): Promise<boolean> {
+  const read = await readArtifactBytesBounded(manifestPathOf(analysisDir), ANALYSIS_ARTIFACT_MAX_BYTES);
+  if (read.state !== 'ok') return false;
+  try {
+    const parsed = JSON.parse(read.bytes.toString('utf8')) as { version?: unknown; state?: unknown };
+    return parsed?.version === GENERATION_MANIFEST_VERSION && parsed?.state === PUBLISHING_SENTINEL_STATE;
+  } catch {
+    return false;
+  }
 }

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -65,7 +65,7 @@ import {
   validateGitRef,
 } from '../../drift/index.js';
 import { readOpenLoreConfig } from '../config-manager.js';
-import { validateDirectory, readCachedContext, isCacheFresh, safeJoin, safeOpenspecDir } from './utils.js';
+import { validateDirectory, readCachedContext, diagnoseIndexUnservable, isCacheFresh, safeJoin, safeOpenspecDir } from './utils.js';
 import { buildWeightedAdjacency, weightedBfs } from './graph.js';
 import { personalizedPageRank } from '../../analyzer/personalized-pagerank.js';
 import { applyTokenBudget, normalizeResponseFormat, truncationReceipt, summarizeListInventory, type ResponseFormat } from './progressive.js';
@@ -203,7 +203,11 @@ export async function handleGetArchitectureOverview(directory: string): Promise<
   const ctx = await readCachedContext(absDir);
 
   if (!depGraph && !ctx) {
-    return { error: 'No analysis found. Run analyze_codebase first.' };
+    // Name WHY rather than always reporting absence: an index that failed its integrity
+    // check is a different situation from one that was never built, and only one of them
+    // is fixed by "run analyze first" without anything else being wrong.
+    const { reason, message } = await diagnoseIndexUnservable(absDir);
+    return { error: message, indexUnservable: reason };
   }
 
   const overview = buildArchitectureOverview(depGraph, ctx, absDir);
@@ -256,7 +260,10 @@ export async function handleGetRefactorReport(directory: string): Promise<unknow
   const absDir = await validateDirectory(directory);
   const ctx = await readCachedContext(absDir);
 
-  if (!ctx) return { error: 'No analysis found. Run analyze_codebase first.' };
+  if (!ctx) {
+    const { reason, message } = await diagnoseIndexUnservable(absDir);
+    return { error: message, indexUnservable: reason };
+  }
   if (!ctx.callGraph) return { error: 'Call graph not available in cached analysis. Re-run analyze_codebase.' };
 
   return analyzeForRefactoring(ctx.callGraph as SerializedCallGraph);

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -205,9 +205,9 @@ export async function handleGetArchitectureOverview(directory: string): Promise<
   if (!depGraph && !ctx) {
     // Name WHY rather than always reporting absence: an index that failed its integrity
     // check is a different situation from one that was never built, and only one of them
-    // is fixed by "run analyze first" without anything else being wrong.
-    const { reason, message } = await diagnoseIndexUnservable(absDir);
-    return { error: message, indexUnservable: reason };
+    // is fixed by "run analyze first" without anything else being wrong. The verdict is the
+    // ordinary `NotReadyResult` shape, so an agent reads one `reason` taxonomy everywhere.
+    return await diagnoseIndexUnservable(absDir);
   }
 
   const overview = buildArchitectureOverview(depGraph, ctx, absDir);
@@ -260,10 +260,7 @@ export async function handleGetRefactorReport(directory: string): Promise<unknow
   const absDir = await validateDirectory(directory);
   const ctx = await readCachedContext(absDir);
 
-  if (!ctx) {
-    const { reason, message } = await diagnoseIndexUnservable(absDir);
-    return { error: message, indexUnservable: reason };
-  }
+  if (!ctx) return await diagnoseIndexUnservable(absDir);
   if (!ctx.callGraph) return { error: 'Call graph not available in cached analysis. Re-run analyze_codebase.' };
 
   return analyzeForRefactoring(ctx.callGraph as SerializedCallGraph);

--- a/src/core/services/mcp-handlers/index-unservable-diagnosis.test.ts
+++ b/src/core/services/mcp-handlers/index-unservable-diagnosis.test.ts
@@ -1,0 +1,120 @@
+/**
+ * An unservable index must say WHY, not report absence.
+ *
+ * `readCachedContext` already distinguishes these cases — it emits a different telemetry
+ * `reason` for each — and then returns a bare `null`, so every caller collapsed them into
+ * "No analysis found. Run analyze_codebase first."
+ *
+ * That message is correct for exactly one of them. For the others it reports a FAILED
+ * INTEGRITY CHECK as a missing index, which is the quiet downgrade `loadPartialFirstRun`'s
+ * own docstring says this lane exists to prevent — and it hides the incident: a user reads
+ * "no analysis", runs analyze, it works, and a lost publish is never reported.
+ *
+ * The generation-mismatch case here is not hypothetical. It was observed on a real
+ * repository: artifacts rewritten at 23:36 against a manifest published at 23:33, four of
+ * five recorded hashes no longer matching, no writer running, and every tool call answering
+ * "No analysis found" for five minutes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { diagnoseIndexUnservable } from './utils.js';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_LLM_CONTEXT } from '../../../constants.js';
+
+let root: string;
+let analysisDir: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'ol-unservable-'));
+  analysisDir = join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+  await mkdir(analysisDir, { recursive: true });
+});
+
+afterEach(async () => {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try { await rm(root, { recursive: true, force: true }); break; }
+    catch { await new Promise((r) => setTimeout(r, 100)); }
+  }
+});
+
+/**
+ * Publish a coherent generation.
+ *
+ * Every REQUIRED artifact is written, because the diagnosis reads the manifest with the same
+ * required set the real serving path does. A fixture that published only llm-context.json
+ * would make `readCurrentGeneration` answer null for a reason the production path never
+ * hits, and the test would then assert a diagnosis for a situation that cannot occur.
+ */
+async function publish(contents: string): Promise<void> {
+  const { publishGeneration, REQUIRED_ANALYSIS_ARTIFACTS } = await import('../../runtime/analysis-generation.js');
+  for (const name of REQUIRED_ANALYSIS_ARTIFACTS) {
+    await writeFile(join(analysisDir, name), name === ARTIFACT_LLM_CONTEXT ? contents : '{}', 'utf-8');
+  }
+  await publishGeneration(analysisDir, [...REQUIRED_ANALYSIS_ARTIFACTS]);
+}
+
+describe('diagnoseIndexUnservable', () => {
+  it('reports a genuinely absent index as absent, with the message that was always right', async () => {
+    const { reason, message } = await diagnoseIndexUnservable(root);
+
+    expect(reason).toBe('absent');
+    // The first-run case is the ONE the old wording fitted; it must not regress into
+    // something more alarming than the situation.
+    expect(message).toContain('No analysis found');
+  });
+
+  it('distinguishes an index whose artifacts no longer match its published generation', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    // Exactly the observed failure: rewrite the artifact WITHOUT republishing the manifest.
+    await writeFile(join(analysisDir, ARTIFACT_LLM_CONTEXT), JSON.stringify({ signatures: [{}] }), 'utf-8');
+
+    const { reason, message } = await diagnoseIndexUnservable(root);
+
+    expect(reason).toBe('generation-mismatch');
+    // The distinction that matters to a human: something WENT WRONG, versus something was
+    // never set up. Asserting the absence of the misleading sentence is the point of the test.
+    expect(message).not.toContain('No analysis found');
+    expect(message).toMatch(/does NOT match its published generation/);
+    expect(message).toMatch(/worth reporting/);
+  });
+
+  it('distinguishes an index whose generation manifest is present but refused', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    const manifest = join(analysisDir, 'generation.json');
+    expect(await readFile(manifest, 'utf-8')).toBeTruthy();
+    // Malformed, NOT deleted. An ABSENT manifest is a legitimate legacy analysis that
+    // `readCurrentGeneration` synthesizes a generation for, so it never reaches this
+    // diagnosis — a test that deleted the file would assert a case that cannot occur, and
+    // the first draft of this test did exactly that.
+    await writeFile(manifest, 'not json', 'utf-8');
+
+    const { reason, message } = await diagnoseIndexUnservable(root);
+
+    expect(reason).toBe('generation-unavailable');
+    expect(message).not.toContain('No analysis found');
+    expect(message).toMatch(/damaged publish, not a missing index/);
+  });
+
+  it('treats an absent manifest as a legacy analysis, not as damage', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    await rm(join(analysisDir, 'generation.json'), { force: true });
+
+    // The synthesized legacy generation still vouches for the artifacts, so the honest
+    // answer is that the index is present and coherent — not that a publish was lost.
+    const { reason } = await diagnoseIndexUnservable(root);
+
+    expect(reason).toBe('unreadable');
+  });
+
+  it('never invents a diagnosis it did not observe', async () => {
+    // A published, coherent index that some OTHER read failed on must not be reported as a
+    // mismatch — the honest answer is that it is present, matches, and could not be loaded.
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+
+    const { reason } = await diagnoseIndexUnservable(root);
+
+    expect(reason).toBe('unreadable');
+  });
+});

--- a/src/core/services/mcp-handlers/index-unservable-diagnosis.test.ts
+++ b/src/core/services/mcp-handlers/index-unservable-diagnosis.test.ts
@@ -14,14 +14,28 @@
  * repository: artifacts rewritten at 23:36 against a manifest published at 23:33, four of
  * five recorded hashes no longer matching, no writer running, and every tool call answering
  * "No analysis found" for five minutes.
+ *
+ * A diagnosis that mislabels is worse than no diagnosis, so three of the cases below pin the
+ * situations where the naive form of this check would confidently say the wrong thing: a
+ * symlinked artifact (which the reader refuses but a path-following `stat` cannot see), a
+ * healthy in-flight publish (whose sentinel manifest reads as "unavailable" BY DESIGN), and
+ * the ordinary mid-write window (whose mismatch is expected, not an incident).
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, rm, readFile, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { diagnoseIndexUnservable } from './utils.js';
-import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_LLM_CONTEXT } from '../../../constants.js';
+import { diagnoseIndexUnservable, _resetContextCacheForTesting, clearMappingCache } from './utils.js';
+import { handleGetArchitectureOverview, handleGetRefactorReport } from './analysis.js';
+import { acquireAnalysisLock } from '../../runtime/advisory-lock.js';
+import { markGenerationUnavailable } from '../../runtime/analysis-generation.js';
+import {
+  OPENLORE_DIR,
+  OPENLORE_ANALYSIS_SUBDIR,
+  ARTIFACT_LLM_CONTEXT,
+  ARTIFACT_DEPENDENCY_GRAPH,
+} from '../../../constants.js';
 
 let root: string;
 let analysisDir: string;
@@ -30,9 +44,13 @@ beforeEach(async () => {
   root = await mkdtemp(join(tmpdir(), 'ol-unservable-'));
   analysisDir = join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
   await mkdir(analysisDir, { recursive: true });
+  _resetContextCacheForTesting();
+  clearMappingCache();
 });
 
 afterEach(async () => {
+  _resetContextCacheForTesting();
+  clearMappingCache();
   for (let attempt = 0; attempt < 5; attempt++) {
     try { await rm(root, { recursive: true, force: true }); break; }
     catch { await new Promise((r) => setTimeout(r, 100)); }
@@ -55,29 +73,35 @@ async function publish(contents: string): Promise<void> {
   await publishGeneration(analysisDir, [...REQUIRED_ANALYSIS_ARTIFACTS]);
 }
 
+/** Rewrite the served artifact WITHOUT republishing — exactly the observed failure. */
+async function rewriteWithoutRepublishing(): Promise<void> {
+  await writeFile(join(analysisDir, ARTIFACT_LLM_CONTEXT), JSON.stringify({ signatures: [{}] }), 'utf-8');
+}
+
 describe('diagnoseIndexUnservable', () => {
   it('reports a genuinely absent index as absent, with the message that was always right', async () => {
-    const { reason, message } = await diagnoseIndexUnservable(root);
+    const result = await diagnoseIndexUnservable(root);
 
-    expect(reason).toBe('absent');
+    expect(result.reason).toBe('index-absent');
+    expect(result.notReady).toBe(true);
     // The first-run case is the ONE the old wording fitted; it must not regress into
     // something more alarming than the situation.
-    expect(message).toContain('No analysis found');
+    expect(result.error).toContain('No analysis found');
+    expect(result.remedy).toBe('openlore analyze');
   });
 
   it('distinguishes an index whose artifacts no longer match its published generation', async () => {
     await publish(JSON.stringify({ signatures: [], callGraph: null }));
-    // Exactly the observed failure: rewrite the artifact WITHOUT republishing the manifest.
-    await writeFile(join(analysisDir, ARTIFACT_LLM_CONTEXT), JSON.stringify({ signatures: [{}] }), 'utf-8');
+    await rewriteWithoutRepublishing();
 
-    const { reason, message } = await diagnoseIndexUnservable(root);
+    const result = await diagnoseIndexUnservable(root);
 
-    expect(reason).toBe('generation-mismatch');
+    expect(result.reason).toBe('index-generation-mismatch');
     // The distinction that matters to a human: something WENT WRONG, versus something was
     // never set up. Asserting the absence of the misleading sentence is the point of the test.
-    expect(message).not.toContain('No analysis found');
-    expect(message).toMatch(/does NOT match its published generation/);
-    expect(message).toMatch(/worth reporting/);
+    expect(result.error).not.toContain('No analysis found');
+    expect(result.error).toMatch(/does NOT match its published generation/);
+    expect(result.error).toMatch(/worth reporting/);
   });
 
   it('distinguishes an index whose generation manifest is present but refused', async () => {
@@ -90,11 +114,11 @@ describe('diagnoseIndexUnservable', () => {
     // the first draft of this test did exactly that.
     await writeFile(manifest, 'not json', 'utf-8');
 
-    const { reason, message } = await diagnoseIndexUnservable(root);
+    const result = await diagnoseIndexUnservable(root);
 
-    expect(reason).toBe('generation-unavailable');
-    expect(message).not.toContain('No analysis found');
-    expect(message).toMatch(/damaged publish, not a missing index/);
+    expect(result.reason).toBe('index-generation-unavailable');
+    expect(result.error).not.toContain('No analysis found');
+    expect(result.error).toMatch(/present and was refused/);
   });
 
   it('treats an absent manifest as a legacy analysis, not as damage', async () => {
@@ -105,7 +129,7 @@ describe('diagnoseIndexUnservable', () => {
     // answer is that the index is present and coherent — not that a publish was lost.
     const { reason } = await diagnoseIndexUnservable(root);
 
-    expect(reason).toBe('unreadable');
+    expect(reason).toBe('index-unreadable');
   });
 
   it('never invents a diagnosis it did not observe', async () => {
@@ -115,6 +139,144 @@ describe('diagnoseIndexUnservable', () => {
 
     const { reason } = await diagnoseIndexUnservable(root);
 
-    expect(reason).toBe('unreadable');
+    expect(reason).toBe('index-unreadable');
+  });
+});
+
+/**
+ * The reader refuses a symlinked artifact (`O_NOFOLLOW` plus a descriptor-identity check,
+ * telemetry reason `artifact_not_a_regular_file`). A path-following `stat` in the diagnosis
+ * cannot see that: it reports the TARGET, so a symlink to a perfectly good artifact would be
+ * diagnosed as a lost publish, and a dangling one as an absent index. Both would be the exact
+ * lie this whole change exists to remove, re-stated one layer up.
+ */
+describe('diagnoseIndexUnservable — the artifact the reader actually refused', () => {
+  it('names a symlinked artifact as refused, not as a lost publish', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    // A symlink to a byte-for-byte VALID, generation-matching artifact. Everything a
+    // path-following stat can see says "healthy"; the reader still refuses it.
+    const real = join(root, 'elsewhere-llm-context.json');
+    await writeFile(real, await readFile(join(analysisDir, ARTIFACT_LLM_CONTEXT), 'utf-8'), 'utf-8');
+    await rm(join(analysisDir, ARTIFACT_LLM_CONTEXT), { force: true });
+    await symlink(real, join(analysisDir, ARTIFACT_LLM_CONTEXT));
+
+    const result = await diagnoseIndexUnservable(root);
+
+    expect(result.reason).toBe('index-unreadable');
+    expect(result.error).toMatch(/not a regular file/);
+    expect(result.error).toMatch(/symbolic link/);
+  });
+
+  it('names a dangling symlink as refused, not as an absent index', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    await rm(join(analysisDir, ARTIFACT_LLM_CONTEXT), { force: true });
+    await symlink(join(root, 'nothing-here.json'), join(analysisDir, ARTIFACT_LLM_CONTEXT));
+
+    const result = await diagnoseIndexUnservable(root);
+
+    // "No analysis found" would send a user to run analyze and wonder why it kept failing.
+    expect(result.reason).toBe('index-unreadable');
+    expect(result.error).not.toContain('No analysis found');
+  });
+});
+
+/**
+ * `markGenerationUnavailable` writes a well-formed `{version, state:'publishing'}` manifest
+ * BEFORE the first artifact replacement of a normal, healthy publish, and
+ * `readCurrentGeneration` answers null for it by design. Calling that "a damaged publish"
+ * would report the commit protocol working exactly as specified as a fault.
+ */
+describe('diagnoseIndexUnservable — a healthy publish in flight', () => {
+  it('reports an in-progress publish as transient, not as damage', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    await markGenerationUnavailable(analysisDir);
+
+    const result = await diagnoseIndexUnservable(root);
+
+    expect(result.reason).toBe('index-publish-in-progress');
+    expect(result.error).toMatch(/publish is in progress/);
+    expect(result.error).not.toMatch(/damaged/);
+    // The remedy is to wait, not to rebuild an index that is being built right now.
+    expect(result.remedy).toBe('retry shortly');
+  });
+});
+
+/**
+ * A writer updates artifacts in place and publishes the manifest LAST, so a mismatch is the
+ * EXPECTED state throughout any concurrent analyze. Only the absence of a writer makes it an
+ * incident — so the diagnosis asks the writer lock instead of asserting one.
+ */
+describe('diagnoseIndexUnservable — mismatch during an ordinary mid-write window', () => {
+  it('reports a mismatch under a held analysis lock as an in-progress publish', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    await rewriteWithoutRepublishing();
+    const release = await acquireAnalysisLock(analysisDir);
+    try {
+      const result = await diagnoseIndexUnservable(root);
+
+      expect(result.reason).toBe('index-publish-in-progress');
+      expect(result.error).toMatch(/expected mid-write window/);
+      expect(result.error).not.toMatch(/publish was lost/);
+    } finally {
+      await release();
+    }
+  });
+
+  it('reports the same mismatch with no writer as the incident it is', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    await rewriteWithoutRepublishing();
+
+    // Identical on-disk artifacts as the case above; only the lock differs. That is the whole
+    // claim: the mismatch alone never establishes an incident.
+    const result = await diagnoseIndexUnservable(root);
+
+    expect(result.reason).toBe('index-generation-mismatch');
+    expect(result.error).toMatch(/No writer holds the analysis lock/);
+    expect(result.error).toMatch(/publish was lost/);
+  });
+});
+
+/**
+ * Wiring, not diagnosis. Nothing else pins the handlers to the diagnosis, so a refactor could
+ * quietly restore the flat sentence and every test above would still pass.
+ */
+describe('handlers serve the diagnosis, not the flat sentence', () => {
+  it('handleGetArchitectureOverview carries the structured absent verdict on a first run', async () => {
+    const result = await handleGetArchitectureOverview(root) as Record<string, unknown>;
+
+    expect(result.notReady).toBe(true);
+    expect(result.reason).toBe('index-absent');
+    expect(result.error).toContain('No analysis found');
+  });
+
+  it('handleGetArchitectureOverview names a lost publish instead of reporting absence', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    await rewriteWithoutRepublishing();
+    // The overview answers from the dependency graph when it can, so this handler only
+    // reaches the not-ready path when that artifact is gone too.
+    await rm(join(analysisDir, ARTIFACT_DEPENDENCY_GRAPH), { force: true });
+
+    const result = await handleGetArchitectureOverview(root) as Record<string, unknown>;
+
+    expect(result.reason).toBe('index-generation-mismatch');
+    expect(result.error).not.toContain('No analysis found');
+  });
+
+  it('handleGetRefactorReport names a lost publish instead of reporting absence', async () => {
+    await publish(JSON.stringify({ signatures: [], callGraph: null }));
+    await rewriteWithoutRepublishing();
+
+    const result = await handleGetRefactorReport(root) as Record<string, unknown>;
+
+    expect(result.notReady).toBe(true);
+    expect(result.reason).toBe('index-generation-mismatch');
+    expect(result.error).not.toContain('No analysis found');
+  });
+
+  it('handleGetRefactorReport keeps the first-run sentence for a first run', async () => {
+    const result = await handleGetRefactorReport(root) as Record<string, unknown>;
+
+    expect(result.reason).toBe('index-absent');
+    expect(result.error).toContain('No analysis found');
   });
 });

--- a/src/core/services/mcp-handlers/utils.ts
+++ b/src/core/services/mcp-handlers/utils.ts
@@ -413,6 +413,87 @@ export async function primeContextCache(directory: string, ctx: CachedContext): 
   _contextCache.set(key, { ctx, mtime, generation });
 }
 
+/** Why a published index could not be served. `absent` is the ordinary first-run case. */
+export type IndexUnservableReason =
+  | 'absent'
+  | 'generation-unavailable'
+  | 'generation-mismatch'
+  | 'unreadable';
+
+export interface IndexUnservableDiagnosis {
+  reason: IndexUnservableReason;
+  /** One sentence naming what was observed and what to do — safe to serve to an agent. */
+  message: string;
+}
+
+/**
+ * Name why {@link readCachedContext} returned null.
+ *
+ * `readCachedContext` already DISTINGUISHES these cases — it emits a different telemetry
+ * `reason` for each — and then returns a bare `null`, so every caller collapses them into
+ * "No analysis found. Run analyze_codebase first." That message is right for exactly one of
+ * them, and actively misleading for the rest: it reports a FAILED INTEGRITY CHECK as an
+ * absent index, which is the quiet downgrade `loadPartialFirstRun`'s docstring says this lane
+ * exists to prevent. It also hides the incident — a user reads "no analysis", runs analyze,
+ * it works, and the lost publish is never reported.
+ *
+ * Called ONLY on the null path, so the ordinary read pays nothing for it. It re-derives
+ * rather than threading state through 56 call sites: the cost is a stat and a hash on a path
+ * that is already returning an error.
+ */
+export async function diagnoseIndexUnservable(directory: string): Promise<IndexUnservableDiagnosis> {
+  const analysisDir = join(directory, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+  const contextPath = join(analysisDir, ARTIFACT_LLM_CONTEXT);
+
+  try {
+    const st = await stat(contextPath);
+    if (!st.isFile()) {
+      return {
+        reason: 'unreadable',
+        message: `The analysis artifact at ${ARTIFACT_LLM_CONTEXT} is not a regular file and was refused. Run analyze to rebuild it.`,
+      };
+    }
+  } catch {
+    return {
+      reason: 'absent',
+      message: 'No analysis found. Run analyze_codebase first.',
+    };
+  }
+
+  const manifest = await readCurrentGeneration(analysisDir, [...REQUIRED_ANALYSIS_ARTIFACTS]);
+  if (!manifest) {
+    return {
+      reason: 'generation-unavailable',
+      // Deliberately NOT "missing": an absent manifest is a legitimate legacy analysis and is
+      // synthesized, so it never reaches here. Reaching here means the manifest is PRESENT and
+      // was REFUSED — a symlink, a FIFO, an oversized or malformed file — which
+      // `readCurrentGeneration` fails closed on rather than synthesizing around.
+      message:
+        'An analysis exists but its generation manifest was refused (it is malformed, oversized, '
+        + 'or not a regular file), so the artifacts cannot be vouched for and are not served. '
+        + 'This is a damaged publish, not a missing index — re-run analyze to republish it.',
+    };
+  }
+
+  if (!await artifactMatchesGeneration(analysisDir, manifest, ARTIFACT_LLM_CONTEXT)) {
+    return {
+      reason: 'generation-mismatch',
+      message:
+        'An analysis exists but does NOT match its published generation '
+        + `(${manifest.generationId}): the artifacts were rewritten and the manifest was not `
+        + 'republished, so serving them would serve unverified bytes. Re-run analyze to '
+        + 'republish. If this recurs without a crash, a publish is being lost and is worth reporting.',
+    };
+  }
+
+  return {
+    reason: 'unreadable',
+    message:
+      'An analysis exists and matches its generation, but could not be read into a usable '
+      + 'context. Re-run analyze; if it recurs, the artifact is likely malformed.',
+  };
+}
+
 export async function readCachedContext(directory: string, timeout?: number): Promise<CachedContext | null> {
   const analysisDir = join(directory, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
   const filePath = join(analysisDir, ARTIFACT_LLM_CONTEXT);

--- a/src/core/services/mcp-handlers/utils.ts
+++ b/src/core/services/mcp-handlers/utils.ts
@@ -5,15 +5,17 @@
 import { createHash } from 'node:crypto';
 import { constants } from 'node:fs';
 import { descriptorIsThePathEntry } from '../../../utils/bounded-artifact-read.js';
-import { open, readFile, realpath, stat, type FileHandle } from 'node:fs/promises';
+import { lstat, open, readFile, realpath, stat, type FileHandle } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import type { LLMContext } from '../../analyzer/artifact-generator.js';
 import { EdgeStore } from '../edge-store.js';
 import {
   REQUIRED_ANALYSIS_ARTIFACTS,
   artifactMatchesGeneration,
+  generationPublishInProgress,
   readCurrentGeneration,
 } from '../../runtime/analysis-generation.js';
+import { isAnalysisLockHeld } from '../../runtime/advisory-lock.js';
 import { readAttestation, reconcile, type IndexIntegrity } from '../../analyzer/index-attestation.js';
 import { recordGraphDigest } from './traversal.js';
 import type { SerializedCallGraph } from '../../analyzer/call-graph.js';
@@ -286,8 +288,29 @@ export function queryTooLongError(query: unknown, field = 'query'): { error: str
  *  - `graph-unavailable`— an analysis exists but its call-graph/edge index is missing,
  *                         typically because a version upgrade reset the graph index
  *                         until the next `analyze`.
+ *
+ * The remaining reasons name an index that EXISTS and could not be served — the cases
+ * every caller used to flatten into "No analysis found", which is the one sentence that
+ * is wrong for all of them (change: name-the-reason-an-index-is-unservable). They are
+ * reasons of the SAME taxonomy deliberately: an agent branches on one `reason` field,
+ * never on two parallel vocabularies.
+ *  - `index-publish-in-progress`   — a writer is mid-publish RIGHT NOW. Expected and
+ *                                    transient; the remedy is to retry, not to rebuild.
+ *  - `index-generation-unavailable`— the generation manifest is present and was REFUSED
+ *                                    (malformed, oversized, not a regular file).
+ *  - `index-generation-mismatch`   — the artifacts no longer hash to their published
+ *                                    generation and NO writer was observed. A publish was
+ *                                    lost; serving would serve unverified bytes.
+ *  - `index-unreadable`            — present and coherent, and still not loadable (a
+ *                                    symlinked/irregular artifact, or a malformed one).
  */
-export type NotReadyReason = 'index-absent' | 'graph-unavailable';
+export type NotReadyReason =
+  | 'index-absent'
+  | 'graph-unavailable'
+  | 'index-publish-in-progress'
+  | 'index-generation-unavailable'
+  | 'index-generation-mismatch'
+  | 'index-unreadable';
 
 /** A structured "not ready" conclusion — see {@link notReadyResult}. */
 export interface NotReadyResult {
@@ -307,8 +330,12 @@ export interface NotReadyResult {
  * `reason` discriminator, and exact `remedy` command are added so an agent can act
  * on the cause deterministically and consistently across every tool.
  */
-export function notReadyResult(error: string, reason: NotReadyReason): NotReadyResult {
-  return { error, notReady: true, reason, remedy: 'openlore analyze' };
+export function notReadyResult(
+  error: string,
+  reason: NotReadyReason,
+  remedy = 'openlore analyze',
+): NotReadyResult {
+  return { error, notReady: true, reason, remedy };
 }
 
 interface ContextCacheEntry {
@@ -413,19 +440,6 @@ export async function primeContextCache(directory: string, ctx: CachedContext): 
   _contextCache.set(key, { ctx, mtime, generation });
 }
 
-/** Why a published index could not be served. `absent` is the ordinary first-run case. */
-export type IndexUnservableReason =
-  | 'absent'
-  | 'generation-unavailable'
-  | 'generation-mismatch'
-  | 'unreadable';
-
-export interface IndexUnservableDiagnosis {
-  reason: IndexUnservableReason;
-  /** One sentence naming what was observed and what to do — safe to serve to an agent. */
-  message: string;
-}
-
 /**
  * Name why {@link readCachedContext} returned null.
  *
@@ -437,61 +451,110 @@ export interface IndexUnservableDiagnosis {
  * exists to prevent. It also hides the incident — a user reads "no analysis", runs analyze,
  * it works, and the lost publish is never reported.
  *
+ * The verdict is a {@link NotReadyResult}, the SAME shape and the same `reason` taxonomy every
+ * other not-ready conclusion already uses, so an agent branches on one field rather than on a
+ * parallel vocabulary.
+ *
  * Called ONLY on the null path, so the ordinary read pays nothing for it. It re-derives
  * rather than threading state through 56 call sites: the cost is a stat and a hash on a path
  * that is already returning an error.
  */
-export async function diagnoseIndexUnservable(directory: string): Promise<IndexUnservableDiagnosis> {
+export async function diagnoseIndexUnservable(directory: string): Promise<NotReadyResult> {
   const analysisDir = join(directory, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
   const contextPath = join(analysisDir, ARTIFACT_LLM_CONTEXT);
 
   try {
-    const st = await stat(contextPath);
-    if (!st.isFile()) {
-      return {
-        reason: 'unreadable',
-        message: `The analysis artifact at ${ARTIFACT_LLM_CONTEXT} is not a regular file and was refused. Run analyze to rebuild it.`,
-      };
+    // `lstat`, not `stat`. The production reader opens `O_NOFOLLOW` and verifies the
+    // descriptor against the path entry, so it refuses a SYMLINK outright
+    // (`artifact_not_a_regular_file`). A path-following `stat` here would report a
+    // symlink-to-a-regular-file as an ordinary artifact and then diagnose the read failure as
+    // a lost publish, and a DANGLING symlink as an absent index — restating, as a diagnosis,
+    // the exact lie this function exists to remove. `lstat` describes the entry the reader
+    // actually refused. (It does not open the file, so the FIFO-blocking concern that forces
+    // the reader's `O_NONBLOCK` does not arise here.)
+    const entry = await lstat(contextPath);
+    if (!entry.isFile()) {
+      return notReadyResult(
+        `The analysis artifact at ${ARTIFACT_LLM_CONTEXT} is not a regular file `
+        + `(it is a ${describeEntryKind(entry)}) and was refused. Run analyze to rebuild it.`,
+        'index-unreadable',
+      );
     }
   } catch {
-    return {
-      reason: 'absent',
-      message: 'No analysis found. Run analyze_codebase first.',
-    };
+    return notReadyResult('No analysis found. Run analyze_codebase first.', 'index-absent');
+  }
+
+  // Ask BEFORE concluding damage. `markGenerationUnavailable` deliberately writes a
+  // well-formed `{version, state:'publishing'}` manifest before the first artifact
+  // replacement of a NORMAL, healthy publish, and `readCurrentGeneration` answers null for it
+  // by design. Reporting that as a damaged publish would call the commit protocol working
+  // exactly as specified a fault.
+  if (await generationPublishInProgress(analysisDir)) {
+    return notReadyResult(
+      'An analysis exists but a publish is in progress: the writer has marked the previous '
+      + 'generation unavailable and has not yet published the new one, so no generation can '
+      + 'currently be vouched for. This is the normal commit protocol, not damage — retry '
+      + 'shortly. If it persists, a writer died mid-publish and `openlore analyze` republishes.',
+      'index-publish-in-progress',
+      'retry shortly',
+    );
   }
 
   const manifest = await readCurrentGeneration(analysisDir, [...REQUIRED_ANALYSIS_ARTIFACTS]);
   if (!manifest) {
-    return {
-      reason: 'generation-unavailable',
+    return notReadyResult(
       // Deliberately NOT "missing": an absent manifest is a legitimate legacy analysis and is
-      // synthesized, so it never reaches here. Reaching here means the manifest is PRESENT and
-      // was REFUSED — a symlink, a FIFO, an oversized or malformed file — which
+      // synthesized, so it never reaches here. Nor "in progress": the sentinel is answered
+      // above. Reaching here means the manifest is PRESENT, is not the sentinel, and was
+      // REFUSED — a symlink, a FIFO, an oversized or malformed file — which
       // `readCurrentGeneration` fails closed on rather than synthesizing around.
-      message:
-        'An analysis exists but its generation manifest was refused (it is malformed, oversized, '
-        + 'or not a regular file), so the artifacts cannot be vouched for and are not served. '
-        + 'This is a damaged publish, not a missing index — re-run analyze to republish it.',
-    };
+      'An analysis exists but its generation manifest is present and was refused (it is '
+      + 'malformed, oversized, or not a regular file — an in-flight publish is reported '
+      + 'separately), so the artifacts cannot be vouched for and are not served. Re-run '
+      + 'analyze to republish.',
+      'index-generation-unavailable',
+    );
   }
 
   if (!await artifactMatchesGeneration(analysisDir, manifest, ARTIFACT_LLM_CONTEXT)) {
-    return {
-      reason: 'generation-mismatch',
-      message:
-        'An analysis exists but does NOT match its published generation '
-        + `(${manifest.generationId}): the artifacts were rewritten and the manifest was not `
-        + 'republished, so serving them would serve unverified bytes. Re-run analyze to '
-        + 'republish. If this recurs without a crash, a publish is being lost and is worth reporting.',
-    };
+    // A mismatch alone proves nothing. A writer updates artifacts IN PLACE and publishes the
+    // manifest LAST, so this is the EXPECTED state throughout any concurrent `analyze` or
+    // watcher persist — the very window `readCachedContext`'s own guard comment describes.
+    // Only the absence of a writer makes it an incident, so ask the writer lock instead of
+    // asserting one and hedging with "if this recurs".
+    if (await isAnalysisLockHeld(analysisDir)) {
+      return notReadyResult(
+        'An analysis exists but does not currently match its published generation '
+        + `(${manifest.generationId}) because a writer holds the analysis lock: a publish is `
+        + 'in progress and the manifest is published last. This is the expected mid-write '
+        + 'window, not damage — retry shortly.',
+        'index-publish-in-progress',
+        'retry shortly',
+      );
+    }
+    return notReadyResult(
+      'An analysis exists but does NOT match its published generation '
+      + `(${manifest.generationId}): the artifacts were rewritten and the manifest was not `
+      + 'republished, so serving them would serve unverified bytes. No writer holds the '
+      + 'analysis lock, so this is not an ordinary mid-write window — a publish was lost. '
+      + 'Re-run analyze to republish, and a recurrence without a crash is worth reporting.',
+      'index-generation-mismatch',
+    );
   }
 
-  return {
-    reason: 'unreadable',
-    message:
-      'An analysis exists and matches its generation, but could not be read into a usable '
-      + 'context. Re-run analyze; if it recurs, the artifact is likely malformed.',
-  };
+  return notReadyResult(
+    'An analysis exists and matches its generation, but could not be read into a usable '
+    + 'context. Re-run analyze; if it recurs, the artifact is likely malformed.',
+    'index-unreadable',
+  );
+}
+
+/** Name the entry kind a refused artifact actually is, without guessing beyond what stat saw. */
+function describeEntryKind(entry: { isSymbolicLink(): boolean; isDirectory(): boolean; isFIFO(): boolean }): string {
+  if (entry.isSymbolicLink()) return 'symbolic link';
+  if (entry.isDirectory()) return 'directory';
+  if (entry.isFIFO()) return 'named pipe';
+  return 'special file';
 }
 
 export async function readCachedContext(directory: string, timeout?: number): Promise<CachedContext | null> {


### PR DESCRIPTION
## What we observed

Every MCP tool call on a real repository answered:

```
No analysis found. Run analyze_codebase first.
```

The analysis was there — 234 MB of it. What had actually happened:

```
generation.json          published 23:33
llm-context.json         written   23:36

dependency-graph.json    MISMATCH
fingerprint.json         MISMATCH   (447 -> 449 bytes)
llm-context.json         MISMATCH
refactor-priorities.json MISMATCH
repo-structure.json      ok
```

Four of five artifacts no longer matched their published generation. No writer was running, and the state had been settled for five minutes — so this was not a mid-write interval. The integrity gate did exactly its job and refused to serve unverified bytes.

**Then it reported that refusal as an absent index.**

## Why the wording is the bug

`readCachedContext` already **distinguishes** these cases. It emits a different telemetry `reason` for each —

```ts
emit(..., { reason: 'artifact_not_a_regular_file' });     return null;
emit(..., { reason: 'analysis_generation_unavailable' }); return null;
emit(..., { reason: 'analysis_generation_changed' });     return null;
```

— and then returns a bare `null`. The diagnosis is computed, recorded, and discarded at the `return`. Every caller collapses three situations into one sentence that is correct for exactly one of them.

For the others it reports a **failed integrity check as a missing index**, which is precisely the quiet downgrade that `loadPartialFirstRun`'s own docstring says this lane exists to prevent:

> A published artifact that failed an integrity gate above **must keep failing**: masking a corrupt or mid-rewrite index with a partial one would turn a loud problem into a quiet downgrade, which is the opposite of what this lane is for.

The policy is right. The message is that downgrade, expressed in words.

**And it hides the incident.** A user reads "no analysis", runs `analyze`, it works, and the lost publish is never reported. That is nearly what happened here: seeing it at all took comparing the manifest's hashes by hand.

Worth noting what the codebase already says about this state — the comment guarding it describes a brief window:

> A writer updates artifacts in place and publishes the manifest last. **During that interval** the old generation id is still visible…

Ours lasted five minutes with nothing writing. The guard behaved correctly; the publish never completed. Whether that is a lost publish under rename contention (#457) or a flush path that does not republish is **not** established here, and this PR does not claim it — it makes the state say its own name so the next occurrence is reportable instead of invisible.

## What this adds

`diagnoseIndexUnservable(directory)` names the reason, and **two** handlers (`get_architecture_overview`, `get_refactor_report`) serve it. It runs **only** on the null path, so an ordinary read pays nothing, and it re-derives rather than threading state through 56 call sites.

**Scope, stated honestly:** "No analysis found" appears about 36 times across 27 files, including one still in the very file this PR edits (`analysis.ts`, `handleGetSignatures`) and one in `architecture.ts`. This lands the mechanism and converts two call sites; the remaining ones are a deliberate follow-up, not an oversight. `classifyToolError` is untouched — no live regression there, noted as a follow-up.

The verdict is the repository's existing `NotReadyResult` shape — `error` + `notReady` + `reason` + `remedy` — so an agent branches on **one** `reason` taxonomy rather than a second parallel vocabulary. `NotReadyReason` gains four members:

| reason | what it means | remedy |
|---|---|---|
| `index-absent` | no index | `openlore analyze` — the original sentence, unchanged |
| `index-publish-in-progress` | a writer is mid-publish right now | **retry shortly** — expected, not damage |
| `index-generation-mismatch` | artifacts rewritten, manifest not republished, **and no writer holds the lock** | `openlore analyze`, and a publish was lost |
| `index-generation-unavailable` | manifest present and refused (malformed, oversized, not a regular file) | `openlore analyze` |
| `index-unreadable` | present and coherent, still not loadable — or an artifact the reader refused (symlink, FIFO) | `openlore analyze` |

The first-run case keeps the wording it always deserved. The other three now say that something went wrong, rather than that something was never set up.

## A correction the code made to me

The first draft called `generation-unavailable` "missing or unreadable", and tested it by **deleting** `generation.json`. That is wrong: an absent manifest is a legitimate legacy analysis, which `readCurrentGeneration` synthesizes a generation for, so it never reaches this diagnosis.

Both the message and the test now say "present but refused", and a fifth test asserts the legacy case explicitly — an absent manifest is not damage.

The diagnosis is deliberately shy elsewhere too: it answers `unreadable` rather than inventing a cause it did not observe.

## Hardening pass (second commit)

Review found three places where the *diagnosis* itself guessed — breaking the PR's own thesis that a confident wrong answer is worse than a vague one.

1. **It followed symlinks; the reader does not.** `loadPublished` opens `O_NOFOLLOW` and verifies the descriptor against the path entry, so a symlinked artifact is refused. A path-following `stat` reports the *target*: a symlink to a valid artifact was diagnosed `generation-mismatch`, a dangling one `absent` — the same lie, one layer up. Now `lstat`.
2. **It called a healthy publish damage.** `markGenerationUnavailable` deliberately writes a well-formed `{version, state:'publishing'}` manifest before the first replacement of a *normal* publish, and `readCurrentGeneration` returns null for it by design. A new `generationPublishInProgress` recognizes exactly that sentinel and reports a transient in-flight publish.
3. **It asserted an incident on the ordinary mid-write window.** A writer publishes the manifest last, so a mismatch is *expected* during any concurrent analyze. A new non-blocking `isAnalysisLockHeld` (the existing `isDecisionsLockHeld` peek, generalized) is consulted: a held lock says retry; only an unheld one claims a lost publish.

Plus: four handler-level tests (nothing pinned the handlers to the wiring before), and a spec delta next to `ReadyOrHonestFirstUse`.

Six of the fourteen tests fail against the pre-hardening logic with exactly the mislabels above, and pass after.

## Verification

- 14/14 tests in `index-unservable-diagnosis.test.ts`, including the exact observed shape (publish, rewrite the artifact, do not republish).
- Full unit suite: identical failing-file set to the same suite with this change stashed (17 pre-existing files); the two extra files in the branch run pass in isolation, i.e. load-induced timeouts.
- Lint, typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY7qhboMVqELNAMESEZSks

