### PR TITLE
docs(analyzer): the WASM lane is a deliberate hold, not a missing option

### DIFF
--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -101,8 +101,14 @@ losing templates and namespaces.
 
 If a native grammar is unavailable or ABI-incompatible, OpenLore warns once, keeps the file in
 keyword search, and skips graph extraction for that language without aborting analysis. Lua and
-Dart use portable WASM grammars because their native builds do not match the pinned host binding.
-Each uses an isolated WASM module; if that backend is unavailable, they degrade in the same way.
+Dart are the only two languages served by portable WASM grammars rather than the native lane, each
+in an isolated WASM module; if that backend is unavailable, they degrade in the same way.
+
+Keeping those two on WASM is a deliberate hold rather than an absence of alternatives. Native Dart
+and Lua grammars now exist and were evaluated (issue #472); adopting them would remove the WASM lane
+entirely and unpin `web-tree-sitter`, but the only fitting native Dart package is a single-maintainer
+fork with negligible download volume, so the swap was declined on supply-chain grounds. The pin is
+enforced by a guard test, so a silent capability regression cannot slip through.
 
 ### Out of scope
 

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -2659,8 +2659,9 @@ async function loadGrammarSoft(
 }
 
 /**
- * WASM grammar loader via web-tree-sitter (ABI-agnostic, portable). Used for
- * grammars with no host-ABI-compatible native build (Dart, Lua). Soft-fails.
+ * WASM grammar loader via web-tree-sitter (ABI-agnostic, portable). The only
+ * two callers are Dart and Lua; every other language takes the native lane.
+ * Soft-fails. See the Dart block below for why this lane is still here.
  */
 async function loadWasmGrammarSoft(
   language: string,
@@ -3038,7 +3039,7 @@ const SCALA_SPEC: QueryLangSpec = {
   `,
 };
 
-// ── Lua (via bundled WASM — no ABI-compatible native build for the host) ─────
+// ── Lua (via bundled WASM — see the Dart block for why this lane stays) ────
 const LUA_SPEC: QueryLangSpec = {
   language: 'Lua',
   loader: () => loadWasmGrammarSoft('Lua', 'tree-sitter-wasms/out/tree-sitter-lua.wasm'),
@@ -3104,10 +3105,17 @@ const RECOVERED_RECEIVER_LANGUAGES: ReadonlySet<string> = new Set(['Kotlin', 'C#
 
 // ── Dart (via portable WASM + web-tree-sitter) ───────────────────────────────
 //
-// No ABI-compatible native Dart grammar exists for the pinned host binding, so
 // Dart loads the portable `tree-sitter-wasms` WASM through web-tree-sitter
 // (ABI-agnostic, pure JS/WASM, builds on every platform) — each WASM grammar in
-// its own module instance (see loadWasmGrammarSoft). Dart's grammar places the
+// its own module instance (see loadWasmGrammarSoft).
+//
+// This is a deliberate hold, not an absence. Native grammars for Dart and Lua
+// DO now exist and were evaluated (issue #472): the native Dart grammar parses
+// byte-identically to this one, and migrating both would delete this lane, drop
+// `web-tree-sitter` + `tree-sitter-wasms` from dependencies, and unpin
+// web-tree-sitter 0.26+. It was declined on supply-chain grounds — the only
+// fitting native Dart package is a single-maintainer fork with negligible
+// download volume. Revisit if a well-supported build appears. Dart's grammar places the
 // `function_body` as a SIBLING of `function_signature` (not a child), so a
 // generic query extractor would attribute no calls — hence a custom walk that
 // spans signature+body.

--- a/src/core/analyzer/language-capability-conformance.test.ts
+++ b/src/core/analyzer/language-capability-conformance.test.ts
@@ -100,10 +100,9 @@ describe('language conformance — grammar availability (diagnostic, runs first)
     ).toEqual([]);
   });
 
-  // Dart and Lua have no host-ABI-compatible native build, so they are the only two
-  // languages that reach the WASM lane: `tree-sitter-wasms` binaries loaded through
-  // `web-tree-sitter`. Those two packages are versioned independently and are NOT
-  // freely upgradable together.
+  // Dart and Lua are the only two languages that reach the WASM lane: `tree-sitter-wasms`
+  // binaries loaded through `web-tree-sitter`. Those two packages are versioned
+  // independently and are NOT freely upgradable together.
   //
   // Measured 2026-09-05: `web-tree-sitter` 0.25.10 loads them; 0.26.0 and every version
   // after it reject them outright. The binaries in `tree-sitter-wasms@0.1.13` — the
@@ -113,7 +112,14 @@ describe('language conformance — grammar availability (diagnostic, runs first)
   // them. That is exactly the over-claim this file exists to prevent, and it cost a day
   // to trace, so the constraint is asserted here rather than left as a comment.
   //
-  // Lift this only when `tree-sitter-wasms` publishes binaries built for the new loader.
+  // Note the fault is in these BINARIES, not in the 0.26+ loader: measured 2026-09-07,
+  // web-tree-sitter 0.27.0 loads other grammars' WASM (e.g. the maintained Lua and Dart
+  // grammar packages' own builds) without complaint. So there are two ways out, not one:
+  //   1. `tree-sitter-wasms` publishes binaries built for the new loader, or
+  //   2. Dart and Lua move off this lane entirely — native grammars for both now exist
+  //      (issue #472), which would delete the lane and drop both packages. Evaluated and
+  //      declined on supply-chain grounds, not for lack of a working option.
+  // Lift this pin when either lands, and re-run this suite to confirm Dart and Lua load.
   it('keeps web-tree-sitter on a version whose loader accepts the pinned tree-sitter-wasms binaries', () => {
     const pkg = createRequire(import.meta.url)('../../../package.json') as {
       dependencies: Record<string, string>;


### PR DESCRIPTION
**Status:** LGTM — comments and docs only, no behavior change.

## What was wrong

Four places asserted that no ABI-compatible native grammar exists for Dart or Lua. That was true when written; it is now false, and it made the WASM lane look like a constraint we were stuck with rather than a choice we made.

Investigating #472 also turned up a second inaccuracy: the guard test told future readers to lift the pin "only when `tree-sitter-wasms` publishes binaries built for the new loader." That's one of two exits, not the only one.

## How it was fixed

- `call-graph.ts` (3 comments) — the lane is described by what it actually is: the only two callers are Dart and Lua, kept there by a deliberate, reasoned hold.
- `language-capability-conformance.test.ts` — records that the 0.26+ loader is **not** broken (0.27.0 loads other grammars' WASM fine); the stale artifacts are the `tree-sitter-wasms@0.1.13` binaries specifically. Names both lift conditions.
- `docs/language-support.md` — same correction, plus the note that a guard test prevents a silent capability regression.

The reason the lane stays is now written down: migrating would delete the lane, drop `web-tree-sitter` + `tree-sitter-wasms` (~55 MB of runtime deps), and unpin web-tree-sitter — but the only fitting native Dart package is a single-maintainer fork with negligible download volume, so it was declined on supply-chain grounds.

## Proof it works

Comment-only; the point is that nothing moved.

```
npm run typecheck   clean
npm run lint        clean
language-capability-conformance.test.ts   158 passed
doc-claim-sync                              2 passed
```

## Notes

- #472 stays open by design. The guard test is doing its job — it catches the regression in CI rather than in the field — and the cost is one Dependabot PR close per week.
- Findings behind this are recorded on #472 for whoever revisits it.