### PR TITLE
ci(deps): fail on a digest-less lockfile where it is fixable, not three jobs later

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,17 @@ updates:
           - 'tree-sitter-*'
           - 'web-tree-sitter'
           - '@lancedb/lancedb'
+      # The Pi host packages, in their own PR — same reasoning as parser-stack, a
+      # different cause. Every `@earendil-works/pi-*` release so far ships an
+      # npm-shrinkwrap.json whose nested entries carry no `integrity` field. npm copies
+      # them verbatim, the lockfile loses those SRI digests, and CI fails until someone
+      # runs `npm run lock:integrity` — which Dependabot cannot do. While these sat in
+      # dev-dependencies, every pi bump held four unrelated harmless updates hostage
+      # behind that fixup. Separated, the fixup is one small PR; the rest lands untouched.
+      pi-host:
+        applies-to: version-updates
+        patterns:
+          - '@earendil-works/pi-*'
       # One PR for routine dev-tooling drift (eslint, vitest, tsx, types).
       dev-dependencies:
         applies-to: version-updates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,18 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
+      # Runs BEFORE `npm ci`: it only reads package-lock.json, so it is the cheapest
+      # possible failure, and it names its own remedy.
+      #
+      # A dependency that ships its own npm-shrinkwrap.json can pin nested tarballs with
+      # no `integrity` field (@earendil-works/pi-* does, in every release so far). npm
+      # copies those entries verbatim, and `npm ci` then installs bytes it cannot verify.
+      # `src/workflow-security.test.ts` catches the result, but it catches it three jobs
+      # and ten minutes later, in a Unit Tests failure that does not look like a lockfile
+      # problem. This step is the same assertion, said in the place where it is actionable.
+      - name: Check lockfile integrity digests
+        run: npm run lock:integrity:check
+
       - run: npm ci
 
       - name: Audit dependencies

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "audit:gate": "node scripts/audit-gate.mjs",
     "audit:packlist": "node scripts/audit-packlist.mjs",
     "lock:integrity": "node scripts/backfill-lock-integrity.mjs",
+    "lock:integrity:check": "node scripts/backfill-lock-integrity.mjs --check",
     "audit:deps": "node scripts/audit-dependencies.mjs",
     "typecheck": "tsc --noEmit",
     "postinstall": "node scripts/postinstall.mjs",

--- a/scripts/backfill-lock-integrity.mjs
+++ b/scripts/backfill-lock-integrity.mjs
@@ -29,8 +29,18 @@ if (gaps.length === 0) {
 }
 
 if (checkOnly) {
-  console.error(`lock-integrity: ${gaps.length} entries missing an SRI digest:`);
-  for (const [path] of gaps) console.error(`  ${path}`);
+  const subject = gaps.length === 1 ? 'entry carries' : 'entries carry';
+  console.error(`lock-integrity: ${gaps.length} registry ${subject} no SRI digest in package-lock.json:`);
+  for (const [path, pkg] of gaps) console.error(`  ${path}@${pkg.version ?? '?'}`);
+  console.error('');
+  console.error('This is what a dependency shipping its own digest-less npm-shrinkwrap.json does to');
+  console.error('the lockfile (@earendil-works/pi-* is the recurring source). npm copies those entries');
+  console.error('verbatim, so `npm ci` would install bytes it cannot verify.');
+  console.error('');
+  console.error('Fix it locally and commit the lockfile:');
+  console.error('');
+  console.error('    npm run lock:integrity');
+  console.error('');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Status

LGTM. Ready to review. Touches **no lockfile and no dependency entries** (the only `package.json` change is one added line in `scripts`), so it should not conflict with the concurrent lancedb bump or the #472 work.

## What was wrong

`@earendil-works/pi-coding-agent` ships its own `npm-shrinkwrap.json` with no `integrity` fields. npm copies those entries verbatim into `package-lock.json`, so a fresh pi bump silently drops the SRI digests `npm ci` needs to verify the bytes it downloads.

The repo already had the remedy — `npm run lock:integrity` — but nothing in CI ran or checked it, and Dependabot never will. So the only signal was `src/workflow-security.test.ts` ("pins every registry tarball to an integrity digest") failing in **Unit Tests**, three jobs in, with a message that does not look like a lockfile problem. This burned #468 and was independently re-tripped twice more the same day. pi 0.85.1's shrinkwrap is still digest-less, so it will recur.

## How it was fixed

1. **A CI check that names the problem.** The script already had a `--check` mode (no writes, exit non-zero) — I did **not** need to add one. It is now wired into the `Lint & Type Check` job as `npm run lock:integrity:check`, placed *before* `npm ci`: the check only reads `package-lock.json`, so it is the cheapest failure the pipeline can produce. Its output now names the cause and the fix (`npm run lock:integrity`) instead of just listing paths.
2. **`@earendil-works/pi-*` gets its own Dependabot group**, out of `dev-dependencies` — same shape as the documented `parser-stack` rationale: a pi bump that needs a manual lockfile fixup was holding four unrelated harmless updates hostage for the cycle. No `ignore` entry, per the standing note in that file (Dependabot applies ignores to security updates too).

## Proof it works

**Clean tree — passes:**

```
$ npm run lock:integrity:check
lock-integrity: every registry tarball already carries an SRI digest.
exit=0
```

**Deliberate break — strip the digest from `node_modules/yaml`, then run the check:**

```
stripping integrity from node_modules/yaml (sha512-2AvhNX3mb8zd6Zy7I...)

$ npm run lock:integrity:check
lock-integrity: 1 registry entry carries no SRI digest in package-lock.json:
  node_modules/yaml@2.9.0

This is what a dependency shipping its own digest-less npm-shrinkwrap.json does to
the lockfile (@earendil-works/pi-* is the recurring source). npm copies those entries
verbatim, so `npm ci` would install bytes it cannot verify.

Fix it locally and commit the lockfile:

    npm run lock:integrity

exit=1
```

The existing guard test agrees on the same broken tree, which is the point — same defect, but this one fires first, cheaper, and says what to do:

```
$ npx vitest run src/workflow-security.test.ts -t 'integrity digest'
- []
+ [ "node_modules/yaml" ]
 ❯ src/workflow-security.test.ts:397:7
```

The lockfile was then restored with `git checkout --`; `git status` confirms it is untouched in this branch.

**Other verification:**

```
$ npm run lint                 # exit 0
$ npm run typecheck            # exit 0
$ npx vitest run src/workflow-security.test.ts src/core/analyzer/iac/classify-yaml.test.ts
  Test Files  2 passed (2)   Tests  28 passed (28)
$ npx vitest run src/doc-claim-sync.test.ts src/core/analyzer/iac/github-actions.test.ts src/cli/install/governance-gate.test.ts
  Test Files  3 passed (3)   Tests  36 passed | 10 skipped
```

Both edited YAML files parse under the `yaml` package; the new Dependabot group resolves to `patterns: ['@earendil-works/pi-*']` and sits **before** `dev-dependencies` so it wins the match.

**Green in real CI** (run [34155239023](https://github.com/clay-good/OpenLore/actions/runs/34155239023), all 7 jobs + `CI Success`) — and the new step ran where it was meant to, before `npm ci`:

```
✓ Lint & Type Check in 1m39s
  ✓ Run actions/checkout@3d3c42e5...
  ✓ Run actions/setup-node@8207627...
  ✓ Check lockfile integrity digests
  ✓ Run npm ci
  ✓ Audit dependencies
  ✓ Run ESLint
  ✓ Run TypeScript type check
```

GitHub's own Dependabot config validation check also passes on the edited `.github/dependabot.yml`.

## Notes

- The new CI step adds no action reference, no `${{ }}` in a `run:`, and no job — so every `workflow-security.test.ts` assertion (SHA pinning, version comments, injection, top-level and per-job `permissions`) is unaffected, and the suite passes.
- Group ordering is load-bearing: Dependabot assigns a dependency to the first matching group, so `pi-host` must stay above `dev-dependencies`.
- Not verified from here: that Dependabot actually splits the next pi bump into its own PR. That only proves itself on the next scheduled run.
- The `--check` path still has no unit test of its own. The guard test in `workflow-security.test.ts` asserts the same property, so a regression there is not invisible, but the CLI wrapper itself is uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
