### PR TITLE
chore(release): 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to OpenLore are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2026-09-07
+
+**The release where the first run stops being the worst run — and Windows joins CI.**
+
+- **Install once, and every repository you open works.** `install` wires OpenLore at user scope and
+  points at OpenLore's own CLI instead of an `npx` shim, so no console window flashes on Windows and
+  a second repository needs no second setup.
+- **Answer during the first build, instead of "no index found".** A partially built index serves what
+  it already has, and an index that genuinely cannot be served says *why* rather than reporting absence.
+- **The call graph names where it stops seeing.** Chained intra-object receivers resolve instead of
+  going silent, and unresolved call shapes are disclosed as boundaries rather than assumed empty.
+- **Windows is a tested platform, not a hope.** The unit suite runs on Windows in CI and ten defects
+  it surfaced are fixed; the deny-list dropped from 49 tests to 2. Repository-relative paths OpenLore
+  serves are POSIX on every platform.
+- **The watcher and the serving path stop wasting work.** A flush can no longer skip silently, a
+  deterministic-failure budget is not spent on a wait, per-call serving work is bounded, and serving
+  caches invalidate on external writes.
+- **Dependency and supply-chain upkeep.** Native tree-sitter grammars, LanceDB 0.38.0, Vitest 5, and
+  the dev-dependency group are current; the `sharp` override moves to ^0.35.4 to clear the libheif
+  advisory (GHSA-rgj7-g3m4-5g8c); CI now fails on a digest-less lockfile at the point it is fixable.
+
+No breaking changes. No public API or configuration schema change from 3.1.0.
+
+**Upgrade:** `npm i -g openlore@3.1.1` — or `openlore update`.
+
+**Full Changelog**: https://github.com/clay-good/OpenLore/compare/v3.1.0...v3.1.1
+
 ## [3.1.0] - 2026-08-30
 
 **The release where OpenLore learns the shape and vocabulary of a whole workspace.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Persistent architectural memory and structural cognition for AI coding agents.",
   "type": "module",
   "main": "dist/api/index.js",

--- a/src/core/services/fixtures/configs/3.1.1-default.json
+++ b/src/core/services/fixtures/configs/3.1.1-default.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.2.0",
+  "projectType": "nodejs",
+  "openspecPath": "openspec",
+  "analysis": {
+    "maxFiles": 100000,
+    "includePatterns": [],
+    "excludePatterns": []
+  },
+  "generation": {
+    "model": "claude-sonnet-4-6",
+    "domains": "auto"
+  },
+  "panicResponse": {
+    "mode": "off"
+  },
+  "createdAt": "2026-09-07T00:00:00.000Z",
+  "lastRun": null
+}

--- a/src/core/services/fixtures/configs/README.md
+++ b/src/core/services/fixtures/configs/README.md
@@ -13,6 +13,8 @@ They intentionally do not move with the current schema.
 - `3.1.0-default.json` captures the default configuration factory shape for v3.1.0 and schema 1.2.0.
 - `3.1.0-workspace.json` captures the optional workspace-shard and retrieval settings introduced in
   v3.1.0.
+- `3.1.1-default.json` captures the unchanged default configuration factory shape for v3.1.1 and
+  schema 1.2.0.
 
 For each release, add at least one `<package-version>-*.json` fixture before changing the package
 version. Include both a factory-default shape and a realistic customized shape when the release


### PR DESCRIPTION
**Status:** Ready to merge — release-only change (version bump + changelog).

**What was missing / the motivation:** 33 commits have landed since v3.1.0 and none of them is released. The intended release date was Monday, 2026-09-07.

**What it does:** Bumps `package.json` / `package-lock.json` to 3.1.1 and adds the CHANGELOG entry for it. No source changes.

Highlights covered by the entry:
- user-scope `install` wiring OpenLore's own CLI (no `npx` console flash on Windows)
- serving answers during the first build; an unservable index says why
- chained intra-object receiver resolution and disclosed call-graph boundaries
- the Windows unit lane in CI plus the ten defects it surfaced (deny-list 49 → 2)
- watcher flush durability, bounded per-call serving work, cache invalidation on external writes
- dependency upkeep, including the `sharp` override moving to `^0.35.4` for GHSA-rgj7-g3m4-5g8c

**Proof it works:** `npm run lint`, `npm run typecheck`, and the doc-claim-sync guard pass locally; the Release workflow re-runs the full validate lane against the tag before publishing.

**Notes / nits:**
- The commit is dated 2026-09-07 (the intended release date) and the tag will carry the same date. The GitHub Release and the npm publish timestamps are server-set and will read 2026-09-09; nothing claims otherwise.
- Version is 3.1.1 at the maintainer's request. The branch does contain `feat(...)` commits, which strict semver would put at 3.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)