### PR TITLE
chore(deps): bump @lancedb/lancedb to 0.38.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^4.2.0",
-        "@lancedb/lancedb": "0.37.1",
+        "@lancedb/lancedb": "0.38.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@vitejs/plugin-react": "^6.1.1",
         "apache-arrow": "^21.1.0",
@@ -5534,9 +5534,9 @@
       "license": "MIT"
     },
     "node_modules/@lancedb/lancedb": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.37.1.tgz",
-      "integrity": "sha512-l+si3t+bQ1JNxrnEfbbfKt9gWk2HcWYWx0dzoEBTVAs8B0BP79OrAv+mKTJ0EwG5wRDS3MwEChEg0g0Wh8I3tQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.38.0.tgz",
+      "integrity": "sha512-10+Cy0P8GyGg7d6l6AmuruEfFt6sxdCZNFCmhcJyUofvopxCb1yIiFNXsfzjO8Iyh2hijTEuyKTzIi4LGlH6Kw==",
       "cpu": [
         "x64",
         "arm64"
@@ -5553,21 +5553,21 @@
         "reflect-metadata": "^0.2.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 22"
       },
       "optionalDependencies": {
         "@huggingface/transformers": "3.0.2",
-        "@lancedb/lancedb-darwin-arm64": "0.37.1",
-        "@lancedb/lancedb-linux-arm64-gnu": "0.37.1",
-        "@lancedb/lancedb-linux-arm64-musl": "0.37.1",
-        "@lancedb/lancedb-linux-x64-gnu": "0.37.1",
-        "@lancedb/lancedb-linux-x64-musl": "0.37.1",
-        "@lancedb/lancedb-win32-arm64-msvc": "0.37.1",
-        "@lancedb/lancedb-win32-x64-msvc": "0.37.1",
+        "@lancedb/lancedb-darwin-arm64": "0.38.0",
+        "@lancedb/lancedb-linux-arm64-gnu": "0.38.0",
+        "@lancedb/lancedb-linux-arm64-musl": "0.38.0",
+        "@lancedb/lancedb-linux-x64-gnu": "0.38.0",
+        "@lancedb/lancedb-linux-x64-musl": "0.38.0",
+        "@lancedb/lancedb-win32-arm64-msvc": "0.38.0",
+        "@lancedb/lancedb-win32-x64-msvc": "0.38.0",
         "openai": "4.29.2"
       },
       "peerDependencies": {
-        "@types/node": ">=18",
+        "@types/node": ">=22",
         "apache-arrow": ">=15.0.0 <=18.1.0"
       },
       "peerDependenciesMeta": {
@@ -5577,9 +5577,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-darwin-arm64": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.37.1.tgz",
-      "integrity": "sha512-t/SRU1no2rf7bdgCAIhhAdm8oI/l5ne1Xuq50BEAKxSfJjZq7RSd8Khg0cLy1Pwrfr8v78VpJVluPTbQSn97kQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.38.0.tgz",
+      "integrity": "sha512-AOSqmezmLGjv7SjZfDdzYznebdihApjPklhIJJ8cFfMsqYqc1pJtRAM8zWKotbiwLOg31ttIcGIoWbv/0dUJSQ==",
       "cpu": [
         "arm64"
       ],
@@ -5593,9 +5593,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.37.1.tgz",
-      "integrity": "sha512-YvyxTbjsysvrR4kXRzIspDvg+wGH/Xq1yiXEEg0I+gYO7NFq2I+2bYtjOhUcUM+EDVVFP2Y6n7sKZvqqP5dZ/A==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.38.0.tgz",
+      "integrity": "sha512-Lgw64fSC5+jRpEpYtPnOOOIq7ODc+uXnAbdzAoofqmzjizfT2s8MoFVq1I/oXHxgKbEQLyeM3IrRqp7ur2+ivA==",
       "cpu": [
         "arm64"
       ],
@@ -5612,9 +5612,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-arm64-musl": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.37.1.tgz",
-      "integrity": "sha512-/c8M97zgnpRveB7XBkQb8xtaCgS/h+sZ/txKPE8uNyEKrJK78s8x94hjlnciCZ8cnv90WGzqK0Nf9BA3Up2OGg==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.38.0.tgz",
+      "integrity": "sha512-g1TWe8QxCTU2YwSTs8LqJVnK+kmws6cSxq04xo8ap6RefybUq67ik9DUNR6H0oqkPuM5HBfPNoYvZvCIWeuFAg==",
       "cpu": [
         "arm64"
       ],
@@ -5631,9 +5631,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-gnu": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.37.1.tgz",
-      "integrity": "sha512-PAmTlvNJBE+0t27bBS3PVLt1pSULhnDRSlNSOXkB1roK8g5ay1X6djifkIAkkebM/PCkaJc2aEf3l9lXm2NoAQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.38.0.tgz",
+      "integrity": "sha512-RdlMdP4JjMvK1Ro7esrhtLsSwdO0jrZnD+XNEZswQz00apvPF/F3+nLcY94IVH44Tho8jBP9qgVc4y+GimIHKQ==",
       "cpu": [
         "x64"
       ],
@@ -5650,9 +5650,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-musl": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.37.1.tgz",
-      "integrity": "sha512-ZgpyeNJlzChghoME4P+FwOiuwhNQcVAtab+yiwe4eG87JtSqkS5VjIu40vKWV4XT5lCc5y/yWfpwTuaY496W9g==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.38.0.tgz",
+      "integrity": "sha512-5lbuUJijTuypzRrNHNGEa7iYe2T22sgTZBRmf3S/zis0sFiT3pxPvEEOu8nhF3GstPbJElBweFPW6Yzfpa4o3Q==",
       "cpu": [
         "x64"
       ],
@@ -5669,9 +5669,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-arm64-msvc": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.37.1.tgz",
-      "integrity": "sha512-fzZWKbZfhA7CJ9axZ7ZyOLJRtgItEudkwWHxzvdS1ta+fhvfoLGP0QTozvJkNVJzG95zXsuQ9uHyzA/7MPlGcA==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.38.0.tgz",
+      "integrity": "sha512-ObG2yXxZxo3mEJp7whFh1A4rspJW8DxMGRnLvjPs9EvCoyqjOXaIgrsqL+FnsZ4g3HAGYYOmUhusTYcD0Nu54g==",
       "cpu": [
         "arm64"
       ],
@@ -5685,9 +5685,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-x64-msvc": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.37.1.tgz",
-      "integrity": "sha512-3pfkTlCHPVXn9s7adRbf6mbwUYQxsabzUzCywQnXv+kR46tE1znHjkP44ZganrzH0tVWGL6eOD0Lvsw8tIXYNQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.38.0.tgz",
+      "integrity": "sha512-DrzY0/XSyf7z8+xiSXQWhwREaNXLsxvRqbrdWLr4cisOoZe80PoEWQiwqKNIgHRyHY9alXPoyXj9BV60pkvanw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
   },
   "optionalDependencies": {
     "@huggingface/transformers": "^4.2.0",
-    "@lancedb/lancedb": "0.37.1",
+    "@lancedb/lancedb": "0.38.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@vitejs/plugin-react": "^6.1.1",
     "apache-arrow": "^21.1.0",


### PR DESCRIPTION
**Status:** LGTM. Dependency-only change: one pinned version in `optionalDependencies`, plus the regenerated lockfile. No source files touched.

## What was missing / the motivation

Dependabot PR #467 grouped `@lancedb/lancedb` 0.37.1 -> 0.38.0 with `web-tree-sitter` 0.25.10 -> 0.27.0 and had to be closed. web-tree-sitter >= 0.26 rewrote the WASM loader and silently drops the Dart and Lua grammars — tracked as #472, and the reason the group was dropped. In #467's CI, Build, Integration Tests, Node 22.19 Compatibility, Lint, CodeQL and Windows Smoke all passed; the only failures were the 4 analyzer test files tied to those two grammars.

The lancedb half was innocent. This PR is that half, landed alone.

## What it does

Bumps `@lancedb/lancedb` 0.37.1 -> 0.38.0, keeping the exact-pin style the entry already used. `web-tree-sitter` is untouched at 0.25.10.

**Breaking-change review of lancedb 0.38.0.** The release notes list eleven breaking changes; the Node-facing ones are:

| Breaking change | Applies to us? |
|---|---|
| `feat(node)!: require Node >= 22` — engines floor 18 -> 22 | No. Our `engines` is `^22.19.0 \|\| >=23.5.0`, already inside the floor. |
| `fix(nodejs)!: key parsed embedding configs by vector column` | No. We never use lancedb's embedding registry; embeddings are computed upstream and written as plain vector columns. |
| `feat!: rename branch merge to cherry_pick` | No. We do not use the branch API. |
| `fix(listing)!: page table listings from the store's own cursor` (and `listTables` deprecating `tableNames`) | No. We never call `tableNames` / `listTables`. |
| `fix: make table existence manifest-authoritative` | No behavior change observed; the vector-index open/create/miss paths are covered by tests and all pass. |

Our entire lancedb surface is `connect`, `createTable`, `openTable`, and query — across `vector-index.ts`, `spec-vector-index.ts`, and `text-line-index.ts`.

One pre-existing oddity, unchanged by this PR: lancedb declares `apache-arrow` peer `>=15.0.0 <=18.1.0` while we depend on `^21.1.0`. That mismatch is identical in 0.37.1 and 0.38.0, so this bump neither creates nor worsens it.

The lockfile also carries the required SRI backfill (`npm run lock:integrity`): `npm install` strips integrity digests off the nested `@earendil-works/pi-coding-agent` shrinkwrap entries, which would otherwise fail the "pins every registry tarball to an integrity digest" guard in `src/workflow-security.test.ts`. Five digests were restored; the guard passes.

## Proof it works

Installed version confirmed:

```
$ node -e "console.log(require('./node_modules/@lancedb/lancedb/package.json').version)"
0.38.0
```

SRI backfill and its guard:

```
$ npm run lock:integrity
lock-integrity: node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/chord -> sha512-VDlkEC3dhCzQ5fcyH...
lock-integrity: .../pi-agent-core -> sha512-hIXIP3eAWueAYiAl8...
lock-integrity: .../pi-ai -> sha512-+VgVIJDkDO2efYJKE...
lock-integrity: .../pi-telemetry -> sha512-Bg/YN6kA7Swja/NQx...
lock-integrity: .../pi-tui -> sha512-OIzw9efInmO4WOBnD...
lock-integrity: backfilled 5 digests.

$ npx vitest run src/workflow-security.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

`npm ci` is self-consistent (clean tree afterward), and lint / typecheck / build are all silent-green.

**The vector-index tests — lancedb is the vector store, so these are the load-bearing ones:**

```
$ npx vitest run src/core/analyzer/vector-index.test.ts \
    src/core/analyzer/spec-vector-index.test.ts \
    src/core/analyzer/vector-index-coherence.test.ts \
    src/core/analyzer/vector-index-update-failure.test.ts \
    src/core/analyzer/text-line-index.test.ts \
    src/core/analyzer/bm25-corpus-persistence.test.ts

 Test Files  6 passed (6)
      Tests  128 passed (128)
   Duration  11.39s
```

Full unit suite:

```
$ npm run test:unit
 Test Files  489 passed (489)
      Tests  9381 passed | 2 skipped (9383)
   Duration  578.05s
```

Equivalence suite (where the vector-index files also run):

```
$ npm run test:equivalence
 Test Files  13 passed (13)
      Tests  402 passed (402)
   Duration  37.14s
```

Integration suite:

```
$ npm run test:integration
 Test Files  1 failed | 23 passed (24)
      Tests  1 failed | 193 passed | 1 skipped (195)
```

## Notes / nits

The one integration failure is `mcp-watcher.integration.test.ts > hands libuv the resolved root while keeping the caller's spelling as identity`. It is environmental and unrelated to lancedb: on macOS `os.tmpdir()` is `/var/folders/...`, a symlink to `/private/var/folders/...`, so the watcher resolves the root and the assertion compares against the unresolved spelling. It is a filesystem-watcher path assertion that touches no vector code, the test file is byte-identical to `main`, and CI runs Linux (where `/tmp` is not a symlink) and excludes `*.integration.test.ts` from the gated suite anyway. Not chased here.

Nothing else is unverified: every command above was run on this branch and the output is quoted verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
