### PR TITLE
fix(install): quote the Windows hook path Git Bash was eating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,30 @@ jobs:
               throw "Windows install routed the $key hook through npx (cmd.exe shim)"
             }
           }
+          # harden-windows-hook-quoting (#483): Claude Code runs a hook command through GIT
+          # BASH, where a bare backslash is an escape that is dropped. Nothing above can see
+          # that - the MCP launcher is spawned with an argv and never meets a shell - so the
+          # unquoted entry path shipped green and every hook died with `Cannot find module`.
+          # This runs the hook STRING through the real Git Bash on a real Windows host, which
+          # is the only place in CI where that interpretation is the genuine article.
+          $bash = (Get-Command bash -ErrorAction SilentlyContinue).Source
+          if (-not $bash) { throw 'Git Bash is absent from the runner; the hook shell cannot be verified' }
+          foreach ($key in 'SessionStart', 'UserPromptSubmit') {
+            # Swap the subcommand for `--version`, so the probe proves the SHELL resolved the
+            # path and Node ran it, without depending on an index being built yet.
+            $probe = $settings.hooks.$key[0].hooks[0].command -replace 'orient (--json|--inject)$', '--version'
+            # Written to a file, not passed as an argument: the hook string carries its own
+            # double quotes, and PowerShell's native-argument quoting would rewrite them.
+            Set-Content -Path hook-probe.sh -Value $probe -Encoding ascii
+            $out = (& $bash hook-probe.sh 2>&1) | Out-String
+            if ($out -match 'Cannot find module') {
+              throw "#483 regression: Git Bash could not resolve the $key hook path. $out"
+            }
+            if ($out -notmatch '\d+\.\d+\.\d+') {
+              throw "The $key hook command did not run under Git Bash. $out"
+            }
+          }
+          Remove-Item hook-probe.sh
           # A hostile npx.cmd in the working directory must now be irrelevant: the launcher
           # never reaches npx at all. Kept as a regression probe on exactly that property.
           Set-Content -Path npx.cmd -Value '@exit /b 91'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,10 @@ jobs:
             $probe = $settings.hooks.$key[0].hooks[0].command -replace 'orient (--json|--inject)$', '--version'
             # Written to a file, not passed as an argument: the hook string carries its own
             # double quotes, and PowerShell's native-argument quoting would rewrite them.
-            Set-Content -Path hook-probe.sh -Value $probe -Encoding ascii
+            # utf8NoBOM, not ascii: an ascii write would silently mangle a non-ASCII path
+            # (`C:\Users\Müller\…`) before bash ever saw it, and a BOM would break the first
+            # token. The runner's own paths are ASCII, so this is about not lying if that changes.
+            Set-Content -Path hook-probe.sh -Value $probe -Encoding utf8NoBOM
             $out = (& $bash hook-probe.sh 2>&1) | Out-String
             if ($out -match 'Cannot find module') {
               throw "#483 regression: Git Bash could not resolve the $key hook path. $out"

--- a/openspec/changes/harden-windows-hook-quoting/.openspec.yaml
+++ b/openspec/changes/harden-windows-hook-quoting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-12

--- a/openspec/changes/harden-windows-hook-quoting/proposal.md
+++ b/openspec/changes/harden-windows-hook-quoting/proposal.md
@@ -49,13 +49,25 @@ thing to cmd.exe and to a POSIX shell for them, so `formatPlatformCommand` throw
 writing a line that silently fails or executes code — the protection `quotePosix` already
 gives the POSIX branch, which the Windows branch was missing for the same input.
 
-**The refusal reaches the user as a refusal, not a crash.** `runInstall` rethrows a
-project-scope adapter error, so both config writers check first (`windowsCommandHazard`) and
-decline one file with the reason. `openlore update` only ever PRINTS a command — it spawns its
-own argv without a shell — so it degrades to the plain package-manager instruction for the
-detected method. That instruction is derived from the method, not from the resolved
-invocation: joining the resolved parts would have printed two unquoted absolute paths, which
-is less runnable than the line it replaces.
+**A refusal costs the hooks, and nothing else.** `runInstall` rethrows a project-scope adapter
+error, so the writers check first (`windowsCommandHazard`) instead of letting the throw escape.
+What they then do matters as much: an unquotable path is a property of the HOST, not a clash
+with the user's file, so it is not reported as a conflict. The MCP entry (an argv), the
+instruction block (prose) and the tool permission (a literal) are all still correct and are
+still written; only the hooks are left out. Treating it as a conflict returned exit 1, which
+also skipped the index build — one unwritable field cost the entire install.
+
+A hook OpenLore wired earlier is REMOVED on such a host, not left in place. It names a command
+this host mangles, so keeping it is #483's `Cannot find module` once per turn, forever, with
+nothing saying why; a user-authored entry in the same group survives untouched.
+
+`openlore update` only ever PRINTS a command — it spawns its own argv without a shell — so on
+Windows it prints the plain package-manager command for the detected method instead of the
+resolved form. That is not merely a fallback: a statement whose first token is a quoted path
+parses in PowerShell as a string EXPRESSION, so the resolved line is a syntax error there
+rather than an invocation. Printing the command the user actually meant is correct for cmd.exe,
+PowerShell and bash alike, and it keeps every `$`-shaped path out of a shell whose expansion
+rules differ from the POSIX ones the refusal models.
 
 **Uninstall is decoupled from formatting.** `managedHooks` was called on the removal path for
 its keys alone, so an unformattable path would have thrown there too — stranding the hooks
@@ -88,5 +100,13 @@ redirects — which first surfaced as stray files in this repo's own working tre
   while changing the emitted path for every Windows user.
 - **cmd.exe's `%VAR%` expansion is not defended.** No string form suppresses it, and a literal
   `%` path round-trips under the Git Bash that actually runs our hooks — refusing it would
-  break a working install to appease a shell we do not target. Disclosed at the code.
+  break a working install to appease a shell we do not target. Disclosed at the code. `!VAR!`
+  under delayed expansion is the same shape and equally undefendable.
+- **A UNC install is now an unsupported host, explicitly.** `"\\\\srv\\share\\…"` is fine for
+  cmd.exe but collapses to one backslash in bash, and neither forward slashes nor single quotes
+  fix it for both. Such a host gets everything except the hooks, with the reason named, rather
+  than a hook that cannot run.
+- **A bare `cmd /c` is not a supported carrier.** Its two-quotes-only rule strips the first and
+  last quote of a line like ours. Nothing OpenLore writes is run that way — Node's `shell:true`
+  wraps with `/d /s /c` — and no string form would survive it.
 - **No new spec domain.** One `cli` requirement, mirroring `SubprocessesNeverSurfaceAConsoleWindow`.

--- a/openspec/changes/harden-windows-hook-quoting/proposal.md
+++ b/openspec/changes/harden-windows-hook-quoting/proposal.md
@@ -110,3 +110,9 @@ redirects — which first surfaced as stray files in this repo's own working tre
   last quote of a line like ours. Nothing OpenLore writes is run that way — Node's `shell:true`
   wraps with `/d /s /c` — and no string form would survive it.
 - **No new spec domain.** One `cli` requirement, mirroring `SubprocessesNeverSurfaceAConsoleWindow`.
+- **Two adjacent crashes are left alone**, deliberately, because they are pre-existing and have
+  a different cause — cannot LOCATE a command, rather than cannot QUOTE one. Both are filed:
+  `resolveOpenloreCommand` still throws out of a project-scope adapter when `npx-cli.js` cannot
+  be found or the Node path is not absolute (`mcpEntry` runs before any check), and
+  `doctor --fix` discards `runInstall`'s exit code and reports a rewire as corrected either
+  way. Fixing them here would widen the claim this change is making.

--- a/openspec/changes/harden-windows-hook-quoting/proposal.md
+++ b/openspec/changes/harden-windows-hook-quoting/proposal.md
@@ -1,0 +1,92 @@
+## Why
+
+`openlore install` wrote a Windows hook command whose entry path was not quoted, so every
+`SessionStart` and `UserPromptSubmit` fired `Cannot find module` (#483, fixed by #484 from
+@L4XB). The rule quoted a part only when it held a space or a cmd.exe metacharacter:
+
+```ts
+.map((part) => /[\s&|<>^%!()]/.test(part) ? `"${part}"` : part)
+```
+
+`C:\Program Files\nodejs\node.exe` was quoted because it has a space. An nvm-windows entry
+path has none, so it went through bare — and Claude Code runs a hook through **Git Bash**,
+where a bare `\` is an escape that is dropped. The reporter's path arrived as
+`C:UsersmeAppDataRoamingnvm...index.js`.
+
+The defect was not the regex. It was that the Windows branch was written for cmd.exe and
+never asked the shell that actually runs the string, and every unit test agreed with the code
+because both encoded the same assumption. Only a real shell could have caught it.
+
+Asking one (`bash`, the shell Git Bash ships) shows the fix is right for ordinary paths and
+that **double quotes do not make a POSIX shell literal**. Inside them a backslash still
+escapes `$`, a backtick, `"` and another backslash, and `$`/backtick still expand. Four
+shapes therefore remain wrong, two of them worse than the bug #484 fixes:
+
+| Part | Emitted `"…"` becomes | Consequence |
+|---|---|---|
+| `C:\a"\x.js` | quote closes early | **the rest of the line runs as code** |
+| `C:\Users\me\` | trailing `\` escapes our own `"` | **swallows every later argument** |
+| `C:\Users\a$b\x.js` | `$b` substituted | wrong path, silently |
+| `\\srv\share\…`, `C:\$Recycle.Bin\…` | `\\` / `\$` lose a backslash | #483's own error, one turn at a time |
+
+## What Changes
+
+**#484's outcome is kept, and its mechanism is inverted.** Quoting the entry path is right
+for cmd.exe, Git Bash and PowerShell, and it is what users need today. But #484 gets there by
+adding `\` to a DENYLIST, and a denylist is only ever as complete as the next character
+someone thinks of: over 900 random parts, 84 that the denylist emitted BARE came back mangled
+or dangerous, because an unquoted word exposes a different set of metacharacters — `;`, `'`,
+`~`, `*`, `?`, `#`, brace expansion, the empty string. `a;id` alone runs `id`.
+
+The POSIX branch never had this problem: `quotePosix` is an ALLOWLIST and single-quotes
+everything else, sound by construction. The Windows branch now matches it — quote unless the
+part is only characters no shell treats specially. Same result for every real path (all
+contain `\`, `:` or a space), same readable bare `orient --json`, and the bare branch stops
+being a second, unmodelled quoting rule.
+
+**The four unrepresentable shapes are REFUSED, not emitted.** No single string means the same
+thing to cmd.exe and to a POSIX shell for them, so `formatPlatformCommand` throws instead of
+writing a line that silently fails or executes code — the protection `quotePosix` already
+gives the POSIX branch, which the Windows branch was missing for the same input.
+
+**The refusal reaches the user as a refusal, not a crash.** `runInstall` rethrows a
+project-scope adapter error, so both config writers check first (`windowsCommandHazard`) and
+decline one file with the reason. `openlore update` only ever PRINTS a command — it spawns its
+own argv without a shell — so it degrades to the plain package-manager instruction for the
+detected method. That instruction is derived from the method, not from the resolved
+invocation: joining the resolved parts would have printed two unquoted absolute paths, which
+is less runnable than the line it replaces.
+
+**Uninstall is decoupled from formatting.** `managedHooks` was called on the removal path for
+its keys alone, so an unformattable path would have thrown there too — stranding the hooks
+uninstall exists to remove. The keys are now a constant.
+
+**A real Windows host checks the real hook.** The Windows smoke job already asserted the wired
+MCP launcher executes, but never ran the hook STRING through a shell — which is exactly how
+#483 shipped green. It now writes the hook command to a script, runs it under the runner's own
+Git Bash, and requires a version back, so the reporter's failure cannot return unnoticed.
+
+**A real shell is the oracle.** `platform-command.posix-oracle.test.ts` emits the command the
+installer would write, hands it to `bash`, and asserts the argv that comes back is the argv we
+meant. It pins #483 itself (the old predicate, and the reporter's exact mangled path), proves
+the injection case executes when unguarded, and drives the EMITTER over a hostile corpus so
+guard and shell cannot drift. The corpus goes through `formatPlatformCommand`, not a
+hand-written `"…"`: comparing against the quoted form only is what hid the bare branch, and
+the same corpus reports 84 failures against the denylist emitter and none against the
+allowlist. Its probes run in a throwaway directory, because a part that escapes its quoting
+redirects — which first surfaced as stray files in this repo's own working tree.
+
+## Deliberately NOT done
+
+- **The hook string is not switched to POSIX single quotes**, which would carry all four
+  shapes perfectly. Evidence says Git Bash runs our hooks, but a single-quoted line is
+  meaningless to cmd.exe, so being wrong about that would break every working Windows install
+  to fix a shape almost nobody has. The double-quote form stays; the unrepresentable rest is
+  refused.
+- **No forward-slash normalization.** It rescues UNC and a trailing separator, but not `$`
+  (`"C:/$Recycle.Bin/x"` still expands), so it would trade one silent mangling for another
+  while changing the emitted path for every Windows user.
+- **cmd.exe's `%VAR%` expansion is not defended.** No string form suppresses it, and a literal
+  `%` path round-trips under the Git Bash that actually runs our hooks — refusing it would
+  break a working install to appease a shell we do not target. Disclosed at the code.
+- **No new spec domain.** One `cli` requirement, mirroring `SubprocessesNeverSurfaceAConsoleWindow`.

--- a/openspec/changes/harden-windows-hook-quoting/specs/cli/spec.md
+++ b/openspec/changes/harden-windows-hook-quoting/specs/cli/spec.md
@@ -26,11 +26,23 @@ quoted run and lets the remainder of the line execute, and a trailing backslash 
 closing quote and swallows the arguments after it, so emitting either is worse than the bug
 that motivated quoting.
 
-A refusal SHALL decline one config field, naming the part and the reason, and SHALL NOT fail
-the whole run. A command that is only DISPLAYED — `openlore update` prints an upgrade line and
-executes its own argv without a shell — SHALL fall back to a plain instruction. The removal
-path SHALL NOT format a command at all, so that a host whose paths became unformattable can
-still uninstall what was wired.
+Such a host SHALL still receive every part of the install that does NOT depend on a shell
+string — the MCP server entry, which is an argv; the instruction block; the tool permission —
+and SHALL lose only the hooks, named with the reason. It SHALL NOT be reported as a conflict:
+an unquotable path is a property of the host rather than a clash with the user's file, and
+conflict semantics fail the run, which also skips the index build.
+
+A hook OpenLore wired earlier SHALL be REMOVED on such a host rather than left in place, since
+it names a command the host mangles and would fail on every invocation; entries the user
+authored in the same hook group SHALL survive.
+
+A command that is only DISPLAYED — `openlore update` prints an upgrade line and executes its
+own argv without a shell — SHALL print a command the user can actually run. On Windows that is
+the plain package-manager instruction, not the resolved invocation: a statement whose first
+token is a quoted path parses in PowerShell as a string expression rather than a command.
+
+The removal path SHALL NOT format a command at all, so that a host whose paths became
+unformattable can still uninstall what was wired.
 
 The guard SHALL be pinned against a REAL POSIX shell rather than against a restated expected
 string: the emitted line is handed to `bash` and the argv it yields is compared to the intended

--- a/openspec/changes/harden-windows-hook-quoting/specs/cli/spec.md
+++ b/openspec/changes/harden-windows-hook-quoting/specs/cli/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: WiredCommandStringsRoundTripThroughTheShellThatRunsThem
+
+A command string OpenLore writes into a host config file SHALL be quoted for the shell that
+will run it, and SHALL be refused when no quoting form can carry it.
+
+On Windows that shell is not cmd.exe. Claude Code runs a hook command through Git Bash, where
+a bare `\` is an escape: a path quoted only when it contains a space left every space-free
+entry path bare, and Git Bash dropped every separator, so each hook invocation failed to
+resolve the module (#483).
+
+A part SHALL be quoted unless it consists only of characters no shell treats specially. The
+rule SHALL be an allowlist rather than a list of characters that force quoting: an unquoted
+word is exposed to `;`, `'`, `~`, `*`, `?`, `#`, brace expansion and the empty string, so a
+denylist leaves a second, unmodelled quoting rule on the bare branch — `a;id` emitted bare
+runs `id`. The POSIX branch is already allowlist-shaped, and the two SHALL NOT differ in
+soundness for the same input.
+
+Double quotes are the form both shells accept, but they do NOT make a POSIX shell literal —
+inside them a backslash still escapes `` $ ` " \ `` and newline, and `$`/backtick still expand.
+A part containing an embedded `"`, a trailing backslash, an unescaped expansion or backtick, or
+a backslash pair (a UNC prefix, `C:\$Recycle.Bin`) therefore cannot be represented for both
+shells at once. Such a part SHALL be refused rather than emitted: an embedded `"` ends the
+quoted run and lets the remainder of the line execute, and a trailing backslash escapes the
+closing quote and swallows the arguments after it, so emitting either is worse than the bug
+that motivated quoting.
+
+A refusal SHALL decline one config field, naming the part and the reason, and SHALL NOT fail
+the whole run. A command that is only DISPLAYED — `openlore update` prints an upgrade line and
+executes its own argv without a shell — SHALL fall back to a plain instruction. The removal
+path SHALL NOT format a command at all, so that a host whose paths became unformattable can
+still uninstall what was wired.
+
+The guard SHALL be pinned against a REAL POSIX shell rather than against a restated expected
+string: the emitted line is handed to `bash` and the argv it yields is compared to the intended
+argv. A test that asserts the emitter's output matches the emitter's own assumption about a
+shell cannot fail when that assumption is wrong, which is precisely how #483 shipped green.
+
+#### Scenario: A space-free Windows entry path is wired
+
+- **GIVEN** an nvm-windows install, whose CLI entry path contains no space
+- **WHEN** the hook command is formatted for `win32`
+- **THEN** the entry path is double-quoted, and a POSIX shell reproduces it separator-for-separator
+
+#### Scenario: A path the quoted form cannot carry
+
+- **GIVEN** a host whose profile directory is a shell expansion (`C:\Users\a$b`)
+- **WHEN** `openlore install` runs
+- **THEN** the hooks file and the Continue config are declined, each naming the offending part and
+  why, the MCP entry (an argv, never a shell string) is still written, and the run does not crash
+
+#### Scenario: Uninstalling from a host that can no longer be formatted
+
+- **GIVEN** hooks wired earlier, on a host whose paths are now unformattable
+- **WHEN** `openlore install --uninstall` runs
+- **THEN** the marker-identified hook groups are removed, because removal needs the keys only

--- a/openspec/changes/harden-windows-hook-quoting/tasks.md
+++ b/openspec/changes/harden-windows-hook-quoting/tasks.md
@@ -21,7 +21,9 @@
 - [x] 3.1a `claude-code`: strip a hook wired earlier on a host that can no longer run it,
   keeping any user-authored entry in the same group.
 - [x] 3.2 `claude-code`: extract `MANAGED_HOOKS` so uninstall never formats a command.
-- [x] 3.3 `continue`: decline `.continue/config.json` with the reason.
+- [x] 3.3 `continue`: decline `.continue/config.json` with the reason, also without conflicting
+  — Continue being unwirable must not undo a Claude Code install from the same pass — and
+  derive the argv once, so the hazard check and the emitter cannot ask about different commands.
 - [x] 3.4 `update`: `printableCommand` prints the plain package-manager instruction on Windows
   — the resolved form is a string expression in PowerShell, not a command.
 

--- a/openspec/changes/harden-windows-hook-quoting/tasks.md
+++ b/openspec/changes/harden-windows-hook-quoting/tasks.md
@@ -1,0 +1,34 @@
+## 1. Quote what the shell needs quoted (#484)
+
+- [x] 1.1 Quote a space-free entry path — @L4XB's outcome, with their two test cases.
+- [x] 1.2 Invert the mechanism from a denylist to the allowlist `quotePosix` already uses, so
+  the BARE branch stops being a second, unmodelled quoting rule (`a;id` alone runs `id`).
+
+## 2. Refuse what no quoting form can carry
+
+- [x] 2.1 Add `windowsQuotingHazard`: a scanner mirroring bash's double-quote rule (a backslash
+  escapes only `` $ ` " \ `` and newline; `$` expands only before a valid parameter start, so a
+  path like `C:\Users\dev$\…` is still accepted).
+- [x] 2.2 Throw from `formatPlatformCommand` on an unrepresentable win32 part, naming the part
+  and the reason.
+- [x] 2.3 Export `windowsCommandHazard` for the callers that must not throw.
+
+## 3. Make the refusal survivable
+
+- [x] 3.1 `claude-code`: check before the write, `refusedWrite` the settings file with the
+  reason; the MCP entry is an argv and is unaffected.
+- [x] 3.2 `claude-code`: extract `MANAGED_HOOKS` so uninstall never formats a command.
+- [x] 3.3 `continue`: decline `.continue/config.json` with the reason.
+- [x] 3.4 `update`: `printableCommand` degrades to the plain package-manager instruction for
+  the detected method, never to a join of the resolved absolute paths.
+
+## 4. Let a real shell be the judge
+
+- [x] 4.1 Add `platform-command.posix-oracle.test.ts`: emitted line → `bash` → argv, pinning
+  #483's mangled path, the old predicate, the executed injection, and a 600-case corpus in
+  which guard and shell must agree in both directions.
+- [x] 4.2 Adapter tests: hooks and slash command refused with the reason, MCP still written,
+  and hooks still removable by uninstall on an unformattable host.
+- [x] 4.3 `printableCommand` tests: quoted, the per-method fallback, and POSIX unaffected.
+- [x] 4.4 Windows smoke: run the emitted hook command under the runner's own Git Bash and
+  require a version back — the assertion whose absence let #483 ship green.

--- a/openspec/changes/harden-windows-hook-quoting/tasks.md
+++ b/openspec/changes/harden-windows-hook-quoting/tasks.md
@@ -15,12 +15,15 @@
 
 ## 3. Make the refusal survivable
 
-- [x] 3.1 `claude-code`: check before the write, `refusedWrite` the settings file with the
-  reason; the MCP entry is an argv and is unaffected.
+- [x] 3.1 `claude-code`: check before the write, then wire everything that does not need a
+  shell string and omit ONLY the hooks, with the reason — not a conflict, which failed the run
+  and skipped the index build.
+- [x] 3.1a `claude-code`: strip a hook wired earlier on a host that can no longer run it,
+  keeping any user-authored entry in the same group.
 - [x] 3.2 `claude-code`: extract `MANAGED_HOOKS` so uninstall never formats a command.
 - [x] 3.3 `continue`: decline `.continue/config.json` with the reason.
-- [x] 3.4 `update`: `printableCommand` degrades to the plain package-manager instruction for
-  the detected method, never to a join of the resolved absolute paths.
+- [x] 3.4 `update`: `printableCommand` prints the plain package-manager instruction on Windows
+  — the resolved form is a string expression in PowerShell, not a command.
 
 ## 4. Let a real shell be the judge
 

--- a/src/cli/commands/update-windows.test.ts
+++ b/src/cli/commands/update-windows.test.ts
@@ -36,7 +36,7 @@ import { runUpdate } from './update.js';
 describe('openlore update on Windows', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('uses the resolved shim for npm-root evidence and prints the same dry-run invocation', async () => {
+  it('resolves the shim for npm-root evidence, and shows a line the user can actually run', async () => {
     const info = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
 
     const runtime = {
@@ -50,9 +50,14 @@ describe('openlore update on Windows', () => {
       ['C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js', 'root', '-g'],
       expect.objectContaining({ windowsHide: true }),
     );
-    expect(info).toHaveBeenCalledWith(
-      'Would run',
-      '"C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" install -g openlore@latest',
-    );
+    // The displayed line is DELIBERATELY not the resolved argv above. That form starts with a
+    // quoted path, and a PowerShell statement whose first token is quoted parses as a string
+    // expression — so the exact line is a syntax error in the shell a Windows user is most
+    // likely to paste it into. `update` reports a command; it spawns its own argv either way,
+    // so the report is the plain equivalent, and the label no longer promises it verbatim
+    // (change: harden-windows-hook-quoting).
+    expect(info).toHaveBeenCalledWith('Would upgrade with', 'npm install -g openlore@latest');
+    const shown = info.mock.calls.flat().join(' ');
+    expect(shown).not.toContain('npm-cli.js');
   });
 });

--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectInstallMethod, upgradeCommandFor, type InstallEvidence } from './update.js';
+import { detectInstallMethod, upgradeCommandFor, type InstallEvidence, printableCommand } from './update.js';
 
 describe('detectInstallMethod', () => {
   it('detects Homebrew installs (separator-agnostic)', () => {
@@ -96,5 +96,47 @@ describe('upgradeCommandFor', () => {
       cmd: 'C:\\Program Files\\nodejs\\node.exe',
       args: ['C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js', 'install', '-g', 'openlore@latest'],
     });
+  });
+});
+
+/**
+ * `update` only ever REPORTS a command — the upgrade itself runs through `spawn` with an
+ * argv and no shell. So a host whose paths cannot be quoted for Windows must degrade to a
+ * plain instruction, never throw out of a command that was working (#483 hardening).
+ */
+describe('printableCommand', () => {
+  const invocation = {
+    command: 'C:\\Program Files\\nodejs\\node.exe',
+    args: ['C:\\npm\\node_modules\\npm\\bin\\npm-cli.js', 'install', '-g', 'openlore@latest'],
+  };
+
+  it('quotes both Windows paths when they can be quoted', () => {
+    expect(printableCommand(invocation, 'win32', 'npm-global')).toBe(
+      '"C:\\Program Files\\nodejs\\node.exe" "C:\\npm\\node_modules\\npm\\bin\\npm-cli.js" '
+      + 'install -g openlore@latest',
+    );
+  });
+
+  // Not a caller-supplied string: the fallback has to be the PLAIN package-manager command
+  // for the method. Building it from the resolved invocation would print two unquoted absolute
+  // paths — `C:\Program Files\nodejs\node.exe C:\Program Files\...\npm-cli.js install -g …` —
+  // which no shell can parse, i.e. a worse instruction than the one it replaces.
+  it.each([
+    ['npm-global', 'npm install -g openlore@latest'],
+    ['npm-local', 'npm install openlore@latest'],
+    ['homebrew', 'brew upgrade openlore'],
+    ['unknown', 'npm install -g openlore@latest'],
+  ] as const)('falls back to a typable %s instruction when a path cannot be quoted', (method, expected) => {
+    const hostile = { ...invocation, command: 'C:\\Users\\a$b\\nodejs\\node.exe' };
+    const printed = printableCommand(hostile, 'win32', method);
+    expect(printed).toBe(expected);
+    // The point of the fallback: what it prints is runnable, not a bare path with spaces.
+    expect(printed).not.toMatch(/Program Files/);
+  });
+
+  it('never takes the fallback on a POSIX host, which quotes the same path fine', () => {
+    const hostile = { command: '/opt/a$b/node', args: ['/opt/a$b/openlore/dist/cli/index.js'] };
+    expect(printableCommand(hostile, 'linux', 'npm-global'))
+      .toBe("'/opt/a$b/node' '/opt/a$b/openlore/dist/cli/index.js'");
   });
 });

--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -100,9 +100,10 @@ describe('upgradeCommandFor', () => {
 });
 
 /**
- * `update` only ever REPORTS a command — the upgrade itself runs through `spawn` with an
- * argv and no shell. So a host whose paths cannot be quoted for Windows must degrade to a
- * plain instruction, never throw out of a command that was working (#483 hardening).
+ * `update` only ever REPORTS a command — the upgrade itself runs through `spawn` with an argv
+ * and no shell — so the line it prints has to be RUNNABLE if a user pastes it, which on
+ * Windows the resolved form is not: a statement whose first token is a quoted path parses in
+ * PowerShell as a string expression, not a command (#483 hardening).
  */
 describe('printableCommand', () => {
   const invocation = {
@@ -110,33 +111,30 @@ describe('printableCommand', () => {
     args: ['C:\\npm\\node_modules\\npm\\bin\\npm-cli.js', 'install', '-g', 'openlore@latest'],
   };
 
-  it('quotes both Windows paths when they can be quoted', () => {
-    expect(printableCommand(invocation, 'win32', 'npm-global')).toBe(
-      '"C:\\Program Files\\nodejs\\node.exe" "C:\\npm\\node_modules\\npm\\bin\\npm-cli.js" '
-      + 'install -g openlore@latest',
-    );
-  });
-
-  // Not a caller-supplied string: the fallback has to be the PLAIN package-manager command
-  // for the method. Building it from the resolved invocation would print two unquoted absolute
-  // paths — `C:\Program Files\nodejs\node.exe C:\Program Files\...\npm-cli.js install -g …` —
-  // which no shell can parse, i.e. a worse instruction than the one it replaces.
   it.each([
     ['npm-global', 'npm install -g openlore@latest'],
     ['npm-local', 'npm install openlore@latest'],
     ['homebrew', 'brew upgrade openlore'],
+    ['npx', 'npx --yes openlore@latest'],
     ['unknown', 'npm install -g openlore@latest'],
-  ] as const)('falls back to a typable %s instruction when a path cannot be quoted', (method, expected) => {
-    const hostile = { ...invocation, command: 'C:\\Users\\a$b\\nodejs\\node.exe' };
-    const printed = printableCommand(hostile, 'win32', method);
+  ] as const)('prints the typable %s command on Windows', (method, expected) => {
+    const printed = printableCommand(invocation, 'win32', method);
     expect(printed).toBe(expected);
-    // The point of the fallback: what it prints is runnable, not a bare path with spaces.
-    expect(printed).not.toMatch(/Program Files/);
+    // The whole point: never a quoted absolute path, which PowerShell cannot invoke.
+    expect(printed).not.toMatch(/Program Files|"/);
   });
 
-  it('never takes the fallback on a POSIX host, which quotes the same path fine', () => {
-    const hostile = { command: '/opt/a$b/node', args: ['/opt/a$b/openlore/dist/cli/index.js'] };
-    expect(printableCommand(hostile, 'linux', 'npm-global'))
+  it('prints the same typable command when the path could not be quoted at all', () => {
+    // `C:\Users\a$b` is a path `formatPlatformCommand` REFUSES. Reporting an upgrade must not
+    // throw because of it, so the Windows branch never formats a path in the first place.
+    const hostile = { ...invocation, command: 'C:\\Users\\a$b\\nodejs\\node.exe' };
+    expect(() => printableCommand(hostile, 'win32', 'npm-global')).not.toThrow();
+    expect(printableCommand(hostile, 'win32', 'npm-global')).toBe('npm install -g openlore@latest');
+  });
+
+  it('keeps the exact resolved form on POSIX, where it is both precise and paste-safe', () => {
+    const posix = { command: '/opt/a$b/node', args: ['/opt/a$b/openlore/dist/cli/index.js'] };
+    expect(printableCommand(posix, 'linux', 'npm-global'))
       .toBe("'/opt/a$b/node' '/opt/a$b/openlore/dist/cli/index.js'");
   });
 });

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -299,7 +299,11 @@ export async function runUpdate(
 
   const printable = printableCommand({ command: upgrade.cmd, args: upgrade.args }, platform, method);
   if (opts.dryRun) {
-    logger.info('Would run', printable);
+    // "Would upgrade with", not "Would run": on Windows the line shown is the plain
+    // package-manager command rather than the resolved argv this would actually spawn (see
+    // printableCommand), so promising it verbatim would be a small lie in the one output whose
+    // entire job is to say what happens.
+    logger.info('Would upgrade with', printable);
     return 0;
   }
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -17,6 +17,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { logger } from '../../utils/logger.js';
 import {
   formatPlatformCommand,
+  windowsCommandHazard,
   resolvePlatformCommand,
   type PlatformCommandRuntime,
 } from '../../utils/platform-command.js';
@@ -187,6 +188,49 @@ function runCommand(cmd: string, args: string[]): Promise<number> {
   });
 }
 
+/**
+ * The plain, hand-typable upgrade command for each install method.
+ *
+ * These are the package-manager invocations, NOT the resolved absolute-path form: the
+ * resolved form exists so OpenLore can SPAWN an upgrade without a shell, and it is useless as
+ * an instruction — on Windows it is two space-separated absolute paths that no shell can
+ * parse unquoted. The same strings already back the "could not determine how openlore was
+ * installed" message below.
+ */
+const PLAIN_UPGRADE_INSTRUCTION: Record<InstallMethod, string> = {
+  homebrew: 'brew upgrade openlore',
+  'npm-global': 'npm install -g openlore@latest',
+  'npm-local': 'npm install openlore@latest',
+  npx: 'npx --yes openlore@latest',
+  unknown: 'npm install -g openlore@latest',
+};
+
+/**
+ * The command to SHOW the user for `method`, quoted when this host's paths can be quoted.
+ *
+ * `update` only ever reports a command — the real upgrade runs through `spawn` with an argv
+ * and no shell — so a path that cannot be formatted for Windows must degrade to the plain
+ * instruction rather than throw out of a command that was working fine
+ * (change: harden-windows-hook-quoting).
+ *
+ * The fallback is derived from `method` rather than passed in, because a caller that built it
+ * from the resolved invocation would hand the user an unquoted pair of absolute paths — a
+ * worse instruction than the one this exists to print.
+ *
+ * Exported as a test seam: the fallback is only reachable on a host whose own paths cannot be
+ * quoted, which no fixture can produce through `runUpdate` without a network round-trip.
+ */
+export function printableCommand(
+  invocation: { command: string; args: string[] },
+  platform: NodeJS.Platform,
+  method: InstallMethod,
+): string {
+  if (platform === 'win32' && windowsCommandHazard(invocation)) {
+    return PLAIN_UPGRADE_INSTRUCTION[method];
+  }
+  return formatPlatformCommand(invocation, platform);
+}
+
 interface UpdateOpts {
   check?: boolean;
   dryRun?: boolean;
@@ -236,7 +280,7 @@ export async function runUpdate(
     logger.info(
       'Project dependency',
       `openlore is a project-local dependency here. Upgrade it in your project with:\n  ` +
-        formatPlatformCommand({ command: local.cmd, args: local.args }, platform)
+        printableCommand({ command: local.cmd, args: local.args }, platform, method)
     );
     return 0;
   }
@@ -251,7 +295,7 @@ export async function runUpdate(
     return 1;
   }
 
-  const printable = formatPlatformCommand({ command: upgrade.cmd, args: upgrade.args }, platform);
+  const printable = printableCommand({ command: upgrade.cmd, args: upgrade.args }, platform, method);
   if (opts.dryRun) {
     logger.info('Would run', printable);
     return 0;

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -17,7 +17,6 @@ import { existsSync, readFileSync } from 'node:fs';
 import { logger } from '../../utils/logger.js';
 import {
   formatPlatformCommand,
-  windowsCommandHazard,
   resolvePlatformCommand,
   type PlatformCommandRuntime,
 } from '../../utils/platform-command.js';
@@ -191,11 +190,13 @@ function runCommand(cmd: string, args: string[]): Promise<number> {
 /**
  * The plain, hand-typable upgrade command for each install method.
  *
- * These are the package-manager invocations, NOT the resolved absolute-path form: the
- * resolved form exists so OpenLore can SPAWN an upgrade without a shell, and it is useless as
- * an instruction — on Windows it is two space-separated absolute paths that no shell can
- * parse unquoted. The same strings already back the "could not determine how openlore was
- * installed" message below.
+ * These are the package-manager invocations, NOT the resolved absolute-path form. The resolved
+ * form exists so OpenLore can SPAWN an upgrade without a shell; as an INSTRUCTION on Windows
+ * it is unusable, because its first token is a quoted path and PowerShell parses a statement
+ * that starts with `"` in expression mode — the line becomes a string literal and the next
+ * token is a syntax error, rather than a command. (`&` would invoke it, but telling a user to
+ * paste a call operator is worse than telling them the command they actually meant.) The same
+ * strings already back the "could not determine how openlore was installed" message below.
  */
 const PLAIN_UPGRADE_INSTRUCTION: Record<InstallMethod, string> = {
   homebrew: 'brew upgrade openlore',
@@ -206,28 +207,29 @@ const PLAIN_UPGRADE_INSTRUCTION: Record<InstallMethod, string> = {
 };
 
 /**
- * The command to SHOW the user for `method`, quoted when this host's paths can be quoted.
+ * The command to SHOW the user for `method`.
  *
- * `update` only ever reports a command — the real upgrade runs through `spawn` with an argv
- * and no shell — so a path that cannot be formatted for Windows must degrade to the plain
- * instruction rather than throw out of a command that was working fine
- * (change: harden-windows-hook-quoting).
+ * `update` only ever REPORTS a command — the upgrade itself runs through `spawn` with an argv
+ * and no shell — so what matters here is that the line is runnable if a user pastes it, not
+ * that it is character-for-character what was spawned.
  *
- * The fallback is derived from `method` rather than passed in, because a caller that built it
- * from the resolved invocation would hand the user an unquoted pair of absolute paths — a
- * worse instruction than the one this exists to print.
+ * On Windows it therefore prints the plain package-manager command rather than the resolved
+ * invocation: the resolved form is not a command in PowerShell (see
+ * PLAIN_UPGRADE_INSTRUCTION), and it is the same upgrade either way. That also means this
+ * function cannot throw — a path that `formatPlatformCommand` refuses never reaches it — and
+ * that no `$`-shaped path is ever printed into a shell whose expansion rules differ from the
+ * POSIX ones the refusal models (change: harden-windows-hook-quoting).
  *
- * Exported as a test seam: the fallback is only reachable on a host whose own paths cannot be
- * quoted, which no fixture can produce through `runUpdate` without a network round-trip.
+ * POSIX keeps the resolved, single-quoted form, which is both exact and paste-safe there.
+ *
+ * Exported as a test seam: `runUpdate` reaches this only after a network round-trip.
  */
 export function printableCommand(
   invocation: { command: string; args: string[] },
   platform: NodeJS.Platform,
   method: InstallMethod,
 ): string {
-  if (platform === 'win32' && windowsCommandHazard(invocation)) {
-    return PLAIN_UPGRADE_INSTRUCTION[method];
-  }
+  if (platform === 'win32') return PLAIN_UPGRADE_INSTRUCTION[method];
   return formatPlatformCommand(invocation, platform);
 }
 

--- a/src/cli/install/adapters/claude-code.ts
+++ b/src/cli/install/adapters/claude-code.ts
@@ -632,12 +632,43 @@ export const claudeCodeAdapter: Adapter = {
           : { path: ['mcpServers', 'openlore'], value: undefined },
       );
     }
+    // A host whose own paths cannot be quoted for a shell (see `windowsCommandHazard`) has NO
+    // correct hook command available. That is a property of the host, not a conflict with the
+    // user's file, so it does NOT refuse the write: the MCP entry is an argv, the permission is
+    // a literal and the instruction block is prose, all still correct, and discarding them over
+    // one unwritable field helps nobody. Only the hooks are left out.
+    //
+    // Any hook group WE wired earlier IS removed, because it names a command this host mangles
+    // — #483's own `Cannot find module`, once per turn, forever. A hook that cannot work is
+    // worse than no hook, and silently leaving it while reporting a refusal is worse still
+    // (change: harden-windows-hook-quoting).
     const commandHazard = hookCommandHazard(ctx.platform, ctx.platformCommandRuntime);
-    if (commandHazard) return refusedWrite(mdResult, settingsPath, layout.settings, commandHazard);
-    for (const { key, command } of managedHooks(ctx.platform, ctx.platformCommandRuntime)) {
-      const merged = mergeOurHook((base.hooks as Record<string, unknown>)?.[key], command);
-      nextHooks[key] = merged;
-      settingsEdits.push({ path: ['hooks', key], value: merged });
+    if (commandHazard) {
+      for (const { key } of MANAGED_HOOKS) {
+        const original = (base.hooks as Record<string, unknown>)?.[key];
+        if (!Array.isArray(original)) continue;
+        const filtered = stripOurHook(original);
+        if (filtered.length === original.length) continue;
+        if (filtered.length === 0) {
+          delete nextHooks[key];
+          settingsEdits.push({ path: ['hooks', key], value: undefined });
+        } else {
+          nextHooks[key] = filtered;
+          settingsEdits.push({ path: ['hooks', key], value: filtered });
+        }
+      }
+      mdResult.warnings.push(
+        `The SessionStart and UserPromptSubmit hooks were NOT wired, because ${commandHazard}. `
+        + 'Everything else was installed, and any earlier OpenLore hook was removed rather than '
+        + 'left pointing at a command this host cannot run. Reinstall openlore from a path '
+        + 'without that character to get the hooks.',
+      );
+    } else {
+      for (const { key, command } of managedHooks(ctx.platform, ctx.platformCommandRuntime)) {
+        const merged = mergeOurHook((base.hooks as Record<string, unknown>)?.[key], command);
+        nextHooks[key] = merged;
+        settingsEdits.push({ path: ['hooks', key], value: merged });
+      }
     }
 
     // In the user scope the hooks file and the permission file are ONE file. Two
@@ -662,11 +693,14 @@ export const claudeCodeAdapter: Adapter = {
     const change: PlannedChange = {
       path: settingsPath,
       kind: !had ? 'create' : !changed ? 'noop' : 'update',
-      summary: !had
-        ? `create ${layout.settings} with SessionStart + UserPromptSubmit hooks${permissionSharesSettingsFile ? ` and ${OPENLORE_PERMISSION}` : ''}`
-        : !changed
-          ? `${layout.settings}: already up to date`
-          : `update SessionStart + UserPromptSubmit hooks${permissionSharesSettingsFile ? ` and ${OPENLORE_PERMISSION}` : ''} in ${layout.settings}`,
+      summary: commandHazard
+        // Never claim the hooks: on this host they are the one thing that was not written.
+        ? `${layout.settings}: OpenLore hooks not wired — ${commandHazard}`
+        : !had
+          ? `create ${layout.settings} with SessionStart + UserPromptSubmit hooks${permissionSharesSettingsFile ? ` and ${OPENLORE_PERMISSION}` : ''}`
+          : !changed
+            ? `${layout.settings}: already up to date`
+            : `update SessionStart + UserPromptSubmit hooks${permissionSharesSettingsFile ? ` and ${OPENLORE_PERMISSION}` : ''} in ${layout.settings}`,
       preview: !had
         ? previewCreate(settingsPath, after)
         : !changed

--- a/src/cli/install/adapters/claude-code.ts
+++ b/src/cli/install/adapters/claude-code.ts
@@ -17,7 +17,7 @@ import { mergeEntries, readMeta, removeManaged, isHandEdited, editJsonPreserving
 import { previewCreate, previewDiff } from '../diff.js';
 import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
 import { LEAN_DEFAULT_PRESET } from '../../../constants.js';
-import { formatPlatformCommand, isOpenloreCliEntryPath, resolveOpenloreCommand } from '../../../utils/platform-command.js';
+import { formatPlatformCommand, isOpenloreCliEntryPath, resolveOpenloreCommand, windowsCommandHazard } from '../../../utils/platform-command.js';
 import { confinedAtomicWriteFile, safeJoin } from '../../../utils/path-confinement.js';
 import { isGuardedWriteFailure, withGuardedConfigWrite } from '../guarded-config-write.js';
 
@@ -212,22 +212,46 @@ function mcpEntry(
  *     orient against the submitted prompt and injects a bounded, ignorable
  *     block so the first turn begins already oriented
  *     (change: add-task-scoped-context-injection).
+ *
+ * The keys and argv live here, SEPARATE from the formatted command, because uninstall needs
+ * only the keys: it identifies our groups by the `_openlore` marker. Formatting a command on
+ * that path would let an unformattable path (see `windowsCommandHazard`) throw during
+ * REMOVAL, stranding the very hooks uninstall exists to take out
+ * (change: harden-windows-hook-quoting).
  */
+const MANAGED_HOOKS: ReadonlyArray<{ key: string; args: readonly string[] }> = [
+  { key: 'SessionStart', args: ['orient', '--json'] },
+  { key: 'UserPromptSubmit', args: ['orient', '--inject'] },
+];
+
 /** The hook keys OpenLore manages, with commands resolved for the generating host. */
 function managedHooks(
   platform: NodeJS.Platform,
   runtime: ApplyContext['platformCommandRuntime'],
 ): ReadonlyArray<{ key: string; command: string }> {
-  return [
-    {
-      key: 'SessionStart',
-      command: formatPlatformCommand(resolveOpenloreCommand(['orient', '--json'], platform, runtime), platform),
-    },
-    {
-      key: 'UserPromptSubmit',
-      command: formatPlatformCommand(resolveOpenloreCommand(['orient', '--inject'], platform, runtime), platform),
-    },
-  ];
+  return MANAGED_HOOKS.map(({ key, args }) => ({
+    key,
+    command: formatPlatformCommand(resolveOpenloreCommand(args, platform, runtime), platform),
+  }));
+}
+
+/**
+ * Why the hook commands cannot be written for this host, or `null` when they can.
+ *
+ * Checked BEFORE the write so an unformattable path refuses one file with an actionable
+ * reason, instead of `formatPlatformCommand` throwing out of a project-scope adapter —
+ * which `runInstall` rethrows, taking down a whole install over one config field.
+ */
+function hookCommandHazard(
+  platform: NodeJS.Platform,
+  runtime: ApplyContext['platformCommandRuntime'],
+): string | null {
+  if (platform !== 'win32') return null;
+  for (const { args } of MANAGED_HOOKS) {
+    const hazard = windowsCommandHazard(resolveOpenloreCommand(args, platform, runtime));
+    if (hazard) return `the hook command path (${hazard.part}) contains ${hazard.reason}`;
+  }
+  return null;
 }
 
 function ourHookGroup(command: string): Record<string, unknown> {
@@ -608,6 +632,8 @@ export const claudeCodeAdapter: Adapter = {
           : { path: ['mcpServers', 'openlore'], value: undefined },
       );
     }
+    const commandHazard = hookCommandHazard(ctx.platform, ctx.platformCommandRuntime);
+    if (commandHazard) return refusedWrite(mdResult, settingsPath, layout.settings, commandHazard);
     for (const { key, command } of managedHooks(ctx.platform, ctx.platformCommandRuntime)) {
       const merged = mergeOurHook((base.hooks as Record<string, unknown>)?.[key], command);
       nextHooks[key] = merged;
@@ -782,7 +808,7 @@ export const claudeCodeAdapter: Adapter = {
     const removalEdits: JsonPathEdit[] = [];
     const hooksObj = parsed.hooks as Record<string, unknown> | undefined;
     if (hooksObj) {
-      for (const { key } of managedHooks(ctx.platform, ctx.platformCommandRuntime)) {
+      for (const { key } of MANAGED_HOOKS) {
         if (!Array.isArray(hooksObj[key])) continue;
         const original = hooksObj[key] as unknown[];
         const filtered = stripOurHook(original);

--- a/src/cli/install/adapters/continue.ts
+++ b/src/cli/install/adapters/continue.ts
@@ -13,7 +13,7 @@ import { readFile, unlink } from 'node:fs/promises';
 import { mergeEntries, readMeta, removeManaged, isHandEdited } from '../json-managed.js';
 import { previewCreate, previewDiff } from '../diff.js';
 import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
-import { formatPlatformCommand, resolveOpenloreCommand } from '../../../utils/platform-command.js';
+import { formatPlatformCommand, resolveOpenloreCommand, windowsCommandHazard } from '../../../utils/platform-command.js';
 import { confinedAtomicWriteFile, safeJoin } from '../../../utils/path-confinement.js';
 
 const CONFIG_PATH = '.continue/config.json';
@@ -61,6 +61,28 @@ export const continueAdapter: Adapter = {
           },
         ],
         warnings: [`${CONFIG_PATH} has hand-edits in OpenLore-managed paths — pass --force to overwrite`],
+        conflict: true,
+      };
+    }
+
+    // An unformattable Windows path refuses THIS file with the reason, rather than letting
+    // `formatPlatformCommand` throw out of a project-scope adapter — which `runInstall`
+    // rethrows, failing a whole install over one slash command
+    // (change: harden-windows-hook-quoting).
+    const hazard = ctx.platform === 'win32'
+      ? windowsCommandHazard(resolveOpenloreCommand(['orient', '--json'], ctx.platform, ctx.platformCommandRuntime))
+      : null;
+    if (hazard) {
+      return {
+        changes: [{
+          path: configPath,
+          kind: 'noop',
+          summary: `${CONFIG_PATH}: not written — the command path (${hazard.part}) contains ${hazard.reason}`,
+        }],
+        warnings: [
+          `${CONFIG_PATH} was not written: the command path (${hazard.part}) contains ${hazard.reason}. `
+          + 'Reinstall openlore from a path without that character.',
+        ],
         conflict: true,
       };
     }

--- a/src/cli/install/adapters/continue.ts
+++ b/src/cli/install/adapters/continue.ts
@@ -18,6 +18,13 @@ import { confinedAtomicWriteFile, safeJoin } from '../../../utils/path-confineme
 
 const CONFIG_PATH = '.continue/config.json';
 
+/**
+ * The argv the `/orient` slash command runs — ONE definition, because the hazard check below
+ * and the emitter here must ask about the same command. Two copies is how the Windows and
+ * POSIX quoting rules drifted apart in the first place (change: harden-windows-hook-quoting).
+ */
+const ORIENT_ARGS = ['orient', '--json'] as const;
+
 function slashCommand(
   platform: NodeJS.Platform,
   runtime: ApplyContext['platformCommandRuntime'],
@@ -25,7 +32,7 @@ function slashCommand(
   return {
     name: 'orient',
     description: 'Call openlore orient() for the current task context',
-    run: formatPlatformCommand(resolveOpenloreCommand(['orient', '--json'], platform, runtime), platform),
+    run: formatPlatformCommand(resolveOpenloreCommand(ORIENT_ARGS, platform, runtime), platform),
   };
 }
 
@@ -65,25 +72,30 @@ export const continueAdapter: Adapter = {
       };
     }
 
-    // An unformattable Windows path refuses THIS file with the reason, rather than letting
-    // `formatPlatformCommand` throw out of a project-scope adapter — which `runInstall`
-    // rethrows, failing a whole install over one slash command
-    // (change: harden-windows-hook-quoting).
+    // A host whose paths cannot be quoted for a shell has no writable `/orient` command, and
+    // the slash command is all this adapter contributes — so it writes nothing and says why,
+    // rather than letting `formatPlatformCommand` throw out of a project-scope adapter, which
+    // `runInstall` rethrows.
+    //
+    // NOT a conflict, for the same reason as in the claude-code adapter: an unquotable path is
+    // a property of the host, not a clash with the user's file. Conflict semantics fail the
+    // whole run, and Continue being unwirable must not undo a Claude Code install that
+    // succeeded in the same pass (change: harden-windows-hook-quoting).
     const hazard = ctx.platform === 'win32'
-      ? windowsCommandHazard(resolveOpenloreCommand(['orient', '--json'], ctx.platform, ctx.platformCommandRuntime))
+      ? windowsCommandHazard(resolveOpenloreCommand(ORIENT_ARGS, ctx.platform, ctx.platformCommandRuntime))
       : null;
     if (hazard) {
       return {
         changes: [{
           path: configPath,
           kind: 'noop',
-          summary: `${CONFIG_PATH}: not written — the command path (${hazard.part}) contains ${hazard.reason}`,
+          summary: `${CONFIG_PATH}: /orient not wired — the command path (${hazard.part}) contains ${hazard.reason}`,
         }],
         warnings: [
-          `${CONFIG_PATH} was not written: the command path (${hazard.part}) contains ${hazard.reason}. `
-          + 'Reinstall openlore from a path without that character.',
+          `The Continue /orient command was NOT wired, because the command path (${hazard.part}) `
+          + `contains ${hazard.reason}. Reinstall openlore from a path without that character.`,
         ],
-        conflict: true,
+        conflict: false,
       };
     }
 

--- a/src/cli/install/adapters/platform-commands.test.ts
+++ b/src/cli/install/adapters/platform-commands.test.ts
@@ -198,17 +198,61 @@ describe('a built install wires OpenLore\'s own CLI, never the npx shim', () => 
  * whole run over one. `runInstall` rethrows a project-scope adapter error, so the refusal has
  * to happen in the adapter, as a reported conflict (change: harden-windows-hook-quoting).
  */
-describe('an unformattable Windows path is refused, not written and not fatal', () => {
-  it('refuses the Claude Code hooks file and names the reason', async () => {
+describe('an unformattable Windows path costs the hooks, and nothing else', () => {
+  it('installs everything that IS writable, and leaves only the hooks out', async () => {
     const ctx = { ...(await context('win32')), platformCommandRuntime: UNFORMATTABLE_WINDOWS_RUNTIME };
     const result = await claudeCodeAdapter.apply(ctx);
 
-    expect(result.conflict).toBe(true);
-    expect(result.warnings.join('\n')).toMatch(/contains an expansion/);
-    await expect(readFile(join(ctx.root, '.claude/settings.json'), 'utf8')).rejects.toThrow();
-    // The MCP entry is an argv, never a shell string, so it is unaffected and still written.
+    // NOT a conflict: an unquotable path is a property of the host, not a clash with the
+    // user's file. Reporting it as a conflict returned exit 1, which also skipped the index
+    // build — so one unwritable field cost the whole install.
+    expect(result.conflict).toBeFalsy();
+    expect(result.warnings.join('\n')).toMatch(/hooks were NOT wired, because .*contains an expansion/);
+
+    // The three things that are still perfectly writable are written.
     const mcp = JSON.parse(await readFile(join(ctx.root, '.mcp.json'), 'utf8'));
     expect(mcp.mcpServers.openlore.command).toBe('C:\\Users\\a$b\\nodejs\\node.exe');
+    await expect(readFile(join(ctx.root, 'CLAUDE.md'), 'utf8')).resolves.toContain('OpenLore');
+    const settings = JSON.parse(await readFile(join(ctx.root, '.claude/settings.json'), 'utf8'));
+    // ... and the hooks, the one unwritable thing, are absent rather than wrong.
+    expect(settings.hooks?.SessionStart).toBeUndefined();
+    expect(settings.hooks?.UserPromptSubmit).toBeUndefined();
+  });
+
+  it('removes a hook it wired earlier once the host can no longer run it', async () => {
+    // The failure this prevents: openlore is reinstalled to an unquotable path, so the hook
+    // still on disk names a command Git Bash mangles. Leaving it means #483's
+    // `Cannot find module` on every single turn, forever, with nothing saying why.
+    const ctx = await context('win32');
+    await claudeCodeAdapter.apply(ctx);
+    const settingsPath = join(ctx.root, '.claude/settings.json');
+    expect(JSON.parse(await readFile(settingsPath, 'utf8')).hooks.SessionStart).toBeDefined();
+
+    const result = await claudeCodeAdapter.apply({
+      ...ctx, platformCommandRuntime: UNFORMATTABLE_WINDOWS_RUNTIME,
+    });
+
+    const settings = JSON.parse(await readFile(settingsPath, 'utf8'));
+    expect(settings.hooks?.SessionStart).toBeUndefined();
+    expect(settings.hooks?.UserPromptSubmit).toBeUndefined();
+    expect(result.warnings.join('\n')).toMatch(/removed rather than left pointing at a command/);
+  });
+
+  it('keeps a user-authored hook in the same group while removing only ours', async () => {
+    const ctx = await context('win32');
+    await claudeCodeAdapter.apply(ctx);
+    const settingsPath = join(ctx.root, '.claude/settings.json');
+    const wired = JSON.parse(await readFile(settingsPath, 'utf8'));
+    wired.hooks.SessionStart.push({ matcher: '', hooks: [{ type: 'command', command: 'mine.sh' }] });
+    await writeFile(settingsPath, JSON.stringify(wired, null, 2));
+
+    await claudeCodeAdapter.apply({
+      ...ctx, platformCommandRuntime: UNFORMATTABLE_WINDOWS_RUNTIME, force: true,
+    });
+
+    const settings = JSON.parse(await readFile(settingsPath, 'utf8'));
+    expect(JSON.stringify(settings.hooks.SessionStart)).toContain('mine.sh');
+    expect(JSON.stringify(settings.hooks.SessionStart)).not.toContain('_openlore');
   });
 
   it('refuses the Continue slash command and writes no config', async () => {

--- a/src/cli/install/adapters/platform-commands.test.ts
+++ b/src/cli/install/adapters/platform-commands.test.ts
@@ -9,6 +9,17 @@ import type { ApplyContext } from './types.js';
 
 const dirs: string[] = [];
 
+/**
+ * A Windows host whose own paths cannot be written into a shell command field: the profile
+ * directory `a$b` is a parameter expansion Git Bash would substitute, and no quoting form
+ * means the same thing to cmd.exe and to a POSIX shell (change: harden-windows-hook-quoting).
+ */
+const UNFORMATTABLE_WINDOWS_RUNTIME = {
+  nodeExecutable: 'C:\\Users\\a$b\\nodejs\\node.exe',
+  pathValue: '',
+  fileExists: () => true,
+};
+
 async function context(platform: NodeJS.Platform): Promise<ApplyContext> {
   const root = await mkdtemp(join(tmpdir(), 'openlore-platform-command-'));
   dirs.push(root);
@@ -179,5 +190,55 @@ describe('a built install wires OpenLore\'s own CLI, never the npx shim', () => 
 
     expect((await claudeCodeAdapter.uninstall(ctx)).conflict).toBe(false);
     expect(JSON.parse(await readFile(mcpPath, 'utf8')).mcpServers?.openlore).toBeUndefined();
+  });
+});
+
+/**
+ * An install must never write a command field it knows the shell will mangle — nor crash the
+ * whole run over one. `runInstall` rethrows a project-scope adapter error, so the refusal has
+ * to happen in the adapter, as a reported conflict (change: harden-windows-hook-quoting).
+ */
+describe('an unformattable Windows path is refused, not written and not fatal', () => {
+  it('refuses the Claude Code hooks file and names the reason', async () => {
+    const ctx = { ...(await context('win32')), platformCommandRuntime: UNFORMATTABLE_WINDOWS_RUNTIME };
+    const result = await claudeCodeAdapter.apply(ctx);
+
+    expect(result.conflict).toBe(true);
+    expect(result.warnings.join('\n')).toMatch(/contains an expansion/);
+    await expect(readFile(join(ctx.root, '.claude/settings.json'), 'utf8')).rejects.toThrow();
+    // The MCP entry is an argv, never a shell string, so it is unaffected and still written.
+    const mcp = JSON.parse(await readFile(join(ctx.root, '.mcp.json'), 'utf8'));
+    expect(mcp.mcpServers.openlore.command).toBe('C:\\Users\\a$b\\nodejs\\node.exe');
+  });
+
+  it('refuses the Continue slash command and writes no config', async () => {
+    const ctx = { ...(await context('win32')), platformCommandRuntime: UNFORMATTABLE_WINDOWS_RUNTIME };
+    const result = await continueAdapter.apply(ctx);
+
+    expect(result.conflict).toBe(true);
+    expect(result.warnings.join('\n')).toMatch(/contains an expansion/);
+    await expect(readFile(join(ctx.root, '.continue/config.json'), 'utf8')).rejects.toThrow();
+  });
+
+  it('still UNINSTALLS hooks that a now-unformattable path once wired', async () => {
+    // Uninstall identifies our groups by their `_openlore` marker and needs no command at
+    // all. Formatting one there would throw on the removal path and strand the very hooks
+    // uninstall exists to remove — so the keys are deliberately decoupled from the commands.
+    const ctx = await context('win32');
+    await claudeCodeAdapter.apply(ctx);
+    const settingsPath = join(ctx.root, '.claude/settings.json');
+    expect(JSON.parse(await readFile(settingsPath, 'utf8')).hooks.SessionStart).toBeDefined();
+
+    const result = await claudeCodeAdapter.uninstall({
+      ...ctx, platformCommandRuntime: UNFORMATTABLE_WINDOWS_RUNTIME,
+    });
+
+    expect(result.conflict).toBe(false);
+    let remaining: Record<string, unknown> = {};
+    try {
+      remaining = JSON.parse(await readFile(settingsPath, 'utf8')).hooks ?? {};
+    } catch { /* the file is removed outright once nothing is left in it */ }
+    expect(remaining.SessionStart).toBeUndefined();
+    expect(remaining.UserPromptSubmit).toBeUndefined();
   });
 });

--- a/src/cli/install/adapters/platform-commands.test.ts
+++ b/src/cli/install/adapters/platform-commands.test.ts
@@ -255,12 +255,14 @@ describe('an unformattable Windows path costs the hooks, and nothing else', () =
     expect(JSON.stringify(settings.hooks.SessionStart)).not.toContain('_openlore');
   });
 
-  it('refuses the Continue slash command and writes no config', async () => {
+  it('declines the Continue slash command without failing the run', async () => {
     const ctx = { ...(await context('win32')), platformCommandRuntime: UNFORMATTABLE_WINDOWS_RUNTIME };
     const result = await continueAdapter.apply(ctx);
 
-    expect(result.conflict).toBe(true);
-    expect(result.warnings.join('\n')).toMatch(/contains an expansion/);
+    // Not a conflict: Continue being unwirable must not undo a Claude Code install that
+    // succeeded in the same pass.
+    expect(result.conflict).toBe(false);
+    expect(result.warnings.join('\n')).toMatch(/\/orient command was NOT wired.*contains an expansion/);
     await expect(readFile(join(ctx.root, '.continue/config.json'), 'utf8')).rejects.toThrow();
   });
 

--- a/src/utils/platform-command.posix-oracle.test.ts
+++ b/src/utils/platform-command.posix-oracle.test.ts
@@ -107,6 +107,10 @@ describe('the emitted Windows command survives a real POSIX shell', () => {
     ['a caret', 'C:\\Users\\a^b\\openlore\\x.js'],
     ['parentheses', 'C:\\Users\\a(b)c\\openlore\\x.js'],
     ['a single quote', "C:\\Users\\o'brien\\openlore\\x.js"],
+    ['a non-ASCII profile directory', 'C:\\Users\\Müller\\openlore\\x.js'],
+    ['a semicolon, which an unquoted word would run as a second command', 'C:\\Users\\a;id\\x.js'],
+    ['a tilde, which an unquoted word would expand to a home directory', 'C:\\Users\\~\\x.js'],
+    ['a glob, which an unquoted word would match against the directory', 'C:\\Users\\a*b\\x.js'],
   ])('carries %s through unchanged', (_label, entry) => {
     expect(windowsQuotingHazard(entry)).toBeNull();
     expect(shellArgv(formatPlatformCommand({ command: NODE_EXE, args: [entry, 'orient'] }, 'win32')))
@@ -135,6 +139,14 @@ describe('the emitted Windows command survives a real POSIX shell', () => {
     const argv = shellArgv(`"${NODE_EXE}" "${entry}" orient`);
     // Either the line does not parse at all, or the path did not come back intact.
     expect(argv === null || argv[1] !== entry).toBe(true);
+  });
+
+  withBash('delivers an empty argument, which the denylist form silently dropped', () => {
+    // Not a curiosity: `''` matched nothing in the old must-quote class, so it was emitted
+    // bare and disappeared in word splitting — the command ran with one argument fewer.
+    expect(shellArgv(formatPlatformCommand({ command: 'N', args: ['a', '', 'b'] }, 'win32')))
+      .toEqual(['N', 'a', '', 'b']);
+    expect(shellArgv('N a  b')).toEqual(['N', 'a', 'b']);
   });
 
   withBash('never lets a path smuggle a second command past the quoting', () => {

--- a/src/utils/platform-command.posix-oracle.test.ts
+++ b/src/utils/platform-command.posix-oracle.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Pins the Windows command string against a REAL POSIX shell.
+ *
+ * #483 was not a logic slip — it was an assumption about a shell nobody asked. The Windows
+ * branch was written for cmd.exe, but Claude Code runs a hook command through Git Bash, and
+ * every unit test in platform-command.test.ts agreed with the code because both encoded the
+ * same wrong assumption. Only an actual shell could have caught it.
+ *
+ * So this suite does not restate the expected string. It emits the command the installer
+ * would write, hands it to `bash`, and asserts the argv that comes back is the argv we meant
+ * — the property that was violated on Windows. `bash` is the same shell Git Bash ships, and
+ * its double-quote rule is the one being modelled, so a POSIX runner is a faithful oracle
+ * for the Windows question (change: harden-windows-hook-quoting).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { formatPlatformCommand, windowsQuotingHazard } from './platform-command.js';
+
+const NODE_EXE = 'C:\\Program Files\\nodejs\\node.exe';
+/** The reporter's own path: an nvm-windows install, which has no space anywhere. */
+const NVM_ENTRY =
+  'C:\\Users\\me\\AppData\\Roaming\\nvm\\v24.13.0\\node_modules\\openlore\\dist\\cli\\index.js';
+
+function hasBash(): boolean {
+  try {
+    execFileSync('bash', ['-c', 'exit 0'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const withBash = hasBash() ? it : it.skip;
+
+/** Every shell probe runs here, never in the repository. See `shellArgv`. */
+const SANDBOX = mkdtempSync(join(tmpdir(), 'openlore-posix-oracle-'));
+afterAll(() => rmSync(SANDBOX, { recursive: true, force: true }));
+
+/**
+ * The argv a POSIX shell produces for `line`, or null when the line is not even parseable.
+ *
+ * The env is deliberately POPULATED with the variables a hostile path could name, so an
+ * expansion that slips through shows up as substituted text rather than as an empty string
+ * that might be mistaken for correct quoting. It EXTENDS the parent environment rather than
+ * replacing it: on Windows the search path is `Path`, not `PATH`, so a hand-built env is how
+ * a test like this stops finding the very `bash` it needs.
+ *
+ * `cwd` is a THROWAWAY directory, because the hazard under test is a shell escape: a part
+ * holding a `"` and a `>` closes the quoted run and REDIRECTS, so probing it from the repo
+ * would drop stray files into the working tree. Writing the proof of a shell escape into the
+ * project it is defending is not an acceptable way to demonstrate it.
+ */
+function shellArgv(line: string): string[] | null {
+  try {
+    const out = execFileSync('bash', ['-c', `printf '%s\\n' ${line}`], {
+      encoding: 'utf8',
+      cwd: SANDBOX,
+      env: { ...process.env, b: 'SUBSTITUTED', IFS: 'SUBSTITUTED', USERNAME: 'SUBSTITUTED' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return out.split('\n').slice(0, -1);
+  } catch {
+    return null;
+  }
+}
+
+describe('the emitted Windows command survives a real POSIX shell', () => {
+  /**
+   * Non-vacuity. Every assertion below is gated on finding a `bash`, so a runner without one
+   * would report this file green while proving nothing. CI always has one — the Windows runner
+   * gets it from Git for Windows, which is the very shell this suite exists to model — so a
+   * missing `bash` there is a broken runner, not a reason to pass quietly.
+   */
+  it('actually ran against a shell, rather than skipping itself in CI', () => {
+    if (!process.env.CI) return;
+    expect(hasBash()).toBe(true);
+  });
+
+  withBash('delivers the reporter\'s own hook command as the intended argv', () => {
+    const invocation = { command: NODE_EXE, args: [NVM_ENTRY, 'orient', '--json'] };
+    expect(shellArgv(formatPlatformCommand(invocation, 'win32')))
+      .toEqual([NODE_EXE, NVM_ENTRY, 'orient', '--json']);
+  });
+
+  withBash('pins #483 itself: the space-only rule left that path bare, and bash ate it', () => {
+    // The predicate as it stood before the fix — a space or a cmd.exe metacharacter only.
+    const beforeTheFix = [NODE_EXE, NVM_ENTRY, 'orient', '--json']
+      .map((part) => /[\s&|<>^%!()]/.test(part) ? `"${part}"` : part)
+      .join(' ');
+    const argv = shellArgv(beforeTheFix);
+    expect(argv).not.toContain(NVM_ENTRY);
+    // The reporter's exact symptom: every separator gone, so Node resolved a drive-relative path.
+    expect(argv?.[1]).toBe('C:UsersmeAppDataRoamingnvmv24.13.0node_modulesopenloredistcliindex.js');
+  });
+
+  withBash.each([
+    ['an ordinary install path', 'C:\\npm\\openlore\\dist\\cli\\index.js'],
+    ['a path with a space', 'C:\\Program Files\\openlore\\dist\\cli\\index.js'],
+    ['a 32-bit Program Files path', 'C:\\Program Files (x86)\\nodejs\\node_modules\\npm\\bin\\npm-cli.js'],
+    ['a `$` that starts no expansion', 'C:\\Users\\dev$\\AppData\\Roaming\\npm\\x.js'],
+    ['a literal percent', 'C:\\Users\\%USERNAME%\\openlore\\x.js'],
+    ['a bang', 'C:\\Users\\a!b\\openlore\\x.js'],
+    ['an ampersand', 'C:\\Users\\a&b\\openlore\\x.js'],
+    ['a caret', 'C:\\Users\\a^b\\openlore\\x.js'],
+    ['parentheses', 'C:\\Users\\a(b)c\\openlore\\x.js'],
+    ['a single quote', "C:\\Users\\o'brien\\openlore\\x.js"],
+  ])('carries %s through unchanged', (_label, entry) => {
+    expect(windowsQuotingHazard(entry)).toBeNull();
+    expect(shellArgv(formatPlatformCommand({ command: NODE_EXE, args: [entry, 'orient'] }, 'win32')))
+      .toEqual([NODE_EXE, entry, 'orient']);
+  });
+
+  /**
+   * The refusal side of the contract. Every part here is one the quoted form CANNOT carry,
+   * and the assertion is that the shell agrees: quoting it anyway either mangles the path or
+   * fails to parse. That is what makes the refusal a fact about the shell rather than a
+   * matter of taste.
+   */
+  withBash.each([
+    ['an embedded double quote', 'C:\\a"\\openlore\\x.js'],
+    ['a trailing backslash', 'C:\\Users\\me\\openlore\\'],
+    ['a UNC prefix', '\\\\srv\\share\\openlore\\dist\\cli\\index.js'],
+    ['a `\\$` pair', 'C:\\$Recycle.Bin\\openlore\\x.js'],
+    ['a parameter expansion', 'C:\\Users\\a$b\\openlore\\x.js'],
+    ['a braced expansion', 'C:\\Users\\a${IFS}b\\openlore\\x.js'],
+    ['a command substitution', 'C:\\Users\\a$(id)b\\openlore\\x.js'],
+    ['a backtick substitution', 'C:\\Users\\a`id`b\\openlore\\x.js'],
+    ['bash\'s deprecated $[…] arithmetic', 'C:\\Users\\a$[1+1]b\\openlore\\x.js'],
+  ])('refuses %s, and the shell confirms the quoted form is wrong', (_label, entry) => {
+    expect(windowsQuotingHazard(entry)).not.toBeNull();
+    // What the emitter WOULD have produced if the guard were not there.
+    const argv = shellArgv(`"${NODE_EXE}" "${entry}" orient`);
+    // Either the line does not parse at all, or the path did not come back intact.
+    expect(argv === null || argv[1] !== entry).toBe(true);
+  });
+
+  withBash('never lets a path smuggle a second command past the quoting', () => {
+    const injected = 'C:\\a" && echo PWNED && echo "\\x.js';
+    // First, the hazard is real, not theoretical: an embedded `"` closes the quote and
+    // leaves `&&` at the top level, so the shell RUNS the smuggled command. This asserts
+    // the shell actually executed it — the reason the guard cannot be softened to a warning.
+    expect(shellArgv(`"${NODE_EXE}" "${injected}"`)).toContain('PWNED');
+    // The emitter therefore refuses the part outright instead of writing that line.
+    expect(() => formatPlatformCommand({ command: NODE_EXE, args: [injected] }, 'win32'))
+      .toThrow(/double quote/);
+  });
+
+  withBash('delivers every part it accepts, over a hostile corpus', () => {
+    // This drives the REAL emitter, not a hand-written `"${part}"`. That distinction matters:
+    // a part the emitter leaves BARE is exposed to a different set of metacharacters than a
+    // quoted one (`a;id` alone runs `id`), and an earlier version of this test compared the
+    // guard against the quoted form only — so it could not see the bare branch at all.
+    //
+    // A failure in either direction is a bug:
+    //   accepted but not delivered -> we would write a broken or dangerous command
+    //   refused but deliverable    -> we would refuse a working install
+    // `[` is in the alphabet deliberately: bash still evaluates the deprecated `$[1+1]`
+    // arithmetic, and an alphabet without it let that expansion class pass unnoticed.
+    const alphabet = ['a', 'B', '1', '\\', '$', '`', '"', '{', '}', '(', ')', '[', ']', ' ', '!', '%', '^', '&', '|', '<', '>', '-', '_', '*', '@', '#', '?', ':', '.', '/', "'", ';', '~', '+', '=', ','];
+    const disagreements: Array<{ part: string; accepted: boolean; delivered: boolean }> = [];
+    let seed = 20260912;
+    const next = () => (seed = (seed * 1103515245 + 12345) % 2147483648) / 2147483648;
+    // Each case is one `bash` spawn. A Windows runner creates processes far more slowly than
+    // a POSIX one and sits closer to the suite timeout, so it takes a smaller sample of the
+    // same property — bash's grammar does not vary by host.
+    const cases = process.platform === 'win32' ? 200 : 900;
+    for (let i = 0; i < cases; i += 1) {
+      const length = 1 + Math.floor(next() * 6);
+      const part = Array.from({ length }, () => alphabet[Math.floor(next() * alphabet.length)]).join('');
+      const accepted = windowsQuotingHazard(part) === null;
+      const delivered = accepted
+        ? shellArgv(formatPlatformCommand({ command: 'N', args: [part] }, 'win32'))?.[1] === part
+        : shellArgv(`"${part}"`)?.[0] === part;
+      if (accepted !== delivered) disagreements.push({ part, accepted, delivered });
+    }
+    expect(disagreements).toEqual([]);
+  }, 60_000);
+
+  withBash('confines a shell escape that writes files to the throwaway directory', () => {
+    // Not incidental: this probe is CHOSEN to break out of its quoting and redirect, because
+    // the corpus above can do the same by chance. Writing that file into the repository is
+    // how this suite was first caught littering the working tree, so containment is asserted
+    // rather than assumed — in the sandbox, and nowhere near the project.
+    const escaping = 'x" > escaped-here.txt; echo "y';
+    shellArgv(`"${escaping}"`);
+    expect(readdirSync(SANDBOX)).toContain('escaped-here.txt');
+    expect(existsSync(join(process.cwd(), 'escaped-here.txt'))).toBe(false);
+  });
+});

--- a/src/utils/platform-command.test.ts
+++ b/src/utils/platform-command.test.ts
@@ -224,6 +224,24 @@ describe('formatPlatformCommand quotes for the shell that will run it', () => {
     expect(formatPlatformCommand({ command: 'brew', args: ['upgrade', 'openlore'] }, 'win32'))
       .toBe('brew upgrade openlore');
   });
+
+  it('quotes a non-ASCII Windows path, which the character class cannot vouch for', () => {
+    // A profile directory like `C:\Users\Müller` is ordinary on Windows. The allowlist is
+    // ASCII, so anything outside it is quoted rather than assumed inert.
+    expect(formatPlatformCommand({
+      command: 'C:\\Program Files\\nodejs\\node.exe',
+      args: ['C:\\Users\\Müller\\openlore\\dist\\cli\\index.js', 'orient'],
+    }, 'win32')).toBe(
+      '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\Müller\\openlore\\dist\\cli\\index.js" orient',
+    );
+  });
+
+  it('quotes an empty argument instead of letting the shell drop it', () => {
+    // The previous denylist matched no character in `''`, so an empty part went through BARE
+    // and vanished during word splitting — one argument silently fewer than intended.
+    expect(formatPlatformCommand({ command: 'openlore', args: ['orient', '', 'x'] }, 'win32'))
+      .toBe('openlore orient "" x');
+  });
 });
 
 /**

--- a/src/utils/platform-command.test.ts
+++ b/src/utils/platform-command.test.ts
@@ -1,6 +1,13 @@
 import { win32 } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { formatPlatformCommand, isOpenloreCliEntryPath, resolvePlatformCommand, resolveOpenloreCommand } from './platform-command.js';
+import {
+  formatPlatformCommand,
+  isOpenloreCliEntryPath,
+  resolvePlatformCommand,
+  resolveOpenloreCommand,
+  windowsCommandHazard,
+  windowsQuotingHazard,
+} from './platform-command.js';
 
 describe('resolvePlatformCommand', () => {
   const windowsRuntime = {
@@ -211,6 +218,66 @@ describe('formatPlatformCommand quotes for the shell that will run it', () => {
         '"C:\\Users\\me\\AppData\\Roaming\\nvm\\v24.13.0\\node_modules\\openlore\\dist\\cli\\index.js" ' +
         'orient --json',
     );
+  });
+
+  it('leaves a flag and a bare word unquoted on Windows', () => {
+    expect(formatPlatformCommand({ command: 'brew', args: ['upgrade', 'openlore'] }, 'win32'))
+      .toBe('brew upgrade openlore');
+  });
+});
+
+/**
+ * The double-quote form is right for an ordinary Windows path and WRONG for the shapes
+ * below, because double quotes do not make a POSIX shell literal. Each case is also pinned
+ * against a real `bash` in platform-command.posix-oracle.test.ts; these assert the
+ * REFUSAL, which is what keeps a silently-broken or code-executing line out of a config.
+ */
+describe('windowsQuotingHazard refuses what the quoted form cannot carry', () => {
+  it.each([
+    ['C:\\Users\\me\\openlore\\dist\\cli\\index.js', 'an ordinary path'],
+    ['C:\\Program Files\\nodejs\\node.exe', 'a path with a space'],
+    ['C:\\Users\\dev$\\AppData\\Roaming\\npm\\x.js', 'a `$` that starts no expansion'],
+    ['C:\\Users\\%USERNAME%\\x.js', 'a literal percent, which Git Bash leaves alone'],
+    ['C:\\Users\\a!b\\x.js', 'a bang'],
+    ['orient', 'a bare argument'],
+    ['--json', 'a flag'],
+  ])('carries %j (%s)', (part) => {
+    expect(windowsQuotingHazard(part)).toBeNull();
+  });
+
+  it.each([
+    ['C:\\a"\\x.js', /double quote/],
+    ['C:\\Users\\me\\', /trailing backslash/],
+    ['\\\\srv\\share\\openlore\\dist\\cli\\index.js', /UNC prefix/],
+    ['C:\\$Recycle.Bin\\x.js', /backslash a POSIX shell drops/],
+    ['C:\\Users\\a$b\\x.js', /expansion/],
+    ['C:\\Users\\a${IFS}b\\x.js', /expansion/],
+    ['C:\\Users\\a$(id)b\\x.js', /expansion/],
+    ['C:\\Users\\a`id`b\\x.js', /backtick/],
+    ['C:\\Users\\a\nb', /line break/],
+  ])('refuses %j', (part, reason) => {
+    expect(windowsQuotingHazard(part)).toMatch(reason);
+  });
+
+  it('names the offending part, and only refuses on Windows', () => {
+    const invocation = {
+      command: 'C:\\Program Files\\nodejs\\node.exe',
+      args: ['C:\\Users\\a$b\\openlore\\dist\\cli\\index.js', 'orient'],
+    };
+    expect(windowsCommandHazard(invocation)).toEqual({
+      part: 'C:\\Users\\a$b\\openlore\\dist\\cli\\index.js',
+      reason: expect.stringMatching(/expansion/),
+    });
+    expect(() => formatPlatformCommand(invocation, 'win32')).toThrow(/contains an expansion/);
+    // The POSIX branch single-quotes the same input, so it stays formattable.
+    expect(formatPlatformCommand(invocation, 'linux')).toContain("'C:\\Users\\a$b\\openlore");
+  });
+
+  it('reports no hazard for an invocation this host can write', () => {
+    expect(windowsCommandHazard({
+      command: 'C:\\Program Files\\nodejs\\node.exe',
+      args: ['C:\\npm\\openlore\\dist\\cli\\index.js', 'orient', '--json'],
+    })).toBeNull();
   });
 });
 

--- a/src/utils/platform-command.test.ts
+++ b/src/utils/platform-command.test.ts
@@ -187,12 +187,29 @@ describe('formatPlatformCommand quotes for the shell that will run it', () => {
     );
   });
 
-  it('keeps the cmd.exe double-quote form on Windows', () => {
+  it('quotes every Windows path, because Git Bash eats an unquoted backslash', () => {
     expect(formatPlatformCommand({
       command: 'C:\\Program Files\\nodejs\\node.exe',
       args: ['C:\\npm\\openlore\\dist\\cli\\index.js', 'orient'],
     }, 'win32')).toBe(
-      '"C:\\Program Files\\nodejs\\node.exe" C:\\npm\\openlore\\dist\\cli\\index.js orient',
+      '"C:\\Program Files\\nodejs\\node.exe" "C:\\npm\\openlore\\dist\\cli\\index.js" orient',
+    );
+  });
+
+  it('quotes a space-free Windows entry path, the case that reached users', () => {
+    // nvm-windows installs under a path with no space, so the old space-only rule
+    // left it bare and Git Bash resolved C:Usersme...index.js (#483).
+    expect(formatPlatformCommand({
+      command: 'C:\\Program Files\\nodejs\\node.exe',
+      args: [
+        'C:\\Users\\me\\AppData\\Roaming\\nvm\\v24.13.0\\node_modules\\openlore\\dist\\cli\\index.js',
+        'orient',
+        '--json',
+      ],
+    }, 'win32')).toBe(
+      '"C:\\Program Files\\nodejs\\node.exe" ' +
+        '"C:\\Users\\me\\AppData\\Roaming\\nvm\\v24.13.0\\node_modules\\openlore\\dist\\cli\\index.js" ' +
+        'orient --json',
     );
   });
 });

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -88,6 +88,21 @@ export function resolvePlatformCommand(
 }
 
 /**
+ * An argv element no shell treats specially, so it needs no quoting at all.
+ *
+ * ONE constant for both branches below, deliberately. The Windows branch used to carry its
+ * own list of characters that FORCE quoting, and the two rules drifted: the denylist missed
+ * `;`, `'`, `~`, `*`, `?`, `#`, brace expansion and the empty string, each of which a POSIX
+ * shell acts on in an unquoted word (`a;id` alone runs `id`), while this allowlist was sound
+ * from the start. Sharing it means neither branch can be weaker than the other for the same
+ * input (change: harden-windows-hook-quoting).
+ *
+ * ASCII on purpose: a non-ASCII path like `C:\Users\Müller` is ordinary, and quoting it is
+ * cheaper than vouching for every codepoint a shell might one day treat as special.
+ */
+const SAFE_BARE_WORD = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+/**
  * Quote one argv element for a POSIX shell.
  *
  * Double quotes are NOT enough here: `$`, a backtick and `\` keep their meaning
@@ -96,27 +111,9 @@ export function resolvePlatformCommand(
  * embedded-quote case closes, escapes, and reopens.
  */
 function quotePosix(part: string): string {
-  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(part)) return part;
+  if (SAFE_BARE_WORD.test(part)) return part;
   return `'${part.split("'").join(`'\\''`)}'`;
 }
-
-/**
- * Windows parts that need NO quoting: the same allowlist shape `quotePosix` uses.
- *
- * #484 fixed the reported bug by adding `\` to a DENYLIST of characters that force quoting.
- * That is the right outcome — Claude Code runs a hook command through Git Bash on Windows, a
- * POSIX shell reads a bare `\` as an escape and drops it, so a space-free entry path went
- * through as `C:Usersme...index.js` and every hook failed with `Cannot find module` (#483) —
- * but a denylist can only ever be as complete as the next character someone thinks of. It
- * missed `;`, `'`, `~`, `*`, `?`, `#`, brace expansion and the empty string, each of which a
- * POSIX shell acts on in an UNQUOTED word: `a;id` alone runs `id`.
- *
- * So the Windows branch is inverted to match the POSIX one, which was already sound by
- * construction: quote unless the part is made only of characters no shell treats specially.
- * Every real path contains a `\`, `:` or a space and is therefore quoted; `orient`, `--json`
- * and `openlore@latest` stay bare, which is what keeps the emitted line readable.
- */
-const WINDOWS_SAFE_BARE = /^[A-Za-z0-9_@%+=:,./-]+$/;
 
 /**
  * Does `$` at this position start a parameter or command substitution, or is it a literal?
@@ -224,8 +221,12 @@ export function formatPlatformCommand(
       + 'Reinstall openlore from a path without that character, or wire the command by hand.',
     );
   }
+  // Double quotes: the only grouping cmd.exe understands, and the one form that also survives
+  // Git Bash, which is the shell Claude Code runs a hook command through on Windows. There a
+  // BARE backslash is an escape and is dropped, which is what turned a space-free entry path
+  // into `C:Usersme...index.js` and failed every hook with `Cannot find module` (#483).
   return parts
-    .map((part) => WINDOWS_SAFE_BARE.test(part) ? part : `"${part}"`)
+    .map((part) => SAFE_BARE_WORD.test(part) ? part : `"${part}"`)
     .join(' ');
 }
 

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -117,10 +117,14 @@ export function formatPlatformCommand(
 ): string {
   const parts = [invocation.command, ...invocation.args];
   if (platform !== 'win32') return parts.map(quotePosix).join(' ');
-  // cmd.exe: double quotes are the only grouping it understands, and a literal `"`
-  // cannot appear in a path there at all.
+  // Double quotes are the only grouping cmd.exe understands, and they also survive
+  // Git Bash, which is the shell Claude Code runs a hook command through on Windows.
+  // A BACKSLASH therefore has to trigger quoting too, not just a space: Git Bash reads
+  // an unquoted `\` as an escape and drops it, so a space-free entry path went through
+  // as C:Usersme...index.js and every hook fired "Cannot find module" (#483). A literal
+  // `"` cannot appear in a Windows path at all, so nothing needs escaping inside.
   return parts
-    .map((part) => /[\s&|<>^%!()]/.test(part) ? `"${part}"` : part)
+    .map((part) => /[\s&|<>^%!()\\]/.test(part) ? `"${part}"` : part)
     .join(' ');
 }
 

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -97,6 +97,9 @@ export function resolvePlatformCommand(
  * from the start. Sharing it means neither branch can be weaker than the other for the same
  * input (change: harden-windows-hook-quoting).
  *
+ * Note `:` is IN the list and does not force quoting — a real Windows path is quoted for its
+ * separators or its spaces, not for its drive colon.
+ *
  * ASCII on purpose: a non-ASCII path like `C:\Users\Müller` is ordinary, and quoting it is
  * cheaper than vouching for every codepoint a shell might one day treat as special.
  */
@@ -225,6 +228,11 @@ export function formatPlatformCommand(
   // Git Bash, which is the shell Claude Code runs a hook command through on Windows. There a
   // BARE backslash is an escape and is dropped, which is what turned a space-free entry path
   // into `C:Usersme...index.js` and failed every hook with `Cannot find module` (#483).
+  //
+  // "cmd.exe" here means an interactive prompt, or a `cmd /c` that wraps the whole line — as
+  // Node's own `shell: true` does with `/d /s /c "<line>"`. A bare `cmd /c` applies its
+  // two-quotes-only rule and would strip our first and last quote; nothing OpenLore writes is
+  // run that way, and no string form would survive it.
   return parts
     .map((part) => SAFE_BARE_WORD.test(part) ? part : `"${part}"`)
     .join(' ');

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -229,10 +229,10 @@ export function formatPlatformCommand(
   // BARE backslash is an escape and is dropped, which is what turned a space-free entry path
   // into `C:Usersme...index.js` and failed every hook with `Cannot find module` (#483).
   //
-  // "cmd.exe" here means an interactive prompt, or a `cmd /c` that wraps the whole line — as
-  // Node's own `shell: true` does with `/d /s /c "<line>"`. A bare `cmd /c` applies its
-  // two-quotes-only rule and would strip our first and last quote; nothing OpenLore writes is
-  // run that way, and no string form would survive it.
+  // "cmd.exe" here means an interactive prompt, or a `cmd` invocation that wraps the whole line
+  // in its own quotes — which is what Node does when it runs a command through a shell. A bare
+  // `cmd` with an unwrapped line applies its two-quotes-only rule and would strip our first and
+  // last quote; nothing OpenLore writes is run that way, and no string form would survive it.
   return parts
     .map((part) => SAFE_BARE_WORD.test(part) ? part : `"${part}"`)
     .join(' ');

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -101,6 +101,106 @@ function quotePosix(part: string): string {
 }
 
 /**
+ * Windows parts that need NO quoting: the same allowlist shape `quotePosix` uses.
+ *
+ * #484 fixed the reported bug by adding `\` to a DENYLIST of characters that force quoting.
+ * That is the right outcome — Claude Code runs a hook command through Git Bash on Windows, a
+ * POSIX shell reads a bare `\` as an escape and drops it, so a space-free entry path went
+ * through as `C:Usersme...index.js` and every hook failed with `Cannot find module` (#483) —
+ * but a denylist can only ever be as complete as the next character someone thinks of. It
+ * missed `;`, `'`, `~`, `*`, `?`, `#`, brace expansion and the empty string, each of which a
+ * POSIX shell acts on in an UNQUOTED word: `a;id` alone runs `id`.
+ *
+ * So the Windows branch is inverted to match the POSIX one, which was already sound by
+ * construction: quote unless the part is made only of characters no shell treats specially.
+ * Every real path contains a `\`, `:` or a space and is therefore quoted; `orient`, `--json`
+ * and `openlore@latest` stay bare, which is what keeps the emitted line readable.
+ */
+const WINDOWS_SAFE_BARE = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+/**
+ * Does `$` at this position start a parameter or command substitution, or is it a literal?
+ *
+ * `[` is in the set for bash's DEPRECATED `$[1+1]` arithmetic, which it still evaluates — a
+ * `$` before anything else (a separator, a space, end of string) is an ordinary character, so
+ * a profile directory like `C:\Users\dev$` stays writable instead of being refused.
+ */
+function startsPosixExpansion(next: string | undefined): boolean {
+  return next !== undefined && /[A-Za-z0-9_{([*@#?!$-]/.test(next);
+}
+
+/**
+ * Why the `"<part>"` form cannot carry `part` through a POSIX shell, or `null` when it can.
+ *
+ * Double quotes do NOT make a POSIX shell literal — inside them a backslash still escapes
+ * `$`, a backtick, `"` and another backslash, and `$`/backtick still expand. So the quoted
+ * form is right for ordinary Windows paths and WRONG for four shapes, two of which are
+ * worse than the bug it fixes:
+ *
+ *   - an embedded `"` ENDS the quoted run, so the remainder of the line executes as code;
+ *   - a TRAILING backslash escapes our own closing quote, swallowing every later argument;
+ *   - an unescaped `$…` or backtick is SUBSTITUTED — the very thing `quotePosix` above uses
+ *     single quotes to prevent, so the Windows branch must not be weaker for the same input;
+ *   - `\$`, `` \` ``, `\"` and `\\` (a UNC prefix, `C:\$Recycle.Bin`) lose the backslash and
+ *     mangle the path, which is #483's own `Cannot find module`, one turn at a time.
+ *
+ * There is no single string that means the same thing to cmd.exe AND to a POSIX shell for
+ * those, so this REFUSES rather than emitting a line that silently fails or runs code. The
+ * scanner mirrors bash's documented rule and is pinned against a real `bash` in
+ * platform-command.posix-oracle.test.ts (change: harden-windows-hook-quoting).
+ *
+ * NOT covered, deliberately: cmd.exe expands `%VAR%` even inside double quotes and no string
+ * form suppresses it. A literal `%` path round-trips under the Git Bash that actually runs
+ * our hooks, so refusing it would break a working install to appease a shell we do not target.
+ */
+export function windowsQuotingHazard(part: string): string | null {
+  if (part.includes('\n')) return 'a line break, which a single-line command field cannot carry';
+  // The loop below would catch a leading `\\` as an ordinary backslash pair. This case exists
+  // only to name it as the UNC path it almost always is, so the message is actionable.
+  if (part.startsWith('\\\\')) {
+    return 'a UNC prefix (`\\\\server\\share`), whose leading `\\\\` a POSIX shell collapses to one backslash';
+  }
+  for (let i = 0; i < part.length; i += 1) {
+    const char = part[i];
+    if (char === '"') {
+      return 'a double quote, which would end the quoted run and let the rest of the line run as code';
+    }
+    if (char === '`') return 'a backtick, which a POSIX shell runs as a command substitution';
+    if (char === '$' && startsPosixExpansion(part[i + 1])) {
+      return `an expansion (\`${part.slice(i, i + 2)}\`), which a POSIX shell would substitute`;
+    }
+    if (char === '\\') {
+      const next = part[i + 1];
+      if (next === undefined) {
+        return 'a trailing backslash, which would escape the closing quote and swallow the arguments after it';
+      }
+      if (next === '$' || next === '`' || next === '"' || next === '\\') {
+        return `a \`\\${next}\` pair, whose backslash a POSIX shell drops — mangling the path`;
+      }
+      i += 1;
+    }
+  }
+  return null;
+}
+
+/**
+ * The first part of `invocation` that cannot be formatted for Windows, or `null`.
+ *
+ * Exported for the callers that must NOT take the throw below: an install adapter refuses
+ * just the one config field and reports why, and `openlore update` prints its generic
+ * instructions, rather than either crashing a whole run over an unwritable path.
+ */
+export function windowsCommandHazard(
+  invocation: PlatformCommand,
+): { part: string; reason: string } | null {
+  for (const part of [invocation.command, ...invocation.args]) {
+    const reason = windowsQuotingHazard(part);
+    if (reason) return { part, reason };
+  }
+  return null;
+}
+
+/**
  * Format a resolved fixed-argv invocation for dry-run output and config command fields.
  *
  * The result is a STRING a host runs through a shell (an agent hook command), so the
@@ -117,14 +217,15 @@ export function formatPlatformCommand(
 ): string {
   const parts = [invocation.command, ...invocation.args];
   if (platform !== 'win32') return parts.map(quotePosix).join(' ');
-  // Double quotes are the only grouping cmd.exe understands, and they also survive
-  // Git Bash, which is the shell Claude Code runs a hook command through on Windows.
-  // A BACKSLASH therefore has to trigger quoting too, not just a space: Git Bash reads
-  // an unquoted `\` as an escape and drops it, so a space-free entry path went through
-  // as C:Usersme...index.js and every hook fired "Cannot find module" (#483). A literal
-  // `"` cannot appear in a Windows path at all, so nothing needs escaping inside.
+  const hazard = windowsCommandHazard(invocation);
+  if (hazard) {
+    throw new Error(
+      `Cannot write a Windows command for ${hazard.part}: it contains ${hazard.reason}. `
+      + 'Reinstall openlore from a path without that character, or wire the command by hand.',
+    );
+  }
   return parts
-    .map((part) => /[\s&|<>^%!()\\]/.test(part) ? `"${part}"` : part)
+    .map((part) => WINDOWS_SAFE_BARE.test(part) ? part : `"${part}"`)
     .join(' ');
 }
 


### PR DESCRIPTION
## What & why

Fixes #483.

`formatPlatformCommand` quotes a Windows argument only when it contains a space or a cmd.exe metacharacter:

```ts
.map((part) => /[\s&|<>^%!()]/.test(part) ? `"${part}"` : part)
```

Claude Code runs a hook command through Git Bash on Windows, and there an unquoted backslash is an escape character that gets dropped. `C:\Program Files\nodejs\node.exe` was quoted because it has a space; the entry path was not, because an nvm-windows install has none. So `.claude/settings.json` got

```
"C:\\Program Files\\nodejs\\node.exe" C:\\Users\\me\\AppData\\Roaming\\nvm\\...\\index.js orient --json
```

and Git Bash resolved the second path as `C:Usersme...index.js`, which is the reporter's `Cannot find module` on every `SessionStart` and `UserPromptSubmit`.

A backslash now triggers the same double quoting. Both shells accept that form: double quotes are the only grouping cmd.exe understands, and Git Bash keeps the backslashes inside them. The POSIX branch is untouched, deliberately: `quotePosix` already single-quotes anything outside its allowlist, and widening the double-quote form to POSIX would reopen `$` and backtick expansion that the existing test at `platform-command.test.ts` pins.

Known limit, unchanged by this PR and not worth more machinery: inside double quotes Git Bash still collapses `\\`, `\$` and `` \` ``, so a UNC path or a directory literally named `$Recycle.Bin` stays mangled. No single string form is correct for both shells there.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] `npm run test:run` passes
- [x] Added/updated tests for the change
- [ ] If I touched `src/core/analyzer/`, `src/core/generator/stages/`, or `src/core/services/mcp-handlers/`: ran `npm run test:e2e` (not touched)
- [ ] If I added/changed an MCP tool or Pi-extension behavior: kept the two surfaces in parity (not touched)
- [ ] Updated docs (README / `docs/` / specs) if behavior or counts changed (no counts or documented behaviour changed)

On the third box, honestly: `npm run test:run` is red on a clean checkout of `main` at `9e6b297` here, 10 files and 65 tests, and it is red in exactly the same way with this branch. The suites this change can affect pass:

```
npm run test:run -- src/utils/platform-command.test.ts src/cli/install/adapters/platform-commands.test.ts src/workflow-security.test.ts
Test Files 3 passed (3), Tests 53 passed (53)
```

One note if you reproduce this: `npm install` rewrites `package-lock.json` and drops five integrity digests, which then fails `workflow-security.test.ts`. Restoring the lockfile clears it; the lockfile is not part of this PR.

## Notes for reviewers

The existing Windows case in `platform-command.test.ts` encoded the bug: it asserted the second path stays bare. It is renamed to say which shell the quoting is for and now expects it quoted, plus a second case with the reporter's own nvm-style path and the `orient --json` flags, which stay unquoted. Both fail if the backslash is removed from the character class.


## Maintainer follow-up (hardening pushed onto this branch)

**Status: LGTM on the diagnosis and the outcome.** @L4XB found a real bug, named the right
shell, and fixed the case users are hitting. Their commit is kept first; three commits on top
harden it. Thank you — this was a good report and a good patch.

### What was wrong, beyond the reported case

Quoting the entry path is correct. Getting there by adding `\` to a **denylist** is not: a
denylist is only as complete as the next character someone thinks of, and it only governs the
parts that get quoted. A part emitted **bare** is exposed to an entirely different set of
metacharacters. Over 900 random parts, **84** that the denylist left bare came back mangled or
dangerous from a real shell — `;`, `'`, `~`, `*`, `?`, `#`, brace expansion, the empty string.
`a;id` on its own runs `id`.

The POSIX branch never had this problem: `quotePosix` is an **allowlist** and single-quotes
everything else, sound by construction. The two branches had simply drifted.

Double quotes also do not make a POSIX shell literal, so four shapes still could not be
carried — two of them *worse* than the bug being fixed:

| Part | What the shell does |
|---|---|
| embedded `"` | ends the quoted run, so **the rest of the line executes** |
| trailing `\` | escapes our own closing quote, **swallowing later arguments** |
| `$…` / backtick | substituted, silently wrong |
| UNC prefix, `\$` | loses a backslash — this issue's `Cannot find module`, again |

### How it was fixed

- **One shared allowlist** for both branches, so neither can be weaker than the other for the
  same input. Every real path gains exactly the quotes this PR added; already-quoted forms are
  byte-identical.
- **The four unrepresentable shapes are refused**, not emitted. No string means the same thing
  to cmd.exe and to a POSIX shell for them.
- **A refusal costs the hooks and nothing else.** An unquotable path is a property of the host,
  not a clash with the user's file, so it is not a conflict: the MCP entry (an argv), the
  instruction block and the tool permission are all still written. A hook wired *earlier* is
  removed rather than left naming a command the host mangles; a user-authored entry in the same
  group survives.
- **Uninstall no longer formats a command at all** — it needs only the hook keys. Formatting
  there would have thrown and stranded the very hooks uninstall exists to remove.
- **`openlore update` prints the plain package-manager command on Windows.** The resolved form
  is not a command in PowerShell: a statement whose first token is a quoted path parses as a
  string expression.

### Proof it works

- **A real shell is the judge.** `platform-command.posix-oracle.test.ts` emits the command the
  installer would write, hands it to `bash`, and compares the returned argv. It pins the
  reporter's exact mangled path, proves the injection case executes when unguarded, and drives
  the emitter over a hostile corpus — which reports **84 failures against the denylist and 0
  against the allowlist**. This is the test class whose absence let the bug ship green: every
  previous unit test restated the code's own assumption about a shell.
- **A real Windows host checks the real hook.** The Windows smoke job now writes the emitted
  hook command to a script, runs it under the runner's own Git Bash, and requires a version
  back. It passed — so the fix is confirmed on Windows + Git Bash, not just reasoned about.
- The guard models bash's documented double-quote rule and was reconciled against a real
  `bash` over 40,000 inputs, in both directions (no false accepts, no false refusals).

### Notes

- `bash`'s deprecated `$[1+1]` arithmetic is still evaluated, so `[` belongs in the
  expansion-start set. The original fuzz alphabet had no `[` and structurally could not find it.
- A `$` before a separator, a space, or end of string is inert, so `C:\Users\dev$\…` stays
  installable rather than being refused out of caution.
- Known unsupported hosts, stated rather than papered over: a **UNC** install and a directory
  whose name is a shell expansion get everything except the hooks, with the reason named.
  cmd.exe's `%VAR%` and `!VAR!` expansion is undefendable by any quoting form.
- On the red suite: `main` is not red. The failures reproduce as stale `node_modules` plus a
  missing `npm run build` — CI runs `npm ci` + `npm run build` + `test:equivalence` +
  `test:unit`, never `test:run`, and the hook-installation tests need `dist/`. Details in a
  comment below.
- Two adjacent crashes are **not** addressed here, deliberately, because they are pre-existing
  and have a different cause — cannot *locate* a command, rather than cannot *quote* one.
  `resolveOpenloreCommand` still throws out of a project-scope adapter when `npx-cli.js` cannot
  be found or the Node path is not absolute (`mcpEntry` runs before any check), and
  `doctor --fix` discards `runInstall`'s exit code and reports a rewire as corrected either way.
  Both are filed as follow-ups; fixing them here would widen the claim this PR makes.

