### PR TITLE
fix(analyzer): unpin web-tree-sitter by replacing the stale grammar binaries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,12 @@ updates:
           - 'tree-sitter'
           - 'tree-sitter-*'
           - 'web-tree-sitter'
+          # Scoped grammar packages: a bare `tree-sitter-*` glob does not match a name
+          # that starts with `@scope/`, so each scope is listed. `@repomix/…` carries the
+          # Dart WASM binaries and `@tree-sitter-grammars/…` the native Lua grammar —
+          # both belong in this PR, not in routine drift (issue #472).
+          - '@repomix/tree-sitter-wasms'
+          - '@tree-sitter-grammars/*'
           - '@lancedb/lancedb'
       # The Pi host packages, in their own PR — same reasoning as parser-stack, a
       # different cause. Every `@earendil-works/pi-*` release so far ships an

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -100,15 +100,25 @@ losing templates and namespaces.
 ### Graceful grammar degradation
 
 If a native grammar is unavailable or ABI-incompatible, OpenLore warns once, keeps the file in
-keyword search, and skips graph extraction for that language without aborting analysis. Lua and
-Dart are the only two languages served by portable WASM grammars rather than the native lane, each
-in an isolated WASM module; if that backend is unavailable, they degrade in the same way.
+keyword search, and skips graph extraction for that language without aborting analysis. Dart is the
+only language served by a portable WASM grammar rather than the native lane, in an isolated WASM
+module; if that backend is unavailable, it degrades in the same way.
 
-Keeping those two on WASM is a deliberate hold rather than an absence of alternatives. Native Dart
-and Lua grammars now exist and were evaluated (issue #472); adopting them would remove the WASM lane
-entirely and unpin `web-tree-sitter`, but the only fitting native Dart package is a single-maintainer
-fork with negligible download volume, so the swap was declined on supply-chain grounds. The pin is
-enforced by a guard test, so a silent capability regression cannot slip through.
+Dart stays on WASM as a deliberate hold rather than for lack of an alternative. A native Dart
+grammar does exist and parses byte-identically (issue #472), but the only fitting package is a
+single-maintainer fork with negligible download volume, so the swap was declined on supply-chain
+grounds — the WASM binaries in use come from a build with SLSA provenance instead. Revisit if a
+well-supported native build appears.
+
+Lua used to share that lane and no longer does: it moved to the maintained
+`@tree-sitter-grammars/tree-sitter-lua` grammar on the native lane, which ships prebuilt bindings
+for every supported platform. That migration is what lifted the `web-tree-sitter` pin — the old
+`tree-sitter-wasms` binaries were rejected by every loader from 0.26 onward, with an empty-message
+throw that silently removed both languages from the call graph — and it hands Lua two capabilities
+the WASM lane cannot offer: trustworthy parse-health and an enforceable parse budget. Dart's
+binaries moved to the `@repomix/tree-sitter-wasms` rebuild, whose parse trees are byte-identical to
+the old ones. Both halves of the remaining lane are pinned exactly, and a guard test fails if
+either is loosened to a range, so loader and binaries can never drift apart unreviewed.
 
 ### Out of scope
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^8.7.1",
+        "@repomix/tree-sitter-wasms": "0.1.17",
         "chalk": "^6.0.0",
         "chokidar": "^5.0.0",
         "commander": "^15.0.0",
@@ -19,8 +20,7 @@
         "jsonc-parser": "^3.3.1",
         "minimatch": "^10.2.6",
         "ora": "^9.4.1",
-        "tree-sitter-wasms": "0.1.13",
-        "web-tree-sitter": "0.25.10",
+        "web-tree-sitter": "0.27.0",
         "yaml": "^2.6.1"
       },
       "bin": {
@@ -51,6 +51,7 @@
         "@huggingface/transformers": "^4.2.0",
         "@lancedb/lancedb": "0.38.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@tree-sitter-grammars/tree-sitter-lua": "^0.4.1",
         "@vitejs/plugin-react": "^6.1.1",
         "apache-arrow": "^21.1.0",
         "protobufjs": "^8.8.0",
@@ -1194,7 +1195,6 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/chord": {
       "version": "0.85.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.1.tgz",
-      "integrity": "sha512-VDlkEC3dhCzQ5fcyH1OhG19dq+6jCn+rqc/iXFivwDYGR5anwo2RCiXij9PpHhqNR5GuhhE+Er69Zi1Sn4eY6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1202,12 +1202,12 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-VDlkEC3dhCzQ5fcyH1OhG19dq+6jCn+rqc/iXFivwDYGR5anwo2RCiXij9PpHhqNR5GuhhE+Er69Zi1Sn4eY6w=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
       "version": "0.85.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
-      "integrity": "sha512-hIXIP3eAWueAYiAl8aMvWCvvZ8Q5gT3Dip5bE5uJyIGh4+YlWRjtMLI4BaeoXoSs93zndjue61u1B/vhefLnuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1221,12 +1221,12 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-hIXIP3eAWueAYiAl8aMvWCvvZ8Q5gT3Dip5bE5uJyIGh4+YlWRjtMLI4BaeoXoSs93zndjue61u1B/vhefLnuA=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
       "version": "0.85.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
-      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1246,22 +1246,22 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
       "version": "0.85.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
-      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
       "version": "0.85.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.85.1.tgz",
-      "integrity": "sha512-OIzw9efInmO4WOBnD4TxcTdBjmzvYJpzslkgoUro946nEGoYWg5rwv1p4fDt3/JvMx9QybryUCUwlm7j8Dreig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1270,7 +1270,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-OIzw9efInmO4WOBnD4TxcTdBjmzvYJpzslkgoUro946nEGoYWg5rwv1p4fDt3/JvMx9QybryUCUwlm7j8Dreig=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
@@ -6024,6 +6025,12 @@
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@repomix/tree-sitter-wasms": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@repomix/tree-sitter-wasms/-/tree-sitter-wasms-0.1.17.tgz",
+      "integrity": "sha512-tc3HnFqdMF1pXhIMzG3aTaBDpIiHK2tPfn3fwqA6P3WTbHa+1EuuTubbKshvmN7xCHP5Ojz0/VW4R+XvR88KOw==",
+      "license": "Unlicense"
+    },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
@@ -6423,6 +6430,26 @@
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tree-sitter-grammars/tree-sitter-lua": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-lua/-/tree-sitter-lua-0.4.1.tgz",
+      "integrity": "sha512-EwagFaU6ZveVk18/Y8qUhZkkiBKnQ7dSCHbm//TUroLVKy3i1rOYGy/cNHtSkAb1eDvS1HhCLybH2S541Cya/g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -11360,15 +11387,6 @@
         }
       }
     },
-    "node_modules/tree-sitter-wasms": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
-      "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
-      "license": "Unlicense",
-      "dependencies": {
-        "tree-sitter-wasms": "^0.1.11"
-      }
-    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -11728,18 +11746,10 @@
       }
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
-      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/emscripten": "^1.40.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/emscripten": {
-          "optional": true
-        }
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.27.0.tgz",
+      "integrity": "sha512-XK08gj6RwTMQatAG7uVRP8MunqotL/XC19vHgkSPKmELgbGPBj4ECvB8haHOUnyj6ls2B8t42UTro14zxGgAHg==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.7.1",
+    "@repomix/tree-sitter-wasms": "0.1.17",
     "chalk": "^6.0.0",
     "chokidar": "^5.0.0",
     "commander": "^15.0.0",
@@ -189,14 +190,14 @@
     "jsonc-parser": "^3.3.1",
     "minimatch": "^10.2.6",
     "ora": "^9.4.1",
-    "tree-sitter-wasms": "0.1.13",
-    "web-tree-sitter": "0.25.10",
+    "web-tree-sitter": "0.27.0",
     "yaml": "^2.6.1"
   },
   "optionalDependencies": {
     "@huggingface/transformers": "^4.2.0",
     "@lancedb/lancedb": "0.38.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@tree-sitter-grammars/tree-sitter-lua": "^0.4.1",
     "@vitejs/plugin-react": "^6.1.1",
     "apache-arrow": "^21.1.0",
     "protobufjs": "^8.8.0",

--- a/scripts/api-consumer-smoke.mjs
+++ b/scripts/api-consumer-smoke.mjs
@@ -100,7 +100,7 @@ if (typeof readServeDescriptor !== 'function') { console.error('subpath did not 
 `);
   runNode(root, [probe], { cwd: fixture, trace });
   const loaded = readFileSync(trace, 'utf8');
-  const forbidden = ['core/analyzer', 'web-tree-sitter', 'tree-sitter-wasms', 'lancedb', 'api/index.js'];
+  const forbidden = ['core/analyzer', 'web-tree-sitter', '@repomix/tree-sitter-wasms', 'lancedb', 'api/index.js'];
   const leaked = forbidden.filter((needle) => loaded.includes(needle));
   if (leaked.length > 0) fail('openlore/serve-descriptor loaded modules it must not', leaked.join(', '));
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -790,7 +790,7 @@ export const PAGERANK_MAX_ITERATIONS = 100;
 /**
  * Hard ceiling on extraction worker threads, regardless of core count. Each worker
  * holds its own tree-sitter parsers and grammar handles (native `.node` bindings
- * plus, for Lua/Dart, an isolated web-tree-sitter WASM heap), so pool size is
+ * plus, for Dart, an isolated web-tree-sitter WASM heap), so pool size is
  * bounded by memory, not just cores. Beyond this the marginal parse throughput no
  * longer pays for the resident grammar set.
  */

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -2659,9 +2659,9 @@ async function loadGrammarSoft(
 }
 
 /**
- * WASM grammar loader via web-tree-sitter (ABI-agnostic, portable). The only
- * two callers are Dart and Lua; every other language takes the native lane.
- * Soft-fails. See the Dart block below for why this lane is still here.
+ * WASM grammar loader via web-tree-sitter (ABI-agnostic, portable). Dart is the only
+ * caller; every other language takes the native lane. Soft-fails. See the Dart block
+ * below for why this lane is still here.
  */
 async function loadWasmGrammarSoft(
   language: string,
@@ -3039,27 +3039,48 @@ const SCALA_SPEC: QueryLangSpec = {
   `,
 };
 
-// ── Lua (via bundled WASM — see the Dart block for why this lane stays) ────
+// ── Lua ─────────────────────────────────────────────────────────────────────
+//
+// Native lane, like every other language here. Lua used to load the portable
+// `tree-sitter-wasms` build through web-tree-sitter; it moved to the maintained
+// `@tree-sitter-grammars/tree-sitter-lua` grammar, whose prebuilt bindings ship for
+// every supported platform (issue #472). That change is what made web-tree-sitter
+// upgradable again, and it hands Lua the two capabilities the WASM lane cannot
+// offer: trustworthy parse-health and an enforceable parse budget.
+//
+// The grammar lineage changed with the transport — the WASM build carried the
+// unmaintained Azganoth grammar, which named these nodes
+// `(local_)function_definition_statement` / `call` and wrapped every dotted name in
+// a `variable`. The maintained grammar spells the same constructs
+// `function_declaration` / `function_call` over `dot_index_expression` /
+// `method_index_expression`, with local-ness carried as a parent field rather than a
+// distinct node type. The queries below are that rename, one for one, and extraction
+// is unchanged: the (function, className) and call-name sets came out identical on
+// both Lua fixtures and a 62-line stress file covering goto, varargs, metatables,
+// `t.f`/`t:m`, and nested closures. The conformance sweeps hold that line in CI —
+// including the cross-file and parse-health assertions Lua could not carry on the
+// WASM lane.
 const LUA_SPEC: QueryLangSpec = {
   language: 'Lua',
-  loader: () => loadWasmGrammarSoft('Lua', 'tree-sitter-wasms/out/tree-sitter-lua.wasm'),
+  loader: () => loadGrammarSoft('Lua', () => import('@tree-sitter-grammars/tree-sitter-lua'), m => m.default),
   classTypes: new Set(),
   // `function t.f()` / `function t:m()` record the table name in className.
   extraClassName: (fnNode) => {
-    const nameVar = fnNode.childForFieldName('name');
-    if (nameVar?.type === 'variable') return nameVar.childForFieldName('table')?.text;
+    const nameNode = fnNode.childForFieldName('name');
+    if (nameNode?.type === 'dot_index_expression' || nameNode?.type === 'method_index_expression') {
+      return nameNode.childForFieldName('table')?.text;
+    }
     return undefined;
   },
   fnQuery: `
-    (local_function_definition_statement name: (identifier) @fn.name) @fn.node
-    (function_definition_statement name: (identifier) @fn.name) @fn.node
-    (function_definition_statement name: (variable field: (identifier) @fn.name)) @fn.node
-    (function_definition_statement name: (variable method: (identifier) @fn.name)) @fn.node
+    (function_declaration name: (identifier) @fn.name) @fn.node
+    (function_declaration name: (dot_index_expression field: (identifier) @fn.name)) @fn.node
+    (function_declaration name: (method_index_expression method: (identifier) @fn.name)) @fn.node
   `,
   callQuery: `
-    (call function: (variable name: (identifier) @call.name)) @call.node
-    (call function: (variable field: (identifier) @call.name)) @call.node
-    (call function: (variable method: (identifier) @call.name)) @call.node
+    (function_call name: (identifier) @call.name) @call.node
+    (function_call name: (dot_index_expression field: (identifier) @call.name)) @call.node
+    (function_call name: (method_index_expression method: (identifier) @call.name)) @call.node
   `,
 };
 
@@ -3105,20 +3126,26 @@ const RECOVERED_RECEIVER_LANGUAGES: ReadonlySet<string> = new Set(['Kotlin', 'C#
 
 // ── Dart (via portable WASM + web-tree-sitter) ───────────────────────────────
 //
-// Dart loads the portable `tree-sitter-wasms` WASM through web-tree-sitter
+// Dart loads a portable `@repomix/tree-sitter-wasms` build through web-tree-sitter
 // (ABI-agnostic, pure JS/WASM, builds on every platform) — each WASM grammar in
 // its own module instance (see loadWasmGrammarSoft).
 //
-// This is a deliberate hold, not an absence. Native grammars for Dart and Lua
-// DO now exist and were evaluated (issue #472): the native Dart grammar parses
-// byte-identically to this one, and migrating both would delete this lane, drop
-// `web-tree-sitter` + `tree-sitter-wasms` from dependencies, and unpin
-// web-tree-sitter 0.26+. It was declined on supply-chain grounds — the only
-// fitting native Dart package is a single-maintainer fork with negligible
-// download volume. Revisit if a well-supported build appears. Dart's grammar places the
-// `function_body` as a SIBLING of `function_signature` (not a child), so a
-// generic query extractor would attribute no calls — hence a custom walk that
-// spans signature+body.
+// Dart is the lane's only remaining caller, and staying on it is a deliberate hold.
+// Native Dart grammars do exist and were evaluated (issue #472): one parses
+// byte-identically to this build, and taking it would delete the lane outright and
+// drop `web-tree-sitter` too. It was declined on supply-chain grounds — the only
+// fitting native Dart package is a single-maintainer fork with negligible download
+// volume, whereas the WASM binaries here come from a build with SLSA provenance.
+// Revisit if a well-supported native build appears.
+//
+// The binaries moved from `tree-sitter-wasms` to the `@repomix` rebuild because the
+// former published nothing that the web-tree-sitter 0.26+ loader accepts, which held
+// the loader pinned at 0.25.x. The rebuild's parse trees are byte-identical (verified
+// across the fixtures plus a 697-node Dart file), so the walk below did not change.
+//
+// Dart's grammar places the `function_body` as a SIBLING of `function_signature`
+// (not a child), so a generic query extractor would attribute no calls — hence a
+// custom walk that spans signature+body.
 
 const DART_CLASS_TYPES = new Set(['class_definition', 'mixin_declaration', 'extension_declaration', 'enum_declaration']);
 
@@ -3126,7 +3153,7 @@ async function extractDartGraph(
   filePath: string,
   content: string,
 ): Promise<FileExtractResult> {
-  const handle = await loadWasmGrammarSoft('Dart', 'tree-sitter-wasms/out/tree-sitter-dart.wasm');
+  const handle = await loadWasmGrammarSoft('Dart', '@repomix/tree-sitter-wasms/out/tree-sitter-dart.wasm');
   if (!handle) return { nodes: [], rawEdges: [] };
 
   return handle.withTree(content, (root) => {

--- a/src/core/analyzer/language-capability-conformance.test.ts
+++ b/src/core/analyzer/language-capability-conformance.test.ts
@@ -100,43 +100,52 @@ describe('language conformance — grammar availability (diagnostic, runs first)
     ).toEqual([]);
   });
 
-  // Dart and Lua are the only two languages that reach the WASM lane: `tree-sitter-wasms`
-  // binaries loaded through `web-tree-sitter`. Those two packages are versioned
-  // independently and are NOT freely upgradable together.
+  // Dart is the only language that reaches the WASM lane: a `@repomix/tree-sitter-wasms`
+  // binary loaded through `web-tree-sitter`. Those are two independently versioned packages,
+  // and a loader only parses binaries built for it — which is the trap this guard exists for.
   //
-  // Measured 2026-09-05: `web-tree-sitter` 0.25.10 loads them; 0.26.0 and every version
-  // after it reject them outright. The binaries in `tree-sitter-wasms@0.1.13` — the
-  // newest published build, with no successor — carry an emscripten dylink section the
-  // 0.26+ loader refuses. It throws an Error with an EMPTY message, so the only symptom
-  // is Dart and Lua quietly dropping out of the capability matrix while it still claims
-  // them. That is exactly the over-claim this file exists to prevent, and it cost a day
-  // to trace, so the constraint is asserted here rather than left as a comment.
+  // History (issue #472). The lane used to carry Dart AND Lua on `tree-sitter-wasms@0.1.13`,
+  // whose binaries every `web-tree-sitter` >= 0.26 rejects: they carry an emscripten dylink
+  // section the rewritten loader refuses, and it throws an Error with an EMPTY message. The only
+  // symptom was Dart and Lua quietly dropping out of the call graph while the capability matrix
+  // still claimed them — the exact over-claim this file exists to prevent. `tree-sitter-wasms`
+  // has published nothing since, so web-tree-sitter sat pinned at 0.25.x for months.
   //
-  // Note the fault is in these BINARIES, not in the 0.26+ loader: measured 2026-09-07,
-  // web-tree-sitter 0.27.0 loads other grammars' WASM (e.g. the maintained Lua and Dart
-  // grammar packages' own builds) without complaint. So there are two ways out, not one:
-  //   1. `tree-sitter-wasms` publishes binaries built for the new loader, or
-  //   2. Dart and Lua move off this lane entirely — native grammars for both now exist
-  //      (issue #472), which would delete the lane and drop both packages. Evaluated and
-  //      declined on supply-chain grounds, not for lack of a working option.
-  // Lift this pin when either lands, and re-run this suite to confirm Dart and Lua load.
-  it('keeps web-tree-sitter on a version whose loader accepts the pinned tree-sitter-wasms binaries', () => {
+  // The pin lifted by replacing the stale BINARIES, not by waiting: Dart now loads the
+  // `@repomix/tree-sitter-wasms` rebuild (byte-identical parse trees, so the extractor is
+  // untouched), and Lua left the lane for the maintained native grammar. See
+  // `docs/language-support.md`.
+  //
+  // What still has to hold: BOTH halves of the lane are pinned EXACTLY, so neither the loader nor
+  // the binaries can drift alone on a lockfile refresh or a caret. A bump of either is a reviewed
+  // PR whose CI runs the availability assertion above, which is what actually proves the pair
+  // still fits — a version ceiling only encoded one known-bad boundary.
+  it('pins both halves of the WASM lane exactly, so loader and binaries cannot drift apart', () => {
     const pkg = createRequire(import.meta.url)('../../../package.json') as {
       dependencies: Record<string, string>;
     };
-    const wts = pkg.dependencies['web-tree-sitter'];
-    const wasms = pkg.dependencies['tree-sitter-wasms'];
-    const [major, minor] = wts.replace(/^\D+/, '').split('.').map(Number);
+    const lane = {
+      'web-tree-sitter': pkg.dependencies['web-tree-sitter'],
+      '@repomix/tree-sitter-wasms': pkg.dependencies['@repomix/tree-sitter-wasms'],
+    };
 
-    expect(
-      major === 0 && minor <= 25,
-      `web-tree-sitter is pinned at ${wts} with tree-sitter-wasms at ${wasms}. Every `
-      + `web-tree-sitter >= 0.26 rejects the tree-sitter-wasms 0.1.13 binaries (empty-message `
-      + `throw from its dylink parser), which silently removes Dart and Lua from the call `
-      + `graph while the capability matrix still claims them. Upgrade only alongside a `
-      + `tree-sitter-wasms release built for the new loader, and re-run this suite to confirm `
-      + `Dart and Lua still load.`,
-    ).toBe(true);
+    for (const [name, spec] of Object.entries(lane)) {
+      expect(
+        spec,
+        `${name} must be declared in dependencies — it is half of the WASM grammar lane that `
+        + `serves Dart.`,
+      ).toBeDefined();
+      expect(
+        /^\d+\.\d+\.\d+$/.test(spec ?? ''),
+        `${name} is declared as "${spec}", which is a RANGE. Both halves of the WASM lane — the `
+        + `web-tree-sitter loader and the @repomix/tree-sitter-wasms binaries it loads — must be `
+        + `pinned exactly. A loader only parses binaries built for it: web-tree-sitter 0.26 `
+        + `rewrote its loader and rejects binaries built for the old one with an EMPTY-message `
+        + `throw, which silently removes Dart from the call graph while the capability matrix `
+        + `still claims it (issue #472). Bump the two together in a reviewed PR and let the `
+        + `grammar-availability assertion above prove the pair still loads.`,
+      ).toBe(true);
+    }
   });
 });
 
@@ -419,9 +428,10 @@ describe('language conformance — cross-service HTTP', () => {
 // clean code, this fails here (on the fixture) instead of quietly in a user's repo
 // (change: add-parse-health-boundary-disclosure).
 //
-// NOTE: the WASM-loaded grammars (Lua, Dart) are structurally EXCLUDED from parse-health (their
-// shared WASM Language heap yields spurious ERROR nodes on parses after the first), so they always
-// produce no record here — this canary guards the 16 native-loader languages, not those two.
+// NOTE: Dart is structurally EXCLUDED from parse-health (it is the one WASM-loaded grammar, and
+// its shared WASM Language heap yields spurious ERROR nodes on parses after the first), so it
+// always produces no record here — this canary guards the 17 native-loader languages, not Dart.
+// Lua counts as one of the 17: it moved to the native lane with the maintained grammar (#472).
 describe('grammar-drift canary — every claimed callGraph language parses its fixture cleanly', () => {
   for (const f of BASIC) {
     it(`${f.language}: fixture parses with zero ERROR/MISSING nodes`, async () => {
@@ -444,12 +454,14 @@ describe('grammar-drift canary — every claimed callGraph language parses its f
 // resolver guess):
 //  - Bash: a bare command call (`helper`) is lexically indistinguishable from an external command
 //    across files, so the extractor deliberately does not bind it cross-file. Asserted explicitly below.
-//  - Lua, Dart: WASM-loaded grammars whose shared WASM Language heap yields spurious ERROR nodes on
-//    parses AFTER the first in a process (the same limitation the grammar-drift canary excludes them
-//    for). Their callGraph support — including cross-file name resolution on a first parse — is proven
-//    by the standalone build in section (1); a second in-process build (this sweep) is unreliable, so
-//    they are excluded here rather than asserted flakily.
-const CROSS_FILE_EXCLUDED = new Set(['Bash', 'Lua', 'Dart']);
+//  - Dart: the one WASM-loaded grammar, whose shared WASM Language heap yields spurious ERROR nodes
+//    on parses AFTER the first in a process (the same limitation the grammar-drift canary excludes
+//    it for). Its callGraph support — including cross-file name resolution on a first parse — is
+//    proven by the standalone build in section (1); a second in-process build (this sweep) is
+//    unreliable, so it is excluded here rather than asserted flakily. Lua was excluded for the same
+//    reason until it left the WASM lane for the maintained native grammar (#472); it is asserted
+//    below now that repeated in-process builds resolve it stably.
+const CROSS_FILE_EXCLUDED = new Set(['Bash', 'Dart']);
 interface CrossFile { language: string; a: { path: string; content: string }; b: { path: string; content: string }; caller: string; callee: string; confidence: string }
 const CROSS_FILE: CrossFile[] = [
   { language: 'TypeScript', confidence: 'import',    caller: 'main', callee: 'helper', a: { path: 'a.ts', content: `import { helper } from './b';\nexport function main(){ helper(); }` }, b: { path: 'b.ts', content: `export function helper(){ return 1; }` } },
@@ -467,6 +479,7 @@ const CROSS_FILE: CrossFile[] = [
   { language: 'Swift',      confidence: 'name_only', caller: 'mainFn', callee: 'helper', a: { path: 'a.swift', content: `func mainFn() { helper() }\n` }, b: { path: 'b.swift', content: `func helper() -> Int { return 1 }\n` } },
   { language: 'Scala',      confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'A.scala', content: `object A {\n  def main(): Unit = { B.helper() }\n}` }, b: { path: 'B.scala', content: `object B {\n  def helper(): Int = 1\n}` } },
   { language: 'Elixir',     confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'a.ex', content: `defmodule A do\n  def main(), do: B.helper()\nend\n` }, b: { path: 'b.ex', content: `defmodule B do\n  def helper(), do: 1\nend\n` } },
+  { language: 'Lua',        confidence: 'name_only', caller: 'main', callee: 'helper', a: { path: 'a.lua', content: `function main()\n  helper()\nend\n` }, b: { path: 'b.lua', content: `function helper()\n  return 1\nend\n` } },
 ];
 
 describe('language conformance — cross-file resolution for EVERY claimed callGraph language', () => {

--- a/src/core/analyzer/parse-budget.ts
+++ b/src/core/analyzer/parse-budget.ts
@@ -110,9 +110,15 @@ export interface BudgetableParser<TTree> {
  * Presence is not capability. `web-tree-sitter@0.25` exposes `setTimeoutMicros` and throws
  * `TypeError: Cannot convert 0 to a BigInt` from inside it — its WASM shim passes a Number where
  * the import demands a BigInt. Left to propagate, arming the deadline made every file in the
- * WASM-grammar languages (Dart, Lua) fail to extract: a bound that silently deleted real work,
- * which is the exact failure mode this change exists to prevent. So the first refusal demotes that
- * KIND of parser to unbounded rather than being paid, and thrown, per file.
+ * WASM-grammar languages fail to extract: a bound that silently deleted real work, which is the
+ * exact failure mode this change exists to prevent. So the first refusal demotes that KIND of
+ * parser to unbounded rather than being paid, and thrown, per file.
+ *
+ * The lane that provoked this has since narrowed to Dart alone (Lua moved to the native lane,
+ * #472) and `web-tree-sitter@0.27` omits `setTimeoutMicros` altogether, so today Dart takes the
+ * plain unsupported path above rather than this one. The demotion stays: it is keyed on the
+ * binding, not on a language, and it is the only thing standing between a future
+ * exists-but-throws deadline and silently empty extraction.
  *
  * Keyed on the parser's PROTOTYPE, not the instance. Keying the instance looked right and was
  * useless on the one lane it was written for: the WASM grammar handle constructs a fresh parser

--- a/src/core/analyzer/pass1-fact-cache.test.ts
+++ b/src/core/analyzer/pass1-fact-cache.test.ts
@@ -597,7 +597,8 @@ describe('the extractor stamp', () => {
     const require = createRequire(import.meta.url);
     const names = __grammarPackageNamesForTests(HERE);
     expect(names).toContain('web-tree-sitter');
-    expect(names).toContain('tree-sitter-wasms');
+    expect(names).toContain('@repomix/tree-sitter-wasms');
+    expect(names).toContain('@tree-sitter-grammars/tree-sitter-lua');
 
     const installed = names.filter(n => existsSync(join(REPO_ROOT, 'node_modules', n)));
     expect(installed.length).toBeGreaterThan(1);

--- a/src/core/analyzer/wasm-multigrammar.test.ts
+++ b/src/core/analyzer/wasm-multigrammar.test.ts
@@ -11,18 +11,23 @@ const edge = (g: SerializedCallGraph, caller: string, callee: string) => {
   return !!c && !!d && g.edges.some(e => e.callerId === c.id && e.calleeId === d.id);
 };
 
-// Regression: two WASM-backed grammars (Dart + Lua) in ONE build() must each
-// produce a COMPLETE graph. web-tree-sitter is a singleton emscripten module
-// with a shared heap; loading both grammars into one instance silently corrupts
-// the second grammar's parses (Lua lost half its functions). Each grammar must
-// load in its own module instance. Order both ways to be safe.
-describe('spec-08 WASM multi-grammar isolation (Dart + Lua together)', () => {
+// Regression: the WASM lane (Dart) and the native lane (Lua) in ONE build() must each
+// produce a COMPLETE graph, in either order. web-tree-sitter is a singleton emscripten
+// module with a shared heap, and this pairing is where that used to show: both languages
+// were WASM-backed, loading both grammars into one instance silently corrupted the second
+// one's parses (Lua lost half its functions), so each grammar loads in its own module
+// instance. Lua has since moved to the native lane (#472), which leaves Dart the lane's
+// only caller — so the two-WASM-grammar case now has no second caller to exercise it, and
+// the per-grammar isolation in `loadWasmGrammarSoft` stays keyed per grammar for the next
+// one. What this file still proves is that the two lanes coexist in one build without
+// either disturbing the other.
+describe('spec-08 lane coexistence (WASM Dart + native Lua together)', () => {
   it('both Dart and Lua graph fully when analyzed in the same run', async () => {
     const g = serializeCallGraph(await new CallGraphBuilder().build([
       load('dart/app.dart', 'Dart'),
       load('lua/app.lua', 'Lua'),
     ]));
-    if (fnNames(g, 'Dart').length === 0 && fnNames(g, 'Lua').length === 0) return; // WASM unavailable
+    if (fnNames(g, 'Dart').length === 0 && fnNames(g, 'Lua').length === 0) return; // grammars unavailable
     expect(fnNames(g, 'Dart')).toEqual(['helper', 'main', 'run']);
     expect(fnNames(g, 'Lua')).toEqual(['boot', 'helper', 'run']);
     expect(edge(g, 'run', 'helper')).toBe(true); // resolves within each

--- a/src/types/tree-sitter-extra.d.ts
+++ b/src/types/tree-sitter-extra.d.ts
@@ -1,5 +1,5 @@
 // Ambient declarations for spec-08 modules that ship no usable types.
-// Lua and Dart are loaded via portable WASM (tree-sitter-wasms) through
+// Dart is loaded via a portable WASM build (@repomix/tree-sitter-wasms) through
 // web-tree-sitter, which we access through a minimal structural interface.
 declare module 'web-tree-sitter';
 
@@ -11,6 +11,10 @@ declare module 'web-tree-sitter';
 // build is skipped on the runner), even though the typecheck job — which did
 // install it — passes. Declaring the modules here makes the build resolve them
 // regardless of install state, matching tree-sitter-cpp.d.ts.
+declare module '@tree-sitter-grammars/tree-sitter-lua' {
+  const language: object;
+  export default language;
+}
 declare module 'tree-sitter-bash' {
   const language: object;
   export default language;


### PR DESCRIPTION
## Status

LGTM — ready to merge. Closes #472.

## What was missing / the motivation

`web-tree-sitter` could not move past 0.25.x, and the weekly `parser-stack` Dependabot PR kept
re-proposing it. The blocker: Dart and Lua were the only two languages on the WASM grammar lane,
loading `tree-sitter-wasms@0.1.13` binaries. Every `web-tree-sitter` >= 0.26 rejects those binaries
— they carry an emscripten dylink section the rewritten loader refuses — and the rejection throws an
`Error` with an **empty message**. So the symptom was not a build break: Dart and Lua silently
disappeared from the call graph while the capability matrix kept claiming them. `tree-sitter-wasms`
has published nothing since 2025-10-07.

The standing answer was to keep the pin and close the PR each week. This takes the other exit.

## What it does

The 0.26+ loader was never the fault — only those specific binaries are stale — so the fix replaces
the binaries instead of waiting on one upstream package.

| | Before | After |
|---|---|---|
| Dart | `tree-sitter-wasms` WASM | `@repomix/tree-sitter-wasms` WASM |
| Lua | `tree-sitter-wasms` WASM | `@tree-sitter-grammars/tree-sitter-lua`, native |
| Loader | `web-tree-sitter` 0.25.10 (pinned) | `web-tree-sitter` 0.27.0 |

- **Dart** keeps the WASM lane on a rebuilt binary. Parse trees are byte-identical to the old build,
  so `extractDartGraph` is untouched.
- **Lua** leaves the lane for the maintained grammar on the native lane, like every other language
  here. Prebuilt bindings ship for all six platform/arch pairs, so nothing compiles at install time.
  The grammar lineage changed with the transport (the WASM build carried the unmaintained Azganoth
  grammar), so the queries are rewritten one for one — `function_declaration` / `function_call` over
  `dot_index_expression` / `method_index_expression` in place of
  `(local_)function_definition_statement` / `call` over `variable`.

Three things follow:

- **Lua gains what the WASM lane could not give it**: trustworthy parse-health, an enforceable parse
  budget, and cross-file name resolution that holds across repeated in-process builds. It joins the
  conformance sweeps that had excluded it for WASM-heap flakiness — the parse-health canary now
  guards 17 native-loader languages instead of 16, and the cross-file sweep asserts Lua directly.
- **Install shrinks about 26 MB** (50 MB of `tree-sitter-wasms` out; 23 MB + 1.3 MB in).
- **Supply chain improves.** `@repomix/tree-sitter-wasms` carries SLSA provenance from a GitHub
  Actions build and is published under the repomix org (~68k downloads/week); the original was
  published from a personal account with no attestation. `@tree-sitter-grammars/tree-sitter-lua`
  (~22k/week) is the community grammar org — the same shape of dependency as the Swift, Kotlin, and
  Elixir grammars already here.

Dart staying on WASM is still a deliberate hold: a native Dart grammar exists and parses
byte-identically, but the only fitting package is a single-maintainer fork with negligible download
volume, so that swap remains declined on the same supply-chain grounds as before.

## Proof it works

Measured, not assumed.

**The loader was fine; the binaries were stale.** Loading four grammars under a clean
`web-tree-sitter@0.27.0`:

```
FAIL wasms-lua       Error msg=""      <- the known empty-message throw
FAIL wasms-dart      Error msg=""
OK   repomix-dart    root=program
OK   grammars-lua    root=chunk
```

**Dart parse trees are byte-identical.** Full named-node trees dumped under the old stack
(`web-tree-sitter@0.25.10` + `tree-sitter-wasms@0.1.13`) and the new one, then diffed:

| Fixture | Baseline nodes | Differing lines |
|---|---|---|
| `fixtures/dart/app.dart` | 45 | 0 |
| 697-node stress file (mixins, extensions, generics, async/await, `async*`, cascades, try/on/catch/finally, switch, factory and named constructors) | 697 | 0 |

**Lua extraction is identical across the grammar swap.** The old queries against the old grammar vs.
the new queries against the new one, comparing the extracted `(className, function)` and call-name
sets:

| Fixture | Result |
|---|---|
| `fixtures/lua/app.lua` | identical |
| `fixtures/lua/methods.lua` | identical |
| 62-line stress file (goto/labels, varargs, metatables, `t.f` and `t:m`, nested closures, numeric and generic `for`, `repeat`) | identical |

**End to end through the built CLI**, on a repo of those fixtures: 12 Dart and 8 Lua functions with
their call edges, including `type_inference` and `same_file` provenance — so this is verified through
`analyze`, not only in unit tests.

**Suites:** `vitest run src examples` — 502 files, 9,784 tests green. `fuzz`, `typecheck`, `lint`,
`audit:gate`, `audit:deps`, `audit:packlist`, `lock:integrity:check`, and `test:api-consumer` all
pass. One later run tripped `atomic-store.test.ts` and `file-walker-corpus-boundary.test.ts` on
30-second timeouts; both pass in isolation and both are on the repo's known pre-existing flake list
(subprocess-heavy suites sitting near `testTimeout`), untouched by this change.

**The guard test is replaced, not deleted.** The old assertion encoded a version ceiling
(`web-tree-sitter <= 0.25`), which is exactly the thing being lifted. The invariant that still
matters is that the loader and its binaries cannot drift apart, so the new test asserts **both halves
of the lane are pinned exactly** — a caret on either fails CI. Mutation-checked: changing
`web-tree-sitter` to `^0.27.0` fails with the explanation. What proves a future pair actually fits is
the grammar-availability assertion already in that file, which fails if Dart stops loading.

## Notes / nits

- `.github/dependabot.yml`: a bare `tree-sitter-*` pattern does not match a `@scope/` name, so the
  parser-stack group gains `@repomix/tree-sitter-wasms` and `@tree-sitter-grammars/*`. Without this
  the new packages would drift into the routine-update PR. `@dependabot ignore` is still not used,
  for the reason the file already documents.
- The lockfile diff includes five `@earendil-works/pi-*` integrity digests re-added by
  `npm run lock:integrity`. That is the known pi-shrinkwrap behavior on any `npm install`, not part
  of this change.
- `wasm-multigrammar.test.ts` keeps both of its cases but is reframed: with Lua gone, the WASM lane
  has one caller, so the two-WASM-grammar corruption case it was written for has nothing left to
  exercise. The per-grammar module isolation in `loadWasmGrammarSoft` stays keyed per grammar for the
  next one; what the file proves now is that the WASM and native lanes coexist in one build, in
  either order.
- Follow-up, not taken here: if a well-supported native Dart grammar appears, taking it deletes the
  WASM lane outright and drops `web-tree-sitter` with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
